### PR TITLE
Capture exceptions in fixture constructor when loading tests. Fixes #538.

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework
         #region IFixtureBuilder Members
 
         /// <summary>
-        /// Build a SetUpFixture from type provided. Normally called for a Type
+        /// Build a fixture from type provided. Normally called for a Type
         /// on which the attribute has been placed.
         /// </summary>
         /// <param name="type">The type of the fixture to be used.</param>

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -31,12 +31,49 @@ namespace NUnit.Framework.Tests
     [TestFixture]
     public class TestContextTests
     {
+        private string _name;
+
+#if !SILVERLIGHT && !PORTABLE
+        private string _testDirectory;
+#endif
+        private string _workDirectory;
+
+        public TestContextTests()
+        {
+            _name = TestContext.CurrentContext.Test.Name;
+
+#if !SILVERLIGHT && !PORTABLE
+            _testDirectory = TestContext.CurrentContext.TestDirectory;
+#endif
+            _workDirectory = TestContext.CurrentContext.WorkDirectory;
+        }
+
+#if !SILVERLIGHT && !PORTABLE
+        [Test]
+        public void ConstructorCanAccessTestDirectory()
+        {
+            Assert.That(_testDirectory, Is.Not.Null);
+        }
+#endif
+
+        [Test]
+        public void ConstructorAccessWorkDirectory()
+        {
+            Assert.That(_workDirectory, Is.Not.Null);
+        }
+
         [Test]
         public void TestCanAccessItsOwnName()
         {
             Assert.That(TestContext.CurrentContext.Test.Name, Is.EqualTo("TestCanAccessItsOwnName"));
         }
-        
+
+        [Test]
+        public void ConstructorCanAccessFixtureName()
+        {
+            Assert.That(_name, Is.EqualTo("TestContextTests"));
+        }
+
         [TestCase(5)]
         public void TestCaseCanAccessItsOwnName(int x)
         {
@@ -199,13 +236,13 @@ namespace NUnit.Framework.Tests
             Assert.That(context.Result.PassCount, Is.EqualTo(1));
             Assert.That(context.Result.FailCount, Is.EqualTo(0));
 #if !PORTABLE && !SILVERLIGHT
-			Assert.That(context.TestDirectory, Is.Not.Null);
-			Assert.That(context.WorkDirectory, Is.Not.Null);
+            Assert.That(context.TestDirectory, Is.Not.Null);
+            Assert.That(context.WorkDirectory, Is.Not.Null);
 #endif
-		}
+        }
     }
 
-	[TestFixture]
+    [TestFixture]
     public class TestContextOneTimeTearDownTests
     {
         [Test]


### PR DESCRIPTION
The errors were being handled and the test silently eliminated. Now any error thrown in the consructor at load time will be displayed.

Note: Acess to the TestContext in the constructor will cause this error IFF the fixture has to be constructed while loading the test. This only occurs if a TestCaseSource or ValueSource is contained in the fixture class itself, which is not recommended.