### PR TITLE
Remove unnecessary escape that is breaking TC output

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -96,8 +96,8 @@ namespace NUnit.Engine.Drivers
             if (test.IsSuite)
                 thisNode.AddAttribute("type", test.TestType);
             thisNode.AddAttribute("id", test.TestName.TestID.ToString());
-            thisNode.AddAttribute("name", Escape(test.TestName.Name));
-            thisNode.AddAttribute("fullname", Escape(test.TestName.FullName));
+            thisNode.AddAttribute("name", test.TestName.Name);
+            thisNode.AddAttribute("fullname", test.TestName.FullName);
             thisNode.AddAttribute("runstate", test.RunState.ToString());
 
             if (test.IsSuite)
@@ -256,17 +256,6 @@ namespace NUnit.Engine.Drivers
         #endregion
 
         #region Helper Methods
-
-        // Escapes a string for use in the XML
-        private static string Escape(string original)
-        {
-            return original
-                .Replace("&", "&amp;")
-                .Replace("\"", "&quot;")
-                .Replace("'", "&apos;")
-                .Replace("<", "&lt;")
-                .Replace(">", "&gt;");
-        }
 
         // Returns ResultState translated to a v3 string representation
         private static string GetTranslatedResultState(ResultState resultState)

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -48,7 +48,8 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
-                        + CDataTestFixure.Tests;
+                        + CDataTestFixure.Tests
+                        + TestNameEscaping.Tests;
             
             public const int Suites = MockTestFixture.Suites 
                         + Singletons.OneTestCase.Suites
@@ -60,6 +61,7 @@ namespace NUnit.Tests
                         + ParameterizedFixture.Suites
                         + GenericFixtureConstants.Suites
                         + CDataTestFixure.Suites
+                        + TestNameEscaping.Suites
                         + NamespaceSuites;
             
             public const int Nodes = Tests + Suites;
@@ -338,5 +340,26 @@ namespace NUnit.Tests
         {
             Assert.Fail("The CDATA was: <![CDATA[ My <xml> ]]>");
         }
+    }
+
+    [TestFixture]
+    public class TestNameEscaping
+    {
+        public const int Tests = 10;
+        public const int Suites = 2;
+
+        [TestCase("< left bracket")]
+        [TestCase("> right bracket")]
+        [TestCase("'single quote'")]
+        [TestCase("\"double quote\"")]
+        [TestCase("&amp")]
+        public void MustBeEscaped(string str) { }
+
+        [TestCase("< left bracket", TestName = "<")]
+        [TestCase("> right bracket", TestName = ">")]
+        [TestCase("'single quote'", TestName = "'")]
+        [TestCase("double quote", TestName = "\"")]
+        [TestCase("amp", TestName = "&")]
+        public void MustBeEscaped_CustomName(string str) { }
     }
 }


### PR DESCRIPTION
Fixes #580 

Is there an existing test fixture that I could add an integration test to? I'd like to add a test for the output of the teamcity reporter through the nunit-console -> v2 driver -> teamcity reporter flow. 