### PR TITLE
Issue 318 - Added Fixture to the ITest interface

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -98,6 +98,11 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
         /// <value>A list of child tests</value>
         System.Collections.Generic.IList<ITest> Tests { get; }
+
+        /// <summary>
+        /// Gets a fixture object for running this test.
+        /// </summary>
+        object Fixture { get; }
     }
 }
 

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -66,7 +66,14 @@ namespace NUnit.Framework.Internal.Commands
             {
                 // Use pre-constructed fixture if available, otherwise construct it
                 if (!IsStaticClass(_fixtureType))
+                {
                     context.TestObject = _suite.Fixture ?? Reflect.Construct(_fixtureType, _arguments);
+                    if (_suite.Fixture == null)
+                    {
+                        _suite.Fixture = context.TestObject;
+                    }
+                    Test.Fixture = _suite.Fixture;
+                }
 
                 for (int i = _setUpTearDown.Count; i > 0; )
                     _setUpTearDown[--i].RunSetUp(context);

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
@@ -54,6 +54,9 @@ namespace NUnit.Framework.Internal.Commands
         /// <returns>A TestResult</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
+            if (Test.Fixture == null)
+                Test.Fixture = context.TestObject;
+
             // In the current implementation, upstream actions only apply to tests. If that should change in the future,
             // then actions would have to be tested for here. For now we simply assert it in Debug. We allow 
             // ActionTargets.Default, because it is passed down by ParameterizedMethodSuite.

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -200,14 +200,14 @@ namespace NUnit.Framework.Internal
         /// <value>A list of child tests</value>
         public abstract System.Collections.Generic.IList<ITest> Tests { get; }
 
-        #endregion
-
-        #region Other Public Properties
-
         /// <summary>
         /// Gets or sets a fixture object for running this test.
         /// </summary>
-        public object Fixture { get; set; }
+        public virtual object Fixture { get; set; }
+
+        #endregion
+
+        #region Other Public Properties
 
         /// <summary>
         /// Gets or Sets the Int value representing the seed for the RandomGenerator

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -416,4 +416,43 @@ namespace NUnit.Framework.Internal
         }
         #endregion
     }
+
+
+    #region Issue 318 - Test Fixture is null on ITest objects
+
+    public class FixtureNotNullTestAttribute : TestActionAttribute
+    {
+        private readonly string _location;
+
+        public FixtureNotNullTestAttribute(string location)
+        {
+            _location = location;
+        }
+
+        public override void BeforeTest(ITest test)
+        {
+            Assert.That(test, Is.Not.Null, "ITest is null on a " + _location);
+            Assert.That(test.Fixture, Is.Not.Null, "ITest.Fixture is null on a " + _location);
+            Assert.That(test.Fixture.GetType(), Is.EqualTo(test.FixtureType), "ITest.Fixture is not the correct type on a " + _location);
+        }
+    }
+
+    [FixtureNotNullTest("TestFixture class")]
+    [TestFixture]
+    public class FixtureIsNotNullForTests
+    {
+        [FixtureNotNullTest("Test method")]
+        [Test]
+        public void TestMethod()
+        {
+        }
+
+        [FixtureNotNullTest("TestCase method")]
+        [TestCase(1)]
+        public void TestCaseMethod(int i)
+        {
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Added Fixture to ITest interface and ensure it is not null for non-static test suites and test methods.

Fixes #318 