### PR TITLE
workers option is passed to tests correctly when set to zero #121

### DIFF
--- a/NUnitFramework.msbuild
+++ b/NUnitFramework.msbuild
@@ -90,6 +90,7 @@
     <ManagedExeLauncher Condition="'$(Runtime)' == 'mono'">mono</ManagedExeLauncher>
     <TestRunnerProgram>test-harness.exe</TestRunnerProgram>
     <TestRunnerArgs>nunit.framework.tests.dll $(TestOptions)</TestRunnerArgs>
+    <HarnessSelfTestArgs>--selftest $(TestOptions)</HarnessSelfTestArgs>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -171,6 +172,10 @@
   <Target Name="_NUnitLiteTest">
     <Message Text="Testing NUnitLite $(Framework) - $(Configuration)"></Message>
     <Exec WorkingDirectory="$(FrameworkBuildDir)" Command="$(ManagedExeLauncher) $(FrameworkBuildDir)\nunitlite.tests.exe"></Exec>
+  </Target>
+  <Target Name="SelfTest" Label="Runs harness tests">
+    <Message Text="Testing test-harness $(Framework) - $(Configuration)"></Message>
+    <Exec WorkingDirectory="$(FrameworkBuildDir)" Command="$(ManagedExeLauncher) $(FrameworkBuildDir)\$(TestRunnerProgram) $(HarnessSelfTestArgs)"></Exec>
   </Target>
   <Target Name="TestCoverage">
     <CallTarget Targets="_NUnitCoverage" Condition="'$(Runtime)' != 'netcf'"></CallTarget>

--- a/src/harness/CommandLineOptions.cs
+++ b/src/harness/CommandLineOptions.cs
@@ -163,7 +163,7 @@ namespace NUnit.Framework.TestHarness
         public int DefaultTimeout { get { return defaultTimeout; } }
 
         //DriverSetting
-        public int NumWorkers { get; private set; }
+        public int? NumWorkers { get; private set; }
 
         //DriverSetting
         private int randomSeed = -1;
@@ -238,8 +238,8 @@ namespace NUnit.Framework.TestHarness
 
             if (DefaultTimeout >= 0)
                 settings["DefaultTimeout"] = DefaultTimeout;
-            if (NumWorkers > 0)
-                settings["NumberOfTestWorkers"] = NumWorkers;
+            if (NumWorkers.HasValue)
+                settings["NumberOfTestWorkers"] = NumWorkers.Value;
             if (RandomSeed >= 0)
                 settings["RandomSeed"] = RandomSeed;
             if (CaptureText)

--- a/src/harness/Tests/CommandLineOptionTests.cs
+++ b/src/harness/Tests/CommandLineOptionTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Reflection;
 
 namespace NUnit.Framework.TestHarness.Tests
@@ -115,14 +116,14 @@ namespace NUnit.Framework.TestHarness.Tests
             }
         }
 
-        [TestCase("DefaultTimeout", "timeout")]
-        [TestCase("NumWorkers", "workers")]
-        public void CanRecognizeIntOptions(string propertyName, string pattern)
+        [TestCase("DefaultTimeout", "timeout", typeof(int))]
+        [TestCase("NumWorkers", "workers", typeof(int?))]
+        public void CanRecognizeIntOptions(string propertyName, string pattern, Type realType)
         {
             string[] prototypes = pattern.Split('|');
 
             PropertyInfo property = GetPropertyInfo(propertyName);
-            Assert.AreEqual(typeof(int), property.PropertyType);
+            Assert.AreEqual(realType, property.PropertyType);
 
             foreach (string option in prototypes)
             {
@@ -216,6 +217,7 @@ namespace NUnit.Framework.TestHarness.Tests
 
         [TestCase("-timeout=50", "DefaultTimeout", 50)]
         [TestCase("--workers=3", "NumberOfTestWorkers", 3)]
+        [TestCase("--workers=0", "NumberOfTestWorkers", 0)]
         [TestCase("--seed=123456789", "RandomSeed", 123456789)]
         [TestCase("-capture", "CaptureStandardOutput", true)]
         [TestCase("-capture", "CaptureStandardError", true)]


### PR DESCRIPTION
There was a bug in test-harness whereby passing --workers=0 would not set its value and the test run would use the default value
