### PR TITLE
Fix nunitlite to recognize file paths as well as assemblynames

### DIFF
--- a/src/Common/nunit/AssemblyHelper.cs
+++ b/src/Common/nunit/AssemblyHelper.cs
@@ -108,6 +108,37 @@ namespace NUnit.Common
 
         #endregion
 
+        #region Load
+
+        /// <summary>
+        /// Loads an assembly given a string, which may be the 
+        /// path to the assembly or the AssemblyName
+        /// </summary>
+        /// <param name="nameOrPath"></param>
+        /// <returns></returns>
+        public static Assembly Load(string nameOrPath)
+        {
+#if !SILVERLIGHT && !PORTABLE
+            var ext = Path.GetExtension(nameOrPath).ToLower();
+
+            // It's a path to an assembly, get the AssemblyName and load it
+            if (ext == ".dll" || ext == ".exe")
+            {
+#if NETCF
+                return Assembly.LoadFrom(nameOrPath);
+#else
+                var assemblyRef = AssemblyName.GetAssemblyName(nameOrPath);
+                return Assembly.Load(assemblyRef);
+#endif
+            }
+#endif
+
+            // Assume it's the string representation of an AssemblyName
+            return Assembly.Load(nameOrPath);
+        }
+
+        #endregion
+
         #region Helper Methods
 
 #if !NETCF && !SILVERLIGHT && !PORTABLE

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Api
 
             try
             {
-                var assembly = Load(assemblyName);
+                var assembly = AssemblyHelper.Load(assemblyName);
                 testAssembly = Build(assembly, assemblyName, options);
             }
             catch(Exception ex)
@@ -145,27 +145,6 @@ namespace NUnit.Framework.Api
         #endregion
 
         #region Helper Methods
-
-        private Assembly Load(string path)
-        {
-#if NETCF
-            return Assembly.LoadFrom(path);
-#elif SILVERLIGHT || PORTABLE
-            return Assembly.Load(path);
-#else
-            Assembly assembly = null;
-
-            // Throws if this isn't a managed assembly or if it was built
-            // with a later version of the same assembly. 
-            AssemblyName assemblyName = AssemblyName.GetAssemblyName(path);
-
-            assembly = Assembly.Load(assemblyName);
-
-            log.Info("Loaded assembly " + assembly.FullName);
-
-            return assembly;
-#endif
-        }
 
         private IList GetFixtures(Assembly assembly, IList names)
         {

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
@@ -109,6 +109,8 @@ namespace NUnitLite.Runner
         #endregion
 
         #region Public Methods
+
+#if !SILVERLIGHT
         /// <summary>
         /// Execute a test run based on the aruments passed
         /// from Main.
@@ -127,7 +129,6 @@ namespace NUnitLite.Runner
             else if (!Directory.Exists(_workDirectory))
                 Directory.CreateDirectory(_workDirectory);
 
-#if !SILVERLIGHT
 #if !NETCF
             if (_options.TeamCity)
                 _teamCity = new TeamCityEventListener();
@@ -145,7 +146,7 @@ namespace NUnitLite.Runner
                 _errWriter = new StreamWriter(Path.Combine(_workDirectory, _options.ErrFile));
                 Console.SetError(_errWriter);
             }
-#endif
+
             if (_options.NoColor)
                 ColorConsole.Enabled = false;
 
@@ -194,12 +195,8 @@ namespace NUnitLite.Runner
 
             try
             {
-                foreach (string name in _options.InputFiles)
-#if NETCF
-                    _assemblies.Add(name.IndexOf(',') != -1 || (name.IndexOf('\\') == -1 && !Path.HasExtension(name)) ? Assembly.Load(name) : Assembly.LoadFrom(name));
-#else
-                    _assemblies.Add(Assembly.Load(name));
-#endif
+                foreach (string nameOrPath in _options.InputFiles)
+                    _assemblies.Add(AssemblyHelper.Load(nameOrPath));
 
                 if (_assemblies.Count == 0)
                     _assemblies.Add(callingAssembly);
@@ -243,11 +240,13 @@ namespace NUnitLite.Runner
                     _errWriter.Close();
             }
         }
+#endif
 
         #endregion
 
         #region Helper Methods
 
+#if !SILVERLIGHT
         private int RunTests(ITestFilter filter)
         {
             var startTime = DateTime.UtcNow;
@@ -291,11 +290,8 @@ namespace NUnitLite.Runner
         {
             if (traceLevel != InternalTraceLevel.Off)
             {
-#if !SILVERLIGHT
                 var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
-#else
-                var logName = string.Format(LOG_FILE_FORMAT, DateTime.Now.ToString("o"), Path.GetFileName(assemblyPath));
-#endif
+
 #if NETCF // NETCF: Try to encapsulate this
                 InternalTrace.Initialize(Path.Combine(NUnit.Env.DocumentFolder, logName), traceLevel);
 #else
@@ -310,6 +306,7 @@ namespace NUnitLite.Runner
 #endif
             }
         }
+#endif
 
         /// <summary>
         /// Writes the header.
@@ -342,10 +339,11 @@ namespace NUnitLite.Runner
             writer.WriteLine();
         }
 
+#if !SILVERLIGHT
         private void WriteHelpText()
         {
-            // TODO: The Silverlight code is just a placeholder. Figure out how to do it correctly.
-#if SILVERLIGHT || NETCF
+            // TODO: The NETCF code is just a placeholder. Figure out how to do it correctly.
+#if NETCF
             const string name = "NUNITLITE";
 #else
             string name = Assembly.GetEntryAssembly().GetName().Name.ToUpper();
@@ -442,6 +440,7 @@ namespace NUnitLite.Runner
                 writer.WriteLine();
             }
         }
+#endif
 
         /// <summary>
         /// Writes the runtime environment.
@@ -455,6 +454,7 @@ namespace NUnitLite.Runner
             writer.WriteLine();
         }
 
+#if !SILVERLIGHT
         /// <summary>
         /// Make the settings for this run - this is public for testing
         /// </summary>
@@ -509,6 +509,7 @@ namespace NUnitLite.Runner
                     ? namefilter
                     : new AndFilter(namefilter, catFilter);
         }
+#endif
 
         #endregion
 

--- a/src/NUnitFramework/tests/Runner/CreateTestFilterTests.cs
+++ b/src/NUnitFramework/tests/Runner/CreateTestFilterTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !SILVERLIGHT
 using NUnit.Common;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -132,7 +133,6 @@ namespace NUnitLite.Runner.Tests
                 Is.EqualTo(new string[] { "Slow" }));
         }
 
-#if !SILVERLIGHT
         [Test]
         public void ThreeTestsFromATestListFile()
         {
@@ -157,7 +157,6 @@ namespace NUnitLite.Runner.Tests
                     Is.EqualTo(new string[] { "My.First.Test", "My.Second.Test", "My.Third.Test", "My.Fourth.Test", "My.Fifth.Test", "My.Sixth.Test"}));
             }
         }
-#endif
 
         [Test]
         public void TestListFileMissing()
@@ -175,3 +174,4 @@ namespace NUnitLite.Runner.Tests
         }
     }
 }
+#endif

--- a/src/NUnitFramework/tests/Runner/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/tests/Runner/MakeRunSettingsTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !SILVERLIGHT
 using System.IO;
 using NUnit.Common;
 using NUnit.Framework;
@@ -60,3 +61,4 @@ namespace NUnitLite.Runner.Tests
         }
     }
 }
+#endif


### PR DESCRIPTION
This fixes #487. NUnitLite now can open file paths. I moved the logic for loadiing assemblies into AssemblyHelper, so that we can use our standard pattern more readily when we load assemblies.

I looked briefly at adding the ability to use AssemblyNames rather than paths on the nunit-console command-line, but that's a bit more complicated, so I left it as is.

I also wrapped a lot of code in the nunitlite runner in conditions so it isn't included in the Silverlight build. Really, the runner needs refactoring so that we separate the common code more cleanly from both the text ui and the silverlight display. That's for another pull, however.