### PR TITLE
Issue #85 - removed hardcoded string representations of NaN and infinity

### DIFF
--- a/src/tests/Assertions/AssertEqualsTests.cs
+++ b/src/tests/Assertions/AssertEqualsTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Globalization;
 
 namespace NUnit.Framework.Assertions
 {
@@ -87,7 +88,7 @@ namespace NUnit.Framework.Assertions
 		{
 			expectedMessage =
 				"  Expected: 1.234d +/- 0.0d" + Env.NewLine +
-				"  But was:  NaN" + Env.NewLine;
+				"  But was:  " + Double.NaN + Env.NewLine;
 			Assert.AreEqual(1.234, Double.NaN, 0.0);
 		}    
 
@@ -97,7 +98,7 @@ namespace NUnit.Framework.Assertions
 		public void NanEqualsFails() 
 		{
 			expectedMessage =
-				"  Expected: NaN" + Env.NewLine +
+				"  Expected: " + Double.NaN + Env.NewLine +
 				"  But was:  1.234d" + Env.NewLine;
 			Assert.AreEqual(Double.NaN, 1.234, 0.0);
 		}     
@@ -124,7 +125,7 @@ namespace NUnit.Framework.Assertions
 		public void PosInfinityNotEquals() 
 		{
 			expectedMessage =
-				"  Expected: Infinity" + Env.NewLine +
+				"  Expected: " + Double.PositiveInfinity + Env.NewLine +
 				"  But was:  1.23d" + Env.NewLine;
 			Assert.AreEqual(Double.PositiveInfinity, 1.23, 0.0);
 		}
@@ -133,8 +134,8 @@ namespace NUnit.Framework.Assertions
 		public void PosInfinityNotEqualsNegInfinity() 
 		{
 			expectedMessage =
-				"  Expected: Infinity" + Env.NewLine +
-				"  But was:  -Infinity" + Env.NewLine;
+				"  Expected: " + Double.PositiveInfinity + Env.NewLine +
+				"  But was:  " + Double.NegativeInfinity + Env.NewLine;
 			Assert.AreEqual(Double.PositiveInfinity, Double.NegativeInfinity, 0.0);
 		}
 
@@ -142,8 +143,8 @@ namespace NUnit.Framework.Assertions
 		public void SinglePosInfinityNotEqualsNegInfinity() 
 		{
 			expectedMessage =
-				"  Expected: Infinity" + Env.NewLine +
-				"  But was:  -Infinity" + Env.NewLine;
+				"  Expected: " + Double.PositiveInfinity + Env.NewLine +
+				"  But was:  " + Double.NegativeInfinity + Env.NewLine;
 			Assert.AreEqual(float.PositiveInfinity, float.NegativeInfinity, (float)0.0);
 		}
 

--- a/src/tests/Constraints/BasicConstraintTests.cs
+++ b/src/tests/Constraints/BasicConstraintTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Globalization;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
@@ -98,9 +99,9 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( null, "null" ),
             new TestCaseData( "hello", "\"hello\"" ),
             new TestCaseData( 42, "42" ), 
-            new TestCaseData( double.PositiveInfinity, "Infinity" ),
-            new TestCaseData( double.NegativeInfinity, "-Infinity" ),
-            new TestCaseData( float.PositiveInfinity, "Infinity" ),
-            new TestCaseData( float.NegativeInfinity, "-Infinity" ) };
+            new TestCaseData( double.PositiveInfinity, double.PositiveInfinity.ToString() ),
+            new TestCaseData( double.NegativeInfinity, double.NegativeInfinity.ToString() ),
+            new TestCaseData( float.PositiveInfinity, double.PositiveInfinity.ToString() ),
+            new TestCaseData( float.NegativeInfinity, double.NegativeInfinity.ToString() ) };
     }
 }

--- a/src/tests/Constraints/EqualConstraintTests.cs
+++ b/src/tests/Constraints/EqualConstraintTests.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Constraints
                 new TestCaseData(5, "5"),
                 new TestCaseData(null, "null"),
                 new TestCaseData("Hello", "\"Hello\""),
-                new TestCaseData(double.NaN, "NaN"),
-                new TestCaseData(double.PositiveInfinity, "Infinity")
+                new TestCaseData(double.NaN, double.NaN.ToString()),
+                new TestCaseData(double.PositiveInfinity, double.PositiveInfinity.ToString())
             };
 
         #region DateTimeEquality


### PR DESCRIPTION
Several tests were failing because we were comparing the message of expected assertion failures with handcrafted messages that contained the English string representation of positive and negative infinity and NaN. I corrected them so that the handcrafted messages use the correct string representation of such entities according to the current culture, which is what NUnit uses to format assertion failure messages.
