### PR TITLE
Add Classic asserts to NUnitLite

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -1823,7 +1823,6 @@ namespace NUnit.Framework
 
         #endregion
 
-#if !NUNITLITE
         #region IsNaN
 
         /// <summary>
@@ -3698,7 +3697,6 @@ namespace NUnit.Framework
         }
 
         #endregion
-#endif
 
         #region Helper Methods
 

--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
 using System.Collections;
 using System.ComponentModel;
@@ -667,4 +666,3 @@ namespace NUnit.Framework
         #endregion
     }
 }
-#endif

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -815,7 +815,6 @@ namespace NUnit.Framework.Constraints
 
         #region Matches
 
-#if !NETCF
         /// <summary>
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
@@ -843,7 +842,6 @@ namespace NUnit.Framework.Constraints
         {
             return (RegexConstraint)this.Append(new RegexConstraint(pattern));
         }
-#endif
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
@@ -715,7 +715,6 @@ namespace NUnit.Framework.Constraints
 
         #region Matches
 
-#if !NETCF
         /// <summary>
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
@@ -743,13 +742,11 @@ namespace NUnit.Framework.Constraints
         {
             return new RegexConstraint(pattern);
         }
-#endif
 
         #endregion
 
         #region DoesNotMatch
 
-#if !NETCF
         /// <summary>
         /// Returns a constraint that fails if the actual
         /// value matches the pattern supplied as an argument.
@@ -759,7 +756,6 @@ namespace NUnit.Framework.Constraints
         {
             return new ConstraintExpression().Not.Matches(pattern);
         }
-#endif
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -21,13 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCF
 using System.Text.RegularExpressions;
-#endif
 
 namespace NUnit.Framework.Constraints
 {
-#if !NETCF
     /// <summary>
     /// RegexConstraint can test whether a string matches
     /// the pattern provided.
@@ -56,5 +53,4 @@ namespace NUnit.Framework.Constraints
                     this.caseInsensitive ? RegexOptions.IgnoreCase : RegexOptions.None);
         }
     }
-#endif
 }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -113,7 +113,6 @@ namespace NUnit.Framework
 
         #region Match
 
-#if !NETCF
         /// <summary>
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
@@ -122,7 +121,6 @@ namespace NUnit.Framework
         {
             return new RegexConstraint(pattern);
         }
-#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/StringAssert.cs
+++ b/src/NUnitFramework/framework/StringAssert.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System.ComponentModel;
 using NUnit.Framework.Constraints;
 
@@ -423,4 +422,3 @@ namespace NUnit.Framework
         #endregion
     }
 }
-#endif

--- a/src/NUnitFramework/framework/nunitlite-2.0.csproj
+++ b/src/NUnitFramework/framework/nunitlite-2.0.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Attributes\TestCaseBuilderAttribute.cs" />
     <Compile Include="Attributes\TestOfAttribute.cs" />
     <Compile Include="Attributes\TimeoutAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\ConstraintResult.cs" />
     <Compile Include="Constraints\DelayedConstraint.cs" />
@@ -383,6 +384,7 @@
     <Compile Include="Runner\TeamCityEventListener.cs" />
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/framework/nunitlite-3.5.csproj
+++ b/src/NUnitFramework/framework/nunitlite-3.5.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Attributes\TimeoutAttribute.cs" />
     <Compile Include="Attributes\ValuesAttribute.cs" />
     <Compile Include="Attributes\ValueSourceAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
     <Compile Include="Constraints\AndConstraint.cs" />
@@ -380,6 +381,7 @@
     <Compile Include="Runner\TeamCityEventListener.cs" />
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/framework/nunitlite-4.0.csproj
+++ b/src/NUnitFramework/framework/nunitlite-4.0.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Attributes\TimeoutAttribute.cs" />
     <Compile Include="Attributes\ValuesAttribute.cs" />
     <Compile Include="Attributes\ValueSourceAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\SerializableAttribute.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
@@ -383,6 +384,7 @@
     <Compile Include="Runner\TeamCityEventListener.cs" />
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/framework/nunitlite-4.5.csproj
+++ b/src/NUnitFramework/framework/nunitlite-4.5.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Attributes\TimeoutAttribute.cs" />
     <Compile Include="Attributes\ValuesAttribute.cs" />
     <Compile Include="Attributes\ValueSourceAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\SerializableAttribute.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
@@ -395,6 +396,7 @@
     </Compile>
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/framework/nunitlite-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunitlite-netcf-3.5.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Attributes\TimeoutAttribute.cs" />
     <Compile Include="Attributes\ValuesAttribute.cs" />
     <Compile Include="Attributes\ValueSourceAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\SerializableAttribute.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
@@ -384,6 +385,7 @@
     <Compile Include="Runner\TcpWriter.cs" />
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/framework/nunitlite-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunitlite-sl-5.0.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Attributes\TimeoutAttribute.cs" />
     <Compile Include="Attributes\ValuesAttribute.cs" />
     <Compile Include="Attributes\ValueSourceAttribute.cs" />
+    <Compile Include="CollectionAssert.cs" />
     <Compile Include="Compatibility\SerializableAttribute.cs" />
     <Compile Include="Compatibility\Stopwatch.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
@@ -390,6 +391,7 @@
     <Compile Include="Runner\Silverlight\TextBlockWriter.cs" />
     <Compile Include="Runner\TextUI.cs" />
     <Compile Include="SpecialValue.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="Throws.cs" />

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -21,6 +21,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+// TODO: Get to work in Silverlight and Compact Framework - will require buiding mock-assembly
+#if !SILVERLIGHT
+
 using System;
 using System.Collections;
 using System.IO;
@@ -305,3 +308,4 @@ namespace NUnit.Framework.Api
         #endregion
     }
 }
+#endif

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -21,15 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
 using System.Collections;
-using System.Data;
 using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
 
-#if NET_3_5 || NET_4_0
+#if !SILVERLIGHT
+using System.Data;
+#endif
+
+#if NET_3_5 || NET_4_0 || SILVERLIGHT || NETCF_3_5
 using System.Linq;
 #endif
 
@@ -45,26 +47,20 @@ namespace NUnit.Framework.Assertions
         [Test()]
         public void ItemsOfType()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
-            CollectionAssert.AllItemsAreInstancesOfType(al,typeof(string));
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            CollectionAssert.AllItemsAreInstancesOfType(collection,typeof(string));
         }
 
         [Test]
         public void ItemsOfTypeFailure()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add(new object());
+            var collection = new SimpleObjectCollection("x", "y", new object());
 
             var expectedMessage =
                 "  Expected: all items instance of <System.String>" + Environment.NewLine +
                 "  But was:  < \"x\", \"y\", <System.Object> >" + Environment.NewLine;
             
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(al,typeof(string)));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(collection,typeof(string)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
         #endregion
@@ -73,27 +69,20 @@ namespace NUnit.Framework.Assertions
         [Test()]
         public void ItemsNotNull()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
-
-            CollectionAssert.AllItemsAreNotNull(al);
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            CollectionAssert.AllItemsAreNotNull(collection);
         }
 
         [Test]
         public void ItemsNotNullFailure()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add(null);
-            al.Add("z");
+            var collection = new SimpleObjectCollection("x", null, "z");
 
             var expectedMessage =
                 "  Expected: all items not null" + Environment.NewLine +
                 "  But was:  < \"x\", null, \"z\" >" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreNotNull(al));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreNotNull(collection));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
         #endregion
@@ -144,14 +133,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreEqual()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("z");
+            var set1 = new SimpleObjectCollection("x", "y", "z");
+            var set2 = new SimpleObjectCollection("x", "y", "z");
 
             CollectionAssert.AreEqual(set1,set2);
             CollectionAssert.AreEqual(set1,set2,new TestComparer());
@@ -162,18 +145,11 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreEqualFailCount()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("z");
-            set2.Add("a");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("x", "y", "z", "a");
 
             var expectedMessage =
-                "  Expected is <System.Collections.ArrayList> with 3 elements, actual is <System.Collections.ArrayList> with 4 elements" + Environment.NewLine +
+                "  Expected is <NUnit.TestUtilities.Collections.SimpleObjectList> with 3 elements, actual is <NUnit.TestUtilities.Collections.SimpleObjectList> with 4 elements" + Environment.NewLine +
                 "  Values differ at index [3]" + Environment.NewLine +
                 "  Extra:    < \"a\" >";
 
@@ -184,17 +160,11 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreEqualFail()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("a");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("x", "y", "a");
 
             var expectedMessage =
-                "  Expected and actual are both <System.Collections.ArrayList> with 3 elements" + Environment.NewLine +
+                "  Expected and actual are both <NUnit.TestUtilities.Collections.SimpleObjectList> with 3 elements" + Environment.NewLine +
                 "  Values differ at index [2]" + Environment.NewLine +
                 "  String lengths are both 1. Strings differ at index 0." + Environment.NewLine +
                 "  Expected: \"z\"" + Environment.NewLine +
@@ -259,7 +229,7 @@ namespace NUnit.Framework.Assertions
                                     Contains("But was:  2"));
         }
  
-#if NET_3_5 || NET_4_0
+#if NET_3_5 || NET_4_0 || SILVERLIGHT || NETCF_3_5
         [Test]
         public void AreEqual_UsingLinqQuery()
         {
@@ -338,14 +308,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreNotEqual()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("x");
+            var set1 = new SimpleObjectCollection("x", "y", "z");
+            var set2 = new SimpleObjectCollection("x", "y", "x");
 
             CollectionAssert.AreNotEqual(set1,set2);
             CollectionAssert.AreNotEqual(set1,set2,new TestComparer());
@@ -358,14 +322,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreNotEqual_Fails()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("z");
+            var set1 = new SimpleObjectCollection("x", "y", "z");
+            var set2 = new SimpleObjectCollection("x", "y", "z");
 
             var expectedMessage = 
                 "  Expected: not equal to < \"x\", \"y\", \"z\" >" + Environment.NewLine +
@@ -379,10 +337,7 @@ namespace NUnit.Framework.Assertions
         public void AreNotEqual_HandlesNull()
         {
             object[] set1 = new object[3];
-            ArrayList set2 = new ArrayList();
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("z");
+            var set2 = new SimpleObjectCollection("x", "y", "z");
 
             CollectionAssert.AreNotEqual(set1,set2);
             CollectionAssert.AreNotEqual(set1,set2,new TestComparer());
@@ -395,16 +350,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void NotEquivalent()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            set2.Add("x");
-            set2.Add("y");
-            set2.Add("x");
+            var set1 = new SimpleObjectCollection("x", "y", "z");
+            var set2 = new SimpleObjectCollection("x", "y", "x");
 
             CollectionAssert.AreNotEquivalent(set1,set2);
         }
@@ -412,16 +359,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void NotEquivalent_Fails()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            set2.Add("x");
-            set2.Add("z");
-            set2.Add("y");
+            var set1 = new SimpleObjectCollection("x", "y", "z");
+            var set2 = new SimpleObjectCollection("x", "z", "y");
 
             var expectedMessage =
                 "  Expected: not equivalent to < \"x\", \"y\", \"z\" >" + Environment.NewLine +
@@ -434,16 +373,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void NotEquivalentHandlesNull()
         {
-            ArrayList set1 = new ArrayList();
-            ArrayList set2 = new ArrayList();
-            
-            set1.Add("x");
-            set1.Add(null);
-            set1.Add("z");
-
-            set2.Add("x");
-            set2.Add(null);
-            set2.Add("x");
+            var set1 = new SimpleObjectCollection("x", null, "z");
+            var set2 = new SimpleObjectCollection("x", null, "x");
 
             CollectionAssert.AreNotEquivalent(set1,set2);
         }
@@ -453,61 +384,53 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void Contains_IList()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
-
-            CollectionAssert.Contains(al,"x");
+            var list = new SimpleObjectList("x", "y", "z");
+            CollectionAssert.Contains(list, "x");
         }
 
         [Test]
         public void Contains_ICollection()
         {
-            var ca = new SimpleObjectCollection(new string[] { "x", "y", "z" });
-
-            CollectionAssert.Contains(ca,"x");
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            CollectionAssert.Contains(collection,"x");
         }
 
         [Test]
         public void ContainsFails_ILIst()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
+            var list = new SimpleObjectList("x", "y", "z");
 
             var expectedMessage =
                 "  Expected: collection containing \"a\"" + Environment.NewLine +
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(al,"a"));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(list,"a"));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ContainsFails_ICollection()
         {
-            var ca = new SimpleObjectCollection(new string[] { "x", "y", "z" });
+            var collection = new SimpleObjectCollection("x", "y", "z");
 
             var expectedMessage =
                 "  Expected: collection containing \"a\"" + Environment.NewLine +
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(ca,"a"));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(collection,"a"));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ContainsFails_EmptyIList()
         {
-            ArrayList al = new ArrayList();
+            var list = new SimpleObjectList();
 
             var expectedMessage =
                 "  Expected: collection containing \"x\"" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(al,"x"));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.Contains(list,"x"));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -543,35 +466,27 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void DoesNotContain()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
-
-            CollectionAssert.DoesNotContain(al,"a");
+            var list = new SimpleObjectList();
+            CollectionAssert.DoesNotContain(list,"a");
         }
 
         [Test]
         public void DoesNotContain_Empty()
         {
-            ArrayList al = new ArrayList();
-
-            CollectionAssert.DoesNotContain(al,"x");
+            var list = new SimpleObjectList();
+            CollectionAssert.DoesNotContain(list,"x");
         }
 
         [Test]
         public void DoesNotContain_Fails()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
+            var list = new SimpleObjectList("x", "y", "z");
 
             var expectedMessage = 
                 "  Expected: not collection containing \"y\"" + Environment.NewLine +
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContain(al,"y"));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContain(list,"y"));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
         #endregion
@@ -580,14 +495,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsSubsetOf()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set2.Add("y");
-            set2.Add("z");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("y", "z");
 
             CollectionAssert.IsSubsetOf(set2,set1);
             Assert.That(set2, Is.SubsetOf(set1));
@@ -596,15 +505,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsSubsetOf_Fails()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set2.Add("y");
-            set2.Add("z");
-            set2.Add("a");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("y", "z", "a");
 
             var expectedMessage =
                 "  Expected: subset of < \"y\", \"z\", \"a\" >" + Environment.NewLine +
@@ -617,14 +519,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsSubsetOfHandlesNull()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add(null);
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set2.Add(null);
-            set2.Add("z");
+            var set1 = new SimpleObjectList("x", null, "z");
+            var set2 = new SimpleObjectList(null, "z");
 
             CollectionAssert.IsSubsetOf(set2,set1);
             Assert.That(set2, Is.SubsetOf(set1));
@@ -635,15 +531,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsNotSubsetOf()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set1.Add("y");
-            set1.Add("z");
-            set2.Add("a");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("y", "z", "a");
 
             CollectionAssert.IsNotSubsetOf(set1,set2);
             Assert.That(set1, Is.Not.SubsetOf(set2));
@@ -652,14 +541,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsNotSubsetOf_Fails()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add("y");
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set2.Add("y");
-            set2.Add("z");
+            var set1 = new SimpleObjectList("x", "y", "z");
+            var set2 = new SimpleObjectList("y", "z");
 
             var expectedMessage =
                 "  Expected: not subset of < \"x\", \"y\", \"z\" >" + Environment.NewLine +
@@ -672,15 +555,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsNotSubsetOfHandlesNull()
         {
-            ArrayList set1 = new ArrayList();
-            set1.Add("x");
-            set1.Add(null);
-            set1.Add("z");
-
-            ArrayList set2 = new ArrayList();
-            set1.Add(null);
-            set1.Add("z");
-            set2.Add("a");
+            var set1 = new SimpleObjectList("x", null, "z");
+            var set2 = new SimpleObjectList(null, "z", "a");
 
             CollectionAssert.IsNotSubsetOf(set1,set2);
         }
@@ -691,96 +567,67 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsOrdered()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
-
-            CollectionAssert.IsOrdered(al);
+            var list = new SimpleObjectList("x", "y", "z");
+            CollectionAssert.IsOrdered(list);
         }
 
         [Test]
         public void IsOrdered_Fails()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("z");
-            al.Add("y");
+            var list = new SimpleObjectList("x", "z", "y");
 
             var expectedMessage =
                 "  Expected: collection ordered" + Environment.NewLine +
                 "  But was:  < \"x\", \"z\", \"y\" >" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.IsOrdered(al));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.IsOrdered(list));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void IsOrdered_Allows_adjacent_equal_values()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add("x");
-            al.Add("z");
-
-            CollectionAssert.IsOrdered(al);
+            var list = new SimpleObjectList("x", "x", "z");
+            CollectionAssert.IsOrdered(list);
         }
 
         [Test]
         public void IsOrdered_Handles_null()
         {
-            ArrayList al = new ArrayList();
-            al.Add("x");
-            al.Add(null);
-            al.Add("z");
+            var list = new SimpleObjectList("x", null, "z");
 
-            var ex = Assert.Throws<ArgumentNullException>(() => CollectionAssert.IsOrdered(al));
+            var ex = Assert.Throws<ArgumentNullException>(() => CollectionAssert.IsOrdered(list));
             Assert.That(ex.Message, Does.Contain("index 1"));
         }
 
         [Test]
         public void IsOrdered_ContainedTypesMustBeCompatible()
         {
-            ArrayList al = new ArrayList();
-            al.Add(1);
-            al.Add("x");
-
-            Assert.Throws<ArgumentException>(() => CollectionAssert.IsOrdered(al));
+            var list = new SimpleObjectList(1, "x");
+            Assert.Throws<ArgumentException>(() => CollectionAssert.IsOrdered(list));
         }
 
         [Test]
         public void IsOrdered_TypesMustImplementIComparable()
         {
-            ArrayList al = new ArrayList();
-            al.Add(new object());
-            al.Add(new object());
-
-            Assert.Throws<ArgumentException>(() => CollectionAssert.IsOrdered(al));
+            var list = new SimpleObjectList(new object(), new object());
+            Assert.Throws<ArgumentException>(() => CollectionAssert.IsOrdered(list));
         }
 
         [Test]
         public void IsOrdered_Handles_custom_comparison()
         {
-            ArrayList al = new ArrayList();
-            al.Add(new object());
-            al.Add(new object());
-
-            CollectionAssert.IsOrdered(al, new AlwaysEqualComparer());
+            var list = new SimpleObjectList(new object(), new object());
+            CollectionAssert.IsOrdered(list, new AlwaysEqualComparer());
         }
 
         [Test]
         public void IsOrdered_Handles_custom_comparison2()
         {
-            ArrayList al = new ArrayList();
-            al.Add(2);
-            al.Add(1);
-
-            CollectionAssert.IsOrdered(al, new TestComparer());
+            var list = new SimpleObjectList(2, 1);
+            CollectionAssert.IsOrdered(list, new TestComparer());
         }
 
         #endregion
     }
 }
-#endif
-
-

--- a/src/NUnitFramework/tests/Assertions/ConditionAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ConditionAssertTests.cs
@@ -98,7 +98,6 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
     
-#if !NUNITLITE
         [Test]
         public void IsNaN()
         {
@@ -120,9 +119,12 @@ namespace NUnit.Framework.Assertions
         {
             Assert.IsEmpty( "", "Failed on empty String" );
             Assert.IsEmpty( new int[0], "Failed on empty Array" );
+            Assert.IsEmpty((IEnumerable)new int[0], "Failed on empty IEnumerable");
+
+#if !SILVERLIGHT
             Assert.IsEmpty( new ArrayList(), "Failed on empty ArrayList" );
             Assert.IsEmpty( new Hashtable(), "Failed on empty Hashtable" );
-            Assert.IsEmpty( (IEnumerable)new int[0], "Failed on empty IEnumerable" );
+#endif
         }
 
         [Test]
@@ -169,15 +171,19 @@ namespace NUnit.Framework.Assertions
         public void IsNotEmpty()
         {
             int[] array = new int[] { 1, 2, 3 };
-            ArrayList list = new ArrayList( array );
-            Hashtable hash = new Hashtable();
-            hash.Add( "array", array );
 
             Assert.IsNotEmpty( "Hi!", "Failed on String" );
             Assert.IsNotEmpty( array, "Failed on Array" );
-            Assert.IsNotEmpty( list, "Failed on ArrayList" );
-            Assert.IsNotEmpty( hash, "Failed on Hashtable" );
             Assert.IsNotEmpty( (IEnumerable)array, "Failed on IEnumerable" );
+
+#if !SILVERLIGHT
+            ArrayList list = new ArrayList(array);
+            Hashtable hash = new Hashtable();
+            hash.Add("array", array);
+
+            Assert.IsNotEmpty(list, "Failed on ArrayList");
+            Assert.IsNotEmpty(hash, "Failed on Hashtable");
+#endif
         }
 
         [Test]
@@ -201,12 +207,23 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
+        public void IsNotEmptyFailsOnEmptyIEnumerable()
+        {
+            var expectedMessage =
+                "  Expected: not <empty>" + Environment.NewLine +
+                "  But was:  <empty>" + Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty((IEnumerable)new int[0]));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+#if !SILVERLIGHT
+        [Test]
         public void IsNotEmptyFailsOnEmptyArrayList()
         {
             var expectedMessage =
                 "  Expected: not <empty>" + Env.NewLine +
                 "  But was:  <empty>" + Env.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty( new ArrayList() ));
+            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(new ArrayList()));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -216,19 +233,9 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: not <empty>" + Env.NewLine +
                 "  But was:  <empty>" + Env.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty( new Hashtable() ));
+            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(new Hashtable()));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
-
-        [Test]
-        public void IsNotEmptyFailsOnEmptyIEnumerable()
-        {
-            var expectedMessage =
-                "  Expected: not <empty>" + Environment.NewLine +
-                "  But was:  <empty>" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotEmpty((IEnumerable)new int[0]));
-                    Assert.That(ex.Message, Is.EqualTo(expectedMessage));
-}
 #endif
     }
 }

--- a/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Assertions
@@ -44,8 +44,8 @@ namespace NUnit.Framework.Assertions
         private readonly decimal de2 = 33.4M;
         private readonly double d1 = 4.85948654;
         private readonly double d2 = 1.0;
-        private readonly System.Enum e1 = System.Data.CommandType.TableDirect;
-        private readonly System.Enum e2 = System.Data.CommandType.StoredProcedure;
+        private readonly System.Enum e1 = RunState.Explicit;
+        private readonly System.Enum e2 = RunState.Ignored;
 
         [Test]
         public void GreaterOrEqual_Int32()
@@ -164,9 +164,9 @@ namespace NUnit.Framework.Assertions
         public void NotGreaterEqualIComparable()
         {
             var expectedMessage =
-                "  Expected: greater than or equal to TableDirect" + Environment.NewLine +
-                "  But was:  StoredProcedure" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(e2, e1));
+                "  Expected: greater than or equal to Ignored" + Environment.NewLine +
+                "  But was:  Explicit" + Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(e1, e2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -189,4 +189,3 @@ namespace NUnit.Framework.Assertions
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Assertions/GreaterFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/GreaterFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Assertions
 {
@@ -43,8 +43,8 @@ namespace NUnit.Framework.Assertions
         private readonly decimal de2 = 33.4M;
         private readonly double d1 = 4.85948654;
         private readonly double d2 = 1.0;
-        private readonly System.Enum e1 = System.Data.CommandType.TableDirect;
-        private readonly System.Enum e2 = System.Data.CommandType.StoredProcedure;
+        private readonly System.Enum e1 = RunState.Explicit;
+        private readonly System.Enum e2 = RunState.Ignored;
 
         [Test]
         public void Greater()
@@ -136,9 +136,9 @@ namespace NUnit.Framework.Assertions
         public void NotGreaterIComparable()
         {
             var expectedMessage =
-                "  Expected: greater than TableDirect" + Environment.NewLine +
-                "  But was:  StoredProcedure" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(e2,e1));
+                "  Expected: greater than Ignored" + Environment.NewLine +
+                "  But was:  Explicit" + Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(e1,e2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -153,5 +153,4 @@ namespace NUnit.Framework.Assertions
         }
     }
 }
-#endif
 

--- a/src/NUnitFramework/tests/Assertions/LessEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LessEqualFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Assertions
 {
@@ -43,8 +43,8 @@ namespace NUnit.Framework.Assertions
         private readonly decimal de2 = 83.4M;
         private readonly double d1 = 4.85948654;
         private readonly double d2 = 8.0;
-        private readonly System.Enum e1 = System.Data.CommandType.StoredProcedure;
-        private readonly System.Enum e2 = System.Data.CommandType.TableDirect;
+        private readonly System.Enum e1 = RunState.Explicit;
+        private readonly System.Enum e2 = RunState.Ignored;
 
         [Test]
         public void LessOrEqual()
@@ -164,8 +164,8 @@ namespace NUnit.Framework.Assertions
         public void NotLessEqualIComparable()
         {
             var expectedMessage =
-                "  Expected: less than or equal to StoredProcedure" + Environment.NewLine +
-                "  But was:  TableDirect" + Environment.NewLine;
+                "  Expected: less than or equal to Explicit" + Environment.NewLine +
+                "  But was:  Ignored" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.LessOrEqual(e2, e1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -181,6 +181,5 @@ namespace NUnit.Framework.Assertions
         }
     }
 }
-#endif
 
 

--- a/src/NUnitFramework/tests/Assertions/LessFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LessFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Assertions
@@ -44,8 +44,8 @@ namespace NUnit.Framework.Assertions
         private readonly decimal de2 = 83.4M;
         private readonly double d1 = 4.85948654;
         private readonly double d2 = 8.0;
-        private readonly System.Enum e1 = System.Data.CommandType.StoredProcedure;
-        private readonly System.Enum e2 = System.Data.CommandType.TableDirect;
+        private readonly System.Enum e1 = RunState.Explicit;
+        private readonly System.Enum e2 = RunState.Ignored;
 
         [Test]
         public void Less()
@@ -149,8 +149,8 @@ namespace NUnit.Framework.Assertions
         public void NotLessIComparable()
         {
             var expectedMessage =
-                "  Expected: less than StoredProcedure" + Environment.NewLine +
-                "  But was:  TableDirect" + Environment.NewLine;
+                "  Expected: less than Explicit" + Environment.NewLine +
+                "  But was:  Ignored" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.Less(e2,e1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -174,4 +174,3 @@ namespace NUnit.Framework.Assertions
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Assertions/StringAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/StringAssertTests.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Assertions
@@ -156,10 +155,9 @@ namespace NUnit.Framework.Assertions
         {
             string input = "Hello World";
             byte[] data = System.Text.Encoding.Unicode.GetBytes( input );
-            string garbage = System.Text.Encoding.UTF8.GetString( data );
+            string garbage = System.Text.Encoding.UTF8.GetString( data, 0, data.Length);
 
             Assert.AreNotEqual( input, garbage );
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NUNITLITE
 using System;
 
 namespace NUnit.Framework.Assertions
@@ -48,7 +47,7 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsInstanceOf()
         {
-            ApplicationException ex = new ApplicationException();
+            var ex = new ArgumentException();
 
             Assert.IsInstanceOf(typeof(System.Exception), ex );
             Assert.That( ex, Is.InstanceOf(typeof(Exception)));
@@ -78,8 +77,8 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: not instance of <System.Exception>" + System.Environment.NewLine + 
-                "  But was:  <System.ApplicationException>" + System.Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotInstanceOf( typeof(System.Exception), new ApplicationException() ));
+                "  But was:  <System.ArgumentException>" + System.Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.IsNotInstanceOf( typeof(System.Exception), new ArgumentException() ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -130,4 +129,3 @@ namespace NUnit.Framework.Assertions
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -36,7 +36,6 @@ namespace NUnit.Framework.Attributes
             _context = new TestExecutionContext();
         }
 
-#if !NUNITLITE
         [Test]
         public void ParallelizableAttribute()
         {
@@ -44,7 +43,6 @@ namespace NUnit.Framework.Attributes
             attr.ApplyToContext(_context);
             Assert.That(_context.ParallelScope, Is.EqualTo(ParallelScope.Fixtures));
         }
-#endif
 
 #if !NETCF
         [Test]

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
@@ -1,0 +1,137 @@
+// ***********************************************************************
+// Copyright (c) 2007 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Collections
+{
+    /// <summary>
+    /// SimpleObjectCollection is used in testing to ensure that only
+    /// methods of the ICollection interface are accessible.
+    /// </summary>
+    class SimpleObjectList : IList
+    {
+        private readonly List<object> contents = new List<object>();
+
+        public SimpleObjectList(IEnumerable<object> source)
+        {
+            this.contents = new List<object>(source);
+        }
+
+        public SimpleObjectList(params object[] source)
+        {
+            this.contents = new List<object>(source);
+        }
+
+        #region ICollection Members
+
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)contents).CopyTo(array, index);
+        }
+
+        public int Count
+        {
+            get { return contents.Count; }
+        }
+
+        public bool IsSynchronized
+        {
+            get { return  ((ICollection)contents).IsSynchronized; }
+        }
+
+        public object SyncRoot
+        {
+            get { return ((ICollection)contents).SyncRoot; }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        public IEnumerator GetEnumerator()
+        {
+            return contents.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IList Members
+
+        public int Add(object value)
+        {
+            contents.Add(value);
+            return contents.Count - 1;
+        }
+
+        public void Clear()
+        {
+            contents.Clear();
+        }
+
+        public bool Contains(object value)
+        {
+            return contents.Contains(value);
+        }
+
+        public int IndexOf(object value)
+        {
+            return contents.IndexOf(value);
+        }
+
+        public void Insert(int index, object value)
+        {
+            contents.Insert(index, value);
+        }
+
+        public bool IsFixedSize
+        {
+            get { return false; }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
+
+        public void Remove(object value)
+        {
+            contents.Remove(value);
+        }
+
+        public void RemoveAt(int index)
+        {
+            contents.RemoveAt(index);
+        }
+
+        public object this[int index]
+        {
+            get { return contents[index]; }
+            set { contents[index] = value; }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -224,6 +224,7 @@
     <Compile Include="TestContextTests.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-2.0.csproj
@@ -99,12 +99,19 @@
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
     <Compile Include="Assertions\DirectoryAssertTests.cs" />
     <Compile Include="Assertions\FileAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ActionAttributeTests.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
@@ -236,6 +243,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-3.5.csproj
@@ -97,12 +97,19 @@
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
     <Compile Include="Assertions\DirectoryAssertTests.cs" />
     <Compile Include="Assertions\FileAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ActionAttributeTests.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
@@ -234,6 +241,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-4.0.csproj
@@ -112,12 +112,19 @@
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
     <Compile Include="Assertions\DirectoryAssertTests.cs" />
     <Compile Include="Assertions\FileAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ActionAttributeTests.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
@@ -252,6 +259,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-4.5.csproj
@@ -100,12 +100,19 @@
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
     <Compile Include="Assertions\DirectoryAssertTests.cs" />
     <Compile Include="Assertions\FileAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ActionAttributeTests.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
@@ -198,6 +205,7 @@
     <Compile Include="Internal\TestResultOutputTests.cs" />
     <Compile Include="Runner\CreateTestFilterTests.cs" />
     <Compile Include="Runner\NUnit2XmlOutputWriterTests.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Fakes.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs" />
     <Compile Include="Internal\GenericTestMethodTests.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-netcf-3.5.csproj
@@ -48,6 +48,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -62,6 +63,7 @@
       <Link>FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="Api\ResultStateTests.cs" />
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />
     <Compile Include="Assertions\ArrayEqualsFixture.cs" />
     <Compile Include="Assertions\ArrayNotEqualFixture.cs" />
@@ -73,12 +75,19 @@
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
     <Compile Include="Assertions\DirectoryAssertTests.cs" />
     <Compile Include="Assertions\FileAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ActionAttributeTests.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
@@ -197,6 +206,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />

--- a/src/NUnitFramework/tests/nunitlite.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunitlite.tests-sl-5.0.csproj
@@ -85,6 +85,7 @@
       <Link>FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="Api\ResultStateTests.cs" />
+    <Compile Include="Api\TestAssemblyRunnerTests.cs" />
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
@@ -100,10 +101,17 @@
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\CollectionAssertTest.cs" />
     <Compile Include="Assertions\ConditionAssertTests.cs" />
+    <Compile Include="Assertions\GreaterEqualFixture.cs" />
+    <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\LessEqualFixture.cs" />
+    <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\SameFixture.cs" />
+    <Compile Include="Assertions\StringAssertTests.cs" />
+    <Compile Include="Assertions\TypeAssertTest.cs" />
     <Compile Include="Attributes\ApplyToContextTests.cs" />
     <Compile Include="Attributes\ApplyToTestTests.cs" />
     <Compile Include="Attributes\AttributeInheritanceTests.cs" />
@@ -236,6 +244,7 @@
     <Compile Include="Syntax\SyntaxTest.cs" />
     <Compile Include="Syntax\ThrowsTests.cs" />
     <Compile Include="Syntax\TypeConstraints.cs" />
+    <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />


### PR DESCRIPTION
**Ready to Merge**

With this initial commit, classic asserts as well as StringAssert and CollectionAssert have been added to all NUnitLite desktop builds.

Compact framework still needs to be done. Silverlight is done but it's tests are not yet ready since a number of classes used in the tests are not present in Silverlight. Further commits to follow.
