### PR TITLE
Missing test of RepeatAttribute

### DIFF
--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -290,17 +290,18 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if !SILVERLIGHT && !NETCF && !PORTABLE
-
         #region RepeatAttribute
 
-        // public void RepeatAttributeSetsRepeatCount()
-        // {
-        //    new RepeatAttribute(5).ApplyToTest(test);
-        //    Assert.That(test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
-        // }
+        [Test]
+        public void RepeatAttributeSetsRepeatCount()
+        {
+            new RepeatAttribute(5).ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
+        }
 
         #endregion
+
+#if !SILVERLIGHT && !NETCF && !PORTABLE
 
         #region RequiresMTAAttribute
 


### PR DESCRIPTION
This is a test that was commented out and didn't get added back in the earlier commit.

It has also been moved out of the #if that was keeping it out of the NetCF, Silverlight and Portable builds.