### PR TITLE
Fix bug introduced in NUnit2XmlOutput

### DIFF
--- a/src/NUnitFramework/framework/Runner/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/framework/Runner/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -40,20 +40,6 @@ namespace NUnitLite.Runner
     {
         private XmlWriter xmlWriter;
 
-        private static Dictionary<string, string> resultStates = new Dictionary<string, string>();
-
-        static NUnit2XmlOutputWriter()
-        {
-            resultStates["Passed"] = "Success";
-            resultStates["Failed"] = "Failure";
-            resultStates["Failed:Error"] = "Error";
-            resultStates["Failed:Cancelled"] = "Cancelled";
-            resultStates["Inconclusive"] = "Inconclusive";
-            resultStates["Skipped"] = "Skipped";
-            resultStates["Skipped:Ignored"] = "Ignored";
-            resultStates["Skipped:Invalid"] = "NotRunnable";
-        }
-
         /// <summary>
         /// Write info about a test
         /// </summary>
@@ -222,7 +208,7 @@ namespace NUnitLite.Runner
             }
 
             TestStatus status = result.ResultState.Status;
-            string translatedResult = resultStates[result.ResultState.ToString()];
+            string translatedResult = TranslateResult(result.ResultState);
 
             if (status != TestStatus.Skipped)
             {
@@ -236,6 +222,37 @@ namespace NUnitLite.Runner
             {
                 xmlWriter.WriteAttributeString("executed", "False");
                 xmlWriter.WriteAttributeString("result", translatedResult);
+            }
+        }
+
+        private string TranslateResult(ResultState resultState)
+        {
+            switch (resultState.Status)
+            {
+                default:
+                case TestStatus.Passed:
+                    return "Success";
+                case TestStatus.Inconclusive:
+                    return "Inconclusive";
+                case TestStatus.Failed:
+                    switch (resultState.Label)
+                    {
+                        case "Error":
+                        case "Cancelled":
+                            return resultState.Label;
+                        default:
+                            return "Failure";
+                    }
+                case TestStatus.Skipped:
+                    switch (resultState.Label)
+                    {
+                        case "Ignored":
+                            return "Ignored";
+                        case "Invalid":
+                            return "NotRunnable";
+                        default:
+                            return "Skipped";
+                    }
             }
         }
 


### PR DESCRIPTION
Changes made in introducing new ResultStates broke NUnit2XmlOutput because the new states are not in the dictionary used to generate the NUnit 2 Xml results.

Rather than adding the new states to the dictionary, I introduced code that does the translation using switch statements. This allows a default to be used, which will be more robust in the face of new user-created ResultStates.

It's unfortunate that we are not testing NUnit2XmlOutput other than to validate the XML. An older test is commented out because it no longer combines. This needs to be re-introduced but at the moment the critical thing is to fix the bug that was just introduced.
