### PR TITLE
Improvements to console runner output. Fixes #386

### DIFF
--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -50,7 +50,7 @@ namespace NUnit.ConsoleRunner
             }
             catch (OptionException ex)
             {
-                WriteHeader();
+                WriteHeader(options);
                 ColorConsole.WriteLine(ColorStyle.Error, string.Format(ex.Message, ex.OptionName));
                 return ConsoleRunner.INVALID_ARG;
             }
@@ -75,7 +75,7 @@ namespace NUnit.ConsoleRunner
                 }
 
                 if (!options.NoHeader)
-                    WriteHeader();
+                    WriteHeader(options);
 
                 if (options.ShowHelp)
                 {
@@ -169,7 +169,7 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        private static void WriteHeader()
+        private static void WriteHeader(ConsoleOptions options)
         {
             Assembly executingAssembly = Assembly.GetExecutingAssembly();
             string versionText = executingAssembly.GetName().Version.ToString(3);
@@ -199,6 +199,12 @@ namespace NUnit.ConsoleRunner
             ColorConsole.WriteLine(ColorStyle.Header, string.Format( "{0} {1} {2}", programName, versionText, configText ));
             ColorConsole.WriteLine(ColorStyle.SubHeader, copyrightText);
             Console.WriteLine();
+
+            ColorConsole.WriteLine(ColorStyle.SectionHeader, "Test Files:");
+            foreach (string file in options.InputFiles)
+                ColorConsole.WriteLine(ColorStyle.Default, "    " + file);
+            Console.WriteLine();
+
             ColorConsole.WriteLine(ColorStyle.SectionHeader, "Runtime Environment");
             ColorConsole.WriteLabel("   OS Version: ", Environment.OSVersion.ToString(), true);
             ColorConsole.WriteLabel("  CLR Version: ", Environment.Version.ToString(), true);


### PR DESCRIPTION
This fixes a few things that have been bugging me about the console output. I'd like to get it into the alpha 3 release.

I often have multiple test runs going testing different builds of the framework. There is nothing displayed in the output to tell me which window is which. This PR adds a list of Test Files to the output window so I can see what I was testing.

I think "Skipped" for a test run that has some ignored tests is misleading. I changed it to "Warning", which will also be useful when we add actual Warning assertions to the framework.
