### PR TITLE
Fix Copyright

### DIFF
--- a/NUnitFramework.sln.DotSettings
+++ b/NUnitFramework.sln.DotSettings
@@ -10,7 +10,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">***********************************************************************&#xD;
-Copyright (c) $CURRENT_YEAR$ $USER_NAME$&#xD;
+Copyright (c) $CURRENT_YEAR$ Charlie Poole&#xD;
 &#xD;
 Permission is hereby granted, free of charge, to any person obtaining&#xD;
 a copy of this software and associated documentation files (the&#xD;

--- a/src/tests/Attributes/RequiresMTAAttributeTests.cs
+++ b/src/tests/Attributes/RequiresMTAAttributeTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Rob Prouse
+// Copyright (c) 2014 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/tests/Attributes/RequiresSTAAttributeTests.cs
+++ b/src/tests/Attributes/RequiresSTAAttributeTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Rob Prouse
+// Copyright (c) 2014 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/tests/Attributes/RequiresThreadAttributeTests.cs
+++ b/src/tests/Attributes/RequiresThreadAttributeTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Rob Prouse
+// Copyright (c) 2014 Charlie Poole
 // 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/tests/Attributes/TestExpectedResult.cs
+++ b/src/tests/Attributes/TestExpectedResult.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Rob Prouse
+// Copyright (c) 2014 Charlie Poole
 // 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/tests/Constraints/ToleranceTests.cs
+++ b/src/tests/Constraints/ToleranceTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Rob Prouse
+// Copyright (c) 2014 Charlie Poole
 // 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
The Resharper header template substituted the current user into the copyright. It should have been Charlie Poole.
