### PR TITLE
Fixes #478: RepeatAttribute

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if false
 // TODO: Rework this
 // RepeatAttribute should either
 //  1) Apply at load time to create the exact number of tests, or
@@ -40,9 +39,9 @@ namespace NUnit.Framework
     /// to run it multiple times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
-    public class RepeatAttribute : PropertyAttribute, ICommandDecorator
+    public class RepeatAttribute : PropertyAttribute, IWrapSetUpTearDown
     {
-        private int count;
+        private int _count;
 
         /// <summary>
         /// Construct a RepeatAttribute
@@ -50,29 +49,16 @@ namespace NUnit.Framework
         /// <param name="count">The number of times to run the test</param>
         public RepeatAttribute(int count) : base(count)
         {
-            this.count = count;
+            _count = count;
         }
 
-        #region ICommandDecorator Members
+        #region IWrapSetUpTearDown Members
 
-        CommandStage ICommandDecorator.Stage
+        public TestCommand Wrap(TestCommand command)
         {
-            // TODO: Check this
-            get { return CommandStage.AboveSetUpTearDown; }
-        }
-
-        int ICommandDecorator.Priority
-        {
-            // TODO: Check this
-            get { return 0; }
-        }
-
-        TestCommand ICommandDecorator.Decorate(TestCommand command)
-        {
-            return new RepeatedTestCommand(command, count);
+            return new RepeatedTestCommand(command, _count);
         }
 
         #endregion
     }
 }
-#endif

--- a/src/NUnitFramework/framework/Internal/Commands/RepeatedTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/RepeatedTestCommand.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2010 Charlie Poole
+// Copyright (c) 2010-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitFramework/testdata/RepeatedTestFixture.cs
+++ b/src/NUnitFramework/testdata/RepeatedTestFixture.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if false
 // TODO: Rework this
 // RepeatAttribute should either
 //  1) Apply at load time to create the exact number of tests, or
@@ -140,4 +139,3 @@ namespace NUnit.TestData.RepeatedTestFixture
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Attributes/RepeatedTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatedTestTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if false
 // TODO: Rework this
 // RepeatAttribute should either
 //  1) Apply at load time to create the exact number of tests, or
@@ -120,4 +119,3 @@ namespace NUnit.Framework.Attributes
         }
     }
 }
-#endif


### PR DESCRIPTION
This reinstates the RepeatAttribute exactly as it functions in NUnit 2.6.

I'd like to get this merged so we can have a working attribute to compare with the various alternatives that have been proposed, like Retry and ThreadedRepeat.