### PR TITLE
Fixed failing test on non-US machines

### DIFF
--- a/src/harness/Program.cs
+++ b/src/harness/Program.cs
@@ -27,6 +27,8 @@ using System.Reflection;
 using System.IO;
 using Mono.Options;
 using NUnit.Framework.Internal;
+using System.Threading;
+using System.Globalization;
 
 namespace NUnit.Framework.TestHarness
 {
@@ -40,6 +42,8 @@ namespace NUnit.Framework.TestHarness
     {
         static int Main(string[] args)
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             CommandLineOptions options = new CommandLineOptions();
 
             try


### PR DESCRIPTION
Fixed: test
NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExceptionWithMessage()
fails on machines with culture different from "en-US"
