### PR TITLE
Make TestExecutionContext MBR. Fixes #156

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -25,6 +25,7 @@ using System;
 using System.IO;
 using System.Diagnostics;
 using System.Globalization;
+using System.Reflection;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
@@ -69,7 +70,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class TestExecutionContext
 #if !SILVERLIGHT && !NETCF
-        : ILogicalThreadAffinative
+        : MarshalByRefObject, ILogicalThreadAffinative
 #endif
     {
         // NOTE: Be very careful when modifying this class. It uses
@@ -483,6 +484,21 @@ namespace NUnit.Framework.Internal
             while(count-- > 0)
                 System.Threading.Interlocked.Increment(ref _assertCount);
         }
+
+        #endregion
+
+        #region InitializeLifetimeService
+
+#if !SILVERLIGHT && !NETCF
+        /// <summary>
+        /// Obtain lifetime service object
+        /// </summary>
+        /// <returns></returns>
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
+#endif
 
         #endregion
     }

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -363,5 +363,25 @@ namespace NUnit.Framework.Internal
         }
 
         #endregion
+
+        #region Cross-domain Tests
+
+#if !SILVERLIGHT && !NETCF
+        [Test]
+        public void CanCreateObjectInAppDomain()
+        {
+            var domain = AppDomain.CreateDomain("TestCanCreateAppDomain");
+            var obj = domain.CreateInstanceAndUnwrap("nunit.framework.tests", "NUnit.Framework.Internal.TestExecutionContextTests+TestClass");
+
+            Assert.NotNull(obj);
+        }
+
+        [Serializable]
+        private class TestClass
+        {
+        }
+#endif
+
+        #endregion
     }
 }


### PR DESCRIPTION
This request replaces PR 159, which wasn't completed. It fixes issue #156 by making TestExecutionContext an MBR class. A test was added to illustrate the bug and passes with this fix.
