### PR TITLE
Add tests to verify that #17 does not affect NUnit 3

### DIFF
--- a/src/testdata/TestCaseAttributeFixture.cs
+++ b/src/testdata/TestCaseAttributeFixture.cs
@@ -55,6 +55,16 @@ namespace NUnit.TestData.TestCaseAttributeFixture
             return x + y;
         }
 
+        [TestCase(1, ExpectedResult = 1)]
+        public void VoidTestCaseWithExpectedResult(int value)
+        { }
+
+        [TestCase(2, ExpectedResult = null)]
+        public double? TestCaseWithNullableReturnValueAndNullExpectedResult(object input)
+        {
+            return 2;
+        }
+
         [TestCase(1)]
         [TestCase(2, Ignore = true)]
         [TestCase(3, IgnoreReason = "Don't Run Me!")]

--- a/src/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/tests/Attributes/TestCaseAttributeTests.cs
@@ -93,12 +93,14 @@ namespace NUnit.Framework.Attributes
             return (sbyte)(x + y);
         }
 
-        [Test]
-        public void ConversionOverflowMakesTestNotRunnable()
+        [TestCase("MethodCausesConversionOverflow", RunState.NotRunnable)]
+        [TestCase("VoidTestCaseWithExpectedResult", RunState.NotRunnable)]
+        [TestCase("TestCaseWithNullableReturnValueAndNullExpectedResult", RunState.Runnable)]
+        public void TestCaseRunnableState(string methodName, RunState expectedState)
         {
-            Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodCausesConversionOverflow").Tests[0];
-            Assert.AreEqual(RunState.NotRunnable, test.RunState);
+            var test = (Test)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture), methodName).Tests[0];
+            Assert.AreEqual(expectedState, test.RunState);
         }
 
         [TestCase("12-October-1942")]
@@ -182,6 +184,25 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual("a", s1);
             Assert.AreEqual("b", s2);
             Assert.AreEqual("c", array[0]);
+        }
+
+        [TestCase(1)]
+        public void NullableSimpleFormalParametersWithArgument(int? a)
+        {
+            Assert.AreEqual(1, a);
+        }
+
+        [TestCase(null)]
+        public void NullableSimpleFormalParametersWithNullArgument(int? a)
+        {
+            Assert.IsNull(a);
+        }
+
+        [TestCase(null, ExpectedResult = null)]
+        [TestCase(1, ExpectedResult = 1)]
+        public int? TestCaseWithNullableReturnValue(int? a)
+        {
+            return a;
         }
 
         [Test]


### PR DESCRIPTION
This PR includes just additional tests to verify that #17 (although it didn't mention any specific case in which nullable types are not supported) and #138 (closed as duplicate of #17) do not affect NUnit 3.
