### PR TITLE
Fix for intermittent failures of ActionAttributeTests

### DIFF
--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -34,6 +34,7 @@ using NUnit.TestData.ActionAttributeTests;
 namespace NUnit.Framework.Tests
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.None)]
     public class ActionAttributeTests
     {
         // NOTE: An earlier version of this fixture attempted to test


### PR DESCRIPTION
Just noticed this today when running the tests on a 12 logical core machine. Looks like other tests were adding to the counts in these tests.
