### PR TITLE
Travis build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
 
 script: 
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test" /p:ContinueOnFailure=ErrorAndContinue
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test"
   
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
 
 script: 
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test" /p:ContinueOnFailure=ErrorAndContinue
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework /t:$Target /p:ContinueOnFailure=ErrorAndContinue
   
 env:
   matrix:
-    - Framework="net-2.0"
-    - Framework="net-3.5"
-    - Framework="net-4.0"
-    - Framework="net-4.5"
+    - Target="Build;Test" Framework="net-2.0"
+    - Target="BuildFramework;TestFramework" Framework="net-3.5"
+    - Target="BuildFramework;TestFramework" Framework="net-4.0"
+    - Target="BuildFramework;TestFramework" Framework="net-4.5"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - sudo apt-get install mono-devel -qq -y
 
 before_script:
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings"
 
 script: 
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework /t:$Targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
 
 script: 
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework /t:$Target /p:ContinueOnFailure=ErrorAndContinue
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test" /p:ContinueOnFailure=ErrorAndContinue
   
 env:
   matrix:
-    - Target="Build;Test" Framework="net-2.0"
-    - Target="BuildFramework;TestFramework" Framework="net-3.5"
-    - Target="BuildFramework;TestFramework" Framework="net-4.0"
-    - Target="BuildFramework;TestFramework" Framework="net-4.5"
+    - Framework="net-2.0"
+    - Framework="net-3.5"
+    - Framework="net-4.0"
+    - Framework="net-4.5"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
 
 script: 
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test"
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test" /p:ContinueOnFailure=ErrorAndContinue
   
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings;CleanAll"
 
 script: 
-  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:Build;Test"
+  - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework /t:$Targets
   
 env:
   matrix:
-    - Framework="net-2.0"
-    - Framework="net-3.5"
-    - Framework="net-4.0"
-    - Framework="net-4.5"
+    - Framework="net-2.0" Targets="Build;Test"
+    - Framework="net-3.5" Targets="Build;TestFramework"
+    - Framework="net-4.0" Targets="Build;TestFramework"
+    - Framework="net-4.5" Targets="Build;TestFramework"
     

--- a/NUnit.proj
+++ b/NUnit.proj
@@ -112,7 +112,7 @@
 		<ConsoleRunner>$(ConsoleBuildDir)\nunit-console.exe</ConsoleRunner>
 		<ResultDir>$(ConfigurationBuildDir)\Results</ResultDir>
 		<ResultFormat Condition="'$(ResultFormat)' == ''">nunit3</ResultFormat>
-		<ContinueOnFailure Condition="'$(ContinueOnFailure)' == ''">true</ContinueOnFailure>
+		<ContinueOnFailure Condition="'$(ContinueOnFailure)' == ''">false</ContinueOnFailure>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Properties for building NuGet packages">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 branches:
   except:
-    - /travis.*/
+    - /travis-.*/
 
 build_script: 
   - msbuild nunit.sln /p:Configuration=Release /t:Rebuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  except:
+    - /travis.*/
+
 build_script: 
   - msbuild nunit.sln /p:Configuration=Release /t:Rebuild
   

--- a/src/NUnitConsole/nunit-console/nunit-console.csproj
+++ b/src/NUnitConsole/nunit-console/nunit-console.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>addins/tests/addin-tests.dll -process:Single</Commandlineparameters>
+    <Commandlineparameters>nunit.engine.tests.dll</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,6 +35,8 @@
     <DefineConstants>TRACE;NUNIT_CONSOLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Commandlineparameters>nunit.engine.tests.dll -process:Single</Commandlineparameters>
+    <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
@@ -26,6 +26,10 @@ using System.Collections.Generic;
 
 namespace NUnit.Engine
 {
+    /// <summary>
+    /// Implemented by a type that provides information about the
+    /// current and other available runtimes.
+    /// </summary>
     public interface IRuntimeFrameworkService
     {
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Tests
         [Test]
         public void CurrentFrameworkMustBeAvailable()
         {
-            Assert.That(RuntimeFramework.CurrentFramework.IsAvailable);
+            Assert.That(RuntimeFramework.CurrentFramework.IsAvailable, "{0} not available", RuntimeFramework.CurrentFramework);
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -532,10 +532,26 @@ namespace NUnit.Engine
                     frameworks.Add(framework);
                 }
 
+                if (Directory.Exists(Path.Combine(monoPrefix, "lib/mono/3.5")))
+                {
+                    RuntimeFramework framework = new RuntimeFramework(RuntimeType.Mono, new Version(2, 0, 50727));
+                    framework.FrameworkVersion = new Version(3,5);
+                    framework.DisplayName = string.Format(displayFmt, "3.5");
+                    frameworks.Add(framework);
+                }
+
                 if (File.Exists(Path.Combine(monoPrefix, "lib/mono/4.0/mscorlib.dll")))
                 {
                     RuntimeFramework framework = new RuntimeFramework(RuntimeType.Mono, new Version(4, 0, 30319));
                     framework.DisplayName = string.Format(displayFmt, "4.0");
+                    frameworks.Add(framework);
+                }
+
+                if (File.Exists(Path.Combine(monoPrefix, "lib/mono/4.5/mscorlib.dll")))
+                {
+                    RuntimeFramework framework = new RuntimeFramework(RuntimeType.Mono, new Version(4, 0, 30319));
+                    framework.FrameworkVersion = new Version(4,5);
+                    framework.DisplayName = string.Format(displayFmt, "4.5");
                     frameworks.Add(framework);
                 }
             }

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
@@ -33,10 +33,10 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class ArrayEqualsFixture : AssertionHelper
     {
-#pragma warning disable 184
+#pragma warning disable 183 184
         // Used to detect runtimes where ArraySegments implement IEnumerable
         private static readonly bool ArraySegmentImplementsIEnumerable = new ArraySegment<int>() is IEnumerable;
-#pragma warning restore 184
+#pragma warning restore 183 184
 
         [Test]
         public void ArrayIsEqualToItself()

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
@@ -33,7 +33,10 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class ArrayEqualsFixture : AssertionHelper
     {
+#pragma warning disable 184
+        // Used to detect runtimes where ArraySegments implement IEnumerable
         private static readonly bool ArraySegmentImplementsIEnumerable = new ArraySegment<int>() is IEnumerable;
+#pragma warning restore 184
 
         [Test]
         public void ArrayIsEqualToItself()

--- a/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 namespace NUnit.Framework.Internal
 {
+#pragma warning disable 1998
     public class RealAsyncSetupTeardownTests
     {
         private object _initializedOnce;
@@ -45,5 +46,6 @@ namespace NUnit.Framework.Internal
         }
 
     }
+#pragma warning restore 1998
 }
 #endif


### PR DESCRIPTION
This PR fixes #508 and fixes #509. The two are combined because the first bug (in the build script) was concealing the existence of the second.

The build script is now changed so that any failing test run fails the build and the following test runs are not run. This is not the favored approach but is necessitated on Linux because xbuild does not properly support the ContinueOnError=ErrorAndContinue setting on a task as msbuild does on Windows. Additional changes were made to the build script at the same time.
 * The engine and console tests are only run for the net-2.0 job. Hence, the other jobs now only include the framework test run.
 * The CleanAll target is no longer run. It's not needed because on travis we work in a clean directory.
 * For branches starting "travis-" like this one, no run is made on Appveyor.

Issue #509 was caused by the fact that there was simply no code to check for those profiles. The test that the current framework is among those available would fail when we were running on the 3.5 or 4.5 profiles. This has been fixed and the tests now pass.