### PR TITLE
Added ArgumentNullException to NUnit.Framework.Throws.

### DIFF
--- a/src/NUnitFramework/framework/Throws.cs
+++ b/src/NUnitFramework/framework/Throws.cs
@@ -81,6 +81,18 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region ArgumentNullException
+
+        /// <summary>
+        /// Creates a constraint specifying an expected ArgumentNUllException
+        /// </summary>
+        public static ExactTypeConstraint ArgumentNullException
+        {
+            get { return TypeOf(typeof (System.ArgumentNullException)); }
+        }
+
+        #endregion
+
         #region InvalidOperationException
 
         /// <summary>

--- a/src/NUnitFramework/framework/Throws.cs
+++ b/src/NUnitFramework/framework/Throws.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework
         #region ArgumentException
 
         /// <summary>
-        /// Creates a constraint specifying an expected TargetInvocationException
+        /// Creates a constraint specifying an expected ArgumentException
         /// </summary>
         public static ExactTypeConstraint ArgumentException
         {
@@ -96,7 +96,7 @@ namespace NUnit.Framework
         #region InvalidOperationException
 
         /// <summary>
-        /// Creates a constraint specifying an expected TargetInvocationException
+        /// Creates a constraint specifying an expected InvalidOperationException
         /// </summary>
         public static ExactTypeConstraint InvalidOperationException
         {

--- a/src/NUnitFramework/tests/TestUtilities/TestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestDelegates.cs
@@ -32,6 +32,11 @@ namespace NUnit.TestUtilities
             throw new ArgumentException("myMessage", "myParam");
         }
 
+        public static void ThrowsArgumentNullException()
+        {
+            throw new ArgumentNullException("myParam", "myMessage");
+        }
+
         public static void ThrowsNullReferenceException()
         {
             throw new NullReferenceException("my message");

--- a/src/NUnitFramework/tests/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/ThrowsTests.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Tests
+{
+    [TestFixture]
+    public class ThrowsTests
+    {
+        [Test]
+        public void ArgumentNullException_ConstraintMatchesThrownArgumentNullException()
+        {
+            Assert.That(TestDelegates.ThrowsArgumentNullException, Throws.ArgumentNullException);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -257,6 +257,7 @@
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="Constraints\ExactCountConstraintTests.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Proposed fix for feature request #576.