### PR TITLE
Add missing StackTrace.Filter call to one overload of RecordException

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -441,7 +441,7 @@ namespace NUnit.Framework.Internal
             if (ex is ResultStateException)
                 SetResult(((ResultStateException)ex).ResultState.WithSite(site),
                     ex.Message,
-                    ex.StackTrace);
+                    StackFilter.Filter(ex.StackTrace));
             else if (ex is System.Threading.ThreadAbortException)
                 SetResult(ResultState.Cancelled.WithSite(site),
                     "Test cancelled by user",


### PR DESCRIPTION
One overload has the call. The other needs it as well. Pointed out by Neil.
