### PR TITLE
Use ReflectionOnlyLoadFrom when checking the test assembly

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverFactory.cs
@@ -47,11 +47,7 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                // Throws if this isn't a managed assembly or if it was built
-                // with a later version of the same assembly. 
-                AssemblyName assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
-
-                var testAssembly = domain.Load(assemblyName);
+                var testAssembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
                 var nunitV3 = new Version(3, 0);
 
                 foreach (var refAssembly in testAssembly.GetReferencedAssemblies())


### PR DESCRIPTION
Fix for the issue where nunit-console fails to load tests in a different directory or built with a different runtime. We should not be attempting to load the assembly into the nunit-console process, it could easily be the wrong .NET version, or conflict with another test assembly. The domain.Load(assemblyName) also always fails unless the current working directory is the directory the test assembly is in.
