### PR TITLE
Fix for issue #45 - Add Until to IgnoreAttribute to ignore the test until the given date

### DIFF
--- a/src/framework/Attributes/IgnoreAttribute.cs
+++ b/src/framework/Attributes/IgnoreAttribute.cs
@@ -28,50 +28,58 @@ using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
-	/// <summary>
-	/// Attribute used to mark a test that is to be ignored.
-	/// Ignored tests result in a warning message when the
-	/// tests are run.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
+    /// <summary>
+    /// Attribute used to mark a test that is to be ignored.
+    /// Ignored tests result in a warning message when the
+    /// tests are run.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class IgnoreAttribute : NUnitAttribute, IApplyToTest
-	{
-		private string reason;
-        private DateTime? upToDate;
-        private string upTo;
+    {
+        private string _reason;
+        private DateTime? _untilDate;
+        private string _until;
 
-	    /// <summary>
-		/// Constructs the attribute without giving a reason 
-		/// for ignoring the test.
-		/// </summary>
-		public IgnoreAttribute()
-		{
-			this.reason = "";
-		}
-
-		/// <summary>
-		/// Constructs the attribute giving a reason for ignoring the test
-		/// </summary>
-		/// <param name="reason">The reason for ignoring the test</param>
-		public IgnoreAttribute(string reason)
-		{
-			this.reason = reason;
+        /// <summary>
+        /// Constructs the attribute without giving a reason 
+        /// for ignoring the test.
+        /// </summary>
+        public IgnoreAttribute()
+        {
+            _reason = String.Empty;
         }
 
         /// <summary>
-        /// The date in the future to stop ignoring the test (invariant culture)
+        /// Constructs the attribute giving a reason for ignoring the test
         /// </summary>
-	    public string UpTo
-	    {
-	        get { return upTo; }
+        /// <param name="reason">The reason for ignoring the test</param>
+        public IgnoreAttribute(string reason)
+        {
+            _reason = reason;
+        }
+
+        /// <summary>
+        /// The date in the future to stop ignoring the test as a string in UTC time. 
+        /// For example for a date and time, "2014-12-25 08:10:00Z" or for just a date,
+        /// "2014-12-25". If just a date is given, the Ignore will expire at midnight UTC.
+        /// </summary>
+        /// <remarks>
+        /// Once the ignore until date has passed, the test will be marked
+        /// as runnable. Tests with an ignore until date will have an IgnoreUntilDate
+        /// property set which will appear in the test results.
+        /// </remarks>
+        /// <exception cref="FormatException">The string does not contain a valid string representation of a date and time.</exception> 
+        public string Until
+        {
+            get { return _until; }
             set
             {
-                upTo = value;
-                upToDate = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
+                _until = value;
+                _untilDate = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
             }
-	    }
+        }
 
-	    #region IApplyToTest members
+        #region IApplyToTest members
 
         /// <summary>
         /// Modifies a test by marking it as Ignored.
@@ -81,14 +89,21 @@ namespace NUnit.Framework
         {
             if (test.RunState != RunState.NotRunnable)
             {
-                if (upToDate != null && upToDate < DateTime.Now)
+                if (_untilDate.HasValue)
                 {
-                    test.RunState = RunState.NotRunnable;
+                    if (_untilDate.Value > DateTime.Now)
+                    {
+                        test.RunState = RunState.Ignored;
+                        if (String.IsNullOrEmpty(_reason))
+                            _reason = string.Format("Ignoring until {0}", _untilDate.Value.ToString("u"));
+                        test.Properties.Set(PropertyNames.SkipReason, _reason);
+                    }
+                    test.Properties.Set(PropertyNames.IgnoreUntilDate, _untilDate.Value.ToString("u") );
+
                     return;
                 }
-
                 test.RunState = RunState.Ignored;
-                test.Properties.Set(PropertyNames.SkipReason, reason);
+                test.Properties.Set(PropertyNames.SkipReason, _reason);
             }
         }
 

--- a/src/framework/Internal/PropertyNames.cs
+++ b/src/framework/Internal/PropertyNames.cs
@@ -101,5 +101,10 @@ namespace NUnit.Framework.Internal
         /// The FriendlyName of the AppDomain in which the assembly is running
         /// </summary>
         public static readonly string AppDomain = "_APPDOMAIN";
+
+        /// <summary>
+        /// The test will be ignored until the given date
+        /// </summary>
+        public static readonly string IgnoreUntilDate = "IgnoreUntilDate";
     }
 }

--- a/src/tests/Attributes/ApplyToTestTests.cs
+++ b/src/tests/Attributes/ApplyToTestTests.cs
@@ -88,25 +88,77 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void IgnoreAttributeIgnoresTestUpToDateSpecified()
+        public void IgnoreAttributeIgnoresTestUntilDateSpecified()
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
-            ignoreAttribute.UpTo = "4242-01-01";
+            ignoreAttribute.Until = "4242-01-01";
             ignoreAttribute.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
         }
 
         [Test]
-        public void IgnoreAttributeWithUpToDateMarksTestAsNonRunnableAfterDatePasses()
+        public void IgnoreAttributeIgnoresTestUntilDateTimeSpecified()
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
-            ignoreAttribute.UpTo = "1492-01-01";
+            ignoreAttribute.Until = "4242-01-01 12:00:00Z";
             ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-        } 
+            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+        }
 
+        [Test]
+        public void IgnoreAttributeMarksTestAsRunnableAfterUntilDatePasses()
+        {
+            var ignoreAttribute = new IgnoreAttribute("BECAUSE");
+            ignoreAttribute.Until = "1492-01-01";
+            ignoreAttribute.ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+        }
 
+        [Test]
+        public void IgnoreAttributeWithReasonDoesNotOverwriteTheReason()
+        {
+            var ignoreAttribute = new IgnoreAttribute("BECAUSE");
+            ignoreAttribute.Until = "4242-01-01";
+            ignoreAttribute.ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
+        }
+
+        [TestCase("4242-01-01", "Ignoring until 4242-01-01 00:00:00Z")]
+        [TestCase("4242-01-01 00:00:00Z", "Ignoring until 4242-01-01 00:00:00Z")]
+        [TestCase("4242-01-01 00:00:00", "Ignoring until 4242-01-01 00:00:00Z")]
+        public void IgnoreAttributeWithoutReasonSetsTheReason(string date, string reason)
+        {
+            var ignoreAttribute = new IgnoreAttribute();
+            ignoreAttribute.Until = date;
+            ignoreAttribute.ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Ignoring until 4242-01-01 00:00:00Z"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(FormatException))]
+        public void IgnoreAttributeWithInvalidDateThrowsException()
+        {
+            var ignoreAttribute = new IgnoreAttribute();
+            ignoreAttribute.Until = "Thursday the twenty fifth of December";
+        }
+
+        [Test]
+        public void IgnoreAttributeWithUntilAddsIgnoreUntilDateProperty()
+        {
+            var ignoreAttribute = new IgnoreAttribute();
+            ignoreAttribute.Until = "4242-01-01";
+            ignoreAttribute.ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("4242-01-01 00:00:00Z"));
+        }
+
+        [Test]
+        public void IgnoreAttributeWithUntilAddsIgnoreUntilDatePropertyPastUntilDate()
+        {
+            var ignoreAttribute = new IgnoreAttribute();
+            ignoreAttribute.Until = "1242-01-01";
+            ignoreAttribute.ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("1242-01-01 00:00:00Z"));
+        }
 
         #endregion
 


### PR DESCRIPTION
For some reason, pushing to the pull request branch did not add to the existing pull request, so I am opening a new one and closing the original.

See https://github.com/nunit/nunit-framework/pull/69 for the full discussion.
- Merged recent changes from master into the pull request to make merging easier.
- Renamed UpTo to Until.
- The test now runs when the Until date has expired
- Added an IgnoreUntilDate property that gets set
- The date and/or time is specified in UTC. If no time is given, it defaults to midnight UTC.
- If no reason is given, it is set to "Ignoring until yyyy-mm-dd hh:mm:ssZ"
- If a reason is given, it is not altered since that information is in the IgnoreUntilDate property.
