### PR TITLE
Made not shadow copy default for console and added a --shadowcopy command line

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -118,6 +118,9 @@ namespace NUnit.Common
 
             this.Add("dispose-runners", "Dispose each test runner after it has finished running its tests.",
                 v => DisposeRunners = v != null);
+
+            this.Add("shadowcopy", "Shadow copy test files",
+                v => ShadowCopyFiles = v != null);
 #endif
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
@@ -235,6 +238,8 @@ namespace NUnit.Common
         public bool RunAsX86 { get; private set; }
 
         public bool DisposeRunners { get; private set; }
+
+        public bool ShadowCopyFiles { get; private set; }
 
         private int defaultTimeout = -1;
         public int DefaultTimeout { get { return defaultTimeout; } }

--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -83,6 +83,11 @@ namespace NUnit.Common
         /// </summary>
         public const string DisposeRunners = "DisposeRunners";
 
+        /// <summary>
+        /// Indicates that the test assemblies should be shadow copied. Defaults to false.
+        /// </summary>
+        public const string ShadowCopyFiles = "ShadowCopyFiles";
+
         #endregion
 
         #region Settings taken from DriverSettings in the framework

--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -59,6 +59,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("NoHeader", "noheader|noh")]
         [TestCase("RunAsX86", "x86")]
         [TestCase("DisposeRunners", "dispose-runners")]
+        [TestCase("ShadowCopyFiles", "shadowcopy")]
         [TestCase("TeamCity", "teamcity")]
         public void CanRecognizeBooleanOptions(string propertyName, string pattern)
         {

--- a/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
@@ -57,6 +57,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--timeout=50", "DefaultTimeout", 50)]
         [TestCase("--x86", "RunAsX86", true)]
         [TestCase("--dispose-runners", "DisposeRunners", true)]
+        [TestCase("--shadowcopy", "ShadowCopyFiles", true)]
         [TestCase("--process=Separate", "ProcessModel", "Separate")]
         [TestCase("--process=separate", "ProcessModel", "Separate")]
         [TestCase("--domain=Multiple", "DomainUsage", "Multiple")]

--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -270,6 +270,9 @@ namespace NUnit.ConsoleRunner
             if (options.DisposeRunners)
                 package.Settings[PackageSettings.DisposeRunners] = true;
 
+            if (options.ShadowCopyFiles)
+                package.Settings[PackageSettings.ShadowCopyFiles] = true;
+
             if (options.DefaultTimeout >= 0)
                 package.Settings[PackageSettings.DefaultTimeout] = options.DefaultTimeout;
 

--- a/src/NUnitEngine/Addins/nunit-project-loader/RunnerSettings.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/RunnerSettings.cs
@@ -79,5 +79,10 @@ namespace NUnit.Engine
         /// Indicates that test runners should be disposed after the tests are executed
         /// </summary>
         public const string DisposeRunners = "DisposeRunners";
+
+        /// <summary>
+        /// Indicates that the test assemblies should be shadow copied. Defaults to false.
+        /// </summary>
+        public const string ShadowCopyFiles = "ShadowCopyFiles";
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -174,7 +174,7 @@ namespace NUnit.Engine.Services
 
             setup.PrivateBinPath = binPath;
 
-            if (package.GetSetting("ShadowCopyFiles", true))
+            if (package.GetSetting("ShadowCopyFiles", false))
             {
                 setup.ShadowCopyFiles = "true";
                 setup.ShadowCopyDirectories = appBase;

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -59,6 +59,7 @@ namespace NUnit.Common.Tests
 #if !NUNITLITE
         [TestCase("RunAsX86", "x86")]
         [TestCase("DisposeRunners", "dispose-runners")]
+        [TestCase("ShadowCopyFiles", "shadowcopy")]
 #endif
 #if !SILVERLIGHT && !NETCF
         [TestCase("TeamCity", "teamcity")]


### PR DESCRIPTION
This fixes #521 

For the console, I decided that the fact that shadow copy is not needed for building and testing at the same time and that there will be a slight performance gain with not shadow copying was enough to warrant the default for the console to be to not shadow copy. Based on this, I added a `--shadowcopy` command line to turn on shadow copying.

My only concern is that the engine now defaults to not shadow copying unless you set "ShadowCopyFiles" to true. This might make not be the default we want. Thoughts?

This is tested with unit tests and in the debugger.