### PR TITLE
Fixed five unreachable code warnings.

### DIFF
--- a/src/framework/Internal/DefaultTestAssemblyBuilder.cs
+++ b/src/framework/Internal/DefaultTestAssemblyBuilder.cs
@@ -111,7 +111,6 @@ namespace NUnit.Framework.Internal
             AssemblyName assemblyName = AssemblyName.GetAssemblyName(path);
 
             assembly = Assembly.Load(assemblyName);
-#endif
 
             // TODO: Can this ever be null?
             if (assembly == null)
@@ -127,6 +126,7 @@ namespace NUnit.Framework.Internal
             }
 
             return assembly;
+#endif
         }
 
         private IList GetFixtures(Assembly assembly, IList names)

--- a/src/testdata/AsyncDummyFixture.cs
+++ b/src/testdata/AsyncDummyFixture.cs
@@ -81,11 +81,8 @@ namespace NUnit.TestData
 
         private async Task<int> Throw()
         {
-            return await Task.Run(() =>
-            {
-                throw new InvalidOperationException();
-                return 1;
-            });
+            Func<int> thrower = () => { throw new InvalidOperationException(); };
+            return await Task.Run( thrower );
         }
     }
 }

--- a/src/testdata/AsyncRealFixture.cs
+++ b/src/testdata/AsyncRealFixture.cs
@@ -357,12 +357,9 @@ namespace NUnit.TestData
 		}
 
 		private static Task<int> ThrowException()
-		{
-			return Task.Run(() =>
-			{
-				throw new InvalidOperationException();
-				return 1;
-			});
+        {
+            Func<int> throws = () => { throw new InvalidOperationException(); };
+			return Task.Run( throws );
 		}
 	}
 }


### PR DESCRIPTION
One was a mis-scoped #if and the other two were return calls after throwing exceptions. I have built in 2.0, 3.5, 4.0, 4.5 and SL. I have tested all except SL.
