### PR TITLE
InnerExceptions of AggregateExceptions are now unrolled

### DIFF
--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -37,6 +37,32 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
         }
 
         [Test]
+        public void ThrowsWithNestedInnerException()
+        {
+            throw new Exception("Outer Exception",
+                new Exception("Inner Exception",
+                    new Exception("Inner Inner Exception")));
+        }
+
+#if !NET_2_0 && !NET_3_5
+        [Test]
+        public void ThrowsWithAggregateException()
+        {
+            throw new AggregateException("Outer Aggregate Exception", 
+                new Exception("Inner Exception 1 of 2"),
+                new Exception("Inner Exception 2 of 2"));
+        }
+
+        [Test]
+        public void ThrowsWithAggregateExceptionContainingNestedInnerException()
+        {
+            throw new AggregateException("Outer Aggregate Exception",
+                new Exception("Inner Exception",
+                    new Exception("Inner Inner Exception")));
+        }
+#endif
+
+        [Test]
         public void ThrowsWithBadStackTrace()
         {
             throw new ExceptionWithBadStackTrace("thrown by me");

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -47,6 +47,56 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        public void FailRecordsNestedInnerException()
+        {
+            string expectedMessage =
+                "System.Exception : Outer Exception" + Environment.NewLine +
+                "  ----> System.Exception : Inner Exception" + Environment.NewLine +
+                "  ----> System.Exception : Inner Inner Exception";
+
+            ITestResult result = TestBuilder.RunTestCase(
+                typeof(UnexpectedExceptionFixture),
+                "ThrowsWithNestedInnerException");
+
+            Assert.AreEqual(ResultState.Error, result.ResultState);
+            Assert.AreEqual(expectedMessage, result.Message);
+        }
+
+#if !NET_2_0 && !NET_3_5
+        [Test]
+        public void FailRecordsInnerExceptionsAsPartOfAggregateException()
+        {
+            string expectedMessage =
+                "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +
+                "  ----> System.Exception : Inner Exception 1 of 2" + Environment.NewLine +
+                "  ----> System.Exception : Inner Exception 2 of 2";
+
+            ITestResult result = TestBuilder.RunTestCase(
+                typeof(UnexpectedExceptionFixture),
+                "ThrowsWithAggregateException");
+
+            Assert.AreEqual(ResultState.Error, result.ResultState);
+            Assert.AreEqual(expectedMessage, result.Message);
+        }
+
+        [Test]
+        public void FailRecordsNestedInnerExceptionAsPartOfAggregateException()
+        {
+            string expectedMessage =
+                "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +
+                "  ----> System.Exception : Inner Exception" + Environment.NewLine +
+                "  ----> System.Exception : Inner Inner Exception";
+
+            ITestResult result = TestBuilder.RunTestCase(
+                typeof(UnexpectedExceptionFixture),
+                "ThrowsWithAggregateExceptionContainingNestedInnerException");
+
+            Assert.AreEqual(ResultState.Error, result.ResultState);
+            Assert.AreEqual(expectedMessage, result.Message);
+        }
+#endif
+
+        [Test]
         public void BadStackTraceIsHandled()
         {
             ITestResult result = TestBuilder.RunTestCase(


### PR DESCRIPTION
Hi, this should fix #16 - adding support for reporting AggregateExceptions thrown within tests.
