### PR TITLE
Add manifest to nunit-console and nunit-agent

### DIFF
--- a/src/NUnitConsole/nunit-console/app.manifest
+++ b/src/NUnitConsole/nunit-console/app.manifest
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" 
+                xmlns="urn:schemas-microsoft-com:asm.v1" 
+                xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" 
+                xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- We should update the version number if we remember, but it is not required -->
+  <assemblyIdentity version="3.0.0.0" name="nunit-console"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+            Specifying requestedExecutionLevel node will disable file and registry virtualization. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of all Windows versions that this application is designed to work with. 
+      Windows will automatically select the most compatible environment.-->
+
+      <!-- If your application is designed to work with Windows Vista, uncomment the following supportedOS node-->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+
+      <!-- If your application is designed to work with Windows 7, uncomment the following supportedOS node-->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- If your application is designed to work with Windows 8, uncomment the following supportedOS node-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+
+      <!-- If your application is designed to work with Windows 8.1, uncomment the following supportedOS node-->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+
+    </application>
+  </compatibility>
+</asmv1:assembly>

--- a/src/NUnitConsole/nunit-console/nunit-console.csproj
+++ b/src/NUnitConsole/nunit-console/nunit-console.csproj
@@ -36,6 +36,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -80,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\NUnitEngine\nunit.engine.api\nunit.engine.api.csproj">

--- a/src/NUnitEngine/nunit-agent/app.manifest
+++ b/src/NUnitEngine/nunit-agent/app.manifest
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0"
+                xmlns="urn:schemas-microsoft-com:asm.v1"
+                xmlns:asmv1="urn:schemas-microsoft-com:asm.v1"
+                xmlns:asmv2="urn:schemas-microsoft-com:asm.v2"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- We should update the version number if we remember, but it is not required -->
+  <assemblyIdentity version="3.0.0.0" name="nunit-agent"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+            Specifying requestedExecutionLevel node will disable file and registry virtualization. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of all Windows versions that this application is designed to work with. 
+      Windows will automatically select the most compatible environment.-->
+
+      <!-- If your application is designed to work with Windows Vista, uncomment the following supportedOS node-->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+
+      <!-- If your application is designed to work with Windows 7, uncomment the following supportedOS node-->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- If your application is designed to work with Windows 8, uncomment the following supportedOS node-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+
+      <!-- If your application is designed to work with Windows 8.1, uncomment the following supportedOS node-->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+
+    </application>
+  </compatibility>
+</asmv1:assembly>

--- a/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
@@ -36,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Remoting" />
@@ -54,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nunit.engine.api\nunit.engine.api.csproj">

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -34,6 +34,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Remoting" />
@@ -52,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nunit.engine.api\nunit.engine.api.csproj">


### PR DESCRIPTION
Fix for #269.

I added an application manifest to nunit-console and both nunit-agents that specifies;
- does not need to run elevated. This turns off registry and filesystem virtualization. I used asInvoker so it will run elevated from an elevated command prompt, but never prompt for UAC.
- works on Windows Vista through 8.1, so we won't run in any compatibility modes.

There is an assembly name and version number in the manifest. They need to be there, but do not override the version number in CommonAssemblyInfo.cs. We should increment the version number when we release, but if we forget, it won't cause any problems. It also isn't a problem that both nunit-agents share the same name. We have the same thing at work and it has never caused a problem.

I also did a quick scan of our code for anything that might need registry or filesystem virtualization, but couldn't find anything of concern. All access of HKEY_LOCAL_MACHINE is read-only.
