### PR TITLE
Fix #437 - errors in Linux using hard-coded paths in test resource files

### DIFF
--- a/src/NUnitConsole/nunit-console/nunit-console.csproj
+++ b/src/NUnitConsole/nunit-console/nunit-console.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>net-4.5/nunit.framework.tests.dll</Commandlineparameters>
+    <Commandlineparameters>nunit.engine.tests.dll -process:Single</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitEngine/nunit.engine/Services/ProjectLoaders/VSProject.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectLoaders/VSProject.cs
@@ -427,12 +427,22 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
             public string OutputDirectory
             {
-                get { return Path.Combine(Path.GetDirectoryName(_project.ProjectPath), _outputPath);  }
+                get { return Normalize(Path.Combine(Path.GetDirectoryName(_project.ProjectPath), _outputPath));  }
             }
 
             public string AssemblyPath
             {
-                get { return Path.Combine(OutputDirectory, _assemblyName); }
+                get { return Normalize(Path.Combine(OutputDirectory, _assemblyName)); }
+            }
+
+            private static string Normalize(string path)
+            {
+                char sep = Path.DirectorySeparatorChar;
+
+                if (sep != '\\')
+                    path = path.Replace('\\', sep);
+
+                return path;
             }
         }
 


### PR DESCRIPTION
This fixes errors in our own tests, which use resource files containing NUnit and VS projects. The files use the backslash for a path separator and this leads to problems. This would lead to errors in real projects as well.

This PR adds code to both NUnitProject and VSProject to normalize the paths for the OS before they are used in a package. VSProjects are assumed to always contain backslash while NUnit projects may use either. NUnit projects will normally use the separator of the OS on which they were created but they need to be usable when opened on another OS.
