### PR TITLE
xmldoc fixes

### DIFF
--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -117,7 +117,7 @@ namespace NUnit.Engine.Agents
         /// Explore a loaded TestPackage and return information about
         /// the tests found.
         /// </summary>
-        /// <param name="package">The TestPackage to be explored</param>
+        /// <param name="filter">Criteria used to filter the search results</param>
         /// <returns>A TestEngineResult.</returns>
         public TestEngineResult Explore(TestFilter filter)
         {

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -44,10 +44,11 @@ namespace NUnit.Engine.Agents
         #region Constructors
 
         /// <summary>
-        /// Constructs a TestAgent
+        /// Initializes a new instance of the <see cref="TestAgent"/> class.
         /// </summary>
-        /// <param name="agentId"></param>
-        /// <param name="agency"></param>
+        /// <param name="agentId">The identifier of the agent.</param>
+        /// <param name="agency">The agency that this agent is associated with.</param>
+        /// <param name="services">The context under which to run the agent.</param>
         public TestAgent( Guid agentId, ITestAgency agency, ServiceContext services )
         {
             this.agency = agency;
@@ -92,7 +93,7 @@ namespace NUnit.Engine.Agents
         /// <summary>
         /// Starts the agent, performing any required initialization
         /// </summary>
-        /// <returns>True if successful, otherwise false</returns>
+        /// <returns><c>true</c> if the agent was started successfully.</returns>
         public abstract bool Start();
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/ITestEngineRunner.cs
+++ b/src/NUnitEngine/nunit.engine/ITestEngineRunner.cs
@@ -35,7 +35,6 @@ namespace NUnit.Engine
         /// <summary>
         /// Load a TestPackage for possible execution
         /// </summary>
-        /// <param name="package">The TestPackage to be loaded</param>
         /// <returns>A TestEngineResult.</returns>
         TestEngineResult Load();
 
@@ -88,7 +87,7 @@ namespace NUnit.Engine
         /// Explore a loaded TestPackage and return information about
         /// the tests found.
         /// </summary>
-        /// <param name="package">The TestPackage to be explored</param>
+        /// <param name="filter">Criteria used to filter the search results</param>
         /// <returns>A TestEngineResult.</returns>
         TestEngineResult Explore(TestFilter filter);
     }

--- a/src/NUnitEngine/nunit.engine/ITestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/ITestRunnerFactory.cs
@@ -42,7 +42,7 @@ namespace NUnit.Engine
         /// the test package provided. Otherwise, return false. Runners that
         /// cannot be reused must always return false.
         /// </summary>
-        /// <param name="runner>An ITestRunner to possibly be used.</param>
+        /// <param name="runner">An ITestRunner to possibly be used.</param>
         /// <param name="package">The TestPackage to be loaded.</param>
         /// <returns>True if the runner may be reused for the provided package.</returns>
         bool CanReuse(ITestEngineRunner runner, TestPackage package);

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -44,33 +44,37 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Aggregate the XmlNodes under a TestEngineResult into a single XmlNode.
         /// </summary>
-        /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project</param>
-        /// <param name="elementName"></param>
-        /// <param name="suiteType"></param>
-        /// <param name="name"></param>
-        /// <param name="fullname"></param>
+        /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project.</param>
+        /// <param name="elementName">The root node name under which to aggregate the nodes.</param>
+        /// <param name="suiteType">The suite type to associate with the <see cref="TestEngineResult"/>.</param>
+        /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
+        /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string suiteType, string name, string fullname)
+        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string suiteType, string name, string fullName)
         {
-            return new TestEngineResult(Aggregate(elementName, suiteType, name, fullname, result.XmlNodes));
+            return new TestEngineResult(Aggregate(elementName, suiteType, name, fullName, result.XmlNodes));
         }
 
         /// <summary>
         /// Aggregate the XmlNodes under a TestEngineResult into a single XmlNode.
         /// </summary>
-        /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project</param>
-        /// <param name="elementName"></param>
-        /// <param name="name"></param>
-        /// <param name="fullname"></param>
+        /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project.</param>
+        /// <param name="elementName">The root node name under which to aggregate the results.</param>
+        /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
+        /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string name, string fullname)
+        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string name, string fullName)
         {
-            return new TestEngineResult(Aggregate(elementName, name, fullname, result.XmlNodes));
+            return new TestEngineResult(Aggregate(elementName, name, fullName, result.XmlNodes));
         }
 
         /// <summary>
         /// Aggregate all the separate assembly results of a project as a single node.
         /// </summary>
+        /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project.</param>
+        /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
+        /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
+        /// <returns>A TestEngineResult with a single top-level element.</returns>
         public static TestEngineResult MakePackageResult(this TestEngineResult result, string name, string fullName)
         {
             return Aggregate(result, TEST_SUITE_ELEMENT, PROJECT_SUITE_TYPE, name, fullName);
@@ -84,8 +88,8 @@ namespace NUnit.Engine.Internal
         /// Merges multiple test engine results into a single result. The
         /// result element contains all the XML nodes found in the input.
         /// </summary>
-        /// <param name="results">A list of TestEngineResults</param>
-        /// <returns>A TestEngineResult merging all the imput results</returns>
+        /// <param name="results">A collection of <see cref="TestEngineResult"/> to merge.</param>
+        /// <returns>A TestEngineResult merging all the input results.</returns>
         /// <remarks>Used by AbstractTestRunner MakePackageResult method.</remarks>
         public static TestEngineResult Merge(IList<TestEngineResult> results) 
         {
@@ -105,7 +109,7 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Insert an environment element as a child of the node provided.
         /// </summary>
-        /// <param name="resultNode">Attribute to which environment element attributes will be added.</param>
+        /// <param name="resultNode">The node under which the environment element is placed.</param>
         public static void InsertEnvironmentElement(this XmlNode resultNode)
         {
             XmlNode env = resultNode.OwnerDocument.CreateElement("environment");
@@ -131,12 +135,29 @@ namespace NUnit.Engine.Internal
 
         #region Methods that operate on a list of XmlNodes
 
-        public static XmlNode Aggregate(string elementName, string name, string fullname, IList<XmlNode> resultNodes)
+        /// <summary>
+        /// Aggregates a collection of XmlNodes under a single XmlNode.
+        /// </summary>
+        /// <param name="elementName">The root node name under which to aggregate the results.</param>
+        /// <param name="name">The name to associated with the root node.</param>
+        /// <param name="fullName">The full name to associated with the root node.</param>
+        /// <param name="resultNodes">A collection of XmlNodes to aggregate</param>
+        /// <returns>A single XmlNode containing the aggregated list of XmlNodes.</returns>
+        public static XmlNode Aggregate(string elementName, string name, string fullName, IList<XmlNode> resultNodes)
         {
-            return Aggregate(elementName, null, name, fullname, resultNodes);
+            return Aggregate(elementName, null, name, fullName, resultNodes);
         }
 
-        public static XmlNode Aggregate(string elementName, string testType, string name, string fullname, IList<XmlNode> resultNodes)
+        /// <summary>
+        /// Aggregates a collection of XmlNodes under a single XmlNode.
+        /// </summary>
+        /// <param name="elementName">The root node name under which to aggregate the results.</param>
+        /// <param name="testType">The type to associated with the root node.</param>
+        /// <param name="name">The name to associated with the root node.</param>
+        /// <param name="fullName">The full name to associated with the root node.</param>
+        /// <param name="resultNodes">A collection of XmlNodes to aggregate</param>
+        /// <returns>A single XmlNode containing the aggregated list of XmlNodes.</returns>
+        public static XmlNode Aggregate(string elementName, string testType, string name, string fullName, IList<XmlNode> resultNodes)
         {
             XmlNode combinedNode = XmlHelper.CreateTopLevelElement(elementName);
             if (testType != null)
@@ -144,8 +165,8 @@ namespace NUnit.Engine.Internal
             combinedNode.AddAttribute("id", "2"); // TODO: Should not be hard-coded
             if (name != null && name != string.Empty)
                 combinedNode.AddAttribute("name", name);
-            if (fullname != null && fullname != string.Empty)
-                combinedNode.AddAttribute("fullname", fullname);
+            if (fullName != null && fullName != string.Empty)
+                combinedNode.AddAttribute("fullname", fullName);
 
             string status = "Inconclusive";
             //double totalDuration = 0.0d;

--- a/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.cs
@@ -31,18 +31,20 @@ using System.Reflection;
 namespace NUnit.Engine.Internal
 {
     /// <summary>
-    /// Summary description for RemotingUtilities.
+    /// A collection of utility methods used to create, retrieve
+    /// and release <see cref="TcpChannel"/>s.
     /// </summary>
     public static class ServerUtilities
     {
         static Logger log = InternalTrace.GetLogger(typeof(ServerUtilities));
 
         /// <summary>
-        ///  Create a TcpChannel with a given name, on a given port.
+        ///  Create a <see cref="TcpChannel"/> with a given name on a given port.
         /// </summary>
-        /// <param name="port"></param>
-        /// <param name="name"></param>
-        /// <returns></returns>
+        /// <param name="name">The name of the channel to create.</param>
+        /// <param name="port">The port number of the channel to create.</param>
+        /// <param name="limit">The rate limit of the channel to create.</param>
+        /// <returns>A <see cref="TcpChannel"/> configured with the given name and port.</returns>
         private static TcpChannel CreateTcpChannel( string name, int port, int limit )
         {
             Hashtable props = new Hashtable();
@@ -70,34 +72,38 @@ namespace NUnit.Engine.Internal
             return new TcpChannel( props, clientProvider, serverProvider );
         }
 
+        /// <summary>
+        /// Get a default channel. If one does not exist, then one is created and registered.
+        /// </summary>
+        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
         public static TcpChannel GetTcpChannel()
         {
             return GetTcpChannel( "", 0, 2 );
         }
 
         /// <summary>
-        /// Get a channel by name, casting it to a TcpChannel.
-        /// Otherwise, create, register and return a TcpChannel with
+        /// Get a channel by name, casting it to a <see cref="TcpChannel"/>.
+        /// Otherwise, create, register and return a <see cref="TcpChannel"/> with
         /// that name, on the port provided as the second argument.
         /// </summary>
-        /// <param name="name">The channel name</param>
+        /// <param name="name">The name of the channel</param>
         /// <param name="port">The port to use if the channel must be created</param>
-        /// <returns>A TcpChannel or null</returns>
+        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
         public static TcpChannel GetTcpChannel( string name, int port )
         {
             return GetTcpChannel( name, port, 2 );
         }
         
         /// <summary>
-        /// Get a channel by name, casting it to a TcpChannel.
-        /// Otherwise, create, register and return a TcpChannel with
+        /// Get a channel by name, casting it to a <see cref="TcpChannel"/>.
+        /// Otherwise, create, register and return a <see cref="TcpChannel"/> with
         /// that name, on the port provided as the second argument.
         /// </summary>
-        /// <param name="name">The channel name</param>
+        /// <param name="name">The name of the channel</param>
         /// <param name="port">The port to use if the channel must be created</param>
         /// <param name="limit">The client connection limit or negative for the default</param>
-        /// <returns>A TcpChannel or null</returns>
-        public static TcpChannel GetTcpChannel( string name, int port, int limit )
+        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
+        public static TcpChannel GetTcpChannel(string name, int port, int limit)
         {
             TcpChannel channel = ChannelServices.GetChannel( name ) as TcpChannel;
 
@@ -123,6 +129,10 @@ namespace NUnit.Engine.Internal
             return channel;
         }
 
+        /// <summary>
+        /// Unregisters the <see cref="IChannel"/> from the <see cref="ChannelServices"/> registry.
+        /// </summary>
+        /// <param name="channel">The channel to unregister.</param>
         public static void SafeReleaseChannel( IChannel channel )
         {
             if( channel != null )

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
@@ -48,8 +48,8 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Load the value of one of the group's settings
         /// </summary>
-        /// <param name="settingName">Name of setting to load</param>
-        /// <returns>Value of the setting or null</returns>
+        /// <param name="settingName">The name of setting to load</param>
+        /// <returns>The value of the setting</returns>
         public object GetSetting(string settingName)
         {
             return _settings.ContainsKey(settingName)
@@ -60,9 +60,9 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Load the value of one of the group's settings or return a default value
         /// </summary>
-        /// <param name="settingName">Name of setting to load</param>
-        /// <param name="defaultValue">Value to return if the setting is not present</param>
-        /// <returns>Value of the setting or the default</returns>
+        /// <param name="settingName">The name of setting to load</param>
+        /// <param name="defaultValue">The value to return if the setting is not present</param>
+        /// <returns>The value of the setting or the default</returns>
         public T GetSetting<T>(string settingName, T defaultValue)
         {
             object result = GetSetting(settingName);
@@ -93,7 +93,7 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Remove a setting from the group
         /// </summary>
-        /// <param name="settingName">Name of the setting to remove</param>
+        /// <param name="settingName">The name of the setting to remove</param>
         public void RemoveSetting(string settingName)
         {
             _settings.Remove(settingName);
@@ -105,7 +105,7 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Remove a group of settings
         /// </summary>
-        /// <param name="GroupName"></param>
+        /// <param name="groupName">The name of the group to remove</param>
         public void RemoveGroup(string groupName)
         {
             List<string> keysToRemove = new List<string>();
@@ -125,8 +125,8 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Save the value of one of the group's settings
         /// </summary>
-        /// <param name="settingName">Name of the setting to save</param>
-        /// <param name="settingValue">Value to be saved</param>
+        /// <param name="settingName">The name of the setting to save</param>
+        /// <param name="settingValue">The value to be saved</param>
         public void SaveSetting(string settingName, object settingValue)
         {
             object oldValue = GetSetting(settingName);
@@ -151,7 +151,7 @@ namespace NUnit.Engine.Internal
 
         #region IDisposable Members
         /// <summary>
-        /// Dispose of this group by disposing of it's _settings implementation
+        /// Dispose of this group by disposing of it's settings
         /// </summary>
         public void Dispose()
         {

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -403,8 +403,8 @@ namespace NUnit.Engine
         /// are equal. Negative (i.e. unspecified) version
         /// components are ignored.
         /// </summary>
-        /// <param name="other">The RuntimeFramework to be matched.</param>
-        /// <returns>True on match, otherwise false</returns>
+        /// <param name="target">The RuntimeFramework to be matched.</param>
+        /// <returns><c>true</c> on match, otherwise <c>false</c></returns>
         public bool Supports(RuntimeFramework target)
         {
             if (this.Runtime != RuntimeType.Any

--- a/src/NUnitEngine/nunit.engine/TestRun.cs
+++ b/src/NUnitEngine/nunit.engine/TestRun.cs
@@ -39,10 +39,9 @@ namespace NUnit.Engine
         private TestEngineResult _result;
 
         /// <summary>
-        /// Construct a new TestRun
+        /// Initializes a new instance of the <see cref="TestRun"/> class.
         /// </summary>
-        /// <param name="listener">The ITestEventListener to use for this run</param>
-        /// <param name="filter">The TestFilter to use for this run</param>
+        /// <param name="runner">The <see cref="ITestEngineRunner"/> to use for this run.</param>
         public TestRun(ITestEngineRunner runner)
         {
             _runner = runner;
@@ -52,6 +51,10 @@ namespace NUnit.Engine
             _worker.WorkerReportsProgress = true; // ?
         }
 
+        /// <summary>
+        /// Get the result of this run.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Cannot retrieve Result from an incomplete or cancelled TestRun.</exception>
         public XmlNode Result
         {
             get

--- a/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.Framework
 {
@@ -29,7 +30,7 @@ namespace NUnit.Framework
     /// Used to mark a field, property or method providing a set of datapoints to 
     /// be used in executing any theories within the same fixture that require an 
     /// argument of the Type provided. The data source may provide an array of
-    /// the required Type or an IEnumerable&lt;T&gt;.
+    /// the required Type or an <see cref="IEnumerable{T}"/>.
     /// Synonymous with DatapointsAttribute.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.Framework
 {
@@ -29,7 +30,7 @@ namespace NUnit.Framework
     /// Used to mark a field, property or method providing a set of datapoints to 
     /// be used in executing any theories within the same fixture that require an 
     /// argument of the Type provided. The data source may provide an array of
-    /// the required Type or an IEnumerable&lt;T&gt;.
+    /// the required Type or an <see cref="IEnumerable{T}"/>.
     /// Synonymous with DatapointSourceAttribute.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer and returns self.
+        /// Modifies the constraint to use an <see cref="IComparer"/> and returns self.
         /// </summary>
         public CollectionOrderedConstraint Using(IComparer comparer)
         {
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer&lt;T&gt; and returns self.
+        /// Modifies the constraint to use an <see cref="IComparer{T}"/> and returns self.
         /// </summary>
         public CollectionOrderedConstraint Using<T>(IComparer<T> comparer)
         {
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use a Comparison&lt;T&gt; and returns self.
+        /// Modifies the constraint to use a <see cref="Comparison{T}"/> and returns self.
         /// </summary>
         public CollectionOrderedConstraint Using<T>(Comparison<T> comparer)
         {

--- a/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
@@ -30,7 +30,8 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// ComparisonAdapter class centralizes all comparisons of
     /// _values in NUnit, adapting to the use of any provided
-    /// IComparer, IComparer&lt;T&gt; or Comparison&lt;T&gt;
+    /// <see cref="IComparer"/>, <see cref="IComparer{T}"/>
+    /// or <see cref="Comparison{T}"/>.
     /// </summary>
     public abstract class ComparisonAdapter
     {
@@ -44,7 +45,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a ComparisonAdapter that wraps an IComparer
+        /// Returns a ComparisonAdapter that wraps an <see cref="IComparer"/>
         /// </summary>
         public static ComparisonAdapter For(IComparer comparer)
         {
@@ -52,7 +53,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a ComparisonAdapter that wraps an IComparer&lt;T&gt;
+        /// Returns a ComparisonAdapter that wraps an <see cref="IComparer{T}"/>
         /// </summary>
         public static ComparisonAdapter For<T>(IComparer<T> comparer)
         {
@@ -60,7 +61,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Returns a ComparisonAdapter that wraps a Comparison&lt;T&gt;
+        /// Returns a ComparisonAdapter that wraps a <see cref="Comparison{T}"/>
         /// </summary>
         public static ComparisonAdapter For<T>(Comparison<T> comparer)
         {
@@ -85,7 +86,7 @@ namespace NUnit.Framework.Constraints
             private readonly IComparer comparer;
 
             /// <summary>
-            /// Construct a ComparisonAdapter for an IComparer
+            /// Construct a ComparisonAdapter for an <see cref="IComparer"/>
             /// </summary>
             public ComparerAdapter(IComparer comparer)
             {
@@ -105,8 +106,8 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// ComparisonAdapter&lt;T&gt; extends ComparisonAdapter and
-        /// allows use of an IComparer&lt;T&gt; or Comparison&lt;T&gt;
+        /// ComparerAdapter extends <see cref="ComparisonAdapter"/> and
+        /// allows use of an <see cref="IComparer{T}"/> or <see cref="Comparison{T}"/>
         /// to actually perform the comparison.
         /// </summary>
         class ComparerAdapter<T> : ComparisonAdapter
@@ -114,7 +115,7 @@ namespace NUnit.Framework.Constraints
             private readonly IComparer<T> comparer;
 
             /// <summary>
-            /// Construct a ComparisonAdapter for an IComparer&lt;T&gt;
+            /// Construct a ComparisonAdapter for an <see cref="IComparer{T}"/>
             /// </summary>
             public ComparerAdapter(IComparer<T> comparer)
             {
@@ -141,7 +142,7 @@ namespace NUnit.Framework.Constraints
             private readonly Comparison<T> comparison;
 
             /// <summary>
-            /// Construct a ComparisonAdapter for a Comparison&lt;T&gt;
+            /// Construct a ComparisonAdapter for a <see cref="Comparison{T}"/>
             /// </summary>
             public ComparisonAdapterForComparison(Comparison<T> comparer)
             {

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         private ComparisonAdapter comparer = ComparisonAdapter.Default;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:ComparisonConstraint"/> class.
+        /// Initializes a new instance of the <see cref="ComparisonConstraint"/> class.
         /// </summary>
         /// <param name="value">The value against which to make a comparison.</param>
         /// <param name="lessComparisonResult">if set to <c>true</c> less succeeds.</param>
@@ -94,8 +94,10 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer and returns self
+        /// Modifies the constraint to use an <see cref="IComparer"/> and returns self
         /// </summary>
+        /// <param name="comparer">The comparer used for comparison tests</param>
+        /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using(IComparer comparer)
         {
             this.comparer = ComparisonAdapter.For(comparer);
@@ -103,8 +105,10 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer&lt;T&gt; and returns self
+        /// Modifies the constraint to use an <see cref="IComparer{T}"/> and returns self
         /// </summary>
+        /// <param name="comparer">The comparer used for comparison tests</param>
+        /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using<T>(IComparer<T> comparer)
         {
             this.comparer = ComparisonAdapter.For(comparer);
@@ -112,8 +116,10 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use a Comparison&lt;T&gt; and returns self
+        /// Modifies the constraint to use a <see cref="Comparison{T}"/> and returns self
         /// </summary>
+        /// <param name="comparer">The comparer used for comparison tests</param>
+        /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using<T>(Comparison<T> comparer)
         {
             this.comparer = ComparisonAdapter.For(comparer);

--- a/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
             private readonly Stack<ConstraintOperator> stack = new Stack<ConstraintOperator>();
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="T:OperatorStack"/> class.
+            /// Initializes a new instance of the <see cref="OperatorStack"/> class.
             /// </summary>
             /// <param name="builder">The ConstraintBuilder using this stack.</param>
             public OperatorStack(ConstraintBuilder builder)
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
             }
 
             /// <summary>
-            /// Gets a value indicating whether this <see cref="T:OpStack"/> is empty.
+            /// Gets a value indicating whether this <see cref="OperatorStack"/> is empty.
             /// </summary>
             /// <value><c>true</c> if empty; otherwise, <c>false</c>.</value>
             public bool Empty
@@ -65,7 +65,6 @@ namespace NUnit.Framework.Constraints
             /// <summary>
             /// Gets the topmost operator without modifying the stack.
             /// </summary>
-            /// <value>The top.</value>
             public ConstraintOperator Top
             {
                 get { return stack.Peek(); }
@@ -74,7 +73,7 @@ namespace NUnit.Framework.Constraints
             /// <summary>
             /// Pushes the specified operator onto the stack.
             /// </summary>
-            /// <param name="op">The op.</param>
+            /// <param name="op">The operator to put onto the stack.</param>
             public void Push(ConstraintOperator op)
             {
                 stack.Push(op);
@@ -83,7 +82,7 @@ namespace NUnit.Framework.Constraints
             /// <summary>
             /// Pops the topmost operator from the stack.
             /// </summary>
-            /// <returns></returns>
+            /// <returns>The topmost operator on the stack</returns>
             public ConstraintOperator Pop()
             {
                 return stack.Pop();
@@ -103,7 +102,7 @@ namespace NUnit.Framework.Constraints
             private readonly ConstraintBuilder builder;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="T:ConstraintStack"/> class.
+            /// Initializes a new instance of the <see cref="ConstraintStack"/> class.
             /// </summary>
             /// <param name="builder">The ConstraintBuilder using this stack.</param>
             public ConstraintStack(ConstraintBuilder builder)
@@ -112,7 +111,7 @@ namespace NUnit.Framework.Constraints
             }
 
             /// <summary>
-            /// Gets a value indicating whether this <see cref="T:ConstraintStack"/> is empty.
+            /// Gets a value indicating whether this <see cref="ConstraintStack"/> is empty.
             /// </summary>
             /// <value><c>true</c> if empty; otherwise, <c>false</c>.</value>
             public bool Empty
@@ -125,7 +124,7 @@ namespace NUnit.Framework.Constraints
             /// the constraint's Builder field is set to the 
             /// ConstraintBuilder owning this stack.
             /// </summary>
-            /// <param name="constraint">The constraint.</param>
+            /// <param name="constraint">The constraint to put onto the stack</param>
             public void Push(IConstraint constraint)
             {
                 stack.Push(constraint);
@@ -137,7 +136,7 @@ namespace NUnit.Framework.Constraints
             /// As a side effect, the constraint's Builder
             /// field is set to null.
             /// </summary>
-            /// <returns></returns>
+            /// <returns>The topmost contraint on the stack</returns>
             public IConstraint Pop()
             {
                 IConstraint constraint = stack.Pop();
@@ -161,7 +160,7 @@ namespace NUnit.Framework.Constraints
         #region Constructor
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:ConstraintBuilder"/> class.
+        /// Initializes a new instance of the <see cref="ConstraintBuilder"/> class.
         /// </summary>
         public ConstraintBuilder()
         {

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Constraints
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:ConstraintExpression"/> class.
+        /// Initializes a new instance of the <see cref="ConstraintExpression"/> class.
         /// </summary>
         public ConstraintExpression() 
         {
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:ConstraintExpression"/> 
+        /// Initializes a new instance of the <see cref="ConstraintExpression"/> 
         /// class passing in a ConstraintBuilder, which may be pre-populated.
         /// </summary>
         /// <param name="builder">The builder.</param>

--- a/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Constraints
         #region Properties
 
         /// <summary>
-        /// The actual value that was passed to the <see cref="Constraint.ApplyTo&lt;TActual&gt;(TActual)"/> method.
+        /// The actual value that was passed to the <see cref="Constraint.ApplyTo{TActual}(TActual)"/> method.
         /// </summary>
         public object ActualValue { get; private set; }
 
@@ -122,7 +122,7 @@ namespace NUnit.Framework.Constraints
 
         /// <summary>
         /// Description of the constraint may be affected by the state the constraint had
-        /// when <see cref="Constraint.ApplyTo&lt;TActual&gt;(TActual)"/> was performed against the actual value.
+        /// when <see cref="Constraint.ApplyTo{TActual}(TActual)"/> was performed against the actual value.
         /// </summary>
         public string Description { get; private set; }
 

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
     public class EndsWithConstraint : StringConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:EndsWithConstraint"/> class.
+        /// Initializes a new instance of the <see cref="EndsWithConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected string</param>
         public EndsWithConstraint(string expected) : base(expected) 

--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -29,8 +29,8 @@ namespace NUnit.Framework.Constraints
 {
     /// <summary>
     /// EqualityAdapter class handles all equality comparisons
-    /// that use an IEqualityComparer, IEqualityComparer&lt;T&gt;
-    /// or a ComparisonAdapter.
+    /// that use an <see cref="IEqualityComparer"/>, <see cref="IEqualityComparer{T}"/>
+    /// or a <see cref="ComparisonAdapter"/>.
     /// </summary>
     public abstract class EqualityAdapter
     {
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         #region Nested IComparer Adapter
 
         /// <summary>
-        /// Returns an EqualityAdapter that wraps an IComparer.
+        /// Returns an <see cref="EqualityAdapter"/> that wraps an <see cref="IComparer"/>.
         /// </summary>
         public static EqualityAdapter For(IComparer comparer)
         {
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// EqualityAdapter that wraps an IComparer.
+        /// <see cref="EqualityAdapter"/> that wraps an <see cref="IComparer"/>.
         /// </summary>
         class ComparerAdapter : EqualityAdapter
         {
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Constraints
         #region Nested IEqualityComparer Adapter
 
         /// <summary>
-        /// Returns an EqualityAdapter that wraps an IEqualityComparer.
+        /// Returns an <see cref="EqualityAdapter"/> that wraps an <see cref="IEqualityComparer"/>.
         /// </summary>
         public static EqualityAdapter For(IEqualityComparer comparer)
         {
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Constraints
         #region Nested IEqualityComparer<T> Adapter
 
         /// <summary>
-        /// Returns an EqualityAdapter that wraps an IEqualityComparer&lt;T&gt;.
+        /// Returns an <see cref="EqualityAdapter"/> that wraps an <see cref="IEqualityComparer{T}"/>.
         /// </summary>
         public static EqualityAdapter For<T>(IEqualityComparer<T> comparer)
         {
@@ -168,7 +168,7 @@ namespace NUnit.Framework.Constraints
         #region Nested IComparer<T> Adapter
 
         /// <summary>
-        /// Returns an EqualityAdapter that wraps an IComparer&lt;T&gt;.
+        /// Returns an <see cref="EqualityAdapter"/> that wraps an <see cref="IComparer{T}"/>.
         /// </summary>
         public static EqualityAdapter For<T>(IComparer<T> comparer)
         {
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// EqualityAdapter that wraps an IComparer.
+        /// <see cref="EqualityAdapter"/> that wraps an <see cref="IComparer"/>.
         /// </summary>
         class ComparerAdapter<T> : GenericEqualityAdapter<T>
         {
@@ -199,7 +199,7 @@ namespace NUnit.Framework.Constraints
         #region Nested Comparison<T> Adapter
 
         /// <summary>
-        /// Returns an EqualityAdapter that wraps a Comparison&lt;T&gt;.
+        /// Returns an <see cref="EqualityAdapter"/> that wraps a <see cref="Comparison{T}"/>.
         /// </summary>
         public static EqualityAdapter For<T>(Comparison<T> comparer)
         {

--- a/src/NUnitFramework/framework/Constraints/FalseConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/FalseConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class FalseConstraint : Constraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FalseConstraint"/> class.
+        /// Initializes a new instance of the <see cref="FalseConstraint"/> class.
         /// </summary>
         public FalseConstraint()
         {

--- a/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class GreaterThanConstraint : ComparisonConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:GreaterThanConstraint"/> class.
+        /// Initializes a new instance of the <see cref="GreaterThanConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
         public GreaterThanConstraint(object expected) : base(expected, false, false, true, "greater than") { }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class GreaterThanOrEqualConstraint : ComparisonConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:GreaterThanOrEqualConstraint"/> class.
+        /// Initializes a new instance of the <see cref="GreaterThanOrEqualConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
         public GreaterThanOrEqualConstraint(object expected) : base(expected, false, true, true, "greater than or equal to") { }

--- a/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class LessThanConstraint : ComparisonConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:LessThanConstraint"/> class.
+        /// Initializes a new instance of the <see cref="LessThanConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
         public LessThanConstraint(object expected) : base(expected, true, false, false, "less than") { }

--- a/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class LessThanOrEqualConstraint : ComparisonConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:LessThanOrEqualConstraint"/> class.
+        /// Initializes a new instance of the <see cref="LessThanOrEqualConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
         public LessThanOrEqualConstraint(object expected) : base(expected, true, true, false, "less than or equal to") { }

--- a/src/NUnitFramework/framework/Constraints/NullConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NullConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class NullConstraint : Constraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:NullConstraint"/> class.
+        /// Initializes a new instance of the <see cref="NullConstraint"/> class.
         /// </summary>
         public NullConstraint()
         {

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Constraints
         private object propValue;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:PropertyConstraint"/> class.
+        /// Initializes a new instance of the <see cref="PropertyConstraint"/> class.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="baseConstraint">The constraint to apply to the property.</param>

--- a/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
         Type actualType;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:PropertyExistConstraint"/> class.
+        /// Initializes a new instance of the <see cref="PropertyExistsConstraint"/> class.
         /// </summary>
         /// <param name="name">The name of the property.</param>
         public PropertyExistsConstraint(string name)

--- a/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
@@ -28,7 +28,7 @@ using System.Collections.Generic;
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
-    /// RangeConstraint tests whethe two _values are within a 
+    /// RangeConstraint tests whether two _values are within a 
     /// specified range.
     /// </summary>
     public class RangeConstraint : Constraint
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Constraints
         private ComparisonAdapter comparer = ComparisonAdapter.Default;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:RangeConstraint"/> class.
+        /// Initializes a new instance of the <see cref="RangeConstraint"/> class.
         /// </summary>
         /// <remarks>from must be less than or equal to true</remarks> 
         /// <param name="from">Inclusive beginning of the range. Must be less than or equal to to.</param>
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer and returns self.
+        /// Modifies the constraint to use an <see cref="IComparer"/> and returns self.
         /// </summary>
         public RangeConstraint Using(IComparer comparer)
         {
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use an IComparer&lt;T&gt; and returns self.
+        /// Modifies the constraint to use an <see cref="IComparer{T}"/> and returns self.
         /// </summary>
         public RangeConstraint Using<T>(IComparer<T> comparer)
         {
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Modifies the constraint to use a Comparison&lt;T&gt; and returns self.
+        /// Modifies the constraint to use a <see cref="Comparison{T}"/> and returns self.
         /// </summary>
         public RangeConstraint Using<T>(Comparison<T> comparer)
         {

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
     public class RegexConstraint : StringConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:RegexConstraint"/> class.
+        /// Initializes a new instance of the <see cref="RegexConstraint"/> class.
         /// </summary>
         /// <param name="pattern">The pattern.</param>
         public RegexConstraint(string pattern) : base(pattern) 

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
         private readonly object expected;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:SameAsConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SameAsConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected object.</param>
         public SameAsConstraint(object expected) : base(expected)

--- a/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     public class SamePathConstraint : PathConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:SamePathConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SamePathConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected path</param>
         public SamePathConstraint(string expected) : base(expected) { }

--- a/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     public class SamePathOrUnderConstraint : PathConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:SamePathOrUnderConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SamePathOrUnderConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected path</param>
         public SamePathOrUnderConstraint(string expected) : base(expected) { }

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
     public class StartsWithConstraint : StringConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:StartsWithConstraint"/> class.
+        /// Initializes a new instance of the <see cref="StartsWithConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected string</param>
         public StartsWithConstraint(string expected) : base(expected) 

--- a/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     public class SubPathConstraint : PathConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:SubPathConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SubPathConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected path</param>
         public SubPathConstraint(string expected) : base(expected) { }

--- a/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
     public class SubstringConstraint : StringConstraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:SubstringConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SubstringConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected.</param>
         public SubstringConstraint(string expected) : base(expected) 

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
         private Exception caughtException;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:ThrowsConstraint"/> class,
+        /// Initializes a new instance of the <see cref="ThrowsConstraint"/> class,
         /// using a constraint to be applied to the exception.
         /// </summary>
         /// <param name="baseConstraint">A constraint to apply to the caught exception.</param>

--- a/src/NUnitFramework/framework/Constraints/TrueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TrueConstraint.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     public class TrueConstraint : Constraint
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TrueConstraint"/> class.
+        /// Initializes a new instance of the <see cref="TrueConstraint"/> class.
         /// </summary>
         public TrueConstraint()
         {

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TestCaseData"/> class.
+        /// Initializes a new instance of the <see cref="TestCaseData"/> class.
         /// </summary>
         /// <param name="args">The arguments.</param>
         public TestCaseData(params object[] args)
@@ -49,7 +49,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TestCaseData"/> class.
+        /// Initializes a new instance of the <see cref="TestCaseData"/> class.
         /// </summary>
         /// <param name="arg">The argument.</param>
         public TestCaseData(object arg)
@@ -58,7 +58,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TestCaseData"/> class.
+        /// Initializes a new instance of the <see cref="TestCaseData"/> class.
         /// </summary>
         /// <param name="arg1">The first argument.</param>
         /// <param name="arg2">The second argument.</param>
@@ -68,7 +68,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TestCaseData"/> class.
+        /// Initializes a new instance of the <see cref="TestCaseData"/> class.
         /// </summary>
         /// <param name="arg1">The first argument.</param>
         /// <param name="arg2">The second argument.</param>

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextRunner.cs
@@ -84,15 +84,16 @@ namespace NUnitLite.Runner
 
         #region Constructors
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TextRunner"/> class.
-        /// </summary>
-        /// <param name="writer">The TextWriter to use.</param>
+        //// <summary>
+        //// Initializes a new instance of the <see cref="TextRunner"/> class.
+        //// </summary>
+        //// <param name="writer">The TextWriter to use.</param>
         //public TextRunner(ConsoleOptions options) : this(null, options) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextRunner"/> class.
         /// </summary>
+        /// <param name="textUI">The text-based user interface to output results of the run</param>
 #if SILVERLIGHT
         public TextRunner(TextUI textUI)
         {
@@ -100,6 +101,7 @@ namespace NUnitLite.Runner
             //_workDirectory = NUnit.Env.DefaultWorkDirectory;
         }
 #else
+        /// <param name="options">The options to use when running the test</param>
         public TextRunner(TextUI textUI, ConsoleOptions options)
         {
             _textUI = textUI;

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
@@ -65,7 +65,6 @@ namespace NUnitLite.Runner
         /// <summary>
         /// Writes the header.
         /// </summary>
-        /// <param name="writer">The writer.</param>
         public void DisplayHeader()
         {
             Assembly executingAssembly = Assembly.GetExecutingAssembly();

--- a/src/NUnitFramework/testdata/SetUpFixtureData.cs
+++ b/src/NUnitFramework/testdata/SetUpFixtureData.cs
@@ -122,7 +122,7 @@ namespace NUnit.TestUtilities
         private static Queue<string> _events;
 
         /// <summary>
-        /// Initializes the <see cref="T:EventRegistrar"/> 'static' class.
+        /// Initializes the <see cref="SimpleEventRecorder"/> 'static' class.
         /// </summary>
         static SimpleEventRecorder()
         {

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/GenericComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/GenericComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.TestUtilities.Comparers
 {
     /// <summary>
     /// GenericComparer is used in testing to ensure that only
-    /// the IComparer&lt;T&gt; interface is used.
+    /// the <see cref="IComparer{T}"/> interface is used.
     /// </summary>
     public class GenericComparer<T> : IComparer<T>
     {

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/GenericEqualityComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/GenericEqualityComparer.cs
@@ -27,7 +27,7 @@ namespace NUnit.TestUtilities.Comparers
 {
     /// <summary>
     /// GenericEqualityComparer is used in testing to ensure that only
-    /// the IEqualityComparer&lt;T&gt; interface is used.
+    /// the <see cref="IEqualityComparer{T}"/> interface is used.
     /// </summary>
     public class GenericEqualityComparer<T> : IEqualityComparer<T>
     {


### PR DESCRIPTION
- Fixed invalid field refs
- Fixed invalid class refs
- Replaced &lt; and &gt; with the standard { and }
- Filled in missing descriptions
- Added cross-references to classes