### PR TITLE
Issue 427

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -164,10 +164,10 @@ namespace NUnit.Framework
         /// <summary>
         /// Gets or sets the ignored status of the test
         /// </summary>
-        public bool Ignore 
+        public string Ignore 
         { 
-            get { return this.RunState == RunState.Ignored; }
-            set { this.RunState = value ? RunState.Ignored : RunState.Runnable; } 
+            get { return IgnoreReason; }
+            set { this.IgnoreReason = value; } 
         }
         
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -83,25 +83,20 @@ namespace NUnit.Framework
         public object[] Arguments { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="TestFixtureAttribute"/> should be ignored.
-        /// </summary>
-        /// <value><c>true</c> if ignore; otherwise, <c>false</c>.</value>
-        public bool Ignore { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ignore reason. May set Ignored as a side effect.
+        /// Gets or sets the ignore reason. May set RunState as a side effect.
         /// </summary>
         /// <value>The ignore reason.</value>
-        public string IgnoreReason
+        public string Ignore
         {
-            get { return _ignoreReason; }
-            set
-            {
-                _ignoreReason = value;
-                Ignore = !string.IsNullOrEmpty(_ignoreReason);
-            }
+            get { return IgnoreReason;  }
+            set { IgnoreReason = value; }
         }
-        private string _ignoreReason;
+
+        /// <summary>
+        /// Gets or sets the ignore reason. May set RunState as a side effect.
+        /// </summary>
+        /// <value>The ignore reason.</value>
+        public string IgnoreReason { get; set; }
 
         /// <summary>
         /// Get or set the type arguments. If not set
@@ -134,6 +129,12 @@ namespace NUnit.Framework
         /// <param name="test">The test to modify</param>
         public void ApplyToTest(Test test)
         {
+            if (!string.IsNullOrEmpty(IgnoreReason) && test.RunState != RunState.NotRunnable)
+            {
+                test.Properties.Set(PropertyNames.SkipReason, IgnoreReason);
+                test.RunState = RunState.Ignored;
+            }
+
             if (!test.Properties.ContainsKey(PropertyNames.Description) && Description != null)
                 test.Properties.Set(PropertyNames.Description, Description);
 

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -163,16 +163,6 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Ignores this TestCase.
-        /// </summary>
-        /// <returns></returns>
-        public TestCaseData Ignore()
-        {
-            this.RunState = RunState.Ignored;
-            return this;
-        }
-        
-        /// <summary>
         /// Marks the test case as explicit.
         /// </summary>
         public TestCaseData Explicit()	{

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -66,7 +66,7 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         }
 
         [TestCase(1)]
-        [TestCase(2, Ignore = true)]
+        [TestCase(2, Ignore = "Should not run")]
         [TestCase(3, IgnoreReason = "Don't Run Me!")]
         public void MethodWithIgnoredTestCases(int num)
         {

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -57,8 +57,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             {
                 return new object[] {
                     new TestCaseData(1),
-                    new TestCaseData(2).Ignore(),
-                    new TestCaseData(3).Ignore("Don't Run Me!")
+                    new TestCaseData(2).Ignore("Don't Run Me!")
                 };
             }
         }

--- a/src/NUnitFramework/testdata/TestFixtureData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureData.cs
@@ -132,11 +132,27 @@ namespace NUnit.TestData.TestFixtureData
 
     [TestFixture]
     [Ignore("testing ignore a fixture")]
-    public class IgnoredFixture
+    public class FixtureUsingIgnoreAttribute
     {
         [Test]
         public void Success()
-        {}
+        { }
+    }
+
+    [TestFixture(Ignore = "testing ignore a fixture")]
+    public class FixtureUsingIgnoreProperty
+    {
+        [Test]
+        public void Success()
+        { }
+    }
+
+    [TestFixture(IgnoreReason = "testing ignore a fixture")]
+    public class FixtureUsingIgnoreReasonProperty
+    {
+        [Test]
+        public void Success()
+        { }
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -234,9 +234,6 @@ namespace NUnit.Framework.Attributes
  
             testCase = TestFinder.Find("MethodWithIgnoredTestCases(2)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Ignored));
- 
-            testCase = TestFinder.Find("MethodWithIgnoredTestCases(3)", suite, false);
-            Assert.That(testCase.RunState, Is.EqualTo(RunState.Ignored));
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Don't Run Me!"));
         }
 

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -26,7 +26,6 @@ using NUnit.Framework.Interfaces;
 using NUnit.TestData.OneTimeSetUpTearDownData;
 using NUnit.TestUtilities;
 using NUnit.TestData.TestFixtureData;
-using IgnoredFixture = NUnit.TestData.TestFixtureData.IgnoredFixture;
 
 namespace NUnit.Framework.Internal
 {
@@ -132,14 +131,30 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
-        public void CannotRunIgnoredFixture()
+        public void FixtureUsingIgnoreAttributeIsIgnored()
         {
-            TestSuite suite = TestBuilder.MakeFixture( typeof( IgnoredFixture ) );
-            Assert.AreEqual( RunState.Ignored, suite.RunState );
-            Assert.AreEqual( "testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason) );
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreAttribute));
+            Assert.AreEqual(RunState.Ignored, suite.RunState);
+            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
         }
 
-//		[Test]
+        [Test]
+        public void FixtureUsingIgnorePropertyIsIgnored()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreProperty));
+            Assert.AreEqual(RunState.Ignored, suite.RunState);
+            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+        }
+
+        [Test]
+        public void FixtureUsingIgnoreReasonPropertyIsIgnored()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreReasonProperty));
+            Assert.AreEqual(RunState.Ignored, suite.RunState);
+            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+        }
+
+        //		[Test]
 //		public void CannotRunAbstractFixture()
 //		{
 //            TestAssert.IsNotRunnable(typeof(AbstractTestFixture));


### PR DESCRIPTION
Fixes #427, eliminating several possible ways a user can ignore a test without giving a reason.

* Changed TestFixtureAttribute.Ignore property to a string, representing the reason for ignoring the test.
* Kept the IgnoreReason property for compatibility as a synonym.
* Took the same actions with TestCaseAttribute, which has the same issue.
* Removed the parameterless Ignore() method from TestCaseData