### PR TITLE
Fix for issue #100 - Changes to Tolerance definitions

### DIFF
--- a/src/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected bool ItemsEqual(object x, object y)
         {
-            Tolerance tolerance = Tolerance.Empty;
+            Tolerance tolerance = Tolerance.Default;
             return comparer.AreEqual(x, y, ref tolerance);
         }
 

--- a/src/framework/Constraints/CollectionTally.cs
+++ b/src/framework/Constraints/CollectionTally.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
 
         private bool ItemsEqual(object expected, object actual)
         {
-            Tolerance tolerance = Tolerance.Empty;
+            Tolerance tolerance = Tolerance.Default;
             return comparer.AreEqual(expected, actual, ref tolerance);
         }
 

--- a/src/framework/Constraints/EqualConstraint.cs
+++ b/src/framework/Constraints/EqualConstraint.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Constraints
 
         private readonly object expected;
 
-        private Tolerance tolerance = Tolerance.Empty;
+        private Tolerance tolerance = Tolerance.Default;
 
         /// <summary>
         /// NUnitEqualityComparer used to test equality.
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public EqualConstraint Within(object amount)
         {
-            if (!tolerance.IsEmpty)
+            if (!tolerance.IsUnsetOrDefault)
                 throw new InvalidOperationException("Within modifier may appear only once in a constraint expression");
 
             tolerance = new Tolerance(amount);
@@ -359,7 +359,7 @@ namespace NUnit.Framework.Constraints
             { 
                 System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(expected));
 
-                if (tolerance != null && !tolerance.IsEmpty)
+                if (tolerance != null && !tolerance.IsUnsetOrDefault)
                 {
                     sb.Append(" +/- ");
                     sb.Append(MsgUtils.FormatValue(tolerance.Value));

--- a/src/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/framework/Constraints/NUnitEqualityComparer.cs
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Constraints
             if (xType.IsGenericType && xType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>) &&
                 yType.IsGenericType && yType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
             {
-                var keyTolerance = new Tolerance(0);
+                var keyTolerance = Tolerance.Exact;
                 object xKey = xType.GetProperty("Key").GetValue(x, null);
                 object yKey = yType.GetProperty("Key").GetValue(y, null);
                 object xValue = xType.GetProperty("Value").GetValue(x, null);
@@ -287,7 +287,7 @@ namespace NUnit.Framework.Constraints
 
         private bool DictionaryEntriesEqual(DictionaryEntry x, DictionaryEntry y, ref Tolerance tolerance)
         {
-            var keyTolerance = new Tolerance(0);
+            var keyTolerance = Tolerance.Exact;
             return AreEqual(x.Key, y.Key, ref keyTolerance) && AreEqual(x.Value, y.Value, ref tolerance);
         }
 

--- a/src/framework/Constraints/Numerics.cs
+++ b/src/framework/Constraints/Numerics.cs
@@ -131,12 +131,12 @@ namespace NUnit.Framework.Constraints
                 return expected.Equals(actual);
             }
 
-            if (tolerance.IsEmpty && GlobalSettings.DefaultFloatingPointTolerance > 0.0d)
+            if (tolerance.IsUnsetOrDefault && GlobalSettings.DefaultFloatingPointTolerance > 0.0d)
                 tolerance = new Tolerance(GlobalSettings.DefaultFloatingPointTolerance);
 
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -171,12 +171,12 @@ namespace NUnit.Framework.Constraints
                 return expected.Equals(actual);
             }
 
-            if (tolerance.IsEmpty && GlobalSettings.DefaultFloatingPointTolerance > 0.0d)
+            if (tolerance.IsUnsetOrDefault && GlobalSettings.DefaultFloatingPointTolerance > 0.0d)
                 tolerance = new Tolerance(GlobalSettings.DefaultFloatingPointTolerance);
 
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Constraints
         {
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -229,7 +229,7 @@ namespace NUnit.Framework.Constraints
         {
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -260,7 +260,7 @@ namespace NUnit.Framework.Constraints
         {
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -287,7 +287,7 @@ namespace NUnit.Framework.Constraints
         {
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
@@ -318,7 +318,7 @@ namespace NUnit.Framework.Constraints
         {
             switch (tolerance.Mode)
             {
-                case ToleranceMode.None:
+                case ToleranceMode.Unset:
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:

--- a/src/framework/Constraints/Tolerance.cs
+++ b/src/framework/Constraints/Tolerance.cs
@@ -42,21 +42,33 @@ namespace NUnit.Framework.Constraints
         private const string NumericToleranceRequired = "A numeric tolerance is required";
 
         /// <summary>
-        /// Returns an empty Tolerance object, equivalent to 
-        /// specifying an exact match.
+        /// Returns a default Tolerance object, equivalent to 
+        /// specifying an exact match unless <see cref="GlobalSettings.DefaultFloatingPointTolerance"/>
+        /// is set, in which case, the <see cref="GlobalSettings.DefaultFloatingPointTolerance"/>
+        /// will be used.
         /// </summary>
-        public static Tolerance Empty
+        public static Tolerance Default
         {
-            get { return new Tolerance(0, ToleranceMode.None); }
+            get { return new Tolerance(0, ToleranceMode.Unset); }
         }
 
         /// <summary>
-        /// Constructs a linear tolerance of a specdified amount
+        /// Returns an empty Tolerance object, equivalent to 
+        /// specifying an exact match even if 
+        /// <see cref="GlobalSettings.DefaultFloatingPointTolerance"/> is set.
+        /// </summary>
+        public static Tolerance Exact
+        {
+            get { return new Tolerance(0, ToleranceMode.Linear); }
+        }
+
+        /// <summary>
+        /// Constructs a linear tolerance of a specified amount
         /// </summary>
         public Tolerance(object amount) : this(amount, ToleranceMode.Linear) { }
 
         /// <summary>
-        /// Constructs a tolerance given an amount and ToleranceMode
+        /// Constructs a tolerance given an amount and <see cref="ToleranceMode"/>
         /// </summary>
         private Tolerance(object amount, ToleranceMode mode)
         {
@@ -65,7 +77,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Gets the ToleranceMode for the current Tolerance
+        /// Gets the <see cref="ToleranceMode"/> for the current Tolerance
         /// </summary>
         public ToleranceMode Mode
         {
@@ -80,7 +92,7 @@ namespace NUnit.Framework.Constraints
         private void CheckLinearAndNumeric()
         {
             if (mode != ToleranceMode.Linear)
-                throw new InvalidOperationException(mode == ToleranceMode.None
+                throw new InvalidOperationException(mode == ToleranceMode.Unset
                     ? ModeMustFollowTolerance
                     : MultipleToleranceModes);
 
@@ -93,7 +105,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public object Value
         {
-            get { return this.amount; }
+            get { return amount; }
         }
 
         /// <summary>
@@ -109,7 +121,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance, using the current amount in Ulps.
+        /// Returns a new tolerance, using the current amount in Ulps
         /// </summary>
         public Tolerance Ulps
         {
@@ -121,7 +133,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of days.
         /// </summary>
         public Tolerance Days
@@ -134,7 +146,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of hours.
         /// </summary>
         public Tolerance Hours
@@ -147,7 +159,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of minutes.
         /// </summary>
         public Tolerance Minutes
@@ -160,7 +172,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of seconds.
         /// </summary>
         public Tolerance Seconds
@@ -173,7 +185,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of milliseconds.
         /// </summary>
         public Tolerance Milliseconds
@@ -186,7 +198,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a new tolerance with a TimeSpan as the amount, using 
+        /// Returns a new tolerance with a <see cref="TimeSpan"/> as the amount, using 
         /// the current amount as a number of clock ticks.
         /// </summary>
         public Tolerance Ticks
@@ -199,11 +211,11 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns true if the current tolerance is empty.
+        /// Returns true if the current tolerance has not been set or is using the .
         /// </summary>
-        public bool IsEmpty
+        public bool IsUnsetOrDefault
         {
-            get { return mode == ToleranceMode.None; }
+            get { return mode == ToleranceMode.Unset; }
         }
     }
 }

--- a/src/framework/Constraints/ToleranceMode.cs
+++ b/src/framework/Constraints/ToleranceMode.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Constraints
         /// the mode more than once and is generally changed to Linear
         /// upon execution of the test.
         /// </summary>
-        None,
+        Unset,
         /// <summary>
         /// The tolerance is used as a numeric range within which
         /// two compared _values are considered to be equal.

--- a/src/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/framework/Internal/Execution/TextMessageWriter.cs
@@ -253,7 +253,7 @@ namespace NUnit.Framework.Internal
 			Write(Pfx_Expected);
 			Write(MsgUtils.FormatValue(expected));
 
-            if (tolerance != null && !tolerance.IsEmpty)
+            if (tolerance != null && !tolerance.IsUnsetOrDefault)
             {
                 Write(" +/- ");
                 Write(MsgUtils.FormatValue(tolerance.Value));

--- a/src/tests/Constraints/NUnitComparerTests.cs
+++ b/src/tests/Constraints/NUnitComparerTests.cs
@@ -28,13 +28,11 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class NUnitComparerTests
     {
-        private Tolerance tolerance;
         private NUnitComparer comparer;
 
         [SetUp]
         public void SetUp()
         {
-            tolerance = Tolerance.Empty;
             comparer = new NUnitComparer();
         }
 

--- a/src/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void Setup()
         {
-            tolerance = Tolerance.Empty;
+            tolerance = Tolerance.Default;
             comparer = new NUnitEqualityComparer();
         }
 

--- a/src/tests/Constraints/NumericsTest.cs
+++ b/src/tests/Constraints/NumericsTest.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
         public void SetUp()
         {
             tenPercent = new Tolerance(10.0).Percent;
-            zeroTolerance = new Tolerance(0);
+            zeroTolerance = Tolerance.Exact;
         }
 
         [TestCase(123456789)]

--- a/src/tests/Constraints/ToleranceTests.cs
+++ b/src/tests/Constraints/ToleranceTests.cs
@@ -1,0 +1,103 @@
+﻿// ***********************************************************************
+// Copyright (c) 2014 Rob Prouse
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#region Using Directives
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+#endregion
+
+namespace NUnit.Framework.Tests.Constraints
+{
+    [TestFixture]
+    public class ToleranceTests
+    {
+        private NUnitEqualityComparer _comparer;
+
+        [TearDown]
+        public void TearDown()
+        {
+            GlobalSettings.DefaultFloatingPointTolerance = 0d;
+            _comparer = new NUnitEqualityComparer();
+        }
+
+        [TestCase(2.01d, 2.1d, 0.1d)]
+        [TestCase(2.0d, 2.1d, 0.01d, ExpectedException = typeof(AssertionException))]
+        public void TestGlobalDefaultTolerance(double x, double y, double defaultTolerance)
+        {
+            GlobalSettings.DefaultFloatingPointTolerance = defaultTolerance;
+            Assert.AreEqual(x, y);
+        }
+
+        [Test]
+        public void TestToleranceDefault()
+        {
+            GlobalSettings.DefaultFloatingPointTolerance = 0.5d;
+            var defaultTolerance = Tolerance.Default;
+            Assert.IsTrue(defaultTolerance.IsUnsetOrDefault);
+            Assert.IsTrue(_comparer.AreEqual(2.0d, 2.1d, ref defaultTolerance ));
+        }
+
+        [Test]
+        public void TestToleranceExact()
+        {
+            GlobalSettings.DefaultFloatingPointTolerance = 0.5d;
+            var noneTolerance = Tolerance.Exact;
+            Assert.IsFalse(noneTolerance.IsUnsetOrDefault);
+            Assert.IsFalse(_comparer.AreEqual(2.0d, 2.1d, ref noneTolerance));
+        }
+
+        [Test]
+        public void TestWithinCanOnlyBeUsedOnce()
+        {
+            Assert.That(() => Is.EqualTo(1.1d).Within(0.5d).Within(0.2d),
+                Throws.TypeOf<InvalidOperationException>().With.Message.ContainsSubstring("modifier may appear only once"));
+        }
+
+        [Test]
+        public void TestModesCanOnlyBeUsedOnce()
+        {
+            var tolerance = new Tolerance(5);
+            Assert.That(() => tolerance.Percent.Ulps,
+                Throws.TypeOf<InvalidOperationException>().With.Message.ContainsSubstring("multiple tolerance modes"));
+        }
+
+        [Test]
+        public void TestNumericToleranceRequired()
+        {
+            var tolerance = new Tolerance("Five");
+            Assert.That(() => tolerance.Percent,
+                Throws.TypeOf<InvalidOperationException>().With.Message.ContainsSubstring("numeric tolerance is required"));
+        }
+
+        [Test]
+        public void TestModeMustFollowTolerance()
+        {
+            var tolerance = Tolerance.Default; // which is new Tolerance(0, ToleranceMode.Unset)
+            Assert.That(() => tolerance.Percent, 
+                Throws.TypeOf<InvalidOperationException>().With.Message.ContainsSubstring("Tolerance amount must be specified"));
+        }
+    }
+}

--- a/src/tests/nunit.framework.tests-2.0.csproj
+++ b/src/tests/nunit.framework.tests-2.0.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\AssignableFromConstraintTests.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunit.framework.tests-3.5.csproj
+++ b/src/tests/nunit.framework.tests-3.5.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\AssignableFromConstraintTests.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -145,6 +146,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunit.framework.tests-4.0.csproj
+++ b/src/tests/nunit.framework.tests-4.0.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunit.framework.tests-4.5.csproj
+++ b/src/tests/nunit.framework.tests-4.5.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunitlite.tests-2.0.csproj
+++ b/src/tests/nunitlite.tests-2.0.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Constraints\BasicConstraintTests.cs" />
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunitlite.tests-3.5.csproj
+++ b/src/tests/nunitlite.tests-3.5.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Constraints\BasicConstraintTests.cs" />
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunitlite.tests-4.0.csproj
+++ b/src/tests/nunitlite.tests-4.0.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Constraints\BasicConstraintTests.cs" />
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunitlite.tests-4.5.csproj
+++ b/src/tests/nunitlite.tests-4.5.csproj
@@ -119,6 +119,7 @@
     </Compile>
     <Compile Include="Attributes\ValueSourceTests.cs" />
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\AllItemsConstraintTests.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />

--- a/src/tests/nunitlite.tests-sl-5.0.csproj
+++ b/src/tests/nunitlite.tests-sl-5.0.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />
+    <Compile Include="Constraints\ToleranceTests.cs" />
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />


### PR DESCRIPTION
Created unit tests for Tolerance adding tests for the changes I made plus a few for parts of the class that I felt weren't fully tested.

Renamed Tolerance.Empty to Tolerance.Default and added a Tolerance.Exact which means the default will not be used. I also renamed ToleranceMode.None to Unset to better specify its purpose.

While I was adding the unit tests to the solution, I found that the CollectionsEqualsTests.cs was not included in several of the projects, so I added it.
