### PR TITLE
Shared Resharper Settings for the Solution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 # Prevent files from being exported
 .gitattributes export-ignore
 .gitignore     export-ignore
+
+# Resharper DotSettings files are in Unix Format
+*.DotSettings text eol=lf

--- a/NUnitFramework.sln.DotSettings
+++ b/NUnitFramework.sln.DotSettings
@@ -1,0 +1,152 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">***********************************************************************&#xD;
+Copyright (c) $CURRENT_YEAR$ $USER_NAME$&#xD;
+&#xD;
+Permission is hereby granted, free of charge, to any person obtaining&#xD;
+a copy of this software and associated documentation files (the&#xD;
+"Software"), to deal in the Software without restriction, including&#xD;
+without limitation the rights to use, copy, modify, merge, publish,&#xD;
+distribute, sublicense, and/or sell copies of the Software, and to&#xD;
+permit persons to whom the Software is furnished to do so, subject to&#xD;
+the following conditions:&#xD;
+&#xD;
+The above copyright notice and this permission notice shall be&#xD;
+included in all copies or substantial portions of the Software.&#xD;
+&#xD;
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,&#xD;
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF&#xD;
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND&#xD;
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE&#xD;
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION&#xD;
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION&#xD;
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.&#xD;
+***********************************************************************&#xD;
+</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=USER/Expression/@EntryValue">getUserName()</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=USER/InitialRange/@EntryValue">-1</s:Int64>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=YEAR/Expression/@EntryValue">getCurrentDate("yyyy")</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=YEAR/InitialRange/@EntryValue">-1</s:Int64>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Shortcut/@EntryValue">copyright</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Description/@EntryValue">NUnit Copyright</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Text/@EntryValue">// ***********************************************************************&#xD;
+// Copyright (c) $YEAR$ $USER$&#xD;
+//&#xD;
+// Permission is hereby granted, free of charge, to any person obtaining&#xD;
+// a copy of this software and associated documentation files (the&#xD;
+// "Software"), to deal in the Software without restriction, including&#xD;
+// without limitation the rights to use, copy, modify, merge, publish,&#xD;
+// distribute, sublicense, and/or sell copies of the Software, and to&#xD;
+// permit persons to whom the Software is furnished to do so, subject to&#xD;
+// the following conditions:&#xD;
+// &#xD;
+// The above copyright notice and this permission notice shall be&#xD;
+// included in all copies or substantial portions of the Software.&#xD;
+// &#xD;
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,&#xD;
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF&#xD;
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND&#xD;
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE&#xD;
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION&#xD;
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION&#xD;
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.&#xD;
+// ***********************************************************************</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Reformat/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Scope/=558F05AA0DE96347816FF785232CFB2A/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Scope/=558F05AA0DE96347816FF785232CFB2A/Type/@EntryValue">InCSharpTypeAndNamespace</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Scope/=558F05AA0DE96347816FF785232CFB2A/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=YEAR/@KeyIndexDefined">True</s:Boolean>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=YEAR/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=USER/@KeyIndexDefined">True</s:Boolean>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/Field/=USER/Order/@EntryValue">1</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Description/@EntryValue">Test Method</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Field/=TEST_005FMETHOD/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Field/=TEST_005FMETHOD/Expression/@EntryValue">constant("TestMethod")</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Field/=TEST_005FMETHOD/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Reformat/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/Type/@EntryValue">InCSharpTypeMember</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Shortcut/@EntryValue">test</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=6ACED16A1977164DBEC1AABF77ECAE5F/Text/@EntryValue">[Test]&#xD;
+public void $TEST_METHOD$()&#xD;
+{&#xD;
+	$END$&#xD;
+}</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Description/@EntryValue">Test Fixture</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FCLASS/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FCLASS/Expression/@EntryValue">constant("TestClass")</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FCLASS/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FMETHOD/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FMETHOD/Expression/@EntryValue">constant("TestMethod")</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Field/=TEST_005FMETHOD/Order/@EntryValue">1</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Reformat/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=558F05AA0DE96347816FF785232CFB2A/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=558F05AA0DE96347816FF785232CFB2A/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=558F05AA0DE96347816FF785232CFB2A/Type/@EntryValue">InCSharpTypeAndNamespace</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Scope/=B68999B9D6B43E47A02B22C12A54C3CC/Type/@EntryValue">InCSharpTypeMember</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Shortcut/@EntryValue">tf</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=73F8A8FB97CC7A40BB04F4ACB4DC6D06/Text/@EntryValue">[TestFixture]&#xD;
+public class $TEST_CLASS$&#xD;
+{&#xD;
+	[Test]&#xD;
+	public void $TEST_METHOD$()&#xD;
+	{&#xD;
+		$END$&#xD;
+	}&#xD;
+}</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Applicability/=File/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/CustomProperties/=Extension/@EntryIndexedValue">cs</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/CustomProperties/=FileName/@EntryIndexedValue">TestClass</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/CustomProperties/=ValidateFileName/@EntryIndexedValue">True</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Description/@EntryValue">&amp;Test Class</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=CLASS/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=CLASS/Expression/@EntryValue">getFileNameWithoutExtension()</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=CLASS/InitialRange/@EntryValue">-1</s:Int64>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=CLASS/Order/@EntryValue">2</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=HEADER/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=HEADER/Expression/@EntryValue">fileheader()</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=HEADER/InitialRange/@EntryValue">-1</s:Int64>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=HEADER/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=NAMESPACE/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=NAMESPACE/Expression/@EntryValue">fileDefaultNamespace()</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=NAMESPACE/InitialRange/@EntryValue">-1</s:Int64>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=NAMESPACE/Order/@EntryValue">1</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=TEST_005FMETHOD/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=TEST_005FMETHOD/Expression/@EntryValue">constant("TestMethod")</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Field/=TEST_005FMETHOD/Order/@EntryValue">3</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Reformat/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Scope/=E8F0594528C33E45BBFEC6CFE851095D/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Scope/=E8F0594528C33E45BBFEC6CFE851095D/Type/@EntryValue">InCSharpProjectFile</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=8DB051565EE336439784EE0FE0DE0FB7/Text/@EntryValue">$HEADER$&#xD;
+#region Using Directives&#xD;
+&#xD;
+using System;&#xD;
+using NUnit.Framework;&#xD;
+&#xD;
+#endregion&#xD;
+&#xD;
+namespace $NAMESPACE$&#xD;
+{&#xD;
+	[TestFixture]&#xD;
+	public class $CLASS$ &#xD;
+	{&#xD;
+		[Test]&#xD;
+		public void $TEST_METHOD$()&#xD;
+		{&#xD;
+			$END$&#xD;
+		}&#xD;
+	}&#xD;
+}</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Added a Resharper DotSettings file for the solution with a few templates and the copyright header.

Not sure if you want this in the repository, but I find it useful for maintaining a consistent coding style for developers on the project who use Resharper. If others agree that this is useful, I will take the time to configure all of the resharper coding styles to match those of the project.

So far, it just has code templates for creating test classes, test methods and inserting the copyright.

.gitattributes was changed to respect the fact that Resharper settings files are Unix format.
