### PR TITLE
Issue 582

### DIFF
--- a/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
@@ -35,23 +35,21 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions("test.dll");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.AreEqual(1, package.TestFiles.Count);
-            Assert.AreEqual(Path.GetFullPath("test.dll"), package.TestFiles[0]);
+            Assert.AreEqual(1, package.SubPackages.Count);
+            Assert.AreEqual(Path.GetFullPath("test.dll"), package.SubPackages[0].FullName);
         }
 
         [Test]
         public void MultipleAssemblies()
         {
             var names = new [] { "test1.dll", "test2.dll", "test3.dll" };
-            var expected = new[] {
-                Path.GetFullPath("test1.dll"),
-                Path.GetFullPath("test2.dll"),
-                Path.GetFullPath("test3.dll")
-            };
             var options = new ConsoleOptions(names);
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.AreEqual(expected, package.TestFiles);
+            Assert.AreEqual(3, package.SubPackages.Count);
+            Assert.AreEqual(Path.GetFullPath("test1.dll"), package.SubPackages[0].FullName);
+            Assert.AreEqual(Path.GetFullPath("test2.dll"), package.SubPackages[1].FullName);
+            Assert.AreEqual(Path.GetFullPath("test3.dll"), package.SubPackages[2].FullName);
         }
 
         [TestCase("--timeout=50", "DefaultTimeout", 50)]

--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -256,46 +256,46 @@ namespace NUnit.ConsoleRunner
             TestPackage package = new TestPackage(options.InputFiles);
 
             if (options.ProcessModel != null)//ProcessModel.Default)
-                package.Settings[PackageSettings.ProcessModel] = options.ProcessModel;
+                package.AddSetting(PackageSettings.ProcessModel, options.ProcessModel);
 
             if (options.DomainUsage != null)
-                package.Settings[PackageSettings.DomainUsage] = options.DomainUsage;
+                package.AddSetting(PackageSettings.DomainUsage, options.DomainUsage);
 
             if (options.Framework != null)
-                package.Settings[PackageSettings.RuntimeFramework] = options.Framework;
+                package.AddSetting(PackageSettings.RuntimeFramework, options.Framework);
 
             if (options.RunAsX86)
-                package.Settings[PackageSettings.RunAsX86] = true;
+                package.AddSetting(PackageSettings.RunAsX86, true);
 
             if (options.DisposeRunners)
-                package.Settings[PackageSettings.DisposeRunners] = true;
+                package.AddSetting(PackageSettings.DisposeRunners, true);
 
             if (options.ShadowCopyFiles)
-                package.Settings[PackageSettings.ShadowCopyFiles] = true;
+                package.AddSetting(PackageSettings.ShadowCopyFiles, true);
 
             if (options.DefaultTimeout >= 0)
-                package.Settings[PackageSettings.DefaultTimeout] = options.DefaultTimeout;
+                package.AddSetting(PackageSettings.DefaultTimeout, options.DefaultTimeout);
 
             if (options.InternalTraceLevel != null)
-                package.Settings[PackageSettings.InternalTraceLevel] = options.InternalTraceLevel;
+                package.AddSetting(PackageSettings.InternalTraceLevel, options.InternalTraceLevel);
 
             if (options.ActiveConfig != null)
-                package.Settings[PackageSettings.ActiveConfig] = options.ActiveConfig;
+                package.AddSetting(PackageSettings.ActiveConfig, options.ActiveConfig);
             
             if (options.WorkDirectory != null)
-                package.Settings[PackageSettings.WorkDirectory] = options.WorkDirectory;
+                package.AddSetting(PackageSettings.WorkDirectory, options.WorkDirectory);
 
             if (options.StopOnError)
-                package.Settings[PackageSettings.StopOnError] = true;
+                package.AddSetting(PackageSettings.StopOnError, true);
 
             if (options.NumWorkers >= 0)
-                package.Settings[PackageSettings.NumberOfTestWorkers] = options.NumWorkers;
+                package.AddSetting(PackageSettings.NumberOfTestWorkers, options.NumWorkers);
 
             if (options.RandomSeed > 0)
-                package.Settings[PackageSettings.RandomSeed] = options.RandomSeed;
+                package.AddSetting(PackageSettings.RandomSeed, options.RandomSeed);
 
             if (options.Verbose)
-                package.Settings["Verbose"] = true;
+                package.AddSetting("Verbose", true);
 
 #if DEBUG
             //foreach (KeyValuePair<string, object> entry in package.Settings)

--- a/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
@@ -103,26 +103,26 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 Assert.AreEqual(new string[] { "Debug", "Release" }, _project.ConfigNames);
 
                 TestPackage package1 = _project.GetTestPackage("Debug");
-                Assert.AreEqual(2, package1.TestFiles.Count);
+                Assert.AreEqual(2, package1.SubPackages.Count);
                 Assert.AreEqual(
                     Path.Combine(debugDir, "assembly1.dll"),
-                    package1.TestFiles[0]);
+                    package1.SubPackages[0].FullName);
                 Assert.AreEqual(
                     Path.Combine(debugDir, "assembly2.dll"),
-                    package1.TestFiles[1]);
+                    package1.SubPackages[1].FullName);
 
                 Assert.AreEqual(2, package1.Settings.Count);
                 Assert.AreEqual(debugDir, package1.Settings["BasePath"], "BasePath");
                 Assert.AreEqual(true, package1.Settings["AutoBinPath"], "AutoBinPath");
 
                 TestPackage package2 = _project.GetTestPackage("Release");
-                Assert.AreEqual(2, package2.TestFiles.Count);
+                Assert.AreEqual(2, package2.SubPackages.Count);
                 Assert.AreEqual(
                     Path.Combine(releaseDir, "assembly1.dll"),
-                    package2.TestFiles[0]);
+                    package2.SubPackages[0].FullName);
                 Assert.AreEqual(
                     Path.Combine(releaseDir, "assembly2.dll"),
-                    package2.TestFiles[1]);
+                    package2.SubPackages[1].FullName);
 
                 Assert.AreEqual(2, package2.Settings.Count);
                 Assert.AreEqual(releaseDir, package2.Settings["BasePath"]);
@@ -170,13 +170,13 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 Assert.AreEqual("Multiple", package1.Settings["DomainUsage"]);
                 Assert.AreEqual("v2.0", package1.Settings["RuntimeFramework"]);
 
-                Assert.AreEqual(2, package1.TestFiles.Count);
+                Assert.AreEqual(2, package1.SubPackages.Count);
                 Assert.AreEqual(
                     Path.Combine(debugDir, "assembly1.dll"),
-                    package1.TestFiles[0]);
+                    package1.SubPackages[0].FullName);
                 Assert.AreEqual(
                     Path.Combine(debugDir, "assembly2.dll"),
-                    package1.TestFiles[1]);
+                    package1.SubPackages[1].FullName);
 
                 TestPackage package2 = project.GetTestPackage("Release");
                 Assert.AreEqual(5, package2.Settings.Count);
@@ -186,13 +186,13 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 Assert.AreEqual("Multiple", package2.Settings["DomainUsage"]);
                 Assert.AreEqual("v4.0", package2.Settings["RuntimeFramework"]);
 
-                Assert.AreEqual(2, package2.TestFiles.Count);
+                Assert.AreEqual(2, package2.SubPackages.Count);
                 Assert.AreEqual(
                     Path.Combine(releaseDir, "assembly1.dll"),
-                    package2.TestFiles[0]);
+                    package2.SubPackages[0].FullName);
                 Assert.AreEqual(
                     Path.Combine(releaseDir, "assembly2.dll"),
-                    package2.TestFiles[1]);
+                    package2.SubPackages[1].FullName);
             }
         }
     }

--- a/src/NUnitEngine/Addins/addin-tests/VisualStudioProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/VisualStudioProjectLoaderTests.cs
@@ -93,10 +93,10 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                     TestPackage package = project.GetTestPackage(config);
 
                     Assert.AreEqual(resourceName, package.Name);
-                    Assert.AreEqual(1, package.TestFiles.Count);
-                    Assert.AreEqual(assemblyName, Path.GetFileNameWithoutExtension(package.TestFiles[0]));
+                    Assert.AreEqual(1, package.SubPackages.Count);
+                    Assert.AreEqual(assemblyName, Path.GetFileNameWithoutExtension(package.SubPackages[0].FullName));
                     Assert.That(package.Settings.ContainsKey("BasePath"));
-                    Assert.That(Path.GetDirectoryName(package.TestFiles[0]), Is.SamePath((string)package.Settings["BasePath"]));
+                    Assert.That(Path.GetDirectoryName(package.SubPackages[0].FullName), Is.SamePath((string)package.Settings["BasePath"]));
                 }
             }
         }
@@ -113,8 +113,8 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 IProject project = _loader.LoadFrom(file.Path);
 
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(4, project.GetTestPackage("Debug").TestFiles.Count);
-                Assert.AreEqual(4, project.GetTestPackage("Release").TestFiles.Count);
+                Assert.AreEqual(4, project.GetTestPackage("Debug").SubPackages.Count);
+                Assert.AreEqual(4, project.GetTestPackage("Release").SubPackages.Count);
             }
         }
 
@@ -130,8 +130,8 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 IProject project = _loader.LoadFrom(file.Path);
 
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(4, project.GetTestPackage("Debug").TestFiles.Count);
-                Assert.AreEqual(4, project.GetTestPackage("Release").TestFiles.Count);
+                Assert.AreEqual(4, project.GetTestPackage("Debug").SubPackages.Count);
+                Assert.AreEqual(4, project.GetTestPackage("Release").SubPackages.Count);
             }
         }
 
@@ -143,8 +143,8 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             {
                 IProject project = _loader.LoadFrom(file.Path);
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(1, project.GetTestPackage("Debug").TestFiles.Count);
-                Assert.AreEqual(1, project.GetTestPackage("Release").TestFiles.Count);
+                Assert.AreEqual(1, project.GetTestPackage("Debug").SubPackages.Count);
+                Assert.AreEqual(1, project.GetTestPackage("Release").SubPackages.Count);
             }
         }
 
@@ -158,8 +158,8 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 IProject project = _loader.LoadFrom(file.Path);
 
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(2, project.GetTestPackage("Debug").TestFiles.Count);
-                Assert.AreEqual(2, project.GetTestPackage("Release").TestFiles.Count);
+                Assert.AreEqual(2, project.GetTestPackage("Debug").SubPackages.Count);
+                Assert.AreEqual(2, project.GetTestPackage("Release").SubPackages.Count);
             }
         }
 
@@ -172,8 +172,8 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             {
                 IProject project = _loader.LoadFrom(file.Path);
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(2, project.GetTestPackage("Release").TestFiles.Count, "Release should have 2 assemblies");
-                Assert.AreEqual(1, project.GetTestPackage("Debug").TestFiles.Count, "Debug should have 1 assembly");
+                Assert.AreEqual(2, project.GetTestPackage("Release").SubPackages.Count, "Release should have 2 assemblies");
+                Assert.AreEqual(1, project.GetTestPackage("Debug").SubPackages.Count, "Debug should have 1 assembly");
             }
         }
     }

--- a/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
@@ -105,7 +105,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                         string assembly = node.GetAttribute("path");
                         if (basePath != null)
                             assembly = Path.Combine(basePath, assembly);
-                        package.Add(assembly);
+                        package.AddSubPackage(new TestPackage(assembly));
                     }
 
                     var settings = GetSettingsForConfig(configNode);

--- a/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2DriverFactory.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2DriverFactory.cs
@@ -48,13 +48,14 @@ namespace NUnit.Engine.Drivers
         /// which the assembly is already known to reference.
         /// </summary>
         /// <param name="domain">The domain in which the assembly will be loaded</param>
-        /// <param name="frameworkAssemblyName">The name of the test framework reference</param>
-        /// <param name="assemblyPath">The path to the test assembly</param>
-        /// <param name="settings">A dictionarly of settings to be used for this assembly</param>
+        /// <param name="frameworkReference">The name of the test framework reference</param>
         /// <returns></returns>
-        public IFrameworkDriver GetDriver(AppDomain domain, string frameworkAssemblyName, string assemblyPath, IDictionary<string, object> settings)
+        public IFrameworkDriver GetDriver(AppDomain domain, AssemblyName frameworkReference)
         {
-            return new NUnit2FrameworkDriver(domain, frameworkAssemblyName, assemblyPath, settings);
+            if (!IsSupportedFramework(frameworkReference))
+                throw new ArgumentException("Invalid framework name", "frameworkAssemblyName");
+
+            return new NUnit2FrameworkDriver(domain);
         }
     }
 }

--- a/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2DriverFactory.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2DriverFactory.cs
@@ -33,12 +33,25 @@ namespace NUnit.Engine.Drivers
         private const string NUNIT_FRAMEWORK = "nunit.framework";
         private const string NUNITLITE_FRAMEWORK = "nunitlite";
 
+        /// <summary>
+        /// Gets a flag indicating whether a given AssemblyName
+        /// represents a test framework supported by this factory.
+        /// </summary>
         public bool IsSupportedFramework(AssemblyName reference)
         {
             return reference.Name == NUNIT_FRAMEWORK && reference.Version.Major == 2
                 || reference.Name == NUNITLITE_FRAMEWORK && reference.Version.Major == 1;
         }
 
+        /// <summary>
+        /// Gets a driver for a given test assembly and a framework
+        /// which the assembly is already known to reference.
+        /// </summary>
+        /// <param name="domain">The domain in which the assembly will be loaded</param>
+        /// <param name="frameworkAssemblyName">The name of the test framework reference</param>
+        /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <param name="settings">A dictionarly of settings to be used for this assembly</param>
+        /// <returns></returns>
         public IFrameworkDriver GetDriver(AppDomain domain, string frameworkAssemblyName, string assemblyPath, IDictionary<string, object> settings)
         {
             return new NUnit2FrameworkDriver(domain, frameworkAssemblyName, assemblyPath, settings);

--- a/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Drivers
             "</test-suite>";
 
         private const string RUN_RESULT_FORMAT =
-            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable' result='Skipped' label='NotRunnable'>" +
+            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable' result='Failed' label='Invalid'>" +
                 "<properties>" +
                     "<property name='_SKIPREASON' value='{2}'/>" +
                 "</properties>" +
@@ -64,9 +64,17 @@ namespace NUnit.Engine.Drivers
         TestRunner _runner;
         Core.TestPackage _package;
 
-        public NUnit2FrameworkDriver(AppDomain testDomain, string testAssemblyPath, IDictionary<string, object> settings)
-            : this(testDomain, NUNIT_FRAMEWORK, testAssemblyPath, settings) { }
-
+        /// <summary>
+        /// Create a new NUnit2FrameworkDriver
+        /// </summary>
+        /// <param name="testDomain">The AppDomain to use for the runner</param>
+        /// <param name="frameworkAssemblyName">The name of the framework assembly</param>
+        /// <param name="testAssemblyPath">Path to the test assembly</param>
+        /// <param name="settings">Settings for use in loading and running the test</param>
+        /// <remarks>
+        /// The framework assembly name is needed because this driver is used for both the
+        /// nunit.framework 2.x and nunitlite 1.0.
+        /// </remarks>
         public NUnit2FrameworkDriver(AppDomain testDomain, string frameworkAssemblyName, string testAssemblyPath, IDictionary<string, object> settings)
         {
             if (!File.Exists(testAssemblyPath))

--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -95,9 +95,11 @@ namespace NUnit.Engine.Drivers
 
             if (test.IsSuite)
                 thisNode.AddAttribute("type", test.TestType);
-            thisNode.AddAttribute("id", test.TestName.TestID.ToString());
-            thisNode.AddAttribute("name", test.TestName.Name);
-            thisNode.AddAttribute("fullname", test.TestName.FullName);
+
+            var tn = test.TestName;
+            thisNode.AddAttribute("id", string.Format("{0}-{1}", tn.RunnerID, tn.TestID));
+            thisNode.AddAttribute("name", tn.Name);
+            thisNode.AddAttribute("fullname", tn.FullName);
             thisNode.AddAttribute("runstate", test.RunState.ToString());
 
             if (test.IsSuite)

--- a/src/NUnitEngine/Addins/vs-project-loader/VSProject.cs
+++ b/src/NUnitEngine/Addins/vs-project-loader/VSProject.cs
@@ -123,14 +123,14 @@ namespace NUnit.Engine.Services.ProjectLoaders
                 if (configName == null || configName == name)
                 {
                     var config = _configs[name];
-                    package.Add(config.AssemblyPath);
+                    package.AddSubPackage(new TestPackage(config.AssemblyPath));
                     appbase = config.OutputDirectory;
                     break;
                 }
             }
 
             if (appbase != null)
-                package.Settings["BasePath"] = appbase;
+                package.AddSetting("BasePath", appbase);
 
             return package;
         }

--- a/src/NUnitEngine/Addins/vs-project-loader/VSSolution.cs
+++ b/src/NUnitEngine/Addins/vs-project-loader/VSSolution.cs
@@ -92,7 +92,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     var config = _configs[name];
                     foreach (string assembly in config.Assemblies)
                     {
-                        package.Add(assembly);
+                        package.AddSubPackage(new TestPackage(assembly));
                     }
                     break;
                 }
@@ -157,9 +157,9 @@ namespace NUnit.Engine.Services.ProjectLoaders
                                 _configs.Add(solutionConfig, config);
                             }
 
-                            foreach (string assembly in vsProject.GetTestPackage(projectConfig).TestFiles)
-                                if (!config.Assemblies.Contains(assembly))
-                                    config.Assemblies.Add(assembly);
+                            foreach (var subPackage in vsProject.GetTestPackage(projectConfig).SubPackages)
+                                if (!config.Assemblies.Contains(subPackage.FullName))
+                                    config.Assemblies.Add(subPackage.FullName);
 
                             //if (VSProject.IsProjectFile(vsProjectPath))
                             //    project.Add(new VSProject(Path.Combine(solutionDirectory, vsProjectPath)));

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace NUnit.Engine.Extensibility
@@ -43,10 +42,8 @@ namespace NUnit.Engine.Extensibility
         /// which the assembly is already known to reference.
         /// </summary>
         /// <param name="domain">The domain in which the assembly will be loaded</param>
-        /// <param name="frameworkAssemblyName">The name of the test framework reference</param>
-        /// <param name="assemblyPath">The path to the test assembly</param>
-        /// <param name="settings">A dictionary of settings to be used for this assembly</param>
+        /// <param name="frameworkReference">The AssemblyName of the test framework reference</param>
         /// <returns></returns>
-        IFrameworkDriver GetDriver(AppDomain domain, string frameworkAssemblyName, string assemblyPath, IDictionary<string, object> settings);
+        IFrameworkDriver GetDriver(AppDomain domain, AssemblyName frameworkReference);
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
@@ -39,8 +39,8 @@ namespace NUnit.Engine.Extensibility
         bool IsSupportedFramework(AssemblyName refAssembly);
 
         /// <summary>
-        /// Gets a driver for a given test assembly and framework
-        /// which it is already known to reference.
+        /// Gets a driver for a given test assembly and a framework
+        /// which the assembly is already known to reference.
         /// </summary>
         /// <param name="domain">The domain in which the assembly will be loaded</param>
         /// <param name="frameworkAssemblyName">The name of the test framework reference</param>

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IFrameworkDriver.cs
@@ -35,10 +35,16 @@ namespace NUnit.Engine.Extensibility
     public interface IFrameworkDriver
     {
         /// <summary>
+        /// Gets and sets the unique identifier for this driver,
+        /// used to ensure that test ids are unique across drivers.
+        /// </summary>
+        string ID { get; set; }
+
+        /// <summary>
         /// Loads the tests in an assembly.
         /// </summary>
         /// <returns>An Xml string representing the loaded test</returns>
-        string Load();
+        string Load(string testAssemblyPath, IDictionary<string, object> settings);
 
         /// <summary>
         /// Count the test cases that would be executed.

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -73,7 +73,7 @@ namespace NUnit.Engine
 
         private string GetNextID()
         {
-            return unchecked(_nextID++).ToString();
+            return (_nextID++).ToString();
         }
 
         #endregion
@@ -132,7 +132,6 @@ namespace NUnit.Engine
         /// <summary>
         /// Add a setting to a package and all of its subpackages.
         /// </summary>
-        /// <typeparam name="T">The Type of the setting value</typeparam>
         /// <param name="name">The name of the setting</param>
         /// <param name="value">The value of the setting</param>
         /// <remarks>
@@ -142,7 +141,7 @@ namespace NUnit.Engine
         /// used when the settings are intended to be reflected to all the
         /// subpackages under the package.
         /// </remarks>
-        public void AddSetting<T>(string name, T value)
+        public void AddSetting(string name, object value)
         {
             Settings[name] = value;
             foreach (var subPackage in SubPackages)

--- a/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
@@ -37,23 +37,28 @@ namespace NUnit.Engine.Api.Tests
         }
 
         [Test]
+        public void PackageIDsAreUnique()
+        {
+            var another = new TestPackage("another.dll");
+            Assert.That(another.ID, Is.Not.EqualTo(package.ID));
+        }
+
+        [Test]
         public void AssemblyPathIsUsedAsFilePath()
         {
             Assert.AreEqual(Path.GetFullPath("test.dll"), package.FullName);
         }
 
         [Test]
-        public void AssemblyPathIsIncludedInList()
-        {
-            Assert.AreEqual(
-                new string[] { Path.GetFullPath("test.dll") },
-                package.TestFiles);
-        }
-
-        [Test]
         public void FileNameIsUsedAsPackageName()
         {
             Assert.That(package.Name, Is.EqualTo("test.dll"));
+        }
+
+        [Test]
+        public void HasNoSubPackages()
+        {
+            Assert.That(package.SubPackages.Count, Is.EqualTo(0));
         }
     }
 
@@ -74,14 +79,12 @@ namespace NUnit.Engine.Api.Tests
         }
 
         [Test]
-        public void AssemblyPathsAreIncludedInList()
+        public void PackageContainsThreeSubpackages()
         {
-            string[] expectedAssemblies = new string[] {
-            Path.GetFullPath("test1.dll"),
-            Path.GetFullPath("test2.dll"),
-            Path.GetFullPath("test3.dll") };
-
-            Assert.AreEqual(expectedAssemblies, package.TestFiles);
+            Assert.That(package.SubPackages.Count, Is.EqualTo(3));
+            Assert.That(package.SubPackages[0].FullName, Is.EqualTo(Path.GetFullPath("test1.dll")));
+            Assert.That(package.SubPackages[1].FullName, Is.EqualTo(Path.GetFullPath("test2.dll")));
+            Assert.That(package.SubPackages[2].FullName, Is.EqualTo(Path.GetFullPath("test3.dll")));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -37,6 +37,7 @@ namespace NUnit.Engine.Drivers.Tests
     {
         private string MOCK_ASSEMBLY = "mock-nunit-assembly.exe";
         private const string MISSING_FILE = "junk.dll";
+        private const string NUNIT_FRAMEWORK = "nunit.framework";
 
         private IDictionary<string, object> _settings = new Dictionary<string, object>();
         private NUnit3FrameworkDriver _driver;

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -35,9 +35,10 @@ namespace NUnit.Engine.Drivers.Tests
     // Functional tests of the NUnitFrameworkDriver calling into the framework.
     public class NUnit3FrameworkDriverTests
     {
-        private string MOCK_ASSEMBLY = "mock-nunit-assembly.exe";
+        private const string MOCK_ASSEMBLY = "mock-nunit-assembly.exe";
         private const string MISSING_FILE = "junk.dll";
         private const string NUNIT_FRAMEWORK = "nunit.framework";
+        private const string LOAD_MESSAGE = "Method called without calling Load first";
 
         private IDictionary<string, object> _settings = new Dictionary<string, object>();
         private NUnit3FrameworkDriver _driver;
@@ -47,7 +48,7 @@ namespace NUnit.Engine.Drivers.Tests
         public void CreateDriver()
         {
             _mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-            _driver = new NUnit3FrameworkDriver(AppDomain.CurrentDomain, _mockAssemblyPath, _settings);
+            _driver = new NUnit3FrameworkDriver(AppDomain.CurrentDomain);
         }
 
         #region Construction Test
@@ -62,7 +63,7 @@ namespace NUnit.Engine.Drivers.Tests
 
         public void ConstructController_MissingFile_ThrowsArgumentInvalid()
         {
-            Assert.That(new NUnit3FrameworkDriver(AppDomain.CurrentDomain, MISSING_FILE, _settings), Throws.ArgumentException);
+            Assert.That(new NUnit3FrameworkDriver(AppDomain.CurrentDomain), Throws.ArgumentException);
         }
         #endregion
 
@@ -70,7 +71,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void Load_GoodFile_ReturnsRunnableSuite()
         {
-            var result = XmlHelper.CreateXmlNode(_driver.Load());
+            var result = XmlHelper.CreateXmlNode(_driver.Load(_mockAssemblyPath, _settings));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
@@ -84,7 +85,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void Explore_AfterLoad_ReturnsRunnableSuite()
         {
-            _driver.Load();
+            _driver.Load(_mockAssemblyPath, _settings);
             var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
@@ -101,7 +102,7 @@ namespace NUnit.Engine.Drivers.Tests
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
-            Assert.That(ex.Message, Is.EqualTo("The Explore method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo(LOAD_MESSAGE));
         }
         #endregion
 
@@ -109,7 +110,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void CountTestsAction_AfterLoad_ReturnsCorrectCount()
         {
-            _driver.Load();
+            _driver.Load(_mockAssemblyPath, _settings);
             Assert.That(_driver.CountTestCases(TestFilter.Empty), Is.EqualTo(MockAssembly.Tests - MockAssembly.Explicit));
         }
 
@@ -120,7 +121,7 @@ namespace NUnit.Engine.Drivers.Tests
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
-            Assert.That(ex.Message, Is.EqualTo("The CountTestCases method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo(LOAD_MESSAGE));
         }
         #endregion
 
@@ -128,7 +129,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void RunTestsAction_AfterLoad_ReturnsRunnableSuite()
         {
-            _driver.Load();
+            _driver.Load(_mockAssemblyPath, _settings);
             var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
@@ -150,7 +151,7 @@ namespace NUnit.Engine.Drivers.Tests
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
-            Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo(LOAD_MESSAGE));
         }
         #endregion
 

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Web.UI;
 using System.Xml;
 using NUnit.Engine.Internal;
@@ -45,15 +46,19 @@ namespace NUnit.Engine.Drivers.Tests
         public void CreateDriver()
         {
             _driver = new NotRunnableFrameworkDriver( BAD_FILE, REASON);
+            _driver.ID = "99";
         }
 
         [Test]
         public void Load_ReturnsNonRunnableSuite()
         {
-            var result = XmlHelper.CreateXmlNode(_driver.Load());
+            var result = XmlHelper.CreateXmlNode(_driver.Load(BAD_FILE, new Dictionary<string, object>()));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(BAD_FILE));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(BAD_FILE)));
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
             Assert.That(GetSkipReason(result), Is.EqualTo(REASON));
@@ -66,6 +71,9 @@ namespace NUnit.Engine.Drivers.Tests
             var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(BAD_FILE));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(BAD_FILE)));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
@@ -83,8 +91,10 @@ namespace NUnit.Engine.Drivers.Tests
         public void Run_ReturnsNonRunnableSuite()
         {
             var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty));
-
             Assert.That(result.Name, Is.EqualTo("test-suite"));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(BAD_FILE));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(BAD_FILE)));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -82,7 +82,8 @@ namespace NUnit.Engine.Services.Tests
         {
             var package = new TestPackage(files.Split(new char[] { ' ' }));
             if (processModel != null)
-                package.Settings["ProcessModel"] = processModel;
+                package.AddSetting("ProcessModel", processModel);
+
             var runner = _factory.MakeTestRunner(package);
 
             Assert.That(runner, Is.TypeOf(expectedType));

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -30,8 +30,8 @@ using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services.Tests
 {
-    [TestFixture, Ignore("DriverFactory currently only works in the primary AppDomain")]
-    public class DriverFactoryTests
+    [TestFixture, Ignore("DriverService currently only works in the primary AppDomain")]
+    public class DriverServiceTests
     {
         [Test]
         public void AssemblyUsesNUnitFrameworkDriver()
@@ -56,8 +56,7 @@ namespace NUnit.Engine.Services.Tests
             var factory = new DriverService();
             return factory.GetDriver(
                 AppDomain.CurrentDomain,
-                Path.Combine(TestContext.CurrentContext.TestDirectory, fileName),
-                new Dictionary<string, object>());
+                Path.Combine(TestContext.CurrentContext.TestDirectory, fileName));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -72,7 +72,7 @@
     <Compile Include="RuntimeFrameworkTests.cs" />
     <Compile Include="Services\InProcessTestRunnerFactoryTests.cs" />
     <Compile Include="Services\DomainManagerTests.cs" />
-    <Compile Include="Services\DriverFactoryTests.cs" />
+    <Compile Include="Services\DriverServiceTests.cs" />
     <Compile Include="Services\ResultServiceTests.cs" />
     <Compile Include="Services\ResultWriters\NUnit2XmlResultWriterTests.cs" />
     <Compile Include="Services\ResultWriters\NUnit2XmlValidationTests.cs" />

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
@@ -33,14 +33,29 @@ namespace NUnit.Engine.Drivers
     {
         private const string NUNIT_FRAMEWORK = "nunit.framework";
 
+        /// <summary>
+        /// Gets a flag indicating whether a given AssemblyName
+        /// represents a test framework supported by this factory.
+        /// </summary>
         public bool IsSupportedFramework(AssemblyName reference)
         {
             return reference.Name == NUNIT_FRAMEWORK && reference.Version.Major == 3;
         }
 
+        /// <summary>
+        /// Gets a driver for a given test assembly and a framework
+        /// which the assembly is already known to reference.
+        /// </summary>
+        /// <param name="domain">The domain in which the assembly will be loaded</param>
+        /// <param name="frameworkAssemblyName">The name of the test framework reference</param>
+        /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <param name="settings">A dictionary of settings to be used for this assembly</param>
+        /// <returns></returns>
         public IFrameworkDriver GetDriver(AppDomain domain, string frameworkAssemblyName, string assemblyPath, IDictionary<string, object> settings)
         {
-            return new NUnit3FrameworkDriver(domain, frameworkAssemblyName, assemblyPath, settings);
+            Guard.ArgumentValid(frameworkAssemblyName == "nunit.framework", "Invalid framework name", "frameworkAssemblyName");
+            
+            return new NUnit3FrameworkDriver(domain, assemblyPath, settings);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
@@ -22,9 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Drivers
@@ -47,15 +45,13 @@ namespace NUnit.Engine.Drivers
         /// which the assembly is already known to reference.
         /// </summary>
         /// <param name="domain">The domain in which the assembly will be loaded</param>
-        /// <param name="frameworkAssemblyName">The name of the test framework reference</param>
-        /// <param name="assemblyPath">The path to the test assembly</param>
-        /// <param name="settings">A dictionary of settings to be used for this assembly</param>
+        /// <param name="frameworkReference">The AssemblyName of the test framework reference</param>
         /// <returns></returns>
-        public IFrameworkDriver GetDriver(AppDomain domain, string frameworkAssemblyName, string assemblyPath, IDictionary<string, object> settings)
+        public IFrameworkDriver GetDriver(AppDomain domain, AssemblyName frameworkReference)
         {
-            Guard.ArgumentValid(frameworkAssemblyName == "nunit.framework", "Invalid framework name", "frameworkAssemblyName");
+            Guard.ArgumentValid(IsSupportedFramework(frameworkReference), "Invalid framework name", "frameworkAssemblyName");
             
-            return new NUnit3FrameworkDriver(domain, assemblyPath, settings);
+            return new NUnit3FrameworkDriver(domain);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -22,11 +22,8 @@
 // ***********************************************************************
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
-using System.Web.UI;
-using System.Xml;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Extensibility;
 
@@ -39,6 +36,7 @@ namespace NUnit.Engine.Drivers
     public class NUnit3FrameworkDriver : IFrameworkDriver
     {
         private const string NUNIT_FRAMEWORK = "nunit.framework";
+        private const string LOAD_MESSAGE = "Method called without calling Load first";
 
         private static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
         private static readonly string LOAD_ACTION = CONTROLLER_TYPE + "+LoadTestsAction";
@@ -58,24 +56,25 @@ namespace NUnit.Engine.Drivers
         /// Construct an NUnit3FrameworkDriver
         /// </summary>
         /// <param name="testDomain">The AppDomain in which to create the FrameworkController</param>
-        /// <param name="testAssemblyPath">The path to the assembly this driver will be loading</param>
-        /// <param name="idPrefix">A prefix to be used on all generated test ids</param>
-        /// <param name="settings">A dictionary of settings to be used by the framework</param>
-        public NUnit3FrameworkDriver(AppDomain testDomain, string testAssemblyPath, IDictionary<string, object> settings)
+        public NUnit3FrameworkDriver(AppDomain testDomain)
         {
-            Guard.ArgumentValid(File.Exists(testAssemblyPath), "testAssemblyPath", "Framework driver constructor called with a file name that doesn't exist.");
-
             _testDomain = testDomain;
-            _testAssemblyPath = testAssemblyPath;
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, "ID", (System.Collections.IDictionary)settings);
         }
+
+        public string ID { get; set; }
 
         /// <summary>
         /// Loads the tests in an assembly.
         /// </summary>
         /// <returns>An Xml string representing the loaded test</returns>
-        public string Load()
+        public string Load(string testAssemblyPath, IDictionary<string, object> settings)
         {
+            Guard.ArgumentValid(File.Exists(testAssemblyPath), "testAssemblyPath", "Framework driver constructor called with a file name that doesn't exist.");
+
+            var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
+            _testAssemblyPath = testAssemblyPath;
+            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, (System.Collections.IDictionary)settings);
+
             CallbackHandler handler = new CallbackHandler();
 
             log.Info("Loading {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -86,6 +85,8 @@ namespace NUnit.Engine.Drivers
 
         public int CountTestCases(TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new CallbackHandler();
 
             CreateObject(COUNT_ACTION, _frameworkController, filter.Text, handler);
@@ -101,6 +102,8 @@ namespace NUnit.Engine.Drivers
         /// <returns>An Xml string representing the result</returns>
         public string Run(ITestEventListener listener, TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new RunTestsCallbackHandler(listener);
 
             log.Info("Running {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -125,6 +128,8 @@ namespace NUnit.Engine.Drivers
         /// <returns>An Xml string representing the tests</returns>
         public string Explore(TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new CallbackHandler();
 
             log.Info("Exploring {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -134,6 +139,12 @@ namespace NUnit.Engine.Drivers
         }
 
         #region Helper Methods
+
+        private void CheckLoadWasCalled()
+        {
+            if (_frameworkController == null)
+                throw new InvalidOperationException(LOAD_MESSAGE);
+        }
 
         private object CreateObject(string typeName, params object[] args)
         {

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -51,20 +51,22 @@ namespace NUnit.Engine.Drivers
 
         AppDomain _testDomain;
         string _testAssemblyPath;
-        string _frameworkAssemblyName;
 
         object _frameworkController;
 
+        /// <summary>
+        /// Construct an NUnit3FrameworkDriver
+        /// </summary>
+        /// <param name="testDomain">The AppDomain in which to create the FrameworkController</param>
+        /// <param name="testAssemblyPath">The path to the assembly this driver will be loading</param>
+        /// <param name="idPrefix">A prefix to be used on all generated test ids</param>
+        /// <param name="settings">A dictionary of settings to be used by the framework</param>
         public NUnit3FrameworkDriver(AppDomain testDomain, string testAssemblyPath, IDictionary<string, object> settings)
-            : this(testDomain, NUNIT_FRAMEWORK, testAssemblyPath, settings) { }
-
-        public NUnit3FrameworkDriver(AppDomain testDomain, string frameworkAssemblyName, string testAssemblyPath, IDictionary<string, object> settings)
         {
             Guard.ArgumentValid(File.Exists(testAssemblyPath), "testAssemblyPath", "Framework driver constructor called with a file name that doesn't exist.");
 
             _testDomain = testDomain;
             _testAssemblyPath = testAssemblyPath;
-            _frameworkAssemblyName = frameworkAssemblyName;
             _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, "ID", (System.Collections.IDictionary)settings);
         }
 
@@ -136,7 +138,7 @@ namespace NUnit.Engine.Drivers
         private object CreateObject(string typeName, params object[] args)
         {
             return _testDomain.CreateInstanceAndUnwrap(
-                _frameworkAssemblyName, typeName, false, 0,
+                NUNIT_FRAMEWORK, typeName, false, 0,
 #if !NET_4_0
                 null, args, null, null, null );
 #else

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -65,7 +65,7 @@ namespace NUnit.Engine.Drivers
             _testDomain = testDomain;
             _testAssemblyPath = testAssemblyPath;
             _frameworkAssemblyName = frameworkAssemblyName;
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, (System.Collections.IDictionary)settings);
+            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, "ID", (System.Collections.IDictionary)settings);
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Engine.Extensibility;
 
@@ -30,19 +31,19 @@ namespace NUnit.Engine.Drivers
     {
         // TODO: The id should not be hard-coded
         private const string LOAD_RESULT_FORMAT =
-            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable'>" +
+            "<test-suite type='Assembly' id='{0}' name='{1}' fullname='{2}' testcasecount='0' runstate='NotRunnable'>" +
                 "<properties>" +
-                    "<property name='_SKIPREASON' value='{2}'/>" +
+                    "<property name='_SKIPREASON' value='{3}'/>" +
                 "</properties>" +
             "</test-suite>";
 
         private const string RUN_RESULT_FORMAT =
-            "<test-suite type='Assembly' id='2' name='{0}' fullname='{1}' testcasecount='0' runstate='NotRunnable' result='Failed' label='Invalid'>" +
+            "<test-suite type='Assembly' id='{0}' name='{1}' fullname='{2}' testcasecount='0' runstate='NotRunnable' result='Failed' label='Invalid'>" +
                 "<properties>" +
-                    "<property name='_SKIPREASON' value='{2}'/>" +
+                    "<property name='_SKIPREASON' value='{3}'/>" +
                 "</properties>" +
                 "<reason>" +
-                    "<message>{2}</message>" +
+                    "<message>{3}</message>" +
                 "</reason>" +
             "</test-suite>";
 
@@ -53,13 +54,15 @@ namespace NUnit.Engine.Drivers
         public NotRunnableFrameworkDriver(string assemblyPath, string message)
         {
             _name = Escape(Path.GetFileName(assemblyPath));
-            _fullname = Escape(assemblyPath);
+            _fullname = Escape(Path.GetFullPath(assemblyPath));
             _message = Escape(message);
         }
 
-        public string Load()
+        public string ID { get; set; }
+
+        public string Load(string assemblyPath, IDictionary<string, object> settings)
         {
-            return string.Format(LOAD_RESULT_FORMAT, _name, _fullname, _message);
+            return string.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }
 
         public int CountTestCases(TestFilter filter)
@@ -69,12 +72,12 @@ namespace NUnit.Engine.Drivers
 
         public string Run(ITestEventListener listener, TestFilter filter)
         {
-            return string.Format(RUN_RESULT_FORMAT, _name, _fullname, _message);
+            return string.Format(RUN_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }
 
         public string Explore(TestFilter filter)
         {
-            return string.Format(LOAD_RESULT_FORMAT, _name, _fullname, _message);
+            return string.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }
 
         public void StopRun(bool force)
@@ -89,6 +92,16 @@ namespace NUnit.Engine.Drivers
                 .Replace("'", "&apos;")
                 .Replace("<", "&lt;")
                 .Replace(">", "&gt;");
+        }
+
+        private string TestID
+        {
+            get
+            {
+                return string.IsNullOrEmpty(ID)
+                    ? "1"
+                    : ID + "-1";
+            }
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/IDriverService.cs
+++ b/src/NUnitEngine/nunit.engine/IDriverService.cs
@@ -22,14 +22,22 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine
 {
+    /// <summary>
+    /// The IDriverService interface is implemented by the driver service, which is able
+    /// to provide drivers for loading and running tests using various frameworks.
+    /// </summary>
     public interface IDriverService
     {
-        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, IDictionary<string, object> settings);
+        /// <summary>
+        /// Get a driver suitable for loading and running tests in the specified assembly.
+        /// </summary>
+        /// <param name="domain">The AppDomain in which to run the tests</param>
+        /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <returns></returns>
+        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -67,22 +67,13 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         protected override TestEngineResult LoadPackage()
         {
-            var packages = new List<TestPackage>();
-
-            foreach (string testFile in TestPackage.TestFiles)
-            {
-                var subPackage = new TestPackage(testFile);
-                if (Services.ProjectService.CanLoadFrom(testFile))
-                    Services.ProjectService.ExpandProjectPackage(subPackage);
-                foreach (string key in TestPackage.Settings.Keys)
-                    subPackage.Settings[key] = TestPackage.Settings[key];
-                packages.Add(subPackage);
-            }
-
             var results = new List<TestEngineResult>();
 
-            foreach (TestPackage subPackage in packages)
+            foreach (var subPackage in TestPackage.SubPackages)
             {
+                if (Services.ProjectService.CanLoadFrom(subPackage.FullName))
+                    Services.ProjectService.ExpandProjectPackage(subPackage);
+
                 var runner = CreateRunner(subPackage);
                 _runners.Add(runner);
                 results.Add(runner.Load());

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -74,10 +74,18 @@ namespace NUnit.Engine.Runners
         {
             var result = new TestEngineResult();
 
-            foreach (string testFile in TestPackage.TestFiles)
+            // DirectRunner may be called with a single-assembly package
+            // or a set of assemblies as subpackages.
+            var packages = TestPackage.SubPackages;
+            if (packages.Count == 0)
+                packages.Add(TestPackage);
+
+            foreach (var subPackage in packages)
             {
-                IFrameworkDriver driver = Services.DriverFactory.GetDriver(TestDomain, testFile, TestPackage.Settings);
-                result.Add(driver.Load());
+                var testFile = subPackage.FullName;
+                IFrameworkDriver driver = Services.DriverService.GetDriver(TestDomain, testFile);
+                driver.ID = TestPackage.ID;
+                result.Add(driver.Load(testFile, subPackage.Settings));
                 _drivers.Add(driver);
             }
 

--- a/src/NUnitEngine/nunit.engine/ServiceContext.cs
+++ b/src/NUnitEngine/nunit.engine/ServiceContext.cs
@@ -117,17 +117,17 @@ namespace NUnit.Engine
 
         #endregion
 
-        #region DriverFactory
+        #region DriverService
 
-        private IDriverService _driverFactory;
-        public IDriverService DriverFactory
+        private IDriverService _driverService;
+        public IDriverService DriverService
         {
             get
             {
-                if (_driverFactory == null)
-                    _driverFactory = GetService<IDriverService>();
+                if (_driverService == null)
+                    _driverService = GetService<IDriverService>();
 
-                return _driverFactory;
+                return _driverService;
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -157,7 +157,7 @@ namespace NUnit.Engine.Services
                     configFile = testFile.Name + ".config";
             }
             else if (appBase == null || appBase == string.Empty)
-                appBase = GetCommonAppBase(package.TestFiles);
+                appBase = GetCommonAppBase(package.SubPackages);
 
             char lastChar = appBase[appBase.Length - 1];
             if (lastChar != Path.DirectorySeparatorChar && lastChar != Path.AltDirectorySeparatorChar)
@@ -170,7 +170,7 @@ namespace NUnit.Engine.Services
                 : configFile;
 
             if (package.GetSetting(PackageSettings.AutoBinPath, binPath == string.Empty))
-                binPath = GetPrivateBinPath(appBase, package.TestFiles);
+                binPath = GetPrivateBinPath(appBase, package.SubPackages);
 
             setup.PrivateBinPath = binPath;
 
@@ -335,6 +335,15 @@ namespace NUnit.Engine.Services
             return domain.FriendlyName.StartsWith( "test-domain-" );
         }
 
+        public static string GetCommonAppBase(IList<TestPackage> packages)
+        {
+            var assemblies = new List<string>();
+            foreach (var package in packages)
+                assemblies.Add(package.FullName);
+
+            return GetCommonAppBase(assemblies);
+        }
+
         public static string GetCommonAppBase(IList<string> assemblies)
         {
             string commonBase = null;
@@ -349,6 +358,15 @@ namespace NUnit.Engine.Services
             }
 
             return commonBase;
+        }
+
+        public static string GetPrivateBinPath(string basePath, IList<TestPackage> packages)
+        {
+            var assemblies = new List<string>();
+            foreach (var package in packages)
+                assemblies.Add(package.FullName);
+
+            return GetPrivateBinPath(basePath, assemblies);
         }
 
         public static string GetPrivateBinPath(string basePath, IList<string> assemblies)

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -25,26 +25,29 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using Mono.Addins;
 using NUnit.Engine.Drivers;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services
 {
+    /// <summary>
+    /// The DriverService provides drivers able to load and run tests
+    /// using various frameworks.
+    /// </summary>
     public class DriverService : IDriverService, IService
     {
-        private const string NUNIT_FRAMEWORK = "nunit.framework";
-        private const string NUNITLITE_FRAMEWORK = "nunitlite";
-
-        private const string OLDER_NUNIT_NOT_SUPPORTED_MESSAGE =
-            "Unable to load {0}. This runner only supports tests written for NUnit 3.0 or higher.";
-
         IList<IDriverFactory> _factories = new List<IDriverFactory>();
 
         #region IDriverService Members
 
-        public IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, IDictionary<string, object> settings)
+        /// <summary>
+        /// Get a driver suitable for use with a particular test assembly.
+        /// </summary>
+        /// <param name="domain">The AppDomain to use for the tests</param>
+        /// <param name="assemblyPath">The full path to the test assembly</param>
+        /// <returns></returns>
+        public IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath)
         {
             if (!File.Exists(assemblyPath))
                 return new NotRunnableFrameworkDriver(assemblyPath, "File not found: " + assemblyPath);
@@ -59,7 +62,7 @@ namespace NUnit.Engine.Services
                     foreach (var reference in references)
                     {
                         if (factory.IsSupportedFramework(reference))
-                            return factory.GetDriver(domain, reference.Name, assemblyPath, settings);
+                            return factory.GetDriver(domain, reference);
                     }
                 }
             }

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Services
             {
                 default:
                 case DomainUsage.Default:
-                    if (package.TestFiles.Count > 1)
+                    if (package.SubPackages.Count > 1)
                         return new MultipleTestDomainRunner(this.ServiceContext, package);
                     else
                         return new TestDomainRunner(this.ServiceContext, package);

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -74,7 +74,7 @@ namespace NUnit.Engine.Services
         public void ExpandProjectPackage(TestPackage package)
         {
             Guard.ArgumentNotNull(package, "package");
-            Guard.ArgumentValid(package.TestFiles.Count == 0, "Package is already expanded", "package");
+            Guard.ArgumentValid(package.SubPackages.Count == 0, "Package is already expanded", "package");
 
             string path = package.FullName;
             IProject project = LoadFrom(path);
@@ -89,8 +89,8 @@ namespace NUnit.Engine.Services
                 if (!package.Settings.ContainsKey(key)) // Don't override settings from command line
                     package.Settings[key] = tempPackage.Settings[key];
 
-            foreach (string assembly in tempPackage.TestFiles)
-                package.Add(assembly);
+            foreach (var subPackage in tempPackage.SubPackages)
+                package.AddSubPackage(subPackage);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -105,8 +105,10 @@ namespace NUnit.Engine.Services
             {
                 if (ServiceContext.UserSettings.GetSetting("Options.TestLoader.RuntimeSelectionEnabled", true))
                 {
-                    foreach (string assembly in package.TestFiles)
+                    foreach (var subPackage in package.SubPackages)
                     {
+                        var assembly = subPackage.FullName;
+
                         // If the file is not an assembly or doesn't exist, then it can't
                         // contribute any information to the decision, so we skip it.
                         if (PathUtils.IsAssemblyFileType(assembly) && File.Exists(assembly))

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -58,11 +58,12 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Construct a FrameworkController using the default builder and runner.
         /// </summary>
-        public FrameworkController(string assemblyPath, IDictionary settings)
+        public FrameworkController(string assemblyPath, string idPrefix, IDictionary settings)
         {
             this.Builder = new DefaultTestAssemblyBuilder();
             this.Runner = new NUnitTestAssemblyRunner(this.Builder);
 
+            Test.IdPrefix = idPrefix;
             Initialize(assemblyPath, settings);
         }
 
@@ -75,20 +76,21 @@ namespace NUnit.Framework.Api
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         /// <param name="runnerType">The Type of the test runner</param>
         /// <param name="builderType">The Type of the test builder</param>
-        public FrameworkController(string assemblyPath, IDictionary settings, string runnerType, string builderType)
+        public FrameworkController(string assemblyPath, string idPrefix, IDictionary settings, string runnerType, string builderType)
         {
             Assembly myAssembly = Assembly.GetExecutingAssembly();
             this.Builder = (ITestAssemblyBuilder)myAssembly.CreateInstance(builderType);
             this.Runner = (ITestAssemblyRunner)myAssembly.CreateInstance(
                 runnerType, false, 0, null, new object[] { this.Builder }, null, null);
 
+            Test.IdPrefix = idPrefix;
             Initialize(assemblyPath, settings);
         }
 
         private void Initialize(string assemblyPath, IDictionary settings)
         {
-            this.AssemblyPath = assemblyPath;
-            this.Settings = settings;
+            AssemblyPath = assemblyPath;
+            Settings = settings;
 
             if (settings.Contains(PackageSettings.InternalTraceLevel))
             {

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -73,6 +73,7 @@ namespace NUnit.Framework.Api
         /// purposes of development.
         /// </summary>
         /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         /// <param name="runnerType">The Type of the test runner</param>
         /// <param name="builderType">The Type of the test builder</param>
@@ -83,7 +84,7 @@ namespace NUnit.Framework.Api
             this.Runner = (ITestAssemblyRunner)myAssembly.CreateInstance(
                 runnerType, false, 0, null, new object[] { this.Builder }, null, null);
 
-            Test.IdPrefix = idPrefix;
+            Test.IdPrefix = idPrefix ?? "";
             Initialize(assemblyPath, settings);
         }
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -58,6 +58,9 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Construct a FrameworkController using the default builder and runner.
         /// </summary>
+        /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
+        /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         public FrameworkController(string assemblyPath, string idPrefix, IDictionary settings)
         {
             this.Builder = new DefaultTestAssemblyBuilder();

--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Gets the id of the test
         /// </summary>
-        int Id { get; }
+        string Id { get; }
 
         /// <summary>
         /// Gets the name of the test

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal.Filters
     /// IdFilter selects tests based on their id
     /// </summary>
     [Serializable]
-    public class IdFilter : ValueMatchFilter<int>
+    public class IdFilter : ValueMatchFilter<string>
     {
         /// <summary>
         /// Construct an empty IdFilter
@@ -42,18 +42,18 @@ namespace NUnit.Framework.Internal.Filters
         /// Construct an IdFilter for a single value
         /// </summary>
         /// <param name="id">The id the filter will recognize.</param>
-        public IdFilter(int id) : base (id) { }
+        public IdFilter(string id) : base (id) { }
 
         /// <summary>
         /// Construct a IdFilter for multiple ids
         /// </summary>
         /// <param name="ids">The ids the filter will recognize.</param>
-        public IdFilter(IEnumerable<int> ids) : base(ids) { }
+        public IdFilter(IEnumerable<string> ids) : base(ids) { }
 
         /// <summary>
         /// Match a test against a single value.
         /// </summary>
-        protected override bool Match(ITest test, int id)
+        protected override bool Match(ITest test, string id)
         {
             return test.Id == id;
         }

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Internal
                 case "id":
                     var idFilter = new IdFilter();
                     foreach (string id in xmlNode.InnerText.Split(COMMA))
-                        idFilter.Add(int.Parse(id));
+                        idFilter.Add(id);
                     return idFilter;
 
                 case "tests":

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal
         {
             this.FullName = name;
             this.Name = name;
-            this.Id = unchecked(nextID++);
+            this.Id = unchecked(nextID++).ToString();
 
             this.Properties = new PropertyBag();
             this.RunState = RunState.Runnable;
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal
             this.FullName = pathName == null || pathName == string.Empty 
                 ? name : pathName + "." + name;
             this.Name = name;
-            this.Id = unchecked(nextID++);
+            this.Id = unchecked(nextID++).ToString();
 
             this.Properties = new PropertyBag();
             this.RunState = RunState.Runnable;
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Internal
         /// Gets or sets the id of the test
         /// </summary>
         /// <value></value>
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the test

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Internal
         /// Static value to seed ids. It's started at 1000 so any
         /// uninitialized ids will stand out.
         /// </summary>
-        private static int nextID = 1000;
+        private static int _nextID = 1000;
 
         /// <summary>
         /// The SetUp methods.
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal
         {
             this.FullName = name;
             this.Name = name;
-            this.Id = unchecked(nextID++).ToString();
+            this.Id = GetNextId();
 
             this.Properties = new PropertyBag();
             this.RunState = RunState.Runnable;
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal
             this.FullName = pathName == null || pathName == string.Empty 
                 ? name : pathName + "." + name;
             this.Name = name;
-            this.Id = unchecked(nextID++).ToString();
+            this.Id = GetNextId();
 
             this.Properties = new PropertyBag();
             this.RunState = RunState.Runnable;
@@ -104,6 +104,11 @@ namespace NUnit.Framework.Internal
             this.Name = method.Name;
             this.FullName += "." + this.Name;
             this.Method = method;
+        }
+
+        private static string GetNextId()
+        {
+            return IdPrefix + unchecked(_nextID++).ToString();
         }
 
         #endregion
@@ -237,6 +242,12 @@ namespace NUnit.Framework.Internal
         #endregion
 
         #region Other Public Properties
+
+        /// <summary>
+        /// Static prefix used for ids in this AppDomain.
+        /// Set by FrameworkController.
+        /// </summary>
+        public static string IdPrefix { get; set; }
 
         /// <summary>
         /// Gets or Sets the Int value representing the seed for the RandomGenerator

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -256,7 +256,7 @@ namespace NUnit.Framework
             /// <summary>
             /// Gets the unique Id of a test
             /// </summary>
-            public int ID
+            public String ID
             {
                 get { return _test.Id; }
             }

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Api
         public void CreateController()
         {
             _mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-            _controller = new FrameworkController(_mockAssemblyPath, _settings);
+            _controller = new FrameworkController(_mockAssemblyPath, "ID", _settings);
             _handler = new CallbackEventHandler();
         }
 
@@ -74,6 +74,8 @@ namespace NUnit.Framework.Api
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(GetAttribute(result, "type"), Is.EqualTo("Assembly"));
+            Assert.That(GetAttribute(result, "id"), Is.Not.Null.And.StartWith("ID"));
+            Assert.That(GetAttribute(result, "name"), Is.EqualTo(MOCK_ASSEMBLY));
             Assert.That(GetAttribute(result, "runstate"), Is.EqualTo("Runnable"));
             Assert.That(GetAttribute(result, "testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
@@ -82,7 +84,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void LoadTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
-            new FrameworkController.LoadTestsAction(new FrameworkController(MISSING_FILE, _settings), _handler);
+            new FrameworkController.LoadTestsAction(new FrameworkController(MISSING_FILE, "ID", _settings), _handler);
             var result = GetXmlResult();
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
@@ -96,7 +98,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void LoadTestsAction_BadFile_ReturnsNonRunnableSuite()
         {
-            new FrameworkController.LoadTestsAction(new FrameworkController(BAD_FILE, _settings), _handler);
+            new FrameworkController.LoadTestsAction(new FrameworkController(BAD_FILE, "ID", _settings), _handler);
             var result = GetXmlResult();
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
@@ -117,6 +119,8 @@ namespace NUnit.Framework.Api
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(GetAttribute(result, "type"), Is.EqualTo("Assembly"));
+            Assert.That(GetAttribute(result, "id"), Is.Not.Null.And.StartWith("ID"));
+            Assert.That(GetAttribute(result, "name"), Is.EqualTo(MOCK_ASSEMBLY));
             Assert.That(GetAttribute(result, "runstate"), Is.EqualTo("Runnable"));
             Assert.That(GetAttribute(result, "testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");
@@ -133,7 +137,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void ExploreTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(MISSING_FILE, _settings);
+            var controller = new FrameworkController(MISSING_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.ExploreTestsAction(controller, EMPTY_FILTER, _handler);
             var result = GetXmlResult();
@@ -149,7 +153,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void ExploreTestsAction_BadFile_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(BAD_FILE, _settings);
+            var controller = new FrameworkController(BAD_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.ExploreTestsAction(controller, EMPTY_FILTER, _handler);
             var result = GetXmlResult();
@@ -183,7 +187,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void CountTestsAction_FileNotFound_ReturnsZero()
         {
-            var controller = new FrameworkController(MISSING_FILE, _settings);
+            var controller = new FrameworkController(MISSING_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.CountTestsAction(controller, EMPTY_FILTER, _handler);
             Assert.That(_handler.GetCallbackResult(), Is.EqualTo("0"));
@@ -192,7 +196,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void CountTestsAction_BadFile_ReturnsZero()
         {
-            var controller = new FrameworkController(BAD_FILE, _settings);
+            var controller = new FrameworkController(BAD_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.CountTestsAction(controller, EMPTY_FILTER, _handler);
             Assert.That(_handler.GetCallbackResult(), Is.EqualTo("0"));
@@ -208,6 +212,8 @@ namespace NUnit.Framework.Api
             var result = GetXmlResult();
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
+            Assert.That(GetAttribute(result, "id"), Is.Not.Null.And.StartWith("ID"));
+            Assert.That(GetAttribute(result, "name"), Is.EqualTo(MOCK_ASSEMBLY));
             Assert.That(GetAttribute(result, "type"), Is.EqualTo("Assembly"));
             Assert.That(GetAttribute(result, "runstate"), Is.EqualTo("Runnable"));
             Assert.That(GetAttribute(result, "testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
@@ -230,7 +236,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(MISSING_FILE, _settings);
+            var controller = new FrameworkController(MISSING_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.RunTestsAction(controller, EMPTY_FILTER, _handler);
             var result = GetXmlResult();
@@ -246,7 +252,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunTestsAction_BadFile_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(BAD_FILE, _settings);
+            var controller = new FrameworkController(BAD_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.RunTestsAction(controller, EMPTY_FILTER, _handler);
             var result = GetXmlResult();
@@ -270,6 +276,8 @@ namespace NUnit.Framework.Api
 
             //Assert.That(result.Name, Is.EqualTo("test-suite"));
             //Assert.That(GetAttribute(result, "type"), Is.EqualTo("Assembly"));
+            //Assert.That(GetAttribute(result, "id"), Is.Not.Null.And.StartWith("ID"));
+            //Assert.That(GetAttribute(result, "name"), Is.EqualTo(MOCK_ASSEMBLY));
             //Assert.That(GetAttribute(result, "runstate"), Is.EqualTo("Runnable"));
             //Assert.That(GetAttribute(result, "testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             //Assert.That(GetAttribute(result, "result"), Is.EqualTo("Failed"));
@@ -291,7 +299,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunAsyncAction_FileNotFound_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(MISSING_FILE, _settings);
+            var controller = new FrameworkController(MISSING_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.RunAsyncAction(controller, EMPTY_FILTER, _handler);
             //var result = GetXmlResult();
@@ -307,7 +315,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunAsyncAction_BadFile_ReturnsNonRunnableSuite()
         {
-            var controller = new FrameworkController(BAD_FILE, _settings);
+            var controller = new FrameworkController(BAD_FILE, "ID", _settings);
             new FrameworkController.LoadTestsAction(controller, _handler);
             new FrameworkController.RunAsyncAction(controller, EMPTY_FILTER, _handler);
             //var result = GetXmlResult();

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Internal
             Assert.That(ec.CurrentTest.Name, Is.EqualTo("TestExecutionContextTests"));
             Assert.That(ec.CurrentTest.FullName,
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests"));
-            Assert.That(fixtureContext.CurrentTest.Id, Is.GreaterThan(0));
+            Assert.That(fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(fixtureContext.CurrentTest.Properties.Get("Question"), Is.EqualTo("Why?"));
         }
 
@@ -125,7 +125,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void FixtureSetUpCanAccessFixtureId()
         {
-            Assert.That(fixtureContext.CurrentTest.Id, Is.GreaterThan(0));
+            Assert.That(fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void SetUpCanAccessTestId()
         {
-            Assert.That(setupContext.CurrentTest.Id, Is.GreaterThan(0));
+            Assert.That(setupContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestCanAccessItsOwnId()
         {
-            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Id, Is.GreaterThan(0));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFilterTests.cs
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void IdFilter_ConstructWithMultipleIds()
         {
-            var filter = new IdFilter(new int[] { dummyFixture.Id, anotherFixture.Id });
+            var filter = new IdFilter(new string[] { dummyFixture.Id, anotherFixture.Id });
 
             Assert.False(filter.IsEmpty);
             Assert.That(filter.Match(dummyFixture));

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Tests
         [Test]
         public void TestCanAccessItsOwnId()
         {
-            Assert.That(TestContext.CurrentContext.Test.ID, Is.GreaterThan(0));
+            Assert.That(TestContext.CurrentContext.Test.ID, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
@@ -199,13 +199,13 @@ namespace NUnit.Framework.Tests
             Assert.That(context.Result.PassCount, Is.EqualTo(1));
             Assert.That(context.Result.FailCount, Is.EqualTo(0));
 #if !PORTABLE && !SILVERLIGHT
-			Assert.That(context.TestDirectory, Is.Not.Null);
-			Assert.That(context.WorkDirectory, Is.Not.Null);
+            Assert.That(context.TestDirectory, Is.Not.Null);
+            Assert.That(context.WorkDirectory, Is.Not.Null);
 #endif
-		}
+        }
     }
 
-	[TestFixture]
+    [TestFixture]
     public class TestContextOneTimeTearDownTests
     {
         [Test]


### PR DESCRIPTION
**Now ready to merge. See comment below.**

Fixes #582 

This could be merged harmlessly, but there doesn't seem to be a need right now. However, if anyone is going to work in areas that are affected, feel free to merge it.

The current state of the code is that work on the framework side is done. A new static property of the Test class contains a prefix that is used for all ids. The framework controller sets the id based on an argument passed in from the driver.

Currently, the driver is hard-coded to pass in the string "ID" so the only change is that test ids are of the form "IDxxxx" rather than just xxxx.

The v2 driver now generates ids of the form rrrr-tttt, where rrrr is the runner id and tttt is the test id. However, the framework is currently always passed a runner id of 1, giving us ids like 1-xxxx. This will eventually be changed, once the engine is generating IDs.

Bottom line: the framework works, the ids are all prefixed but they are not yet unique. 

Next steps: Work in the engine to create unique ids for each assembly.