### PR TITLE
Editorconfig and Rebracer.xml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig helps developers define and 
+# maintain consistent coding styles between 
+# different editors and IDEs
+
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+[*.csproj]
+indent_style = space
+indent_size = 2
+
+[*.vcxproj]
+indent_style = space
+indent_size = 2
+
+[*.config]
+indent_style = space
+indent_size = 2
+
+[NUnit.proj]
+indent_style = tab
+indent_size = 2

--- a/Rebracer.xml
+++ b/Rebracer.xml
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--Rebracer Solution Settings File-->
+<!--This file contains Visual Studio settings for nunit.sln.-->
+<!--Rebracer uses this file to apply settings for this solution-->
+<!--when the solution is opened.-->
+<!--Install Rebracer from http://visualstudiogallery.msdn.microsoft.com/410e9b9f-65f3-4495-b68e-15567e543c58 -->
+<!--See https://github.com/SLaks/Rebracer for more information-->
+<UserSettings>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="TextEditor">
+      <ToolsOptionsSubCategory name="CSharp-Specific">
+        <PropertyValue name="AutoComment">1</PropertyValue>
+        <PropertyValue name="BringUpOnIdentifier">1</PropertyValue>
+        <PropertyValue name="Formatting_TriggerOnBlockCompletion">1</PropertyValue>
+        <PropertyValue name="Formatting_TriggerOnPaste">1</PropertyValue>
+        <PropertyValue name="Formatting_TriggerOnStatementCompletion">1</PropertyValue>
+        <PropertyValue name="Indent_BlockContents">1</PropertyValue>
+        <PropertyValue name="Indent_Braces">0</PropertyValue>
+        <PropertyValue name="Indent_CaseContents">1</PropertyValue>
+        <PropertyValue name="Indent_CaseLabels">0</PropertyValue>
+        <PropertyValue name="Indent_FlushLabelsLeft">0</PropertyValue>
+        <PropertyValue name="Indent_UnindentLabels">2</PropertyValue>
+        <PropertyValue name="NewLines_AnonymousTypeInitializer_EachMember">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_AnonymousMethod">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_AnonymousTypeInitializer">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ArrayInitializer">0</PropertyValue>
+        <PropertyValue name="NewLines_Braces_CollectionInitializer">0</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ControlFlow">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_LambdaExpressionBody">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_Method">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ObjectInitializer">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_Type">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Catch">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Else">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Finally">1</PropertyValue>
+        <PropertyValue name="NewLines_ObjectInitializer_EachMember">1</PropertyValue>
+        <PropertyValue name="NewLines_QueryExpression_EachClause">1</PropertyValue>
+        <PropertyValue name="RemoveUnusedUsings">1</PropertyValue>
+        <PropertyValue name="SortUsings">1</PropertyValue>
+        <PropertyValue name="SortUsings_PlaceSystemFirst">1</PropertyValue>
+        <PropertyValue name="Space_AfterBasesColon">1</PropertyValue>
+        <PropertyValue name="Space_AfterCast">0</PropertyValue>
+        <PropertyValue name="Space_AfterComma">1</PropertyValue>
+        <PropertyValue name="Space_AfterDot">0</PropertyValue>
+        <PropertyValue name="Space_AfterLambdaArrow">1</PropertyValue>
+        <PropertyValue name="Space_AfterMethodCallName">0</PropertyValue>
+        <PropertyValue name="Space_AfterMethodDeclarationName">0</PropertyValue>
+        <PropertyValue name="Space_AfterSemicolonsInForStatement">1</PropertyValue>
+        <PropertyValue name="Space_AroundBinaryOperator">1</PropertyValue>
+        <PropertyValue name="Space_BeforeBasesColon">1</PropertyValue>
+        <PropertyValue name="Space_BeforeComma">0</PropertyValue>
+        <PropertyValue name="Space_BeforeDot">0</PropertyValue>
+        <PropertyValue name="Space_BeforeLambdaArrow">1</PropertyValue>
+        <PropertyValue name="Space_BeforeOpenSquare">0</PropertyValue>
+        <PropertyValue name="Space_BeforeSemicolonsInForStatement">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptyMethodCallParentheses">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptyMethodDeclarationParentheses">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptySquares">0</PropertyValue>
+        <PropertyValue name="Space_InControlFlowConstruct">1</PropertyValue>
+        <PropertyValue name="Space_Normalize">0</PropertyValue>
+        <PropertyValue name="Space_WithinCastParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinExpressionParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinMethodCallParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinMethodDeclarationParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinOtherParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinSquares">0</PropertyValue>
+        <PropertyValue name="Wrapping_IgnoreSpacesAroundBinaryOperators">0</PropertyValue>
+        <PropertyValue name="Wrapping_IgnoreSpacesAroundVariableDeclaration">0</PropertyValue>
+        <PropertyValue name="Wrapping_KeepStatementsOnSingleLine">1</PropertyValue>
+        <PropertyValue name="Wrapping_PreserveSingleLine">1</PropertyValue>
+      </ToolsOptionsSubCategory>
+    </ToolsOptionsCategory>
+  </ToolsOptions>
+</UserSettings>

--- a/nunit.sln
+++ b/nunit.sln
@@ -97,11 +97,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SL-5.0", "SL-5.0", "{A21BFC
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		BUILDING.txt = BUILDING.txt
 		LICENSE.txt = LICENSE.txt
 		NOTICES.txt = NOTICES.txt
 		NUnit.proj = NUnit.proj
 		README.md = README.md
+		Rebracer.xml = Rebracer.xml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{A972031D-2F61-4183-AF75-99EE1A9F6B32}"


### PR DESCRIPTION
I added these two files to the root of our solution. For developers without the extensions installed, they have no effect. These two files are really useful for people that work on projects/work with different coding standards. They will automatically configure your editor to the coding standards of the solution when you open it and restore your settings to your defaults when you close.

**Editor Config**

This file defines spacing and tabs for the files in the solution. There are plugins available for pretty much every editor and IDE out there including Visual Studio, Vi, Emacs and even Notepad++. 

For more information, got to http://editorconfig.org/. The Visual Studio extension is on [GitHub](https://github.com/editorconfig/editorconfig-visualstudio) and can be installed from the [Visual Studio Gallery](https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328)

**Rebracer**

Thanks to @SLaks for pointing this out. Rebracer sets all of the code formatting rules for the project when you open the solution and restores your defaults when you close. I have gone through all the settings and set them to the NUnit coding standard. If anyone finds that they are incorrect, if you have the extension installed, you simply need to open the Visual Studio options and change the settings. The changes will automatically be saved out to the Rebracer.xml file.

Rebracer is also on [GitHub](https://github.com/SLaks/Rebracer) and can be installed from the [Visual Studio Gallery](https://visualstudiogallery.msdn.microsoft.com/410e9b9f-65f3-4495-b68e-15567e543c58)

If this pull request is accepted, I will add this info to the developer documentation.
