### PR TITLE
MSBuild: batching multiple frameworks

### DIFF
--- a/NUnitFramework.msbuild
+++ b/NUnitFramework.msbuild
@@ -73,11 +73,11 @@
     <Runtime>mono</Runtime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Framework)'=='netcf-3.5'">
-    <ProjectSuffix>3.5</ProjectSuffix>
+    <ProjectSuffix>netcf-3.5</ProjectSuffix>
     <Runtime>netcf</Runtime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Framework)'=='netcf-2.0'">
-    <ProjectSuffix>2.0</ProjectSuffix>
+    <ProjectSuffix>netcf-2.0</ProjectSuffix>
     <Runtime>netcf</Runtime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Framework)'=='silverlight-5.0'">
@@ -232,10 +232,10 @@
     <SupportedFrameworks Include="silverlight-5.0"></SupportedFrameworks>
   </ItemGroup>
   <Target Name="BuildAll">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="Framework=%(SupportedFrameworks.Identity)"></MSBuild>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true"></MSBuild>
   </Target>
   <Target Name="TestAll">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Test" Properties="Framework=%(SupportedFrameworks.Identity)"></MSBuild>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Test" Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true"></MSBuild>
   </Target>
   <Target Name="CleanAll" DependsOnTargets="Clean">
     <Exec Command="$(RemoveDir) $(ProjectBuildDir)" Condition="Exists('$(ProjectBuildDir)')" ></Exec>


### PR DESCRIPTION
I intended to continue working on the previous pull request but since it was closed here's another one (I'm  not sure it really makes sense to keep a pull request open once it's been merged btw).

One of the missing features from the switch to MSBuild was the ability to build for multiple frameworks at once. I initially thought that this could be achieved with shell scripting but it's actually more straightforward.

Alongside some other minor changes (underscore-prefixed internal targets and cosmetics) I added a couple of new tasks which invoke the script itself via the MSBuild task multiple times using an `ItemGroup`, a feature of MSBuild which enables batching.

I still have to figure out how to build for the compact framework, right now specifying that as the framework has basically no effect because we are not doing anything special with those properties, besides using the correct project files, but we don't have project files for CF so we either need to create specific ones, like we did for Silverlight, or we need to pass additional properties to MSBuild. [This](http://msdn.microsoft.com/en-us/library/bb629394.aspx) MSDN page mentions a `TargetCompactFramework` property but I still have to figure out what it does.
