### PR TITLE
Implement StopOnError; fixes #442

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -288,6 +288,9 @@ namespace NUnit.Framework.Internal.Execution
                     childTask.Completed -= new EventHandler(OnChildCompleted);
                     Result.AddResult(childTask.Result);
 
+                    if (Context.StopOnError && childTask.Result.ResultState.Status == TestStatus.Failed)
+                        Context.ExecutionStatus = TestExecutionStatus.StopRequested;
+
                     // Check to see if all children completed
                     CountDownChildTest();
                 }

--- a/src/NUnitFramework/nunitlite.runner/Runner/ResultReporter.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/ResultReporter.cs
@@ -36,6 +36,7 @@ namespace NUnitLite.Runner
     {
         private ExtendedTextWriter _writer;
         private ITestResult _result;
+        private bool _stopOnFirstError;
         private string _overallResult;
 
         private int _reportIndex = 0;
@@ -45,10 +46,12 @@ namespace NUnitLite.Runner
         /// </summary>
         /// <param name="result">The top-level result being reported</param>
         /// <param name="writer">A TextWriter to which the report is written</param>
-        public ResultReporter(ITestResult result, ExtendedTextWriter writer)
+        /// <param name="stopOnFirstError">True if user requested stop after first error</param>
+        public ResultReporter(ITestResult result, ExtendedTextWriter writer, bool stopOnFirstError)
         {
             _result = result;
             _writer = writer;
+            _stopOnFirstError = stopOnFirstError;
 
             _overallResult = result.ResultState.Status.ToString();
             if (_overallResult == "Skipped")
@@ -71,6 +74,12 @@ namespace NUnitLite.Runner
                 _writer.WriteLine(ColorStyle.Warning, "Warning: No tests found");
 
             _writer.WriteLine();
+
+            if (_stopOnFirstError && Summary.FailureCount + Summary.ErrorCount > 0)
+            {
+                _writer.WriteLine(ColorStyle.Failure, "Execution terminated after first error");
+                _writer.WriteLine();
+            }
 
             WriteSummaryReport();
 

--- a/src/NUnitFramework/nunitlite.runner/Runner/Silverlight/TestPage.xaml.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/Silverlight/TestPage.xaml.cs
@@ -58,7 +58,7 @@ namespace NUnitLite.Runner.Silverlight
         private void ExecuteTests()
         {
             ITestResult result = runner.Run(TestListener.NULL, TestFilter.Empty);
-            ResultReporter reporter = new ResultReporter(result, writer);
+            ResultReporter reporter = new ResultReporter(result, writer, false);
 
             reporter.ReportResults();
 

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
@@ -253,7 +253,7 @@ namespace NUnitLite.Runner
             var startTime = DateTime.UtcNow;
 
             ITestResult result = _runner.Run(this, filter);
-            var reporter = new ResultReporter(result, _outWriter);
+            var reporter = new ResultReporter(result, _outWriter, _options.StopOnError);
             reporter.ReportResults();
 
             if (_options.ResultOutputSpecifications.Count > 0)
@@ -471,6 +471,9 @@ namespace NUnitLite.Runner
 
             if (options.DefaultTimeout >= 0)
                 runSettings[DriverSettings.DefaultTimeout] = options.DefaultTimeout;
+
+            if (options.StopOnError)
+                runSettings[DriverSettings.StopOnError] = true;
 
             return runSettings;
         }

--- a/src/NUnitFramework/tests/Runner/ResultReporterTests.cs
+++ b/src/NUnitFramework/tests/Runner/ResultReporterTests.cs
@@ -65,7 +65,7 @@ namespace NUnitLite.Runner.Tests
             _report = new StringBuilder();
             var writer = new ExtendedTextWriter(new StringWriter(_report));
 
-            _reporter = new ResultReporter(_result, writer);
+            _reporter = new ResultReporter(_result, writer, false);
         }
 
         [Test]


### PR DESCRIPTION
Re-implementation of the stoponerror option, which was recognized by both nunit-console and nunitlite but no longer acted upon in NUnit 3.0. Tested by observing the effect of the setting when running mock-nunit-assembly with multiple errors.