### PR TITLE
Vs adapter issues

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -50,6 +50,18 @@ namespace NUnit.Framework.Interfaces
         string FullName { get; }
 
         /// <summary>
+        /// Gets the name of the class containing this test. Returns
+        /// null if the test is not associated with a class.
+        /// </summary>
+        string ClassName { get; }
+
+        /// <summary>
+        /// Gets the name of the method implementing this test.
+        /// Returns null if the test is not implemented as a method.
+        /// </summary>
+        string MethodName { get; }
+
+        /// <summary>
         /// Gets the Type of the test fixture, if applicable, or
         /// null if no fixture type is associated with this test.
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/MethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodHelper.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class MethodHelper
     {
-        private const int STRING_MAX = 20;
+        private const int STRING_MAX = 40;
         private const int STRING_LIMIT = STRING_MAX - 3;
         private const string THREE_DOTS = "...";
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -128,6 +128,35 @@ namespace NUnit.Framework.Internal
         public string FullName { get; set; }
 
         /// <summary>
+        /// Gets the name of the class containing this test. Returns
+        /// null if the test is not associated with a class.
+        /// </summary>
+        public string ClassName
+        { 
+            get
+            {
+                Type type = FixtureType;
+
+                if (type == null)
+                    return null;
+
+                if (type.IsGenericType)
+                    type = type.GetGenericTypeDefinition();
+
+                return type.FullName;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the method implementing this test.
+        /// Returns null if the test is not implemented as a method.
+        /// </summary>
+        public virtual string MethodName
+        {
+            get { return null; }
+        }
+
+        /// <summary>
         /// Gets the Type of the fixture used in running this test
         /// or null if no fixture type is associated with it.
         /// </summary>
@@ -289,6 +318,10 @@ namespace NUnit.Framework.Internal
             thisNode.AddAttribute("id", this.Id.ToString());
             thisNode.AddAttribute("name", this.Name);
             thisNode.AddAttribute("fullname", this.FullName);
+            if (this.MethodName != null)
+                thisNode.AddAttribute("methodname", this.MethodName);
+            if (this.ClassName != null)
+                thisNode.AddAttribute("classname", this.ClassName);
             thisNode.AddAttribute("runstate", this.RunState.ToString());
 
             if (Properties.Keys.Count > 0)

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -153,6 +153,14 @@ namespace NUnit.Framework.Internal
             get { return "test-case"; }
         }
 
+        /// <summary>
+        /// Returns the name of the method
+        /// </summary>
+        public override string MethodName
+        {
+            get { return Method.Name; }
+        }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -35,6 +35,10 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class TypeHelper
     {
+        private const int STRING_MAX = 40;
+        private const int STRING_LIMIT = STRING_MAX - 3;
+        private const string THREE_DOTS = "...";
+
         internal sealed class NonmatchingTypeClass
         {
         }
@@ -120,8 +124,8 @@ namespace NUnit.Framework.Internal
                 else if (arg is ulong) display += "UL";
                 else if (arg is string)
                 {
-                    if (display.Length > 20)
-                        display = display.Substring(0, 17) + "...";
+                    if (display.Length > STRING_MAX)
+                        display = display.Substring(0, STRING_LIMIT) + THREE_DOTS;
                     display = "\"" + display + "\"";
                 }
 

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -292,6 +292,14 @@ namespace NUnit.Framework
             }
 
             /// <summary>
+            /// The ClassName of the test
+            /// </summary>
+            public string ClassName
+            {
+                get { return _test.ClassName;  }
+            }
+
+            /// <summary>
             /// The properties of the test.
             /// </summary>
             public IPropertyBag Properties

--- a/src/NUnitFramework/tests/Internal/TestNamingTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNamingTests.cs
@@ -30,6 +30,7 @@ namespace NUnit.Framework.Internal.Tests
         protected const string OUTER_CLASS = "NUnit.Framework.Internal.Tests.TestNamingTests";
 
         protected abstract string FixtureName { get; }
+        protected abstract string ClassName { get; }
 
         protected TestContext.TestAdapter CurrentTest
         {
@@ -39,36 +40,43 @@ namespace NUnit.Framework.Internal.Tests
         [Test]
         public void SimpleTest()
         {
-            CheckNames("SimpleTest");
+            CheckNames("SimpleTest", "SimpleTest");
         }
 
         [TestCase(5, 7, "ABC")]
         public void ParameterizedTest(int x, int y, string s)
         {
-            CheckNames("ParameterizedTest(5,7,\"ABC\")");
+            CheckNames("ParameterizedTest(5,7,\"ABC\")", "ParameterizedTest");
         }
 
         [TestCase("abcdefghijklmnopqrstuvwxyz")]
         public void TestCaseWithLongStringArgument(string s)
         {
-            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnopqrstuvwxyz\")");
+            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnopqrstuvwxyz\")", "TestCaseWithLongStringArgument");
         }
 
         [TestCase(42)]
         public void GenericTest<T>(T arg)
         {
-            CheckNames("GenericTest<Int32>(42)");
+            CheckNames("GenericTest<Int32>(42)", "GenericTest");
         }
 
-        private void CheckNames(string expectedName)
+        private void CheckNames(string expectedTestName, string expectedMethodName)
         {
-            Assert.That(CurrentTest.Name, Is.EqualTo(expectedName));
-            Assert.That(CurrentTest.FullName, Is.EqualTo(OUTER_CLASS + "+" + FixtureName + "." + expectedName));
+            Assert.That(CurrentTest.Name, Is.EqualTo(expectedTestName));
+            Assert.That(CurrentTest.FullName, Is.EqualTo(OUTER_CLASS + "+" + FixtureName + "." + expectedTestName));
+            Assert.That(CurrentTest.MethodName, Is.EqualTo(expectedMethodName));
+            Assert.That(CurrentTest.ClassName, Is.EqualTo(OUTER_CLASS + "+" + ClassName));
         }
 
         public class SimpleFixture : TestNamingTests
         {
             protected override string FixtureName
+            {
+                get { return "SimpleFixture"; }
+            }
+
+            protected override string ClassName
             {
                 get { return "SimpleFixture"; }
             }
@@ -81,6 +89,11 @@ namespace NUnit.Framework.Internal.Tests
             {
                 get { return "GenericFixture<Int32>"; }
             }
+
+            protected override string ClassName
+            {
+                get { return "GenericFixture`1"; }
+            }
         }
 
         [TestFixture(42, "Forty-two")]
@@ -91,6 +104,11 @@ namespace NUnit.Framework.Internal.Tests
             protected override string FixtureName
             {
                 get { return "ParameterizedFixture(42,\"Forty-two\")"; }
+            }
+
+            protected override string ClassName
+            {
+                get { return "ParameterizedFixture"; }
             }
         }
 
@@ -103,6 +121,11 @@ namespace NUnit.Framework.Internal.Tests
             {
                 get { return "ParameterizedFixtureWithLongStringArgument(\"This is really much too long to be us...\")"; }
             }
+
+            protected override string ClassName
+            {
+                get { return "ParameterizedFixtureWithLongStringArgument"; }
+            }
         }
 
         [TestFixture(typeof(int), typeof(string), 42, "Forty-two")]
@@ -113,6 +136,11 @@ namespace NUnit.Framework.Internal.Tests
             protected override string FixtureName
             {
                 get { return "GenericParameterizedFixture<Int32,String>(42,\"Forty-two\")"; }
+            }
+
+            protected override string ClassName
+            {
+                get { return "GenericParameterizedFixture`2"; }
             }
         }
     }

--- a/src/NUnitFramework/tests/Internal/TestNamingTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNamingTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Internal.Tests
         [TestCase("abcdefghijklmnopqrstuvwxyz")]
         public void TestCaseWithLongStringArgument(string s)
         {
-            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnop...\")");
+            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnopqrstuvwxyz\")");
         }
 
         [TestCase(42)]
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Internal.Tests
 
             protected override string FixtureName
             {
-                get { return "ParameterizedFixtureWithLongStringArgument(\"This is really mu...\")"; }
+                get { return "ParameterizedFixtureWithLongStringArgument(\"This is really much too long to be us...\")"; }
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -108,6 +108,16 @@ namespace NUnit.Framework.Internal
             Assert.That(topNode.Attributes["id"], Is.EqualTo(test.Id.ToString()));
             Assert.That(topNode.Attributes["name"], Is.EqualTo(test.Name));
             Assert.That(topNode.Attributes["fullname"], Is.EqualTo(test.FullName));
+            if (test.FixtureType != null)
+            {
+                Assert.NotNull(test.ClassName);
+                Assert.That(topNode.Attributes["classname"], Is.EqualTo(test.ClassName));
+            }
+            if (test is TestMethod)
+            {
+                Assert.NotNull(test.MethodName);
+                Assert.That(topNode.Attributes["methodname"], Is.EqualTo(test.MethodName));
+            }
             Assert.That(topNode.Attributes["runstate"], Is.EqualTo(test.RunState.ToString()));
 
             if (test.Properties.Keys.Count > 0)


### PR DESCRIPTION
This fixes #534 and is a partial fix for #539.

#534: The name of the class and method is now a property in ITest. ClassName has a non-null value in any test with a FixtureType. MethodName has a non-null value for TestMethods. The xml contains classname and methodname attributes whenever the corresponding property is non-null.

#539: I increased the maximum string argument size before truncation to 40 as a workaround. We'll keep this issue open for further work in the next iteration.