### PR TITLE
Truncate string arguments in test names in order to limit the length

### DIFF
--- a/src/NUnitFramework/framework/Internal/MethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodHelper.cs
@@ -32,6 +32,10 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class MethodHelper
     {
+        private const int STRING_MAX = 20;
+        private const int STRING_LIMIT = STRING_MAX - 3;
+        private const string THREE_DOTS = "...";
+
         /// <summary>
         /// Gets the display name for a method as used by NUnit.
         /// </summary>
@@ -150,10 +154,20 @@ namespace NUnit.Framework.Internal
             }
             else if (arg is string)
             {
+                var str = (string)arg;
+                bool tooLong = str.Length > STRING_MAX;
+
                 StringBuilder sb = new StringBuilder();
                 sb.Append("\"");
                 foreach (char c in (string)arg)
+                {
                     sb.Append(EscapeControlChar(c));
+                    if (tooLong && sb.Length >= STRING_LIMIT)
+                    {
+                        sb.Append(THREE_DOTS);
+                        break;
+                    }
+                }
                 sb.Append("\"");
                 display = sb.ToString();
             }

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -118,7 +118,12 @@ namespace NUnit.Framework.Internal
                 else if (arg is decimal) display += "m";
                 else if (arg is long) display += "L";
                 else if (arg is ulong) display += "UL";
-                else if (arg is string) display = "\"" + display + "\"";
+                else if (arg is string)
+                {
+                    if (display.Length > 20)
+                        display = display.Substring(0, 17) + "...";
+                    display = "\"" + display + "\"";
+                }
 
                 sb.Append(display);
             }

--- a/src/NUnitFramework/tests/Internal/TestNamingTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNamingTests.cs
@@ -1,0 +1,119 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Reflection;
+
+namespace NUnit.Framework.Internal.Tests
+{
+    public abstract class TestNamingTests
+    {
+        protected const string OUTER_CLASS = "NUnit.Framework.Internal.Tests.TestNamingTests";
+
+        protected abstract string FixtureName { get; }
+
+        protected TestContext.TestAdapter CurrentTest
+        {
+            get { return TestContext.CurrentContext.Test; }
+        }
+
+        [Test]
+        public void SimpleTest()
+        {
+            CheckNames(MethodInfo.GetCurrentMethod().Name);
+        }
+
+        [TestCase(5, 7, "ABC")]
+        public void ParameterizedTest(int x, int y, string s)
+        {
+            CheckNames(MethodInfo.GetCurrentMethod().Name + "(5,7,\"ABC\")");
+        }
+
+        [TestCase("abcdefghijklmnopqrstuvwxyz")]
+        public void TestCaseWithLongStringArgument(string s)
+        {
+            CheckNames(MethodInfo.GetCurrentMethod().Name + "(\"abcdefghijklmnop...\")");
+        }
+
+        [TestCase(42)]
+        public void GenericTest<T>(T arg)
+        {
+            CheckNames("GenericTest<Int32>(42)");
+        }
+
+        private void CheckNames(string expectedName)
+        {
+            Assert.That(CurrentTest.Name, Is.EqualTo(expectedName));
+            Assert.That(CurrentTest.FullName, Is.EqualTo(OUTER_CLASS + "+" + FixtureName + "." + expectedName));
+        }
+
+        public class SimpleFixture : TestNamingTests
+        {
+            protected override string FixtureName
+            {
+                get { return "SimpleFixture"; }
+            }
+        }
+
+        [TestFixture(typeof(int))]
+        public class GenericFixture<T> : TestNamingTests
+        {
+            protected override string FixtureName
+            {
+                get { return "GenericFixture<Int32>"; }
+            }
+        }
+
+        [TestFixture(42, "Forty-two")]
+        public class ParameterizedFixture : TestNamingTests
+        {
+            public ParameterizedFixture(int x, string s) { }
+
+            protected override string FixtureName
+            {
+                get { return "ParameterizedFixture(42,\"Forty-two\")"; }
+            }
+        }
+
+        [TestFixture("This is really much too long to be used in the test name!")]
+        public class ParameterizedFixtureWithLongStringArgument : TestNamingTests
+        {
+            public ParameterizedFixtureWithLongStringArgument(string s) { }
+
+            protected override string FixtureName
+            {
+                get { return "ParameterizedFixtureWithLongStringArgument(\"This is really mu...\")"; }
+            }
+        }
+
+        [TestFixture(typeof(int), typeof(string), 42, "Forty-two")]
+        public class GenericParameterizedFixture<T1,T2> : TestNamingTests
+        {
+            public GenericParameterizedFixture(T1 x, T2 y) { }
+
+            protected override string FixtureName
+            {
+                get { return "GenericParameterizedFixture<Int32,String>(42,\"Forty-two\")"; }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
+    <Compile Include="Internal\TestNamingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />
     <Compile Include="Assertions\ArrayEqualsFixture.cs" />


### PR DESCRIPTION
This is a partial fix for issue #59. Truncating string arguments to test cases and fixture constructors will eliminate the major cause of name overflows that have been troubling us. We can keep the issue open for a while to see if further changes are needed.

The code in MethodHelper and TypeHelper, which deal with generating names for test cases and fixtures respectively, could be combined but I haven't done it here.