### PR TITLE
Issue 70

### DIFF
--- a/src/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/framework/Constraints/NUnitEqualityComparer.cs
@@ -145,11 +145,14 @@ namespace NUnit.Framework.Constraints
                 return DictionariesEqual((IDictionary)x, (IDictionary)y, ref tolerance);
             
             // Issue #70 - EquivalentTo isn't compatible with IgnoreCase for dictionaries
-            // IDictionary will eventually try to compare it's key value pairs when using CollectionTally
+            if (x is DictionaryEntry && y is DictionaryEntry)
+                return DictionaryEntriesEqual((DictionaryEntry)x, (DictionaryEntry)y, ref tolerance);
+
+            // IDictionary<,> will eventually try to compare it's key value pairs when using CollectionTally
             if (xType.IsGenericType && xType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>) &&
                 yType.IsGenericType && yType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
             {
-                var keyTolerance = Tolerance.Empty;
+                var keyTolerance = new Tolerance(0);
                 object xKey = xType.GetProperty("Key").GetValue(x, null);
                 object yKey = yType.GetProperty("Key").GetValue(y, null);
                 object xValue = xType.GetProperty("Value").GetValue(x, null);
@@ -280,6 +283,12 @@ namespace NUnit.Framework.Constraints
                     return false;
  
             return true;
+        }
+
+        private bool DictionaryEntriesEqual(DictionaryEntry x, DictionaryEntry y, ref Tolerance tolerance)
+        {
+            var keyTolerance = new Tolerance(0);
+            return AreEqual(x.Key, y.Key, ref keyTolerance) && AreEqual(x.Value, y.Value, ref tolerance);
         }
 
         private bool CollectionsEqual(ICollection x, ICollection y, ref Tolerance tolerance)

--- a/src/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
-        [TestCaseSource( "IgnoreCaseData" )]
+        [TestCaseSource(typeof(IgnoreCaseDataProvider), "TestCases")]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             var constraint = new CollectionEquivalentConstraint( expected ).IgnoreCase;
@@ -117,14 +117,29 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private static readonly object[] IgnoreCaseData =
+        public class IgnoreCaseDataProvider
         {
-            new object[] {new SimpleObjectCollection("x", "y", "z"),new SimpleObjectCollection("z", "Y", "X")},
-            new object[] {new[] {'A', 'B', 'C'}, new object[] {'a', 'c', 'b'}},
-            new object[] {new[] {"a", "b", "c"}, new object[] {"A", "C", "B"}},
-            new object[] {new Dictionary<int, string> {{2, "b"},{ 1, "a" }}, new Dictionary<int, string> {{ 1, "A" },{2, "b"}}},
-            new object[] {new Dictionary<int, char> {{ 1, 'A' }}, new Dictionary<int, char> {{ 1, 'a' }}}
-        };
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    yield return new TestCaseData(new SimpleObjectCollection("x", "y", "z"), new SimpleObjectCollection("z", "Y", "X"));
+                    yield return new TestCaseData(new[] {'A', 'B', 'C'}, new object[] {'a', 'c', 'b'});
+                    yield return new TestCaseData(new[] {"a", "b", "c"}, new object[] {"A", "C", "B"});
+                    yield return new TestCaseData(new Dictionary<int, string> {{2, "b"}, {1, "a"}}, new Dictionary<int, string> {{1, "A"}, {2, "b"}});
+                    yield return new TestCaseData(new Dictionary<int, char> {{1, 'A'}}, new Dictionary<int, char> {{1, 'a'}});
+                    yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"A", 1}, {"b", 2}});
+                    yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }}, new Dictionary<char, int> {{'a', 1}});
+                    
+#if !NETCF && !SILVERLIGHT
+                    yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"},{2, "B"}});
+                    yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{1, 'a'},{2, 'b'}});
+                    yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}, {"b", 2}});
+                    yield return new TestCaseData(new Hashtable {{'A', 1}}, new Hashtable {{'a', 1}});
+#endif
+                }
+            }
+        }
 
 
         [Test]

--- a/src/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
             new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" } };
 
         [Test]
-        [TestCaseSource( "IgnoreCaseData" )]
+        [TestCaseSource(typeof(IgnoreCaseDataProvider), "TestCases")]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             var constraint = new CollectionSubsetConstraint( expected ).IgnoreCase;
@@ -58,13 +58,28 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private static readonly object[] IgnoreCaseData =
+        public class IgnoreCaseDataProvider
         {
-            new object[] {new SimpleObjectCollection("w", "x", "y", "z"),new SimpleObjectCollection("z", "Y", "X")},
-            new object[] {new[] {'A', 'B', 'C', 'D', 'E'}, new object[] {'a', 'b', 'c'}},
-            new object[] {new[] {"a", "b", "c", "d", "e"}, new object[] {"A", "C", "B"}},
-            new object[] {new Dictionary<int, string> {{ 1, "a" }, {2, "b"}}, new Dictionary<int, string> {{ 1, "A" }}},
-            new object[] {new Dictionary<int, char> {{ 1, 'A' }, {2, 'B'}}, new Dictionary<int, char> {{ 1, 'a' }}}
-        };
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    yield return new TestCaseData(new SimpleObjectCollection("w", "x", "y", "z"), new SimpleObjectCollection("z", "Y", "X"));
+                    yield return new TestCaseData(new[] {'A', 'B', 'C', 'D', 'E'}, new object[] {'a', 'b', 'c'});
+                    yield return new TestCaseData(new[] {"a", "b", "c", "d", "e"}, new object[] {"A", "C", "B"});
+                    yield return new TestCaseData(new Dictionary<int, string> {{1, "a"}, {2, "b"}}, new Dictionary<int, string> {{1, "A"}});
+                    yield return new TestCaseData(new Dictionary<int, char> {{1, 'A'}, {2, 'B'}}, new Dictionary<int, char> {{1, 'a'}});
+                    yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"b", 2}});
+                    yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }, {'B', 2}}, new Dictionary<char, int> {{'a', 1}});
+
+#if !NETCF && !SILVERLIGHT
+                    yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"}});
+                    yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{2, 'b'}});
+                    yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}});
+                    yield return new TestCaseData(new Hashtable {{'A', 1}, {'B', 2}}, new Hashtable {{'a', 1}});
+#endif
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is the fix for issue #70, EquivalentTo isn't compatible with Ignorecase for dictionaries. This fixes CollectionEquivalentContraint and CollectionSubsetConstraint.

I tried making the fix in the CollectionTally class, but it ended up being much more code and harder to read than the equivalent fix in NUnitEqualityComparer. Based on Charlie's comments on a previous attempt at this, I make sure I compare keys with Tolerance.Empty. This will work comparing keys case-insensitive, but that is the same behaviour of the existing DictionariesEqual method in NUnitEqualityComparer. That method actually compares keys with tolerance, so do we want to do that for KeyValuePairs?

All tests pass on TeamCity and I have tested SilverLight.
