### PR TITLE
Experiment with generic EqualConstraint

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -112,7 +112,7 @@ namespace NUnit.Engine.Services.Tests
                 Path.GetFileName( setup.ConfigurationFile ),
                 Is.EqualTo("mock-nunit-assembly.exe.config").IgnoreCase,
                 "ConfigurationFile");
-            Assert.AreEqual( null, setup.PrivateBinPath, "PrivateBinPath" );
+            Assert.IsNull(setup.PrivateBinPath, "PrivateBinPath" );
             Assert.That(setup.ShadowCopyDirectories, Is.SamePath(Path.GetDirectoryName(mockDll)), "ShadowCopyDirectories" );
         }
 

--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -98,6 +98,38 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region strings
+
+        /// <summary>
+        /// Verifies that two strings are equal.  Two objects are considered
+        /// equal if both are null, or if both have the same value. NUnit
+        /// has special semantics for some object types.
+        /// If they are not equal an <see cref="AssertionException"/> is thrown.
+        /// </summary>
+        /// <param name="expected">The value that is expected</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">The message to display in case of failure</param>
+        /// <param name="args">Array of objects to be used in formatting the message</param>
+        public static void AreEqual(string expected, string actual, string message, params object[] args)
+        {
+            Assert.That(actual, Is.EqualTo(expected), message, args);
+        }
+
+        /// <summary>
+        /// Verifies that two objects are equal.  Two objects are considered
+        /// equal if both are null, or if both have the same value. NUnit
+        /// has special semantics for some object types.
+        /// If they are not equal an <see cref="AssertionException"/> is thrown.
+        /// </summary>
+        /// <param name="expected">The value that is expected</param>
+        /// <param name="actual">The actual value</param>
+        public static void AreEqual(string expected, string actual)
+        {
+            Assert.That(actual, Is.EqualTo(expected), null, null);
+        }
+
+        #endregion
+
         #region Objects
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -98,10 +98,10 @@ namespace NUnit.Framework
 
         #endregion
 
-        #region strings
+        #region Generic
 
         /// <summary>
-        /// Verifies that two strings are equal.  Two objects are considered
+        /// Verifies that two objects are equal.  Two objects are considered
         /// equal if both are null, or if both have the same value. NUnit
         /// has special semantics for some object types.
         /// If they are not equal an <see cref="AssertionException"/> is thrown.
@@ -110,7 +110,7 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(string expected, string actual, string message, params object[] args)
+        public static void AreEqual<TExpected, TActual>(TExpected expected, TActual actual, string message, params object[] args)
         {
             Assert.That(actual, Is.EqualTo(expected), message, args);
         }
@@ -123,39 +123,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
-        public static void AreEqual(string expected, string actual)
-        {
-            Assert.That(actual, Is.EqualTo(expected), null, null);
-        }
-
-        #endregion
-
-        #region Objects
-
-        /// <summary>
-        /// Verifies that two objects are equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are not equal an <see cref="AssertionException"/> is thrown.
-        /// </summary>
-        /// <param name="expected">The value that is expected</param>
-        /// <param name="actual">The actual value</param>
-        /// <param name="message">The message to display in case of failure</param>
-        /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(object expected, object actual, string message, params object[] args)
-        {
-            Assert.That(actual, Is.EqualTo(expected), message, args);
-        }
-
-        /// <summary>
-        /// Verifies that two objects are equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are not equal an <see cref="AssertionException"/> is thrown.
-        /// </summary>
-        /// <param name="expected">The value that is expected</param>
-        /// <param name="actual">The actual value</param>
-        public static void AreEqual(object expected, object actual)
+        public static void AreEqual<TExpected, TActual>(TExpected expected, TActual actual)
         {
             Assert.That(actual, Is.EqualTo(expected), null, null);
         }
@@ -165,8 +133,6 @@ namespace NUnit.Framework
         #endregion
 
         #region AreNotEqual
-
-        #region Objects
 
         /// <summary>
         /// Verifies that two objects are not equal.  Two objects are considered
@@ -178,7 +144,7 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreNotEqual(object expected, object actual, string message, params object[] args)
+        public static void AreNotEqual<TExpected,TActual>(TExpected expected, TActual actual, string message, params object[] args)
         {
             Assert.That(actual, Is.Not.EqualTo(expected), message, args);
         }
@@ -191,12 +157,10 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
-        public static void AreNotEqual(object expected, object actual)
+        public static void AreNotEqual<TExpected,TActual>(TExpected expected, TActual actual)
         {
             Assert.That(actual, Is.Not.EqualTo(expected), null, null);
         }
-
-        #endregion
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -457,9 +457,9 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public EqualConstraint EqualTo(object expected)
+        public EqualConstraint<TExpected> EqualTo<TExpected>(TExpected expected)
         {
-            return (EqualConstraint)this.Append(new EqualConstraint(expected));
+            return (EqualConstraint<TExpected>)this.Append(new EqualConstraint<TExpected>(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
@@ -328,9 +328,9 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public EqualConstraint EqualTo(object expected)
+        public EqualConstraint<TExpected> EqualTo<TExpected>(TExpected expected)
         {
-            return new EqualConstraint(expected);
+            return new EqualConstraint<TExpected>(expected);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
@@ -64,9 +64,9 @@ namespace NUnit.Framework.Constraints
         /// <param name="actualValue">The actual value to which the Constraint was applied.</param>
         public ConstraintResult(IConstraint constraint, object actualValue)
         {
-            this.Name = constraint.DisplayName;
-            this.Description = constraint.Description;
-            this.ActualValue = actualValue;
+            Name = constraint.DisplayName;
+            Description = constraint.Description;
+            ActualValue = actualValue;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -34,11 +34,9 @@ namespace NUnit.Framework.Constraints
     /// considered equal if both are null, or if both have the same 
     /// value. NUnit has special semantics for some object types.
     /// </summary>
-    public class EqualConstraint : Constraint
+    public class EqualConstraint<TExpected> : Constraint
     {
         #region Static and Instance Fields
-
-        private readonly object _expected;
 
         private Tolerance _tolerance = Tolerance.Default;
 
@@ -54,12 +52,12 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
-        public EqualConstraint(object expected)
+        public EqualConstraint(TExpected expected)
             : base(expected)
         {
             AdjustArgumentIfNeeded(ref expected);
 
-            _expected = expected;
+            Expected = expected;
             ClipStrings = true;
         }
         #endregion
@@ -71,11 +69,13 @@ namespace NUnit.Framework.Constraints
         // EqualConstraint should inject them into the constructor.
 
         /// <summary>
+        /// Gets the expected value of the constraint
+        /// </summary>
+        public TExpected Expected { get; private set; }
+
+        /// <summary>
         /// Gets the tolerance for this comparison.
         /// </summary>
-        /// <value>
-        /// The tolerance.
-        /// </value>
         public Tolerance Tolerance
         {
             get { return _tolerance; }
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag the constraint to ignore case and return self.
         /// </summary>
-        public EqualConstraint IgnoreCase
+        public EqualConstraint<TExpected> IgnoreCase
         {
             get
             {
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to suppress string clipping 
         /// and return self.
         /// </summary>
-        public EqualConstraint NoClip
+        public EqualConstraint<TExpected> NoClip
         {
             get
             {
@@ -143,7 +143,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to compare arrays as collections
         /// and return self.
         /// </summary>
-        public EqualConstraint AsCollection
+        public EqualConstraint<TExpected> AsCollection
         {
             get
             {
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="amount">Tolerance value to be used</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Within(object amount)
+        public EqualConstraint<TExpected> Within(object amount)
         {
             if (!_tolerance.IsUnsetOrDefault)
                 throw new InvalidOperationException("Within modifier may appear only once in a constraint expression");
@@ -180,7 +180,7 @@ namespace NUnit.Framework.Constraints
         /// point results instead of fixed tolerances is safer because it will
         /// automatically compensate for the added inaccuracy of larger numbers.
         /// </remarks>
-        public EqualConstraint Ulps
+        public EqualConstraint<TExpected> Ulps
         {
             get
             {
@@ -195,7 +195,7 @@ namespace NUnit.Framework.Constraints
         /// the expected value.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Percent
+        public EqualConstraint<TExpected> Percent
         {
             get
             {
@@ -208,7 +208,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in days.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Days
+        public EqualConstraint<TExpected> Days
         {
             get
             {
@@ -221,7 +221,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in hours.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Hours
+        public EqualConstraint<TExpected> Hours
         {
             get
             {
@@ -234,7 +234,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in minutes.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Minutes
+        public EqualConstraint<TExpected> Minutes
         {
             get
             {
@@ -247,7 +247,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in seconds.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Seconds
+        public EqualConstraint<TExpected> Seconds
         {
             get
             {
@@ -260,7 +260,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in milliseconds.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Milliseconds
+        public EqualConstraint<TExpected> Milliseconds
         {
             get
             {
@@ -273,7 +273,7 @@ namespace NUnit.Framework.Constraints
         /// Causes the tolerance to be interpreted as a TimeSpan in clock ticks.
         /// </summary>
         /// <returns>Self</returns>
-        public EqualConstraint Ticks
+        public EqualConstraint<TExpected> Ticks
         {
             get
             {
@@ -287,7 +287,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Using(IComparer comparer)
+        public EqualConstraint<TExpected> Using(IComparer comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
@@ -298,7 +298,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Using<T>(IComparer<T> comparer)
+        public EqualConstraint<TExpected> Using<T>(IComparer<T> comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
@@ -309,7 +309,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Using<T>(Comparison<T> comparer)
+        public EqualConstraint<TExpected> Using<T>(Comparison<T> comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
@@ -320,7 +320,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Using(IEqualityComparer comparer)
+        public EqualConstraint<TExpected> Using(IEqualityComparer comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
@@ -331,7 +331,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
         /// <returns>Self.</returns>
-        public EqualConstraint Using<T>(IEqualityComparer<T> comparer)
+        public EqualConstraint<TExpected> Using<T>(IEqualityComparer<T> comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
@@ -349,7 +349,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             AdjustArgumentIfNeeded(ref actual);
-            return new EqualConstraintResult(this, actual, _comparer.AreEqual(_expected, actual, ref _tolerance));
+            return new EqualConstraintResult<TExpected,TActual>(this, actual, _comparer.AreEqual(Expected, actual, ref _tolerance));
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ namespace NUnit.Framework.Constraints
         {
             get 
             { 
-                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected));
+                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(Expected));
 
                 if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
                 {

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -32,13 +32,13 @@ namespace NUnit.Framework.Constraints
     /// The EqualConstraintResult class is tailored for formatting
     /// and displaying the result of an EqualConstraint. 
     /// </summary>
-    public class EqualConstraintResult : ConstraintResult
+    public class EqualConstraintResult<TExpected, TActual> : ConstraintResult
     {
-        private object expectedValue;
-        private Tolerance tolerance;
-        private bool caseInsensitive;
-        private bool clipStrings;
-        private IList<NUnitEqualityComparer.FailurePoint> failurePoints;
+        private TExpected _expectedValue;
+        private Tolerance _tolerance;
+        private bool _caseInsensitive;
+        private bool _clipStrings;
+        private IList<NUnitEqualityComparer.FailurePoint> _failurePoints;
 
         #region Message Strings
         private static readonly string StringsDiffer_1 =
@@ -62,14 +62,14 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Construct an EqualConstraintResult
         /// </summary>
-        public EqualConstraintResult(EqualConstraint constraint, object actual, bool hasSucceeded)
+        public EqualConstraintResult(EqualConstraint<TExpected> constraint, TActual actual, bool hasSucceeded)
             : base(constraint, actual, hasSucceeded) 
         {
-            this.expectedValue = constraint.Arguments[0];
-            this.tolerance = constraint.Tolerance;
-            this.caseInsensitive = constraint.CaseInsensitive;
-            this.clipStrings = constraint.ClipStrings;
-            this.failurePoints = constraint.FailurePoints;
+            _expectedValue = constraint.Expected;
+            _tolerance = constraint.Tolerance;
+            _caseInsensitive = constraint.CaseInsensitive;
+            _clipStrings = constraint.ClipStrings;
+            _failurePoints = constraint.FailurePoints;
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The MessageWriter to write to</param>
         public override void WriteMessageTo(MessageWriter writer)
         {
-            DisplayDifferences(writer, expectedValue, ActualValue, 0);
+            DisplayDifferences(writer, _expectedValue, ActualValue, 0);
         }
 
         private void DisplayDifferences(MessageWriter writer, object expected, object actual, int depth)
@@ -92,8 +92,8 @@ namespace NUnit.Framework.Constraints
                 DisplayEnumerableDifferences(writer, (IEnumerable)expected, (IEnumerable)actual, depth);
             else if (expected is Stream && actual is Stream)
                 DisplayStreamDifferences(writer, (Stream)expected, (Stream)actual, depth);
-            else if (tolerance != null)
-                writer.DisplayDifferences(expected, actual, tolerance);
+            else if (_tolerance != null)
+                writer.DisplayDifferences(expected, actual, _tolerance);
             else
                 writer.DisplayDifferences(expected, actual);
         }
@@ -101,14 +101,14 @@ namespace NUnit.Framework.Constraints
         #region DisplayStringDifferences
         private void DisplayStringDifferences(MessageWriter writer, string expected, string actual)
         {
-            int mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, caseInsensitive);
+            int mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, _caseInsensitive);
 
             if (expected.Length == actual.Length)
                 writer.WriteMessageLine(StringsDiffer_1, expected.Length, mismatch);
             else
                 writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatch);
 
-            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, clipStrings);
+            writer.DisplayStringDifferences(expected, actual, mismatch, _caseInsensitive, _clipStrings);
         }
         #endregion
 
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Constraints
         {
             if (expected.Length == actual.Length)
             {
-                long offset = failurePoints[depth].Position;
+                long offset = _failurePoints[depth].Position;
                 writer.WriteMessageLine(StreamsDiffer_1, expected.Length, offset);
             }
             else
@@ -137,9 +137,9 @@ namespace NUnit.Framework.Constraints
         {
             DisplayTypesAndSizes(writer, expected, actual, depth);
 
-            if (failurePoints.Count > depth)
+            if (_failurePoints.Count > depth)
             {
-                NUnitEqualityComparer.FailurePoint failurePoint = (NUnitEqualityComparer.FailurePoint)failurePoints[depth];
+                NUnitEqualityComparer.FailurePoint failurePoint = (NUnitEqualityComparer.FailurePoint)_failurePoints[depth];
 
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 
@@ -256,9 +256,9 @@ namespace NUnit.Framework.Constraints
         {
             DisplayTypesAndSizes(writer, expected, actual, depth);
 
-            if (failurePoints.Count > depth)
+            if (_failurePoints.Count > depth)
             {
-                NUnitEqualityComparer.FailurePoint failurePoint = (NUnitEqualityComparer.FailurePoint)failurePoints[depth];
+                NUnitEqualityComparer.FailurePoint failurePoint = (NUnitEqualityComparer.FailurePoint)_failurePoints[depth];
 
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -116,6 +116,14 @@ namespace NUnit.Framework.Constraints
 
         #region Public Methods
         /// <summary>
+        /// Compares two strings for equality.
+        /// </summary>
+        public bool AreEqual(string x, string y, ref Tolerance tolerance)
+        {
+            return StringsEqual(x, y);
+        }
+
+        /// <summary>
         /// Compares two objects for equality within a tolerance.
         /// </summary>
         public bool AreEqual(object x, object y, ref Tolerance tolerance)

--- a/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Constraints
             get
             {
                 return string.Format(
-                    baseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}", 
+                    baseConstraint.DisplayName == "Equal" ? "{0} equal to {1}" : "{0} {1}", 
                     descriptionPrefix, 
                     baseConstraint.Description);
             }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -190,9 +190,9 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public static EqualConstraint EqualTo(object expected)
+        public static EqualConstraint<TExpected> EqualTo<TExpected>(TExpected expected)
         {
-            return new EqualConstraint(expected);
+            return new EqualConstraint<TExpected>(expected);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Api/ResultStateTests.cs
+++ b/src/NUnitFramework/tests/Api/ResultStateTests.cs
@@ -170,10 +170,11 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestEquality_Null()
         {
+            object nullObj = null;
             var rs = new ResultState(TestStatus.Passed);
-            Assert.AreNotEqual(null, rs);
-            Assert.AreNotEqual(rs, null);
-            Assert.False(rs.Equals(null));
+            Assert.AreNotEqual(nullObj, rs);
+            Assert.AreNotEqual(rs, nullObj);
+            Assert.False(rs.Equals(nullObj));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -45,7 +45,9 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void EqualsNull() 
         {
-            Assert.AreEqual(null, null);
+            object obj1 = null;
+            object obj2 = null;
+            Assert.AreEqual(obj1, obj2);
         }
         
         [Test]

--- a/src/NUnitFramework/tests/Assertions/NotEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/NotEqualFixture.cs
@@ -47,16 +47,19 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void NullNotEqualToNonNull()
         {
-            Assert.AreNotEqual( null, 3 );
+            object nullObj = null;
+            Assert.AreNotEqual( nullObj, 3 );
         }
 
         [Test]
         public void NullEqualsNull()
         {
+            object obj1 = null;
+            object obj2 = null;
             var expectedMessage =
                 "  Expected: not equal to null" + Env.NewLine +
                 "  But was:  null" + Env.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreNotEqual( null, null ));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreNotEqual( obj1, obj2 ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items not equal to null" + NL +
                 TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL;
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new NotConstraint(new EqualConstraint(null)))));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new NotConstraint(new EqualConstraint<object>(null)))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
@@ -10,35 +10,35 @@ namespace NUnit.Framework.Constraints.Tests
 		[Test]
 		public void ConstraintSuccess()
 		{
-			Assert.IsTrue(new DelayedConstraint(new EqualConstraint(1), 100)
+            Assert.IsTrue(new DelayedConstraint(Is.EqualTo(1), 100)
 				.ApplyTo(async () => await One()).IsSuccess);
 		}
 
 		[Test]
 		public void ConstraintFailure()
 		{
-			Assert.IsFalse(new DelayedConstraint(new EqualConstraint(2), 100)
+            Assert.IsFalse(new DelayedConstraint(Is.EqualTo(2), 100)
 				.ApplyTo(async () => await One()).IsSuccess);
 		}
 
 		[Test]
 		public void ConstraintError()
 		{
-			Assert.Throws<InvalidOperationException>(() => 
-				new DelayedConstraint(new EqualConstraint(1), 100).ApplyTo(new ActualValueDelegate<Task>(async () => await Throw())));
+			Assert.Throws<InvalidOperationException>(() =>
+                new DelayedConstraint(Is.EqualTo(1), 100).ApplyTo(new ActualValueDelegate<Task>(async () => await Throw())));
 		}
 
 		[Test]
 		public void ConstraintVoidDelegateFailureAsDelegateIsNotCalled()
 		{
-			Assert.IsFalse(new DelayedConstraint(new EqualConstraint(1), 100)
+            Assert.IsFalse(new DelayedConstraint(Is.EqualTo(1), 100)
 				.ApplyTo(new TestDelegate(async () => { await One(); })).IsSuccess);
 		}
 
 		[Test]
 		public void ConstraintVoidDelegateExceptionIsFailureAsDelegateIsNotCalled()
 		{
-			Assert.IsFalse(new DelayedConstraint(new EqualConstraint(1), 100)
+            Assert.IsFalse(new DelayedConstraint(Is.EqualTo(1), 100)
 				.ApplyTo(new TestDelegate(async () => { await Throw(); })).IsSuccess);
 		}
 

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new DelayedConstraint(new EqualConstraint(true), 500);
+            theConstraint = new DelayedConstraint(Is.EqualTo(true), 500);
             expectedDescription = "True after 500 millisecond delay";
             stringRepresentation = "<after 500 <equal True>>";
 
@@ -83,27 +83,27 @@ namespace NUnit.Framework.Constraints
         public void SimpleTest()
         {
             SetValuesAfterDelay(DELAY);
-            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), AFTER, POLLING));
+            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint<bool>(true), AFTER, POLLING));
         }
 
         [Test]
         public void SimpleTestUsingBoolean()
         {
             SetValuesAfterDelay(DELAY);
-            Assert.That(() => boolValue, new DelayedConstraint(new EqualConstraint(true), AFTER, POLLING));
+            Assert.That(() => boolValue, new DelayedConstraint(new EqualConstraint<bool>(true), AFTER, POLLING));
         }
 
         [Test]
         public void ThatOverload_ZeroDelayIsAllowed()
         {
-            Assert.That(DelegateReturningZero, new DelayedConstraint(new EqualConstraint(0), 0));
+            Assert.That(DelegateReturningZero, new DelayedConstraint(Is.EqualTo(0), 0));
         }
 
         [Test]
         public void ThatOverload_DoesNotAcceptNegativeDelayValues()
         {
             Assert.Throws<ArgumentException>(
-                () => Assert.That(DelegateReturningZero, new DelayedConstraint(new EqualConstraint(0), -1)));
+                () => Assert.That(DelegateReturningZero, new DelayedConstraint(Is.EqualTo(0), -1)));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new EqualConstraint(4);
+            theConstraint = Is.EqualTo(4);
             expectedDescription = "4";
             stringRepresentation = "<equal 4>";
         }
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1);
                 DateTime actual = new DateTime(2007, 4, 1);
-                Assert.That(actual, new EqualConstraint(expected));
+                Assert.That(actual, new EqualConstraint<DateTime>(expected));
             }
 
             [Test]
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Constraints
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
                 TimeSpan tolerance = TimeSpan.FromMinutes(5.0);
-                Assert.That(actual, new EqualConstraint(expected).Within(tolerance));
+                Assert.That(actual, Is.EqualTo(expected).Within(tolerance));
             }
 
             [Test]
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 4, 13, 0, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Days);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Days);
             }
 
             [Test]
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 16, 0, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Hours);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Hours);
             }
 
 
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Minutes);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Minutes);
             }
 
             [Test]
@@ -111,7 +111,7 @@ namespace NUnit.Framework.Constraints
             {
                 TimeSpan expected = new TimeSpan(10, 0, 0);
                 TimeSpan actual = new TimeSpan(10, 2, 30);
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Minutes);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Minutes);
             }
 
             [Test]
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(300).Seconds);
+                Assert.That(actual, Is.EqualTo(expected).Within(300).Seconds);
             }
 
             [Test]
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(300000).Milliseconds);
+                Assert.That(actual, Is.EqualTo(expected).Within(300000).Milliseconds);
             }
 
             [Test]
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute*5).Ticks);
+                Assert.That(actual, Is.EqualTo(expected).Within(TimeSpan.TicksPerMinute*5).Ticks);
             }
 
             [Test]
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1));
                 var actual = new DateTimeOffset(new DateTime(2007, 4, 1));
-                Assert.That(actual, new EqualConstraint(expected));
+                Assert.That(actual, Is.EqualTo(expected));
             }
 
             [Test]
@@ -196,7 +196,7 @@ namespace NUnit.Framework.Constraints
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
                 var tolerance = TimeSpan.FromMinutes(5.0);
-                Assert.That(actual, new EqualConstraint(expected).Within(tolerance));
+                Assert.That(actual, Is.EqualTo(expected).Within(tolerance));
             }
 
             [Test]
@@ -204,7 +204,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual = new DateTimeOffset(new DateTime(2007, 4, 4, 13, 0, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Days);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Days);
             }
 
             [Test]
@@ -220,7 +220,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(5).Minutes);
+                Assert.That(actual, Is.EqualTo(expected).Within(5).Minutes);
             }
 
             [Test]
@@ -228,7 +228,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(300).Seconds);
+                Assert.That(actual, Is.EqualTo(expected).Within(300).Seconds);
             }
 
             [Test]
@@ -236,7 +236,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(300000).Milliseconds);
+                Assert.That(actual, Is.EqualTo(expected).Within(300000).Milliseconds);
             }
 
             [Test]
@@ -244,7 +244,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute*5).Ticks);
+                Assert.That(actual, Is.EqualTo(expected).Within(TimeSpan.TicksPerMinute * 5).Ticks);
             }
 
             [Test]
@@ -331,21 +331,21 @@ namespace NUnit.Framework.Constraints
             [TestCase(float.NegativeInfinity)]
             public void CanMatchSpecialFloatingPointValues(object value)
             {
-                Assert.That(value, new EqualConstraint(value));
+                Assert.That(value, Is.EqualTo(value));
             }
 
             [TestCase(20000000000000004.0)]
             [TestCase(19999999999999996.0)]
             public void CanMatchDoublesWithUlpTolerance(object value)
             {
-                Assert.That(value, new EqualConstraint(20000000000000000.0).Within(1).Ulps);
+                Assert.That(value, Is.EqualTo(20000000000000000.0).Within(1).Ulps);
             }
 
             [TestCase(20000000000000008.0)]
             [TestCase(19999999999999992.0)]
             public void FailsOnDoublesOutsideOfUlpTolerance(object value)
             {
-                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, new EqualConstraint(20000000000000000.0).Within(1).Ulps));
+                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, Is.EqualTo(20000000000000000.0).Within(1).Ulps));
                 Assert.That(ex.Message, Does.Contain("+/- 1 Ulps"));
             }
 
@@ -353,14 +353,14 @@ namespace NUnit.Framework.Constraints
             [TestCase(20000002.0f)]
             public void CanMatchSinglesWithUlpTolerance(object value)
             {
-                Assert.That(value, new EqualConstraint(20000000.0f).Within(1).Ulps);
+                Assert.That(value, Is.EqualTo(20000000.0f).Within(1).Ulps);
             }
 
             [TestCase(19999996.0f)]
             [TestCase(20000004.0f)]
             public void FailsOnSinglesOutsideOfUlpTolerance(object value)
             {
-                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, new EqualConstraint(20000000.0f).Within(1).Ulps));
+                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, Is.EqualTo(20000000.0f).Within(1).Ulps));
                 Assert.That(ex.Message, Does.Contain("+/- 1 Ulps"));
             }
 
@@ -369,14 +369,14 @@ namespace NUnit.Framework.Constraints
             [TestCase(10500.0)]
             public void CanMatchDoublesWithRelativeTolerance(object value)
             {
-                Assert.That(value, new EqualConstraint(10000.0).Within(10.0).Percent);
+                Assert.That(value, Is.EqualTo(10000.0).Within(10.0).Percent);
             }
 
             [TestCase(8500.0)]
             [TestCase(11500.0)]
             public void FailsOnDoublesOutsideOfRelativeTolerance(object value)
             {
-                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, new EqualConstraint(10000.0).Within(10.0).Percent));
+                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, Is.EqualTo(10000.0).Within(10.0).Percent));
                 Assert.That(ex.Message, Does.Contain("+/- 10.0d Percent"));
             }
 
@@ -385,14 +385,14 @@ namespace NUnit.Framework.Constraints
             [TestCase(10500.0f)]
             public void CanMatchSinglesWithRelativeTolerance(object value)
             {
-                Assert.That(value, new EqualConstraint(10000.0f).Within(10.0f).Percent);
+                Assert.That(value, Is.EqualTo(10000.0f).Within(10.0f).Percent);
             }
 
             [TestCase(8500.0f)]
             [TestCase(11500.0f)]
             public void FailsOnSinglesOutsideOfRelativeTolerance(object value)
             {
-                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, new EqualConstraint(10000.0f).Within(10.0f).Percent));
+                var ex = Assert.Throws<AssertionException>(() => Assert.That(value, Is.EqualTo(10000.0f).Within(10.0f).Percent));
                 Assert.That(ex.Message, Does.Contain("+/- 10.0f Percent"));
             }
 
@@ -402,7 +402,7 @@ namespace NUnit.Framework.Constraints
             {
                 Assert.Throws<InvalidOperationException>(() =>
                 {
-                    var shouldFail = new EqualConstraint(100.0f).Within(10.0f).Percent.Ulps;
+                    var shouldFail = Is.EqualTo(100.0f).Within(10.0f).Percent.Ulps;
                 });
             }
 
@@ -412,7 +412,7 @@ namespace NUnit.Framework.Constraints
             {
                 Assert.Throws<InvalidOperationException>(() =>
                 {
-                    EqualConstraint shouldFail = new EqualConstraint(100.0f).Within(10.0f).Ulps.Percent;
+                    EqualConstraint<Single> shouldFail = Is.EqualTo(100.0f).Within(10.0f).Ulps.Percent;
                 });
             }
 

--- a/src/NUnitFramework/tests/Constraints/EqualTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualTest.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That("abcdgfe", new EqualConstraint("abcdefg"));
+                    Assert.That("abcdgfe", new EqualConstraint<string>("abcdefg"));
                 }));
         }
 
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, Is.EqualTo(expected));
                 }));
         }
 
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, new EqualConstraint<string>(expected));
                 }));
         }
 
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, Is.EqualTo(expected));
                 }));
         }
 
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Constraints
             if (actual != null && actual.Length > 11)
                 actual = actual.Substring(11);
             string line = rdr.ReadLine();
-            Assert.That(line, new NotConstraint(new EqualConstraint(null)), "No caret line displayed");
+            Assert.That(line, new NotConstraint(new EqualConstraint<object>(null)), "No caret line displayed");
             int caret = line.Substring(11).IndexOf('^');
 
             int minLength = Math.Min(expected.Length, actual.Length);

--- a/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new NotConstraint( new EqualConstraint(null) );
+            theConstraint = new NotConstraint( new EqualConstraint<object>(null) );
             expectedDescription = "not equal to null";
             stringRepresentation = "<not <equal null>>";
         }
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void NotHonorsIgnoreCaseUsingConstructors()
         {
-            var ex = Assert.Throws<AssertionException>(() => Assert.That("abc", new NotConstraint(new EqualConstraint("ABC").IgnoreCase)));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That("abc", new NotConstraint(new EqualConstraint<string>("ABC").IgnoreCase)));
             Assert.That(ex.Message, Does.Contain("ignoring case"));
         }
 
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanUseNotOperator()
         {
-            Assert.That(42, !new EqualConstraint(99));
+            Assert.That(42, !new EqualConstraint<int>(99));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new OrConstraint(new EqualConstraint(42), new EqualConstraint(99));
+            theConstraint = new OrConstraint(new EqualConstraint<int>(42), new EqualConstraint<int>(99));
             expectedDescription = "42 or 99";
             stringRepresentation = "<or <equal 42> <equal 99>>";
         }
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanCombineTestsWithOrOperator()
         {
-            Assert.That(99, new EqualConstraint(42) | new EqualConstraint(99) );
+            Assert.That(99, new EqualConstraint<int>(42) | new EqualConstraint<int>(99) );
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new PropertyConstraint("Length", new EqualConstraint(5));
+            theConstraint = new PropertyConstraint("Length", new EqualConstraint<int>(5));
             expectedDescription = "property Length equal to 5";
             stringRepresentation = "<property Length <equal 5>>";
         }
@@ -83,10 +83,10 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void PropertyEqualToValueWithTolerance()
         {
-            Constraint c = new EqualConstraint(105m).Within(0.1m);
+            Constraint c = Is.EqualTo(105m).Within(0.1m);
             Assert.That(c.Description, Is.EqualTo("105m +/- 0.1m"));
 
-            c = new PropertyConstraint("D", new EqualConstraint(105m).Within(0.1m));
+            c = new PropertyConstraint("D", Is.EqualTo(105m).Within(0.1m));
             Assert.That(c.Description, Is.EqualTo("property D equal to 105m +/- 0.1m"));
         }
     }

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Constraints
             theConstraint = new ThrowsConstraint(
                 new AndConstraint(
                     new ExactTypeConstraint(typeof(ArgumentException)),
-                    new PropertyConstraint("ParamName", new EqualConstraint("myParam"))));
+                    new PropertyConstraint("ParamName", new EqualConstraint<string>("myParam"))));
             expectedDescription = @"<System.ArgumentException> and property ParamName equal to ""myParam""";
             stringRepresentation = @"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>";
         }

--- a/src/NUnitFramework/tests/Internal/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestResultTests.cs
@@ -235,8 +235,8 @@ namespace NUnit.Framework.Internal
             XmlNode testNode = testResult.ToXml(true);
 
             Assert.AreEqual("Passed", testNode.Attributes["result"]);
-            Assert.AreEqual(null, testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.IsNull(testNode.Attributes["label"]);
+            Assert.IsNull(testNode.Attributes["site"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", testNode.Attributes["start-time"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", testNode.Attributes["end-time"]);
             Assert.AreEqual("0.125000", testNode.Attributes["duration"]);
@@ -255,8 +255,8 @@ namespace NUnit.Framework.Internal
             XmlNode suiteNode = suiteResult.ToXml(true);
 
             Assert.AreEqual("Passed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual(null, suiteNode.Attributes["site"]);
+            Assert.IsNull(suiteNode.Attributes["label"]);
+            Assert.IsNull(suiteNode.Attributes["site"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", suiteNode.Attributes["start-time"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", suiteNode.Attributes["end-time"]);
             Assert.AreEqual("0.125000", suiteNode.Attributes["duration"]);
@@ -314,7 +314,7 @@ namespace NUnit.Framework.Internal
 
             Assert.AreEqual("Skipped", testNode.Attributes["result"]);
             Assert.AreEqual("Ignored", testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.IsNull(testNode.Attributes["site"]);
             XmlNode reason = testNode.FindDescendant("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.FindDescendant("message"));
@@ -334,7 +334,7 @@ namespace NUnit.Framework.Internal
 
             Assert.AreEqual("Skipped", suiteNode.Attributes["result"]);
             Assert.AreEqual("Ignored", suiteNode.Attributes["label"]);
-            Assert.AreEqual(null, suiteNode.Attributes["site"]);
+            Assert.IsNull(suiteNode.Attributes["site"]);
             Assert.AreEqual("0", suiteNode.Attributes["passed"]);
             Assert.AreEqual("0", suiteNode.Attributes["failed"]);
             Assert.AreEqual("1", suiteNode.Attributes["skipped"]);
@@ -389,7 +389,7 @@ namespace NUnit.Framework.Internal
 
             Assert.AreEqual("Failed", testNode.Attributes["result"]);
             Assert.AreEqual("Invalid", testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.IsNull(testNode.Attributes["site"]);
             XmlNode failure = testNode.FindDescendant("failure");
             Assert.NotNull(failure);
             Assert.NotNull(failure.FindDescendant("message"));
@@ -403,7 +403,7 @@ namespace NUnit.Framework.Internal
             XmlNode suiteNode = suiteResult.ToXml(true);
 
             Assert.AreEqual("Failed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
+            Assert.IsNull(suiteNode.Attributes["label"]);
             Assert.AreEqual("Child", suiteNode.Attributes["site"]);
             Assert.AreEqual("0", suiteNode.Attributes["passed"]);
             Assert.AreEqual("1", suiteNode.Attributes["failed"]);
@@ -469,8 +469,8 @@ namespace NUnit.Framework.Internal
             XmlNode testNode = testResult.ToXml(true);
 
             Assert.AreEqual("Failed", testNode.Attributes["result"]);
-            Assert.AreEqual(null, testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.IsNull(testNode.Attributes["label"]);
+            Assert.IsNull(testNode.Attributes["site"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", testNode.Attributes["start-time"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", testNode.Attributes["end-time"]);
             Assert.AreEqual("0.125000", testNode.Attributes["duration"]);
@@ -521,7 +521,7 @@ namespace NUnit.Framework.Internal
             XmlNode suiteNode = suiteResult.ToXml(true);
 
             Assert.AreEqual("Failed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
+            Assert.IsNull(suiteNode.Attributes["label"]);
             Assert.AreEqual("Child", suiteNode.Attributes["site"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", suiteNode.Attributes["start-time"]);
             Assert.AreEqual("1968-04-08 15:05:30Z", suiteNode.Attributes["end-time"]);


### PR DESCRIPTION
**Experiment - Do Not Merge**

This branch is for the purpose of continuing a discussion Rob and I have been having about the use of generic constraints. We can continue here with the code in front of us and others are welcome to chime in.

In this branch, I have made EqualConstraint generic with a single type argument TExpected. That argument supplements the already existing TActual used in the generic ApplyTo method. Creating a class with two type args has been tried by both of us in the past and has run into issues, primarily because we don't know what the actual will be at the moment of instantiating the type.

I also added an overload to Assert.AreEqual using string types, so we would see the class being used with other than object types. Until we make more modifications to Assert, the constraint will only be used with objects.

Basically, going toward generic constraints has two aims: (1) providing more type-safety on the user side and (2) providing more efficiency by avoiding boxing of constants. So far, it doesn't look like we can get rid of the eventual boxing, but the type-safety is important enough by itself.