### PR TITLE
Fixes to timing tests that are failing intermittently under Appveyor

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -353,7 +353,7 @@
 		<Message Text="* Testing NUnitFramework $(Framework) - $(Configuration)" />
 		<Message Text="******************************************************************" />
 
-		<Error Condition="'$(Runtime)' == 'netcf' Or '$(Runtime)' == 'silverlight' And '$(Runtime)' != 'portable'"
+		<Error Condition="'$(Runtime)' == 'netcf' Or '$(Runtime)' == 'silverlight' Or '$(Runtime)' == 'portable'"
 			Text="The full NUnit framework cannot be tested under $(Runtime)" />
 
 		<Exec WorkingDirectory="$(ConsoleBuildDir)" 
@@ -379,7 +379,7 @@
 
 		<Error Condition="'$(Runtime)' == 'silverlight'"
 			Text="Silverlight test is not supported by this script" />
-      
+	  
 		<Error Condition="'$(Runtime)' == 'portable'"
 			Text="Portable tests are not supported by this script" />
 

--- a/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Attributes
     /// <summary>
     /// Tests for MaxTime decoration.
     /// </summary>
-    [TestFixture]
+    [TestFixture, Parallelizable(ParallelScope.None)]
     public class MaxTimeTests
     {
         [Test,MaxTime(1000)]

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -32,6 +32,7 @@ using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
+    [Parallelizable(ParallelScope.None)]
     public class TimeoutTests
     {
         Thread parentThread;


### PR DESCRIPTION
These are mostly adhoc fixes and may not stop all the errors but I'd like to get it merged and move on to something else for a while. We should watch for similar errors and come back to this if they recur.

Changes made:
- Use stopwatch in DelayedConstraintTests.cs
- Remove intermittently failing assert
- Don't run timing tests in parallel
- Fix logic error in NUnit.proj
