### PR TITLE
Fixes #584 - NonRunnable assembly has incorrect result state

### DIFF
--- a/src/NUnitConsole/nunit-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit-console/ResultReporter.cs
@@ -152,7 +152,7 @@ namespace NUnit.ConsoleRunner
                         else
                         {
                             var site = result.GetAttribute("site");
-                            if (site == "SetUp" || site == "TearDown")
+                            if (site != "Parent" && site != "Child")
                                 WriteSingleResult(result, ColorStyle.Failure);
                             if (site == "SetUp") return;
                         }

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -90,8 +90,8 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
             Assert.That(GetSkipReason(result), Is.EqualTo(REASON));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
-            Assert.That(result.GetAttribute("result"), Is.EqualTo("Skipped"));
-            Assert.That(result.GetAttribute("label"), Is.EqualTo("NotRunnable"));
+            Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
+            Assert.That(result.GetAttribute("label"), Is.EqualTo("Invalid"));
             Assert.That(result.SelectSingleNode("reason/message").InnerText, Is.EqualTo(REASON));
         }
 

--- a/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Drivers
             "</test-suite>";
 
         private const string RUN_RESULT_FORMAT =
-            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable' result='Skipped' label='NotRunnable'>" +
+            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable' result='Failed' label='Invalid'>" +
                 "<properties>" +
                     "<property name='_SKIPREASON' value='{2}'/>" +
                 "</properties>" +


### PR DESCRIPTION
This turned out to be a double issue:

1. The XML string returned by NotRunnableFrameworkDriver had result="Skipped" label="NonRunnable" rather than the new values of result="Failed" label="Invalid". This caused the errors and failures report to be skipped entirely.

2. Even when the report was run, failures at the suite level were only reported when the site was SetUp or TearDown. This has been changed so that a suite failure is reported _unless_ the site is either Parent or Child.