### PR TITLE
fix issue #488 for async setup and teardown

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -27,6 +27,10 @@ using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 
+#if NET_4_0 || NET_4_5
+using System.Threading.Tasks;
+#endif
+
 namespace NUnit.Framework.Internal
 {
     /// <summary>
@@ -237,7 +241,12 @@ namespace NUnit.Framework.Internal
                 if (method.IsAbstract ||
                      !method.IsPublic && !method.IsFamily ||
                      method.GetParameters().Length > 0 ||
-                     !method.ReturnType.Equals(typeof(void)))
+                     method.ReturnType != typeof(void) 
+#if NET_4_0 || NET_4_5
+                     &&
+                     method.ReturnType != typeof(Task)
+#endif
+                    )
                 {
                     this.Properties.Set(
                         PropertyNames.SkipReason,

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -1,3 +1,4 @@
+#if NET_4_0 || NET_4_5
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -84,3 +85,4 @@ namespace NUnit.Framework.Internal
         }
     }
 }
+#endif

--- a/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
@@ -1,0 +1,49 @@
+#if NET_4_0 || NET_4_5
+using System.Threading.Tasks;
+
+namespace NUnit.Framework.Internal
+{
+    public class RealAsyncSetupTeardownTests
+    {
+        private object _initializedOnce;
+        private object _initializedEveryTime;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetup()
+        {
+            _initializedOnce = new object();
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            Assume.That(_initializedOnce, Is.Not.Null);
+            _initializedEveryTime = new object();
+        }
+
+
+        [Test]
+        public void TestCurrentFixtureInitialization()
+        {
+            Assert.That(_initializedOnce, Is.Not.Null);
+            Assert.That(_initializedEveryTime, Is.Not.Null);
+
+            _initializedEveryTime = null;
+        }
+
+        [TearDown]
+        public async Task TearDown()
+        {
+            Assume.That(_initializedEveryTime, Is.Null);
+            _initializedOnce = null;
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDown()
+        {
+            Assume.That(_initializedOnce, Is.Null);
+        }
+
+    }
+}
+#endif

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -61,8 +61,10 @@
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
+    <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
@@ -182,6 +183,7 @@
     <Compile Include="Internal\PropertyBagTests.cs" />
     <Compile Include="Internal\RandomGeneratorTests.cs" />
     <Compile Include="Internal\RandomizerTests.cs" />
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\RuntimeFrameworkTests.cs" />
     <Compile Include="Internal\SetUpFixtureTests.cs" />
     <Compile Include="Internal\SetUpTearDownTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Internal\PropertyBagTests.cs" />
     <Compile Include="Internal\RandomGeneratorTests.cs" />
     <Compile Include="Internal\RandomizerTests.cs" />
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\RuntimeFrameworkTests.cs" />
     <Compile Include="Internal\SetUpFixtureTests.cs" />
     <Compile Include="Internal\SetUpTearDownTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
@@ -224,6 +225,7 @@
     <Compile Include="Internal\RandomizerTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\RuntimeFrameworkTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
@@ -218,6 +219,7 @@
     <Compile Include="Internal\RandomizerTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\RuntimeFrameworkTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Support for async setup and teardown was not actually complete as there was a check still in place which prevented non-void methods to be used for this purpose and marked tests as invalid.

I've put an e2e test in place to verify that all setup and teardown methods support asynchronous execution and their behavior is as intended.