### PR TITLE
Fixed failing test on machine with german culture

### DIFF
--- a/src/tests/Syntax/ThrowsTests.cs
+++ b/src/tests/Syntax/ThrowsTests.cs
@@ -130,10 +130,11 @@ namespace NUnit.Framework.Syntax
         [Test]
         public void LambdaThrowsExceptionWithMessage()
         {
+            string expectedExceptionMessage = (new ArgumentNullException()).Message;
             Assert.That(
                 () => new MyClass(null),
                 Throws.InstanceOf<ArgumentNullException>()
-                .And.Message.Matches("null"));
+                .And.Message.EqualTo(expectedExceptionMessage));
         }
 #endif
 


### PR DESCRIPTION
```
Errors and Failures -
1) Failed :
NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExceptionWithMessage
Expected: instance of <System.ArgumentNullException> and property
Message String matching "null"
But was:  "Der Wert darf nicht NULL sein."
```
