### PR TITLE
Expected exception

### DIFF
--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework
     /// Summary description for MaxTimeAttribute.
     /// </summary>
     [AttributeUsage( AttributeTargets.Method, AllowMultiple=false, Inherited=false )]
-    public sealed class MaxTimeAttribute : PropertyAttribute, ICommandDecorator
+    public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown
     {
         private int _milliseconds;
         /// <summary>
@@ -45,9 +45,9 @@ namespace NUnit.Framework
             _milliseconds = milliseconds;
         }
 
-        #region ICommandDecorator Members
+        #region ICommandWrapper Members
 
-        TestCommand ICommandDecorator.Decorate(TestCommand command)
+        TestCommand ICommandWrapper.Wrap(TestCommand command)
         {
             return new MaxTimeCommand(command, _milliseconds);
         }

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -24,6 +24,7 @@
 #if !SILVERLIGHT && !PORTABLE
 using System;
 using System.Threading;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -23,6 +23,7 @@
 
 #if !NETCF
 using System;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -23,6 +23,7 @@
 
 #if !NETCF
 using System;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework

--- a/src/NUnitFramework/framework/Interfaces/IApplyToContext.cs
+++ b/src/NUnitFramework/framework/Interfaces/IApplyToContext.cs
@@ -21,7 +21,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Framework.Internal
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Interfaces
 {
     /// <summary>
     /// The IApplyToContext interface is implemented by attributes

--- a/src/NUnitFramework/framework/Interfaces/IApplyToTest.cs
+++ b/src/NUnitFramework/framework/Interfaces/IApplyToTest.cs
@@ -22,8 +22,9 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Internal;
 
-namespace NUnit.Framework.Internal
+namespace NUnit.Framework.Interfaces
 {
     /// <summary>
     /// The IApplyToTest interface is implemented by self-applying

--- a/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
+++ b/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
+++ b/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
@@ -28,18 +28,39 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework.Interfaces
 {
     /// <summary>
-    /// ICommandDecorator is implemented by attributes and other
-    /// objects able to decorate a TestCommand, usually by wrapping
-    /// it with an outer command.
+    /// ICommandWrapper is implemented by attributes and other
+    /// objects able to wrap a TestCommand with another command.
     /// </summary>
-    public interface ICommandDecorator
+    /// <remarks>
+    /// Attributes or other objects should implement one of the
+    /// derived interfaces, rather than this one, since they
+    /// indicate in which part of the command chain the wrapper
+    /// should be applied.
+    /// </remarks>
+    public interface ICommandWrapper
     {
         /// <summary>
-        /// Decorate a command, usually by wrapping it with another
-        /// command, and return the decorated command.
+        /// Wrap a command and return the result.
         /// </summary>
-        /// <param name="command">The command to be decorated</param>
-        /// <returns>The decorated command</returns>
-        TestCommand Decorate(TestCommand command);
+        /// <param name="command">The command to be wrapped</param>
+        /// <returns>The wrapped command</returns>
+        TestCommand Wrap(TestCommand command);
+    }
+
+    /// <summary>
+    /// Objects implementing this interface are used to wrap
+    /// the TestMethodCommand itself. They apply after SetUp
+    /// has been run and before TearDown.
+    /// </summary>
+    public interface IWrapTestMethod : ICommandWrapper
+    {
+    }
+
+    /// <summary>
+    /// Objects implementing this interface are used to wrap
+    /// the entire test, including SetUp and TearDown.
+    /// </summary>
+    public interface IWrapSetUpTearDown : ICommandWrapper
+    {
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
@@ -23,6 +23,8 @@
 
 using System;
 using System.Threading;
+using NUnit.Framework.Interfaces;
+
 namespace NUnit.Framework.Internal.Commands
 {
     /// <summary>

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -189,8 +189,8 @@
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcher.cs" />
     <Compile Include="Internal\Execution\WorkItemQueue.cs" />
     <Compile Include="Internal\Execution\WorkItemState.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\RandomGenerator.cs" />
     <Compile Include="Internal\StackFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -348,7 +348,7 @@
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\Commands\CommandStage.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Internal\CultureDetector.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Internal\ExceptionHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -273,7 +273,7 @@
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -272,6 +272,8 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
@@ -347,8 +349,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -268,6 +268,8 @@
     <Compile Include="Exceptions\InconclusiveException.cs" />
     <Compile Include="Exceptions\ResultStateException.cs" />
     <Compile Include="Exceptions\SuccessException.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
@@ -346,8 +348,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -269,7 +269,7 @@
     <Compile Include="Exceptions\ResultStateException.cs" />
     <Compile Include="Exceptions\SuccessException.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -275,7 +275,7 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -275,6 +275,8 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
@@ -350,8 +352,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -285,8 +285,10 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
@@ -360,8 +362,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -269,6 +269,8 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
@@ -344,8 +346,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -270,7 +270,7 @@
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -284,6 +284,8 @@
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
+    <Compile Include="Interfaces\IApplyToContext.cs" />
+    <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
@@ -359,8 +361,6 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
-    <Compile Include="Internal\IApplyToContext.cs" />
-    <Compile Include="Internal\IApplyToTest.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -285,7 +285,7 @@
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
-    <Compile Include="Interfaces\ICommandDecorator.cs" />
+    <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Globalization;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Attributes

--- a/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
@@ -1,0 +1,133 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Attributes.Tests
+{
+    public class CommandWrapperTests
+    {
+        [Test]
+        public void CorrectExceptionThrown()
+        {
+            var result = TestBuilder.RunTestCase(this, "ThrowsCorrectException");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+        }
+
+        [ExpectedException(typeof(NullReferenceException))]
+        public void ThrowsCorrectException()
+        {
+            throw new NullReferenceException();
+        }
+
+        [Test]
+        public void NoExceptionThrown()
+        {
+            var result = TestBuilder.RunTestCase(this, "ThrowsNoException");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+            Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but no exception was thrown"));
+        }
+
+        [ExpectedException(typeof(NullReferenceException))]
+        public void ThrowsNoException()
+        {
+        }
+
+        [Test]
+        public void WrongExceptionThrown()
+        {
+            var result = TestBuilder.RunTestCase(this, "ThrowsWrongException");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+            Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but got Exception"));
+        }
+
+        [ExpectedException(typeof(NullReferenceException))]
+        public void ThrowsWrongException()
+        {
+            throw new Exception();
+        }
+
+        /// <summary>
+        /// Extremely simple ExpectedException implementation for use in the test
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+        private class ExpectedExceptionAttribute : NUnitAttribute, IWrapTestMethod
+        {
+            private Type _expectedExceptionType;
+
+            public ExpectedExceptionAttribute(Type type)
+            {
+                _expectedExceptionType = type;
+            }
+
+            public TestCommand Wrap(TestCommand command)
+            {
+                return new ExpectedExceptionCommand(command, _expectedExceptionType);
+            }
+
+            private class ExpectedExceptionCommand : DelegatingTestCommand
+            {
+                private Type _expectedType;
+
+                public ExpectedExceptionCommand(TestCommand innerCommand, Type expectedType)
+                    : base(innerCommand)
+                {
+                    _expectedType = expectedType;
+                }
+
+                public override TestResult Execute(TestExecutionContext context)
+                {
+                    Type caughtType = null;
+
+                    try
+                    {
+                        innerCommand.Execute(context);
+                    }
+                    catch(Exception ex)
+                    {
+                        if (ex is NUnitException)
+                            ex = ex.InnerException;
+                        caughtType = ex.GetType();
+                    }
+
+                    if (caughtType == _expectedType)
+                        context.CurrentResult.SetResult(ResultState.Success);
+                    else if (caughtType != null)
+                        context.CurrentResult.SetResult(ResultState.Failure,
+                            string.Format("Expected {0} but got {1}", _expectedType.Name, caughtType.Name));
+                    else
+                        context.CurrentResult.SetResult(ResultState.Failure,
+                            string.Format("Expected {0} but no exception was thrown", _expectedType.Name));
+                    
+                    return context.CurrentResult;
+}
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Attributes\AuthorTests.cs" />
     <Compile Include="Attributes\CategoryAttributeTests.cs" />
     <Compile Include="Attributes\CombinatorialTests.cs" />
+    <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\DatapointTests.cs" />
     <Compile Include="Attributes\DerivedPropertyAttributeTests.cs" />
     <Compile Include="Attributes\DescriptionTests.cs" />


### PR DESCRIPTION
Contrary to the name of the branch, this doesn't actually put expected exception back into NUnit. :-)

It does refactor the command structure so that it's now possible to implement EE, and any other attributes that need to run immediately before and after the test method. A highly simplistic variant of EEAttribute is actually created in the tests in order to validate the new structure.

ICommandDecorator is now renamed to ICommandWrapper, which may be a bit clearer. This interface should no longer be implemented directly by attributes, since the test case builder doesn't look for it. Rather, one of the two derived interfaces ITestMethodWrapper and ISetUpTearDownWrapper should be implemented, depending on where the wrapper should be applied. The test EEAttribute implements ITestMethodWrapper while the (existing) MaxtimeAttributre implements ISetUpTearDownWrapper.