### PR TITLE
Make Ignore attribute's reason manditory

### DIFF
--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -41,15 +41,6 @@ namespace NUnit.Framework
         private string _until;
 
         /// <summary>
-        /// Constructs the attribute without giving a reason 
-        /// for ignoring the test.
-        /// </summary>
-        public IgnoreAttribute()
-        {
-            _reason = String.Empty;
-        }
-
-        /// <summary>
         /// Constructs the attribute giving a reason for ignoring the test
         /// </summary>
         /// <param name="reason">The reason for ignoring the test</param>
@@ -94,9 +85,8 @@ namespace NUnit.Framework
                     if (_untilDate.Value > DateTime.Now)
                     {
                         test.RunState = RunState.Ignored;
-                        if (String.IsNullOrEmpty(_reason))
-                            _reason = string.Format("Ignoring until {0}", _untilDate.Value.ToString("u"));
-                        test.Properties.Set(PropertyNames.SkipReason, _reason);
+                        string reason = string.Format("Ignoring until {0}. {1}", _untilDate.Value.ToString("u"), _reason);
+                        test.Properties.Set(PropertyNames.SkipReason, reason);
                     }
                     test.Properties.Set(PropertyNames.IgnoreUntilDate, _untilDate.Value.ToString("u") );
 

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -182,7 +182,7 @@ namespace NUnit.Tests
         }
     }
 
-    [TestFixture, Ignore]
+    [TestFixture, Ignore("BECAUSE")]
     public class IgnoredFixture
     {
         public static readonly int Tests = 3;

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IgnoreAttributeIgnoresTest()
         {
-            new IgnoreAttribute().ApplyToTest(test);
+            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
@@ -114,37 +114,28 @@ namespace NUnit.Framework.Attributes
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
-        [Test]
-        public void IgnoreAttributeWithReasonDoesNotOverwriteTheReason()
+        [TestCase("4242-01-01")]
+        [TestCase("4242-01-01 00:00:00Z")]
+        [TestCase("4242-01-01 00:00:00")]
+        public void IgnoreAttributeUntilSetsTheReason(string date)
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
-            ignoreAttribute.Until = "4242-01-01";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
-        }
-
-        [TestCase("4242-01-01", "Ignoring until 4242-01-01 00:00:00Z")]
-        [TestCase("4242-01-01 00:00:00Z", "Ignoring until 4242-01-01 00:00:00Z")]
-        [TestCase("4242-01-01 00:00:00", "Ignoring until 4242-01-01 00:00:00Z")]
-        public void IgnoreAttributeWithoutReasonSetsTheReason(string date, string reason)
-        {
-            var ignoreAttribute = new IgnoreAttribute();
             ignoreAttribute.Until = date;
             ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Ignoring until 4242-01-01 00:00:00Z"));
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Ignoring until 4242-01-01 00:00:00Z. BECAUSE"));
         }
 
         [Test]
         public void IgnoreAttributeWithInvalidDateThrowsException()
         {
-            var ignoreAttribute = new IgnoreAttribute();
+            var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             Assert.Throws<FormatException>(() => ignoreAttribute.Until = "Thursday the twenty fifth of December");
         }
 
         [Test]
         public void IgnoreAttributeWithUntilAddsIgnoreUntilDateProperty()
         {
-            var ignoreAttribute = new IgnoreAttribute();
+            var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "4242-01-01";
             ignoreAttribute.ApplyToTest(test);
             Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("4242-01-01 00:00:00Z"));
@@ -153,7 +144,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IgnoreAttributeWithUntilAddsIgnoreUntilDatePropertyPastUntilDate()
         {
-            var ignoreAttribute = new IgnoreAttribute();
+            var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "1242-01-01";
             ignoreAttribute.ApplyToTest(test);
             Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("1242-01-01 00:00:00Z"));


### PR DESCRIPTION
Pretty straight forward. Beyond the title, the only functional change is that ignore until will output "Ignoring until <date>. <reason>". Previously, it would output the reason if it was set, or just the first part.
