### PR TITLE
Fixing issue with char, int comparision - #524

### DIFF
--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -98,6 +98,44 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region Ints
+
+        /// <summary>
+        /// Verifies that two ints are equal. If they are not, then an
+        /// <see cref="AssertionException"/> is thrown.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">The message to display in case of failure</param>
+        /// <param name="args">Array of objects to be used in formatting the message</param>
+        public static void AreEqual(int expected, int actual, string message, params object[] args)
+        {
+            Assert.That(actual, Is.EqualTo(expected), message, args);
+        }
+        /// <summary>
+        /// Verifies that two ints are equal. If they are not, then an
+        /// <see cref="AssertionException"/> is thrown.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">The message to display in case of failure</param>
+        public static void AreEqual(int expected, int actual, string message)
+        {
+            Assert.That(actual, Is.EqualTo(expected), message, null);
+        }
+        /// <summary>
+        /// Verifies that two ints are equal. If they are not, then an
+        /// <see cref="AssertionException"/> is thrown.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        public static void AreEqual(int expected, int actual)
+        {
+            Assert.That(actual, Is.EqualTo(expected), null, null);
+        }
+
+        #endregion
+
         #region Objects
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -118,17 +118,6 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
-        /// <param name="message">The message to display in case of failure</param>
-        public static void AreEqual(int expected, int actual, string message)
-        {
-            Assert.That(actual, Is.EqualTo(expected), message, null);
-        }
-        /// <summary>
-        /// Verifies that two ints are equal. If they are not, then an
-        /// <see cref="AssertionException"/> is thrown.
-        /// </summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The actual value</param>
         public static void AreEqual(int expected, int actual)
         {
             Assert.That(actual, Is.EqualTo(expected), null, null);

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -55,6 +55,14 @@ namespace NUnit.Framework.Assertions
             int i32 = 0;
             Assert.AreEqual(i32, l64);
         }
+
+        [Test]
+        public void IntCharComparision()
+        {
+            char c= '\u0000';
+            int i = 0;
+            Assert.AreEqual(c, i);
+        }
         
         [Test]
         public void IntegerLongComparison()


### PR DESCRIPTION
issue #524

In 2.xx there is a INT overload for AreEqual function, thanks to that char is casted to int and we have simple numeric values comparision.
```
public static void AreEqual(int expected, int actual)
```
in 3.0 overloaded AreEqual for INT are missing and char int comparision hits the
```
public static void AreEqual(object expected, object actual)
```
Which in the end yields false due to char not being treated as a numeric value 0


This PR just adds INT overloads from 2.xx