### PR TITLE
Build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+before_install:
+  - sudo add-apt-repository ppa:directhex/monoxide -y
+  - sudo apt-get update -qq -y
+  - sudo apt-get install mono-devel -qq -y
+
+script: ./runbuild /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll;Build;Test"
+  
+env:
+  matrix:
+    - Framework="mono-2.0"
+    - Framework="mono-3.5"
+    - Framework="mono-4.0"
+    - Framework="mono-4.5"
+
+matrix:
+  allow_failures:
+    - env: Framework="mono-4.5"
+  fast_finish: true


### PR DESCRIPTION
This simple addition of a .travis.yml file enables running our mono builds on Linux on the hosted build environment travisci.org.

This won't work alone, someone with enough privileges to enable the build should log into travis with his GitHub credentials and enable building NUnit, but you can see it in action with my fork of the repository [here](https://travis-ci.org/simoneb/nunit-framework).

The builds are running fine except for mono-4.5 which hangs. What's missing is that there is no test reporting nor the builds are failing when tests fail, but we can work on that. 
What's nice is that it comes basically for free, with [build status images](http://docs.travis-ci.com/user/status-images/) that we can even embed in our wiki to show the build statuses. Here's the image for my fork: [![Build Status](https://travis-ci.org/simoneb/nunit-framework.png?branch=travisci)](https://travis-ci.org/simoneb/nunit-framework)
