### PR TITLE
Proposed solution for Issue #33

### DIFF
--- a/src/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/framework/Attributes/TestCaseSourceAttribute.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework
     {
         private readonly string sourceName;
         private readonly Type sourceType;
-        private object[] sourceConstructorParameters;
+        private readonly object[] sourceConstructorParameters;
 
         /// <summary>
         /// Construct with the name of the method, property or field that will prvide data
@@ -55,6 +55,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="sourceType">The Type that will provide data</param>
         /// <param name="sourceName">The name of the method, property or field that will provide data</param>
+        /// <param name="constructorParameters">The constructor parameters to be used when instantiating the <see cref="sourceType"/> instance.</param>
         public TestCaseSourceAttribute(Type sourceType, string sourceName, params object[] constructorParameters)
         {
             this.sourceType = sourceType;

--- a/src/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/tests/Attributes/TestCaseSourceTests.cs
@@ -129,9 +129,9 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(typeof(DataSourceClassWithMethod), "GetStuff", "foo")]
         public void SourceCanHaveMethodProducingIEnumerableWithParameters(string source)
         {
-            var items = new[] { "foo1", "foo2", "foo3" };
-            var found = false;
-            for (var i = 0; i < items.Length; i++)
+            string[] items = new[] { "foo1", "foo2", "foo3" };
+            bool found = false;
+            for (int i = 0; i < items.Length; i++)
             {
                 if (items[i] == source)
                 {

--- a/src/tests/Internal/RandomGeneratorTests.cs
+++ b/src/tests/Internal/RandomGeneratorTests.cs
@@ -84,9 +84,9 @@ namespace NUnit.Framework.Internal
         public static void CanGetRandomBool()
         {
             RandomGenerator r = new RandomGenerator(new Random().Next());
-            var haveTrue = false;
-            var haveFalse = false;
-            var attempts = 0;
+            bool haveTrue = false;
+            bool haveFalse = false;
+            int attempts = 0;
             while (!haveTrue && !haveFalse)
             {
                 if (attempts++ > 10000)


### PR DESCRIPTION
fixing issue #33: "TestCaseSource cannot refer to a parameterized test fixture"
- allow specifying constructor parameters after data source method name
- for the case where no method name would be required for the data source (ie, when the data source class itself implements IEnumerable), require the user to provide null for the method name
  - proposed to cater for the case where the only parameter to the constructor is a string
- had a random test failure whilst working on Issue #33
  - original code tried to get true/false variance in 10 attempts:
    the new test attempts up to 10000 times to get variance, quitting after the first time variance is found and bailing out with a useful message if variance isn't found in 10000 attempts.

``` C#
// code samples (from tests)
// class which implements IEnumerable:
[Test, TestCaseSource(typeof(DataSourceClass), null, "foo")]
public void SourceCanBeInstanceOfIEnumerableWithParameters(string source)
{
    Assert.AreEqual("foo", source);
}

class DataSourceClass : IEnumerable
{
    public DataSourceClass()
    {
    }

    private readonly string enumeratorOverride;

    public DataSourceClass(string enumeratorOverride)
    {
        this.enumeratorOverride = enumeratorOverride;
    }

    public IEnumerator GetEnumerator()
    {
        yield return this.enumeratorOverride ?? "DataSourceClass";
    }
}

// using a method which returns IEnumerable on a data source class
[Test, TestCaseSource(typeof(DataSourceClassWithMethod), "GetStuff", "foo")]
public void SourceCanHaveMethodProducingIEnumerableWithParameters(string source)
{
    string[] items = new[] { "foo1", "foo2", "foo3" };
    bool found = false;
    for (int i = 0; i < items.Length; i++)
    {
        if (items[i] == source)
        {
            found = true;
        }
    }
    Assert.IsTrue(found);
}

class DataSourceClassWithMethod
{
    private readonly string enumeratorPrepend;

    public DataSourceClassWithMethod(string enumeratorPrepend)
    {
        this.enumeratorPrepend = enumeratorPrepend;
    }
    public IEnumerable<string> GetStuff()
    {
        return new[] { enumeratorPrepend+"1", enumeratorPrepend+"2", enumeratorPrepend+"3" };
    }
}
```
