### PR TITLE
Proposed solution for Issue #600

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 //
 // Common Information for the NUnit assemblies
@@ -30,6 +31,14 @@ using System.Reflection;
 [assembly: AssemblyProduct("NUnit 3.0")]
 [assembly: AssemblyCopyright("Copyright (C) 2014 Charlie Poole")]
 [assembly: AssemblyTrademark("NUnit is a trademark of NUnit Software")]
+
+[assembly: InternalsVisibleTo("nunit.framework.tests, PublicKey=002400000480000094" +
+                              "000000060200000024000052534131000400000100010031eea" +
+                              "370b1984bfa6d1ea760e1ca6065cee41a1a279ca234933fe977" +
+                              "a096222c0e14f9e5a17d5689305c6d7f1206a85a53c48ca0100" +
+                              "80799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9" +
+                              "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
+                              "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
 #if DEBUG
 #if NET_4_5

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 //
 // Common Information for the NUnit assemblies
@@ -31,14 +30,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("NUnit 3.0")]
 [assembly: AssemblyCopyright("Copyright (C) 2014 Charlie Poole")]
 [assembly: AssemblyTrademark("NUnit is a trademark of NUnit Software")]
-
-[assembly: InternalsVisibleTo("nunit.framework.tests, PublicKey=002400000480000094" +
-                              "000000060200000024000052534131000400000100010031eea" +
-                              "370b1984bfa6d1ea760e1ca6065cee41a1a279ca234933fe977" +
-                              "a096222c0e14f9e5a17d5689305c6d7f1206a85a53c48ca0100" +
-                              "80799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9" +
-                              "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
-                              "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
 #if DEBUG
 #if NET_4_5

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// Static methods used in creating messages
     /// </summary>
-    public static class MsgUtils
+    internal static class MsgUtils
     {
         /// <summary>
         /// Static string used when strings are clipped

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -23,6 +23,15 @@
 
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("nunit.framework.tests, PublicKey=002400000480000094" +
+                              "000000060200000024000052534131000400000100010031eea" +
+                              "370b1984bfa6d1ea760e1ca6065cee41a1a279ca234933fe977" +
+                              "a096222c0e14f9e5a17d5689305c6d7f1206a85a53c48ca0100" +
+                              "80799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9" +
+                              "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
+                              "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
 #if NET_4_5
 [assembly: AssemblyTitle("NUnit Framework .NET 4.5")]

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-2.0.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-2.0.csproj
@@ -58,6 +58,12 @@
     <DebugType>none</DebugType>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
       <Name>System</Name>
@@ -93,6 +99,11 @@
       <Project>{28C7B9D6-BE1F-45E5-952C-0D5C9CA3EFDF}</Project>
       <Name>nunitlite.runner-2.0</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.0.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.0.csproj
@@ -59,6 +59,12 @@
     <DebugType>none</DebugType>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
       <Name>System</Name>
@@ -92,6 +98,11 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.5.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.5.csproj
@@ -61,6 +61,12 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
       <Name>System</Name>
@@ -94,6 +100,11 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
@@ -32,6 +32,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -100,7 +106,11 @@
       <Name>nunit.framework-2.0</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
@@ -33,6 +33,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -99,7 +105,11 @@
       <Name>nunit.framework-4.0</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
@@ -35,6 +35,12 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +107,11 @@
       <Name>nunit.framework-4.5</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-portable-sl-5.0.csproj
@@ -54,8 +54,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -124,7 +123,11 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-sl-5.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-sl-5.0.csproj
@@ -46,6 +46,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System.Windows" />
@@ -118,7 +124,11 @@
       <Name>nunit.framework-sl-5.0</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
@@ -35,6 +35,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -88,6 +94,11 @@
       <Project>{12B66B03-90F1-4992-BD33-BDF3C69AE49E}</Project>
       <Name>nunit.framework-2.0</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
@@ -34,6 +34,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -97,6 +103,9 @@
     <Compile Include="UnhandledExceptions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
@@ -38,6 +38,12 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -92,6 +98,11 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
@@ -33,11 +33,21 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="system" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>

--- a/src/NUnitFramework/testdata/nunit.testdata-sl-5.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-sl-5.0.csproj
@@ -46,6 +46,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="system" />
@@ -56,7 +62,11 @@
       <Name>nunit.framework-sl-5.0</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -38,6 +38,12 @@
     <NoWarn>0414</NoWarn>
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -296,5 +302,10 @@
       <Project>{15B64946-4989-4873-915C-3E181772FA03}</Project>
       <Name>nunit.testdata-2.0</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -36,6 +36,12 @@
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>0414</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -287,6 +293,9 @@
     <EmbeddedResource Include="TestListFile2.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -40,6 +40,12 @@
     <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>0414</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -296,5 +302,10 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
@@ -62,6 +62,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System.Windows" />
@@ -305,6 +311,9 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
     <None Include="Properties\AppManifest.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -62,6 +62,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System.Windows" />
@@ -299,6 +305,9 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\framework\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
     <None Include="Properties\AppManifest.xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
**Do not merge**

This is a proposed solution to #600. As an example, I have made `MsgUtils` internal and exposed it to the tests through `InternalsVisibleTo`. It works on all platforms.

The only drawback is that InternalsVisibleTo can only use signed assemblies if the current assembly is signed. This caused signing to spread out to many of the framework test assemblies.

If this is the solution we want to pursue, then I think we should identify all of the framework classes that should be made internal and change them.

Next, we might want to look at the console and the engine and do the same thing.