### PR TITLE
ConsoleOptions.RequiredValue canonicalizes case. Fixes #274.

### DIFF
--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -121,6 +121,25 @@ namespace NUnit.ConsoleRunner.Tests
             }
         }
 
+        [TestCase("ProcessModel", "process", new string[] { "Single", "Separate", "Multiple" })]
+        [TestCase("DomainUsage", "domain", new string[] { "None", "Single", "Multiple" })]
+        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "All" })]
+        [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" })]
+        public void CanRecognizeLowerCaseOptionValues(string propertyName, string optionName, string[] canonicalValues)
+        {
+            PropertyInfo property = GetPropertyInfo(propertyName);
+            Assert.AreEqual(typeof(string), property.PropertyType);
+
+            foreach (string canonicalValue in canonicalValues)
+            {
+                string lowercaseValue = canonicalValue.ToLowerInvariant();
+                string optionPlusValue = string.Format("--{0}:{1}", optionName, lowercaseValue);
+                ConsoleOptions options = new ConsoleOptions(optionPlusValue);
+                Assert.True(options.Validate(), "Should be valid: " + optionPlusValue);
+                Assert.AreEqual(canonicalValue, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
+            }
+        }
+
         [TestCase("DefaultTimeout", "timeout")]
         [TestCase("RandomSeed", "seed")]
         [TestCase("NumWorkers", "workers")]

--- a/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
@@ -65,20 +65,22 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.AreEqual(50, package.Settings["DefaultTimeout"]);
         }
 
-        [Test]
-        public void WhenProcessModelIsSpecified_PackageIncludesIt()
+        [TestCase("Separate")]
+        [TestCase("separate")]
+        public void WhenProcessModelIsSpecified_PackageIncludesIt(string optionValue)
         {
-            var options = new ConsoleOptions("test.dll", "--process=Separate");
+            var options = new ConsoleOptions("test.dll", "--process=" + optionValue);
             var package = ConsoleRunner.MakeTestPackage(options);
 
             Assert.That(package.Settings.ContainsKey("ProcessModel"));
             Assert.AreEqual("Separate", package.Settings["ProcessModel"]);
         }
 
-        [Test]
-        public void WhenDomainUsageIsSpecified_PackageIncludesIt()
+        [TestCase("Multiple")]
+        [TestCase("multiple")]
+        public void WhenDomainUsageIsSpecified_PackageIncludesIt(string optionValue)
         {
-            var options = new ConsoleOptions("test.dll", "--domain=Multiple");
+            var options = new ConsoleOptions("test.dll", "--domain=" + optionValue);
             var package = ConsoleRunner.MakeTestPackage(options);
 
             Assert.That(package.Settings.ContainsKey("DomainUsage"));
@@ -105,10 +107,11 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.AreEqual("Release", package.Settings["ActiveConfig"]);
         }
 
-        [Test]
-        public void WhenTraceIsSpecified_PackageIncludesIt()
+        [TestCase("Error")]
+        [TestCase("error")]
+        public void WhenTraceIsSpecified_PackageIncludesIt(string optionValue)
         {
-            var options = new ConsoleOptions("test.dll", "--trace=Error");
+            var options = new ConsoleOptions("test.dll", "--trace=" + optionValue);
             var package = ConsoleRunner.MakeTestPackage(options);
 
             Assert.That(package.Settings.ContainsKey("InternalTraceLevel"));

--- a/src/NUnitConsole/nunit-console/Options/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit-console/Options/ConsoleOptions.cs
@@ -266,6 +266,10 @@ namespace NUnit.ConsoleRunner.Options
 
         #region Helper Methods
 
+        /// <summary>
+        /// Case is ignored when val is compared to validValues. When a match is found, the
+        /// returned value will be in the canonical case from validValues.
+        /// </summary>
         private string RequiredValue(string val, string option, params string[] validValues)
         {
             if (val == null || val == string.Empty)
@@ -279,7 +283,7 @@ namespace NUnit.ConsoleRunner.Options
 
                 foreach (string valid in validValues)
                     if (string.Compare(valid, val, true) == 0)
-                        isValid = true;
+                        return valid;
 
             }
 


### PR DESCRIPTION
I hope this is useful.
