### PR TITLE
Fix: check for zeroes in assert messages #41

### DIFF
--- a/src/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/framework/Internal/Execution/TextMessageWriter.cs
@@ -104,13 +104,10 @@ namespace NUnit.Framework.Internal
             {
                 while (level-- >= 0) Write("  ");
 
-                if(message.Contains("\0"))
-                    message = message.Replace("\0", "\\0");
-
                 if (args != null && args.Length > 0)
                     message = string.Format(message, args);
 
-                WriteLine(message);
+                WriteLine(MsgUtils.EscapeControlChars(message));
             }
         }
 

--- a/src/tests/Internal/TextMessageWriterTests.cs
+++ b/src/tests/Internal/TextMessageWriterTests.cs
@@ -67,6 +67,35 @@ namespace NUnit.Framework.Internal
                 "  ----------------^" + NL));
         }
 
+        [Test]
+        public void WriteMessageLine_EmbeddedZeroes()
+        {
+            string expected, message;
+
+            expected = message = "here's an embedded zero \0, in me";
+            expected = "  " + expected.Replace("\0", "\\0") + NL;
+
+            writer.WriteMessageLine(0, message, null);
+            message = writer.ToString();
+
+            Expect(message, EqualTo(expected));
+        }
+
+        [Test]
+        public void WriteMessageLine_EmbeddedZeroesAsArgs()
+        {
+            string expected, message, arg0;
+
+            message = "here's an embedded zero {0}, in my args";
+            arg0 = "\0";
+            expected = "  " + string.Format(message, arg0).Replace("\0", "\\0") + NL;
+
+            writer.WriteMessageLine(0, message, arg0);
+            message = writer.ToString();
+
+            Expect(message, EqualTo(expected));
+        }
+
         private string Q(string s)
         {
             return "\"" + s + "\"";


### PR DESCRIPTION
Escaping control chars in Assert user messages.
