### PR TITLE
Issue 193 - TestWorkerTests.BusyExecuteIdleEventsCalledInSequence fails occasionally

### DIFF
--- a/src/tests/Internal/TestWorkerTests.cs
+++ b/src/tests/Internal/TestWorkerTests.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal.Execution
             _worker.Start();
             _queue.Start();
 
-            Assert.That(() => sb.ToString(), Is.EqualTo("BusyExecIdle").After(10));
+            Assert.That(() => sb.ToString(), Is.EqualTo("BusyExecIdle").After(200));
         }
 
         private void FakeMethod() { }


### PR DESCRIPTION
This test was failing occasionally on the build machines, probably when they are busy. I increased the time it waits from 10 ms to 200 ms. I can't reproduce locally, so I am leaving this up to the build machines to check.
