### PR TITLE
Fix for issue #256

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
@@ -53,7 +53,9 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return _realConstraint.Description; }
+            get { return _realConstraint != null ? 
+                    _realConstraint.Description : 
+                    "containing " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
@@ -43,5 +43,18 @@ namespace NUnit.Framework.Constraints
         {
             Assert.That(42, new GreaterThanConstraint(40) & new LessThanConstraint(50));
         }
+
+        [Test]
+        public void HandlesFirstPartFailing()
+        {
+            const string test = "Couldn't load c:\\myfile.txt";
+
+            IResolveConstraint expression = Does.StartWith("Could not load").And.Contains("c:\\myfile.txt");
+            var constraint = expression.Resolve();
+            var constraintResult = constraint.ApplyTo(test);
+
+            Assert.That( constraintResult.IsSuccess, Is.False );
+            Assert.That( constraintResult.Description, Is.EqualTo( "String starting with \"Could not load\" and containing \"c:\\myfile.txt\"" ) );
+        }
     }
 }


### PR DESCRIPTION
This fixes the problem where ContainsConstraint breaks when used with AndConstraint. The problem was that the right constraint was short circuited and therefore not constructed. This caused a crash when attempting to get the description.
