### PR TITLE
Make the NUnit v2 result writer into an addin

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -540,6 +540,7 @@
 		<!-- Addins -->
 		<EngineProjects Include="$(AddinSrcDir)\nunit-project-loader\nunit-project-loader.csproj" />
 		<EngineProjects Include="$(AddinSrcDir)\vs-project-loader\vs-project-loader.csproj" />
+		<EngineProjects Include="$(AddinSrcDir)\nunit-v2-result-writer\nunit-v2-result-writer.csproj" />
 		<!-- Addin tests -->
 		<EngineProjects Include="$(AddinSrcDir)\addin-tests\addin-tests.csproj" />
 

--- a/nunit.sln
+++ b/nunit.sln
@@ -141,6 +141,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit-project-loader", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "addin-tests", "src\NUnitEngine\Addins\addin-tests\addin-tests.csproj", "{793CEC1B-D44D-4162-BE03-913BF1FDB458}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit-v2-result-writer", "src\NUnitEngine\Addins\nunit-v2-result-writer\nunit-v2-result-writer.csproj", "{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -533,6 +535,14 @@ Global
 		{793CEC1B-D44D-4162-BE03-913BF1FDB458}.Release|Any CPU.Build.0 = Release|Any CPU
 		{793CEC1B-D44D-4162-BE03-913BF1FDB458}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{793CEC1B-D44D-4162-BE03-913BF1FDB458}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -595,6 +605,7 @@ Global
 		{96181317-7B6F-49F0-B283-6E804D41C8AF} = {B923C1E7-54DD-4E79-A1A9-B21123863B04}
 		{E71A76CA-0089-4E1A-A7FB-210429DBED6E} = {B923C1E7-54DD-4E79-A1A9-B21123863B04}
 		{793CEC1B-D44D-4162-BE03-913BF1FDB458} = {B923C1E7-54DD-4E79-A1A9-B21123863B04}
+		{AECFA3FB-E55A-4151-9DEA-F715FBB972BA} = {B923C1E7-54DD-4E79-A1A9-B21123863B04}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\NUnitFramework\tests\nunitlite.tests-2.0.csproj

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2ResultSummary.cs
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2ResultSummary.cs
@@ -24,11 +24,10 @@
 using System;
 using System.Globalization;
 using System.Xml;
+using NUnit.Common;
 
-namespace NUnit.Engine.Services.ResultWriters
+namespace NUnit.Engine.Addins
 {
-    using Internal;
-
     /// <summary>
     /// NUnit2ResultSummary summarizes test results as used in the NUnit2 XML format.
     /// </summary>

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2ResultWriterFactory.cs
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2ResultWriterFactory.cs
@@ -1,0 +1,39 @@
+﻿// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Engine.Addins
+{
+    class NUnit2ResultWriterFactory : IResultWriterFactory
+    {
+        public string Format { get { return "nunit2";  } }
+
+        public IResultWriter GetResultWriter(params object[] args)
+        {
+            return new NUnit2XmlResultWriter();
+        }
+    }
+}

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2XmlResultWriter.cs
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/NUnit2XmlResultWriter.cs
@@ -27,11 +27,10 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.IO;
+using NUnit.Common;
 
-namespace NUnit.Engine.Services.ResultWriters
+namespace NUnit.Engine.Addins
 {
-    using Internal;
-
     public class NUnit2XmlResultWriter : IResultWriter
     {
         private XmlWriter xmlWriter;

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("nunit2-result-writer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("nunit2-result-writer")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("40b00727-cab1-46fc-85eb-9f62f32b93bb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.addin.xml
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.addin.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Addin>
+	<Runtime>
+		<Import assembly="nunit-v2-result-writer.dll"/>
+	</Runtime>
+
+	<Dependencies>
+		<Addin id="NUnit.Engine" version="1.0"/>
+	</Dependencies>
+
+	<Extension path="/NUnit/Engine/TypeExtensions/IResultWriterFactory">
+		<Type type="NUnit.Engine.Addins.NUnit2ResultWriterFactory"/>
+	</Extension>
+</Addin>

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AECFA3FB-E55A-4151-9DEA-F715FBB972BA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NUnit.Engine.Addins</RootNamespace>
+    <AssemblyName>nunit-v2-result-writer</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\bin\Debug\addins\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\bin\Release\addins\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\Common\nunit\XmlHelper.cs">
+      <Link>XmlHelper.cs</Link>
+    </Compile>
+    <Compile Include="NUnit2ResultSummary.cs" />
+    <Compile Include="NUnit2ResultWriterFactory.cs" />
+    <Compile Include="NUnit2XmlResultWriter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
+      <Project>{775fad50-3623-4922-97c4-dfb29a8be4c7}</Project>
+      <Name>nunit.engine.api</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="nunit-v2-result-writer.addin.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NUnitEngine/nunit.engine.api/IResultWriterFactory.cs
+++ b/src/NUnitEngine/nunit.engine.api/IResultWriterFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// Interface implemented by objects that can create an IResultWriter for a given format.
+    /// </summary>
+    public interface IResultWriterFactory
+    {
+        /// <summary>
+        /// Gets the supported format
+        /// </summary>
+        string Format { get; }
+
+        /// <summary>
+        /// Creates an IResultWriter using the args provided
+        /// </summary>
+        IResultWriter GetResultWriter(object[] args);
+    }
+}

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -59,6 +59,7 @@
     <Compile Include="IProjectLoader.cs" />
     <Compile Include="IResultWriter.cs" />
     <Compile Include="IResultService.cs" />
+    <Compile Include="IResultWriterFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IFrameworkDriver.cs" />
     <Compile Include="ILogging.cs" />

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -32,12 +32,13 @@ namespace NUnit.Engine.Services.Tests
 
     public class ResultServiceTests
     {
-        private IResultService _resultService;
+        private ResultService _resultService;
 
         [SetUp]
         public void CreateService()
         {
             _resultService = new ResultService();
+            _resultService.InitializeService();
         }
 
         [Test]
@@ -46,16 +47,16 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "nunit2", "cases", "user" }));
         }
 
-        [TestCase("nunit3", null, ExpectedResult = typeof(NUnit3XmlResultWriter))]
-        [TestCase("nunit2", null, ExpectedResult = typeof(NUnit2XmlResultWriter))]
-        [TestCase("cases", null, ExpectedResult = typeof(TestCaseResultWriter))]
-        [TestCase("user", new object[] { "TextSummary.xslt" }, ExpectedResult = typeof(XmlTransformResultWriter))]
-        public Type CanGetWriter(string format, object[] args)
+        [TestCase("nunit3", null, ExpectedResult = "NUnit3XmlResultWriter")]
+        [TestCase("nunit2", null, ExpectedResult = "NUnit2XmlResultWriter")]
+        [TestCase("cases", null, ExpectedResult = "TestCaseResultWriter")]
+        [TestCase("user", new object[] { "TextSummary.xslt" }, ExpectedResult = "XmlTransformResultWriter")]
+        public string CanGetWriter(string format, object[] args)
         {
             var writer = _resultService.GetResultWriter(format, args);
 
             Assert.NotNull(writer);
-            return writer.GetType();
+            return writer.GetType().Name;
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
@@ -42,9 +42,11 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
         public void ConvertEngineResultToXml()
         {
             StringBuilder sb = new StringBuilder();
+            ResultService service = new ResultService();
+            service.InitializeService();
             using (StringWriter writer = new StringWriter(sb))
             {
-                new NUnit2XmlResultWriter().WriteResultFile(EngineResult.Xml, writer);
+                service.GetResultWriter("nunit2", null).WriteResultFile(EngineResult.Xml, writer);
             }
 
             doc = new XmlDocument();

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlValidationTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlValidationTests.cs
@@ -65,7 +65,9 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
         {
             StringBuilder output = new StringBuilder();
 
-            new NUnit2XmlResultWriter().WriteResultFile(this.EngineResult.Xml, new StringWriter(output));
+            ResultService service = new ResultService();
+            service.InitializeService();
+            service.GetResultWriter("nunit2", null).WriteResultFile(this.EngineResult.Xml, new StringWriter(output));
 
             if (!validator.Validate(new StringReader(output.ToString())))
             {

--- a/src/NUnitEngine/nunit.engine/nunit.engine.addin.xml
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.addin.xml
@@ -23,8 +23,8 @@
 		<ExtensionNode objectType="NUnit.Engine.IProjectLoader"/>
 	</ExtensionPoint>
 
-	<ExtensionPoint path="/NUnit/Engine/TypeExtensions/IResultWriter">
-		<ExtensionNode objectType="NUnit.Engine.IResultWriter"/>
+	<ExtensionPoint path="/NUnit/Engine/TypeExtensions/IResultWriterFactory">
+		<ExtensionNode objectType="NUnit.Engine.IResultWriterFactory"/>
 	</ExtensionPoint>
 
 	<ExtensionPoint path="/NUnit/Engine/TypeExtensions/IFrameworkDriver">

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -105,9 +105,7 @@
     <Compile Include="Runners\MultipleTestProcessRunner.cs" />
     <Compile Include="Runners\ProcessRunner.cs" />
     <Compile Include="Runners\TestDomainRunner.cs" />
-    <Compile Include="Services\ResultWriters\NUnit2XmlResultWriter.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />
-    <Compile Include="Services\ResultWriters\NUnit2ResultSummary.cs" />
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />
     <Compile Include="Services\ResultWriters\XmlTransformResultWriter.cs" />
     <Compile Include="Services\ResultService.cs" />


### PR DESCRIPTION
This PR fixes #370, making the NUnit V2 Xml output writer into an addin.

In this case, rather than isolating the tests, I kept them in the main engine tests and modified them to use the ResultService and thus the addin. That's because the tests have a reference to the engine, which can't be removed without significant rewriting.

As a consequence, these tests demonstrate that the addin actually works as an addin, something that our isolated addin tests don't do. We should probably add similar tests of other addins that we build ourselves.

Note: Like the previous addins I created, this one is always loaded. It would be desireable to defer loading of this one until it is actually needed, since many runs will not require v2 output. That will be done at a later stage.