### PR TITLE
Fix for issue 210, TestContext.WriteLine in an AppDomain causes an error

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -95,6 +95,11 @@ namespace NUnit.Framework.Internal
         /// </summary>
         private CultureInfo _currentUICulture;
 
+        /// <summary>
+        /// The current test result
+        /// </summary>
+        private TestResult _currentResult;
+
 #if !NETCF && !SILVERLIGHT && !PORTABLE
         /// <summary>
         /// The current Principal.
@@ -251,7 +256,21 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets or sets the current test result
         /// </summary>
-        public TestResult CurrentResult { get; set; }
+        public TestResult CurrentResult
+        {
+            get { return _currentResult; }
+            set
+            {
+                _currentResult = value;
+                if(value != null)
+                    OutWriter = value.OutWriter;
+            }
+        }
+
+        /// <summary>
+        /// Gets a TextWriter that will send output to the current test result.
+        /// </summary>
+        public TextWriter OutWriter { get; private set; }
 
         /// <summary>
         /// The current test object - that is the user fixture

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework
         /// </summary>
         public static TextWriter Out
         {
-            get { return TestExecutionContext.CurrentContext.CurrentResult.OutWriter; }
+            get { return TestExecutionContext.CurrentContext.OutWriter; }
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -389,4 +389,48 @@ namespace NUnit.Framework.Internal
 
         #endregion
     }
+
+#if !PORTABLE && !SILVERLIGHT
+    [TestFixture]
+    public class TextExecutionContextInAppDomain
+    {
+        private RunsInAppDomain _runsInAppDomain;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var domain = AppDomain.CreateDomain("TestDomain", null, AppDomain.CurrentDomain.BaseDirectory, AppDomain.CurrentDomain.RelativeSearchPath, false);
+            _runsInAppDomain = domain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName,
+                "NUnit.Framework.Internal.RunsInAppDomain") as RunsInAppDomain;
+            Assert.That(_runsInAppDomain, Is.Not.Null);
+        }
+
+        [Test]
+        [Description("Issue 71 - NUnit swallows console output from AppDomains created within tests")]
+        public void CanWriteToConsoleInAppDomain()
+        {
+            _runsInAppDomain.WriteToConsole();
+        }
+
+        [Test]
+        [Description("Issue 210 - TestContext.WriteLine in an AppDomain causes an error")]
+        public void CanWriteToTestContextInAppDomain()
+        {
+            _runsInAppDomain.WriteToTestContext();
+        }
+    }
+
+    internal class RunsInAppDomain : MarshalByRefObject
+    {
+        public void WriteToConsole()
+        {
+            Console.WriteLine("RunsInAppDomain.WriteToConsole");
+        }
+
+        public void WriteToTestContext()
+        {
+            TestContext.WriteLine("RunsInAppDomain.WriteToTestContext");
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Fixes #210, got around the TestResult not being serializable by copying the TextWriter to the parent TestContext whenever the TestResult gets set.

I added a test and verified that the output gets captured.
