### PR TITLE
Missing check for running on Linux in earlier commit

### DIFF
--- a/NUnitFramework.sln
+++ b/NUnitFramework.sln
@@ -367,6 +367,21 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\harness\test-harness-4.0.csproj
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.inheritsSet = null
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.ElseIfNewLinePlacement = SameLine
+		$2.AfterDelegateDeclarationParameterComma = True
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
+		$0.TextStylePolicy = $3
+		$3.FileWidth = 120
+		$3.inheritsSet = VisualStudio
+		$3.inheritsScope = text/plain
+		$3.scope = text/plain
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/tests/Internal/AsyncTestMethodTests.cs
@@ -11,16 +11,16 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class AsyncTestMethodTests
     {
+        private static readonly bool ON_LINUX = OSPlatform.CurrentPlatform.IsUnix;
+
         private DefaultTestCaseBuilder _builder;
         private object _testObject;
-		private bool _isLinux;
 
         [SetUp]
         public void Setup()
         {
             _builder = new DefaultTestCaseBuilder();
             _testObject = new AsyncRealFixture();
-			_isLinux = OSPlatform.CurrentPlatform.IsUnix;
         }
 
         public IEnumerable TestCases
@@ -69,10 +69,10 @@ namespace NUnit.Framework.Internal
 		/// Private method to return a test case, optionally ignored on the Linux platform.
 		/// We use this since the Platform attribute is not supported on TestCaseData.
 		/// </summary>
-		private TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreLinux)
+		private TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
 		{
 			var data = new TestCaseData(method, resultState, assertionCount);
-			if (ignoreLinux)
+			if (ON_LINUX && ignoreOnLinux)
 				data = data.Ignore("Intermittent failure on Linux");
 			return data;
 		}


### PR DESCRIPTION
After merging this change on my Windows machine, I realized that the check for running on Linux was not working. The tests were ignored on all platforms, not just Linux.

The added commit fixes this, generating tests that are ignored only on Linux. I have tested in both environments.
