### PR TITLE
Fixed Issue #29 :Specifying a tolerance with "Within" doesn't work for DateTimeOffset data types

### DIFF
--- a/src/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/framework/Constraints/NUnitEqualityComparer.cs
@@ -169,6 +169,9 @@ namespace NUnit.Framework.Constraints
                 if (x is DateTime && y is DateTime)
                     return ((DateTime)x - (DateTime)y).Duration() <= amount;
 
+                if (x is DateTimeOffset && y is DateTimeOffset)
+                    return ((DateTimeOffset)x - (DateTimeOffset)y).Duration() <= amount;
+
                 if (x is TimeSpan && y is TimeSpan)
                     return ((TimeSpan)x - (TimeSpan)y).Duration() <= amount;
             }

--- a/src/tests/Constraints/EqualConstraintTests.cs
+++ b/src/tests/Constraints/EqualConstraintTests.cs
@@ -40,14 +40,16 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<equal 4>";
         }
 
-        object[] SuccessData = new object[] { 4, 4.0f, 4.0d, 4.0000m };
+        private object[] SuccessData = new object[] {4, 4.0f, 4.0d, 4.0000m};
 
-        object[] FailureData = new object[] { 
-            new TestCaseData( 5, "5" ), 
-            new TestCaseData( null, "null" ),
-            new TestCaseData( "Hello", "\"Hello\"" ),
-            new TestCaseData( double.NaN, "NaN" ),
-            new TestCaseData( double.PositiveInfinity, "Infinity" ) };
+        private object[] FailureData = new object[]
+            {
+                new TestCaseData(5, "5"),
+                new TestCaseData(null, "null"),
+                new TestCaseData("Hello", "\"Hello\""),
+                new TestCaseData(double.NaN, "NaN"),
+                new TestCaseData(double.PositiveInfinity, "Infinity")
+            };
 
         #region DateTimeEquality
 
@@ -86,6 +88,16 @@ namespace NUnit.Framework.Constraints
                 Assert.That(actual, new EqualConstraint(expected).Within(5).Hours);
             }
 
+
+            [Test]
+            public void CanMatchUsingIsEqualToWithinTimeSpan()
+            {
+                DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
+                DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
+                Assert.That(actual, Is.EqualTo(expected).Within(TimeSpan.FromMinutes(2)));
+            }
+
+
             [Test]
             public void CanMatchDatesWithinMinutes()
             {
@@ -123,43 +135,123 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute * 5).Ticks);
+                Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute*5).Ticks);
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfDaysPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Days.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfHoursPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Hours.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfMinutesPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Minutes.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfSecondsPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Seconds.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfMillisecondsPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Milliseconds.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfTicksPrecedesWithin()
             {
                 Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Ticks.Within(5));
+            }
+        }
+
+        #endregion
+
+        #region DateTimeOffsetEquality
+
+        public class DateTimeOffSetEquality
+        {
+            [Test]
+            public void CanMatchDates()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1));
+                var actual = new DateTimeOffset(new DateTime(2007, 4, 1));
+                Assert.That(actual, new EqualConstraint(expected));
+            }
+
+            [Test]
+            public void CanMatchDatesWithinTimeSpan()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                var tolerance = TimeSpan.FromMinutes(5.0);
+                Assert.That(actual, new EqualConstraint(expected).Within(tolerance));
+            }
+
+            [Test]
+            public void CanMatchDatesWithinDays()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual = new DateTimeOffset(new DateTime(2007, 4, 4, 13, 0, 0));
+                Assert.That(actual, new EqualConstraint(expected).Within(5).Days);
+            }
+
+            [Test]
+            public void CanMatchUsingIsEqualToWithinTimeSpan()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                Assert.That(actual, Is.EqualTo(expected).Within(TimeSpan.FromMinutes(2)));
+            }
+
+            [Test]
+            public void CanMatchDatesWithinMinutes()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                Assert.That(actual, new EqualConstraint(expected).Within(5).Minutes);
+            }
+
+            [Test]
+            public void CanMatchDatesWithinSeconds()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                Assert.That(actual, new EqualConstraint(expected).Within(300).Seconds);
+            }
+
+            [Test]
+            public void CanMatchDatesWithinMilliseconds()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                Assert.That(actual, new EqualConstraint(expected).Within(300000).Milliseconds);
+            }
+
+            [Test]
+            public void CanMatchDatesWithinTicks()
+            {
+                var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
+                var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
+                Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute*5).Ticks);
+            }
+
+            [Test]
+            public void DTimeOffsetCanMatchDatesWithinHours()
+            {
+                var a = DateTimeOffset.Parse("2012-01-01T12:00Z");
+                var b = DateTimeOffset.Parse("2012-01-01T12:01Z");
+                Assert.That(a, Is.EqualTo(b).Within(TimeSpan.FromMinutes(2)));
             }
         }
 
@@ -172,51 +264,51 @@ namespace NUnit.Framework.Constraints
             [Test]
             public void CanMatchDictionaries_SameOrder()
             {
-                Assert.AreEqual(new Dictionary<int, int> { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Dictionary<int, int> { { 0, 0 }, { 1, 1 }, { 2, 2 } });
+                Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
+                                new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}});
             }
 
-            [Test, ExpectedException(typeof(AssertionException))]
+            [Test, ExpectedException(typeof (AssertionException))]
             public void CanMatchDictionaries_Failure()
             {
-                Assert.AreEqual(new Dictionary<int, int> { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Dictionary<int, int> { { 0, 0 }, { 1, 5 }, { 2, 2 } });
+                Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
+                                new Dictionary<int, int> {{0, 0}, {1, 5}, {2, 2}});
             }
 
             [Test]
             public void CanMatchDictionaries_DifferentOrder()
             {
-                Assert.AreEqual(new Dictionary<int, int> { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Dictionary<int, int> { { 0, 0 }, { 2, 2 }, { 1, 1 } });
+                Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
+                                new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}});
             }
 
 #if !SILVERLIGHT
             [Test]
             public void CanMatchHashtables_SameOrder()
             {
-                Assert.AreEqual(new Hashtable { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Hashtable { { 0, 0 }, { 1, 1 }, { 2, 2 } });
+                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
+                                new Hashtable {{0, 0}, {1, 1}, {2, 2}});
             }
 
-            [Test, ExpectedException(typeof(AssertionException))]
+            [Test, ExpectedException(typeof (AssertionException))]
             public void CanMatchHashtables_Failure()
             {
-                Assert.AreEqual(new Hashtable { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Hashtable { { 0, 0 }, { 1, 5 }, { 2, 2 } });
+                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
+                                new Hashtable {{0, 0}, {1, 5}, {2, 2}});
             }
 
             [Test]
             public void CanMatchHashtables_DifferentOrder()
             {
-                Assert.AreEqual(new Hashtable { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Hashtable { { 0, 0 }, { 2, 2 }, { 1, 1 } });
+                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
+                                new Hashtable {{0, 0}, {2, 2}, {1, 1}});
             }
 
             [Test]
             public void CanMatchHashtableWithDictionary()
             {
-                Assert.AreEqual(new Hashtable { { 0, 0 }, { 1, 1 }, { 2, 2 } },
-                                new Dictionary<int, int> { { 0, 0 }, { 2, 2 }, { 1, 1 } });
+                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
+                                new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}});
             }
 #endif
         }
@@ -245,7 +337,8 @@ namespace NUnit.Framework.Constraints
                 Assert.That(value, new EqualConstraint(20000000000000000.0).Within(1).Ulps);
             }
 
-            [ExpectedException(typeof(AssertionException), ExpectedMessage = "+/- 1 Ulps", MatchType = MessageMatch.Contains)]
+            [ExpectedException(typeof (AssertionException), ExpectedMessage = "+/- 1 Ulps",
+                MatchType = MessageMatch.Contains)]
             [TestCase(20000000000000008.0)]
             [TestCase(19999999999999992.0)]
             public void FailsOnDoublesOutsideOfUlpTolerance(object value)
@@ -260,7 +353,8 @@ namespace NUnit.Framework.Constraints
                 Assert.That(value, new EqualConstraint(20000000.0f).Within(1).Ulps);
             }
 
-            [ExpectedException(typeof(AssertionException), ExpectedMessage = "+/- 1 Ulps", MatchType = MessageMatch.Contains)]
+            [ExpectedException(typeof (AssertionException), ExpectedMessage = "+/- 1 Ulps",
+                MatchType = MessageMatch.Contains)]
             [TestCase(19999996.0f)]
             [TestCase(20000004.0f)]
             public void FailsOnSinglesOutsideOfUlpTolerance(object value)
@@ -276,7 +370,8 @@ namespace NUnit.Framework.Constraints
                 Assert.That(value, new EqualConstraint(10000.0).Within(10.0).Percent);
             }
 
-            [ExpectedException(typeof(AssertionException), ExpectedMessage = "+/- 10.0d Percent", MatchType = MessageMatch.Contains)]
+            [ExpectedException(typeof (AssertionException), ExpectedMessage = "+/- 10.0d Percent",
+                MatchType = MessageMatch.Contains)]
             [TestCase(8500.0)]
             [TestCase(11500.0)]
             public void FailsOnDoublesOutsideOfRelativeTolerance(object value)
@@ -292,7 +387,8 @@ namespace NUnit.Framework.Constraints
                 Assert.That(value, new EqualConstraint(10000.0f).Within(10.0f).Percent);
             }
 
-            [ExpectedException(typeof(AssertionException), ExpectedMessage = "+/- 10.0f Percent", MatchType = MessageMatch.Contains)]
+            [ExpectedException(typeof (AssertionException), ExpectedMessage = "+/- 10.0f Percent",
+                MatchType = MessageMatch.Contains)]
             [TestCase(8500.0f)]
             [TestCase(11500.0f)]
             public void FailsOnSinglesOutsideOfRelativeTolerance(object value)
@@ -301,32 +397,32 @@ namespace NUnit.Framework.Constraints
             }
 
             /// <summary>Applies both the Percent and Ulps modifiers to cause an exception</summary>
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorWithPercentAndUlpsToleranceModes()
             {
                 EqualConstraint shouldFail = new EqualConstraint(100.0f).Within(10.0f).Percent.Ulps;
             }
 
             /// <summary>Applies both the Ulps and Percent modifiers to cause an exception</summary>
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorWithUlpsAndPercentToleranceModes()
             {
                 EqualConstraint shouldFail = new EqualConstraint(100.0f).Within(10.0f).Ulps.Percent;
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfPercentPrecedesWithin()
             {
                 Assert.That(1010, Is.EqualTo(1000).Percent.Within(5));
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfUlpsPrecedesWithin()
             {
                 Assert.That(1010.0, Is.EqualTo(1000.0).Ulps.Within(5));
             }
 
-            [ExpectedException(typeof(InvalidOperationException))]
+            [ExpectedException(typeof (InvalidOperationException))]
             [TestCase(1000, 1010)]
             [TestCase(1000U, 1010U)]
             [TestCase(1000L, 1010L)]
@@ -336,7 +432,7 @@ namespace NUnit.Framework.Constraints
                 Assert.That(y, Is.EqualTo(x).Within(2).Ulps);
             }
 
-            [Test, ExpectedException(typeof(InvalidOperationException))]
+            [Test, ExpectedException(typeof (InvalidOperationException))]
             public void ErrorIfUlpsIsUsedOnDecimal()
             {
                 Assert.That(100m, Is.EqualTo(100m).Within(2).Ulps);
@@ -404,11 +500,11 @@ namespace NUnit.Framework.Constraints
             [Test]
             public void UsesProvidedListComparer()
             {
-                var list1 = new List<int>() { 2, 3 };
-                var list2 = new List<int>() { 3, 4 };
+                var list1 = new List<int>() {2, 3};
+                var list2 = new List<int>() {3, 4};
 
-                var list11 = new List<List<int>>() { list1 };
-                var list22 = new List<List<int>>() { list2 };
+                var list11 = new List<List<int>>() {list1};
+                var list22 = new List<List<int>>() {list2};
                 var comparer = new IntListEqualComparer();
 
                 Assert.That(list11, new CollectionEquivalentConstraint(list22).Using(comparer));
@@ -430,11 +526,11 @@ namespace NUnit.Framework.Constraints
             [Test]
             public void UsesProvidedArrayComparer()
             {
-                var array1 = new int[] { 2, 3 };
-                var array2 = new int[] { 3, 4 };
+                var array1 = new int[] {2, 3};
+                var array2 = new int[] {3, 4};
 
-                var list11 = new List<int[]>() { array1 };
-                var list22 = new List<int[]>() { array2 };
+                var list11 = new List<int[]>() {array1};
+                var list22 = new List<int[]>() {array2};
                 var comparer = new IntArrayEqualComparer();
 
                 Assert.That(list11, new CollectionEquivalentConstraint(list22).Using(comparer));


### PR DESCRIPTION
Added tests and fixed the issue.
