### PR TITLE
Fixes Issue #55 - Incorrect XML comments for CollectionAssert.IsSubsetOf

### DIFF
--- a/src/framework/CollectionAssert.cs
+++ b/src/framework/CollectionAssert.cs
@@ -470,13 +470,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset does not contain the subset
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		public static void IsNotSubsetOf (IEnumerable subset, IEnumerable superset)
 		{
 			IsNotSubsetOf(subset, superset, string.Empty, null);
@@ -485,13 +480,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset does not contain the subset
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		/// <param name="message">The message that will be displayed on failure</param>
 		public static void IsNotSubsetOf (IEnumerable subset, IEnumerable superset, string message)
 		{
@@ -501,13 +491,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset does not contain the subset
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		/// <param name="message">The message that will be displayed on failure</param>
 		/// <param name="args">Arguments to be used in formatting the message</param>
 		public static void IsNotSubsetOf (IEnumerable subset, IEnumerable superset, string message, params object[] args)
@@ -521,13 +506,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset contains the subset.
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		public static void IsSubsetOf (IEnumerable subset, IEnumerable superset)
 		{
 			IsSubsetOf(subset, superset, string.Empty, null);
@@ -536,13 +516,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset contains the subset.
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		/// <param name="message">The message that will be displayed on failure</param>
 		public static void IsSubsetOf (IEnumerable subset, IEnumerable superset, string message)
 		{
@@ -552,13 +527,8 @@ namespace NUnit.Framework
 		/// <summary>
 		/// Asserts that the superset contains the subset.
 		/// </summary>
-<<<<<<< HEAD
         /// <param name="subset">The IEnumerable subset to be considered</param>
         /// <param name="superset">The IEnumerable superset to be considered</param>
-=======
-      /// <param name="subset">The IEnumerable subset to be considered</param>
-      /// <param name="superset">The IEnumerable superset to be considered</param>
->>>>>>> 130d2fbfab89c4e737d716ccb0c9460058b5f282
 		/// <param name="message">The message that will be displayed on failure</param>
 		/// <param name="args">Arguments to be used in formatting the message</param>
 		public static void IsSubsetOf (IEnumerable subset, IEnumerable superset, string message, params object[] args)


### PR DESCRIPTION
I modified the summaries and parameters for all of the CollectionAssert.IsSubsetOf and IsNotSubsetOf methods. The noise in the diff is because I forgot to change the tab spacing from my employers standard to the default 4 spaces.
