### PR TITLE
Added nuspec for packaging nunitlite

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -200,6 +200,23 @@
 			Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true" />
 	</Target>
 
+	<Target Name="BuildAllNUnit" Label="Build the NUnit framework for the current config and all runtimes">
+		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_BuildNunit"
+			 Properties="Framework=%(SupportedFrameworks.Identity)" 
+			 ContinueOnError="true" />
+	</Target>
+
+	<Target Name="_BuildNunit" Label="Build the framework for the current config and runtime">
+		<CallTarget Targets="BuildNUnit" Condition="'$(Runtime)' != 'netcf' And '$(Runtime)' != 'silverlight'" />
+	</Target>
+
+	<Target Name="BuildAllNUnitLite" Label="Build the NUnitLite framework for the current config and all runtimes">
+		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="BuildNUnitLite"
+			 Properties="Framework=%(SupportedFrameworks.Identity)"
+			 ContinueOnError="true" />
+	</Target>
+
+
 	<Target Name="BuildFramework" Label="Build the framework for the current config and runtime">
 		<CallTarget Targets="BuildNUnit" Condition="'$(Runtime)' != 'netcf' And '$(Runtime)' != 'silverlight'" />
 		<CallTarget Targets="BuildNUnitLite" />
@@ -240,6 +257,24 @@
 	<Target Name="TestAllFrameworks" Label="Test the framework for the current config and all runtimes">
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_TestFramework"
 			Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true" />
+	</Target>
+
+	<Target Name="TestAllNUnit" Label="Test the NUnit framework for the current config and all runtimes">
+		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_TestAllNUnit"
+			Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true" />
+	</Target>
+
+	<Target Name="_TestAllNUnit" Label="Test the NUnit framework for the current config conditionally, for use by TestAllNUnit">
+		<CallTarget Targets="_TestNUnit" Condition="'$(Runtime)' != 'netcf' And '$(Runtime)' != 'silverlight'" />
+	</Target>
+
+	<Target Name="TestAllNUnitLite" Label="Test the NUnitLite framework for the current config and all runtimes">
+		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_TestAllNUnitLite"
+			Properties="Framework=%(SupportedFrameworks.Identity)" ContinueOnError="true" />
+	</Target>
+
+	<Target Name="_TestAllNUnitLite" Label="Test the NUnitLite framework for the current config conditionally, for use by TestAllNUnitLite">
+		<CallTarget Targets="_TestNUnitLite" Condition="'$(Runtime)' != 'netcf' And '$(Runtime)' != 'silverlight'" />
 	</Target>
 	
 	<Target Name="TestFramework" Label="Test the framework for the current config and runtime">
@@ -312,18 +347,25 @@
 
 	<Target Name="PackageNuGetAll"
 		Label="Packages all NuGet packages"
-		DependsOnTargets="PackageNuGetFramework;PackageNuGetRunners" />
+		DependsOnTargets="PackageNuGetNUnit;PackageNuGetNUnitLite;PackageNuGetRunners" />
   
-	<Target Name="PackageNuGetFramework"
+	<Target Name="PackageNuGetNUnit"
 		Label="Packages the NUnit NuGet package"
-		DependsOnTargets="_BuildNUnit;_NUnitTest">
+		DependsOnTargets="BuildAllNUnit;TestAllNUnit">
 		<Exec WorkingDirectory="$(ProjectBaseDir)"
 		      Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunit.nuspec -BasePath &quot;$(ProjectBaseDir)&quot; -OutputDirectory &quot;$(NugetOutput)&quot; -Properties version=$(NugetVersion);builddir=$(ConfigurationBuildDir)" />
+	</Target>
+
+	<Target Name="PackageNuGetNUnitLite"
+		Label="Packages the NUnitlite NuGet package"
+		DependsOnTargets="BuildAllNUnitLite;TestAllNUnitLite">
+		<Exec WorkingDirectory="$(ProjectBaseDir)"
+		      Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitlite.nuspec -BasePath &quot;$(ProjectBaseDir)&quot; -OutputDirectory &quot;$(NugetOutput)&quot; -Properties version=$(NugetVersion);builddir=$(ConfigurationBuildDir)" />
 	</Target>
   
 	<Target Name="PackageNuGetRunners" 
 		Label="Packages the NUnit.Runners NuGet package"
-		DependsOnTargets="BuildConsole;BuildEngine;TestConsole;TestEngine">
+		DependsOnTargets="BuildConsole;BuildEngine;TestEngineAndConsole">
 		<Exec WorkingDirectory="$(ProjectBaseDir)"
 		      Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunit.runners.nuspec -NoPackageAnalysis -BasePath &quot;$(ProjectBaseDir)&quot; -OutputDirectory &quot;$(NugetOutput)&quot; -Properties version=$(NugetVersion);builddir=$(ConfigurationBuildDir)" />
 	</Target>

--- a/nuget/nunit.nuspec
+++ b/nuget/nunit.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Charlie Poole</authors>
     <owners>Charlie Poole</owners>
-		<licenseUrl>http://nunit.org/nuget/nunit3_license.txt</licenseUrl>
+    <licenseUrl>http://nunit.org/nuget/nunit3_license.txt</licenseUrl>
     <projectUrl>http://nunit.org</projectUrl>
     <iconUrl>http://nunit.org/nuget/nunit_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/nuget/nunitlite.nuspec
+++ b/nuget/nunitlite.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>NUnitLite3</id>
+    <title>NUnitLite Version 3</title>
+    <version>$version$</version>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <licenseUrl>http://nunit.org/nuget/nunit3_license.txt</licenseUrl>
+    <projectUrl>http://nunit.org</projectUrl>
+    <iconUrl>http://nunit.org/nuget/nunit_32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>NUnitlite is a lightweight testing framework for .NET based on NUnit.</summary>
+    <description>NUnitLite provides a subset of the features of NUnit, uses minimal resources and runs on resource-restricted platforms used in embedded and mobile development. This package contains builds of NUnitLite for .NET 2.0, 3.5, 4.0 and 4.5 as well as Silverlight 5.0.&#10;&#13;&#10;&#13;How to use this package:&#10;&#13;&#10;&#13;1. Create a console application for your tests and delete the generated class containing Main().&#10;&#13;2. Install the NUnitLite package, which creates a new Main() as well as adding a reference to NUnitLite.&#10;&#13;3. Add your tests to the test project and start the project to execute them.</description>
+    <releaseNotes>NUnitlite 3.0 includes breaking changes from previous releases of NUnitLite, so has been released as a new package.</releaseNotes>
+    <language>en-US</language>
+    <tags>test testing tdd framework fluent assert device phone embedded</tags>
+    <copyright>Copyright 2014</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="src\NUnitFramework\CHANGES.txt" />
+    <file src="$builddir$\net-2.0\nunitlite.dll" target="lib\net20" />
+    <file src="$builddir$\net-2.0\nunitlite.xml" target="lib\net20" />
+    <file src="$builddir$\net-3.5\nunitlite.dll" target="lib\net35" />
+    <file src="$builddir$\net-3.5\nunitlite.xml" target="lib\net35" />
+    <file src="$builddir$\net-4.0\nunitlite.dll" target="lib\net40" />
+    <file src="$builddir$\net-4.0\nunitlite.xml" target="lib\net40" />
+    <file src="$builddir$\net-4.5\nunitlite.dll" target="lib\net45" />
+    <file src="$builddir$\net-4.5\nunitlite.xml" target="lib\net45" />
+    <file src="$builddir$\sl-5.0\nunitlite.dll" target="lib\sl5" />
+    <file src="$builddir$\sl-5.0\nunitlite.xml" target="lib\sl5" />
+  </files>
+</package>

--- a/nunit.sln
+++ b/nunit.sln
@@ -113,6 +113,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{A972031D-2F61-4183-AF75-99EE1A9F6B32}"
 	ProjectSection(SolutionItems) = preProject
 		nuget\nunit.nuspec = nuget\nunit.nuspec
+		nuget\nunitlite.nuspec = nuget\nunitlite.nuspec
 		nuget\nunit.runners.nuspec = nuget\nunit.runners.nuspec
 	EndProjectSection
 EndProject

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="..\src\NUnitFramework\testdata\packages.config" />
+  <repository path="..\src\NUnitFramework\tests\packages.config" />
   <repository path="..\testdata\packages.config" />
   <repository path="..\tests\packages.config" />
 </repositories>


### PR DESCRIPTION
Added nunitlite nuget packaging and fixed up the msbuild project. It looks like some of the previous targets got broken in a recent merge because they were renamed.

I was wondering if this should have the same id as the existing nunitlite package or if it should be a new package as we have done for nunit?
