### PR TITLE
Added SL5.0 and Portable to the Add References dialog

### DIFF
--- a/install/framework/nunit-framework.wxs
+++ b/install/framework/nunit-framework.wxs
@@ -190,7 +190,12 @@
                       Source="$(var.BuildDir)portable\nunit.framework.xml" 
                       CompanionFile="nunit.framework.portable.dll" />
             </Component>
-            <!-- What is the AssemblyFoldersEx for Portable? -->
+            <!-- What is the AssemblyFoldersEx for Portable? For now, I am putting this under .NET 4.5 since the portable is valid for that -->
+            <Component Id="AssemblyReferenceFolderPortable">
+                <RegistryKey Root="HKMU" Key="Software\Microsoft\.NETFramework\v4.5\AssemblyFoldersEx\NUnit [ProductVersion] Portable" >
+                    <RegistryValue Action="write" Type="string" Value="[PORTABLE]" />
+                </RegistryKey>
+            </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="SL50" Directory="SL50">
@@ -208,7 +213,11 @@
                       ProcessorArchitecture="msil" 
                       Source="$(var.BuildDir)sl-5.0\nunitlite.dll" />
             </Component>
-            <!-- What is the AssemblyFoldersEx for SilverLight? -->
+            <Component Id="AssemblyReferenceFolderSL50">
+                <RegistryKey Root="HKMU" Key="Software\Microsoft\Microsoft SDKs\Silverlight\v5.0\AssemblyFoldersEx\NUnit [ProductVersion]" >
+                    <RegistryValue Action="write" Type="string" Value="[SL50]" />
+                </RegistryKey>
+            </Component>
         </ComponentGroup>
         
         


### PR DESCRIPTION
This is a partial fix (or possibly full?) for #497. @CharliePoole found the registry entries for SL50 and I added the portable library to the .NET 4.5 registry key for now since it is fully supported under 4.5 and it now appears in the add references for portable projects.

Under a Silverlight project,

![2015-02-08 11_56_43-reference manager - nunit-silverlight](https://cloud.githubusercontent.com/assets/493828/6097383/4d084824-af8a-11e4-92b6-747c14bd25f3.png)

And under a portable project,

![2015-02-08 11_57_51-reference manager - nunit-portable](https://cloud.githubusercontent.com/assets/493828/6097384/551b3d28-af8a-11e4-920e-51976e1b9372.png)
