### PR TITLE
Checking AsyncStateMachineAttribute by name only. #64

### DIFF
--- a/src/framework/Internal/AsyncInvocationRegion.cs
+++ b/src/framework/Internal/AsyncInvocationRegion.cs
@@ -24,6 +24,7 @@
 #if NET_4_5
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -31,7 +32,6 @@ namespace NUnit.Framework.Internal
 {
     internal abstract class AsyncInvocationRegion : IDisposable
     {
-        private static readonly Type AsyncStateMachineAttribute = Type.GetType("System.Runtime.CompilerServices.AsyncStateMachineAttribute");
         private static readonly MethodInfo PreserveStackTraceMethod = typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly Action<Exception> PreserveStackTrace;
 
@@ -63,7 +63,8 @@ at wrapping a non-async method invocation in an async region was done");
 
         public static bool IsAsyncOperation(MethodInfo method)
         {
-            return AsyncStateMachineAttribute != null && method.IsDefined(AsyncStateMachineAttribute, false);
+            return method.GetCustomAttributes(false)
+                    .Any(attr => "System.Runtime.CompilerServices.AsyncStateMachineAttribute" == attr.GetType().FullName);
         }
 
         public static bool IsAsyncOperation(Delegate @delegate)

--- a/src/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -24,11 +24,6 @@
 using System;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
-using NUnit.Framework.Internal.Commands;
-
-#if NET_4_5
-using System.Threading.Tasks;
-#endif
 
 namespace NUnit.Framework.Internal.Builders
 {
@@ -159,9 +154,9 @@ namespace NUnit.Framework.Internal.Builders
             else
             {
 #if NET_4_5
-                if (MethodHelper.IsAsyncMethod(testMethod.Method))
+                if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method))
                 {
-                    bool returnsGenericTask = returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>);
+                    bool returnsGenericTask = returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>);
                     if (returnsGenericTask && (parms == null || !parms.HasExpectedResult))
                         return MarkAsNotRunnable(testMethod, "Async test method must have Task or void return type when no result is expected");
                     else if (!returnsGenericTask && parms != null && parms.HasExpectedResult)

--- a/src/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/framework/Internal/Commands/TestMethodCommand.cs
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal.Commands
         private object RunTestMethod(TestExecutionContext context)
         {
 #if NET_4_5
-            if (MethodHelper.IsAsyncMethod(testMethod.Method))
+            if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method))
                 return RunAsyncTestMethod(context);
             else
 #endif

--- a/src/framework/Internal/MethodHelper.cs
+++ b/src/framework/Internal/MethodHelper.cs
@@ -209,16 +209,5 @@ namespace NUnit.Framework.Internal
                     return c.ToString();
             }
         }
-
-#if NET_4_5
-        /// <summary>
-        /// Returns true if the method specified by the argument
-        /// is an async method.
-        /// </summary>
-        public static bool IsAsyncMethod(MethodInfo method)
-        {
-            return method.IsDefined(typeof(System.Runtime.CompilerServices.AsyncStateMachineAttribute));
-        }
-#endif
     }
 }


### PR DESCRIPTION
This addresses issue #64 in checking the presence of the `AsyncStateMachineAttribute` by its name alone to enable support for async in .NET pre-4.5. This change alone does not introduce full support for that, which is instead requested in #75 and should come with full test coverage (which I'm working on), but only enables it.
