### PR TITLE
Support "TEAMCITY_PROJECT_NAME"  environment variable

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -265,11 +265,7 @@ namespace NUnit.Common
             //   noshadow
             //   nothread
             //   nodots
-
-            // Options to be added:
-            //   teamcity
-            //   workers
-
+           
             // Select Tests
             this.Add("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
                 v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));

--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -41,166 +41,24 @@ namespace NUnit.Common
 
         #region Constructor
 
-        public ConsoleOptions(params string[] args)
+        internal ConsoleOptions(IDefaultOptionsProvider defaultOptionsProvider, params string[] args)
         {
-            // NOTE: The order in which patterns are added
-            // determines the display order for the help.
-
-            // Old Options no longer supported:
-            //   fixture
-            //   xmlConsole
-            //   noshadow
-            //   nothread
-            //   nodots
-
-            // Options to be added:
-            //   teamcity
-            //   workers
-
-            // Select Tests
-            this.Add("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
-                v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));
-
-            this.Add("testlist=", "File {PATH} containing a list of tests to run, one per line. This option may be repeated.",
-                v =>
-            {
-                string testListFile = RequiredValue(v, "--testlist");
-
-                var fullTestListPath = ExpandToFullPath(testListFile);
-
-                if (!File.Exists(fullTestListPath))
-                    ErrorMessages.Add("Unable to locate file: " + testListFile);
-                else
-                {
-                    try
-                    {
-                        using (var rdr = new StreamReader(fullTestListPath))
-                        {
-                            while (!rdr.EndOfStream)
-                            {
-                                var line = rdr.ReadLine().Trim();
-
-                                if (line[0] != '#')
-                                    ((List<string>)TestList).Add(line);
-                            }
-                        }
-                    }
-                    catch (IOException)
-                    {
-                        ErrorMessages.Add("Unable to read file: " + testListFile);
-                    }
-                }
-            });
-
-            this.Add("include=", "Test {CATEGORIES} to be included. May be a single category, a comma-separated list of categories or a category expression.",
-                v => Include = RequiredValue(v, "--include"));
-
-            this.Add("exclude=", "Test {CATEGORIES} to be excluded. May be a single category, a comma-separated list of categories or a category expression.",
-                v => Exclude = RequiredValue(v, "--exclude"));
-
-#if !NUNITLITE
-            this.Add("config=", "{NAME} of a project configuration to load (e.g.: Debug).",
-                v => ActiveConfig = RequiredValue(v, "--config"));
-
-            // Where to Run Tests
-            this.Add("process=", "{PROCESS} isolation for test assemblies.\nValues: Single, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
-                v => ProcessModel = RequiredValue(v, "--process", "Single", "Separate", "Multiple"));
-
-            this.Add("domain=", "{DOMAIN} isolation for test assemblies.\nValues: None, Single, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
-                v => DomainUsage = RequiredValue(v, "--domain", "None", "Single", "Multiple"));
-
-            // How to Run Tests
-            this.Add("framework=", "{FRAMEWORK} type/version to use for tests.\nExamples: mono, net-3.5, v4.0, 2.0, mono-4.0. If not specified, tests will run under the framework they are compiled with.",
-                v => Framework = RequiredValue(v, "--framework"));
-
-            this.Add("x86", "Run tests in an x86 process on 64 bit systems",
-                v => RunAsX86 = v != null);
-
-            this.Add("dispose-runners", "Dispose each test runner after it has finished running its tests.",
-                v => DisposeRunners = v != null);
-
-            this.Add("shadowcopy", "Shadow copy test files",
-                v => ShadowCopyFiles = v != null);
-#endif
-
-            this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
-                v => defaultTimeout = RequiredInt(v, "--timeout"));
-
-            this.Add("seed=", "Set the random {SEED} used to generate test cases.",
-                v => randomSeed = RequiredInt(v, "--seed"));
-
-            this.Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
-                v => numWorkers = RequiredInt(v, "--workers"));
-
-            this.Add("stoponerror", "Stop run immediately upon any test failure or error.",
-                v => StopOnError = v != null);
-
-            this.Add("wait", "Wait for input before closing console window.",
-                v => WaitBeforeExit = v != null);
-
-            this.Add("pause", "Pause before run to allow debugging.",
-                v => PauseBeforeRun = v != null);
-
-            // Output Control
-            this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
-                v => workDirectory = RequiredValue(v, "--work"));
-
-            this.Add("output|out=", "File {PATH} to contain text output from the tests.",
-                v => OutFile = RequiredValue(v, "--output"));
-
-            this.Add("err=", "File {PATH} to contain error output from the tests.",
-                v => ErrFile = RequiredValue(v, "--err"));
-
-            this.Add("full", "Prints full report of all test results.",
-                v => Full = v != null);
-
-            this.Add("result=", "An output {SPEC} for saving the test results.\nThis option may be repeated.",
-                v => resultOutputSpecifications.Add(new OutputSpecification(RequiredValue(v, "--resultxml"))));
-
-            this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
-            {
-                Explore = true;
-                if (v != null)
-                    ExploreOutputSpecifications.Add(new OutputSpecification(v));
-            });
-
-            this.Add("noresult", "Don't save any test results.",
-                v => noresult = v != null);
-
-            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
-                v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "All"));
-
-            this.Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
-                v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
-
-            this.Add("teamcity", "Turns on use of TeamCity service messages.",
-                v => TeamCity = v != null);
-
-            this.Add("noheader|noh", "Suppress display of program information at start of run.",
-                v => NoHeader = v != null);
-
-            this.Add("nocolor|noc", "Displays console output without color.",
-                v => NoColor = v != null);
-
-            this.Add("verbose|v", "Display additional information as the test runs.",
-                v => Verbose = v != null);
-
-            this.Add("help|h", "Display this message and exit.",
-                v => ShowHelp = v != null);
-
-            // Default
-            this.Add("<>", v =>
-            {
-                if (v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/')
-                    ErrorMessages.Add("Invalid argument: " + v);
-                else
-                    InputFiles.Add(v);
-            });
-
+            // Apply default oprions
+            if (defaultOptionsProvider == null) throw new ArgumentNullException("defaultOptionsProvider");
+            TeamCity = defaultOptionsProvider.TeamCity;
+            
+            ConfigureOptions();            
             if (args != null)
-                this.Parse(args);
+                Parse(args);
         }
 
+        public ConsoleOptions(params string[] args)
+        {
+            ConfigureOptions();
+            if (args != null)
+                Parse(args);
+        }
+        
         #endregion
 
         #region Properties
@@ -394,6 +252,163 @@ namespace NUnit.Common
 #else
             return Path.GetFullPath(path);
 #endif
+        }
+
+        private void ConfigureOptions()
+        {
+            // NOTE: The order in which patterns are added
+            // determines the display order for the help.
+
+            // Old Options no longer supported:
+            //   fixture
+            //   xmlConsole
+            //   noshadow
+            //   nothread
+            //   nodots
+
+            // Options to be added:
+            //   teamcity
+            //   workers
+
+            // Select Tests
+            this.Add("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
+                v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));
+
+            this.Add("testlist=", "File {PATH} containing a list of tests to run, one per line. This option may be repeated.",
+                v =>
+                {
+                    string testListFile = RequiredValue(v, "--testlist");
+
+                    var fullTestListPath = ExpandToFullPath(testListFile);
+
+                    if (!File.Exists(fullTestListPath))
+                        ErrorMessages.Add("Unable to locate file: " + testListFile);
+                    else
+                    {
+                        try
+                        {
+                            using (var rdr = new StreamReader(fullTestListPath))
+                            {
+                                while (!rdr.EndOfStream)
+                                {
+                                    var line = rdr.ReadLine().Trim();
+
+                                    if (line[0] != '#')
+                                        ((List<string>)TestList).Add(line);
+                                }
+                            }
+                        }
+                        catch (IOException)
+                        {
+                            ErrorMessages.Add("Unable to read file: " + testListFile);
+                        }
+                    }
+                });
+
+            this.Add("include=", "Test {CATEGORIES} to be included. May be a single category, a comma-separated list of categories or a category expression.",
+                v => Include = RequiredValue(v, "--include"));
+
+            this.Add("exclude=", "Test {CATEGORIES} to be excluded. May be a single category, a comma-separated list of categories or a category expression.",
+                v => Exclude = RequiredValue(v, "--exclude"));
+
+#if !NUNITLITE
+            this.Add("config=", "{NAME} of a project configuration to load (e.g.: Debug).",
+                v => ActiveConfig = RequiredValue(v, "--config"));
+
+            // Where to Run Tests
+            this.Add("process=", "{PROCESS} isolation for test assemblies.\nValues: Single, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
+                v => ProcessModel = RequiredValue(v, "--process", "Single", "Separate", "Multiple"));
+
+            this.Add("domain=", "{DOMAIN} isolation for test assemblies.\nValues: None, Single, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
+                v => DomainUsage = RequiredValue(v, "--domain", "None", "Single", "Multiple"));
+
+            // How to Run Tests
+            this.Add("framework=", "{FRAMEWORK} type/version to use for tests.\nExamples: mono, net-3.5, v4.0, 2.0, mono-4.0. If not specified, tests will run under the framework they are compiled with.",
+                v => Framework = RequiredValue(v, "--framework"));
+
+            this.Add("x86", "Run tests in an x86 process on 64 bit systems",
+                v => RunAsX86 = v != null);
+
+            this.Add("dispose-runners", "Dispose each test runner after it has finished running its tests.",
+                v => DisposeRunners = v != null);
+
+            this.Add("shadowcopy", "Shadow copy test files",
+                v => ShadowCopyFiles = v != null);
+#endif
+
+            this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
+                v => defaultTimeout = RequiredInt(v, "--timeout"));
+
+            this.Add("seed=", "Set the random {SEED} used to generate test cases.",
+                v => randomSeed = RequiredInt(v, "--seed"));
+
+            this.Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
+                v => numWorkers = RequiredInt(v, "--workers"));
+
+            this.Add("stoponerror", "Stop run immediately upon any test failure or error.",
+                v => StopOnError = v != null);
+
+            this.Add("wait", "Wait for input before closing console window.",
+                v => WaitBeforeExit = v != null);
+
+            this.Add("pause", "Pause before run to allow debugging.",
+                v => PauseBeforeRun = v != null);
+
+            // Output Control
+            this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
+                v => workDirectory = RequiredValue(v, "--work"));
+
+            this.Add("output|out=", "File {PATH} to contain text output from the tests.",
+                v => OutFile = RequiredValue(v, "--output"));
+
+            this.Add("err=", "File {PATH} to contain error output from the tests.",
+                v => ErrFile = RequiredValue(v, "--err"));
+
+            this.Add("full", "Prints full report of all test results.",
+                v => Full = v != null);
+
+            this.Add("result=", "An output {SPEC} for saving the test results.\nThis option may be repeated.",
+                v => resultOutputSpecifications.Add(new OutputSpecification(RequiredValue(v, "--resultxml"))));
+
+            this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
+            {
+                Explore = true;
+                if (v != null)
+                    ExploreOutputSpecifications.Add(new OutputSpecification(v));
+            });
+
+            this.Add("noresult", "Don't save any test results.",
+                v => noresult = v != null);
+
+            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
+                v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "All"));
+
+            this.Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
+                v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
+
+            this.Add("teamcity", "Turns on use of TeamCity service messages.",
+                v => TeamCity = v != null);
+
+            this.Add("noheader|noh", "Suppress display of program information at start of run.",
+                v => NoHeader = v != null);
+
+            this.Add("nocolor|noc", "Displays console output without color.",
+                v => NoColor = v != null);
+
+            this.Add("verbose|v", "Display additional information as the test runs.",
+                v => Verbose = v != null);
+
+            this.Add("help|h", "Display this message and exit.",
+                v => ShowHelp = v != null);
+
+            // Default
+            this.Add("<>", v =>
+            {
+                if (v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/')
+                    ErrorMessages.Add("Invalid argument: " + v);
+                else
+                    InputFiles.Add(v);
+            });
         }
 
         #endregion

--- a/src/Common/nunit/DefaultOptionsProvider.cs
+++ b/src/Common/nunit/DefaultOptionsProvider.cs
@@ -26,11 +26,20 @@ namespace NUnit.Common
 
     internal sealed class DefaultOptionsProvider : IDefaultOptionsProvider
     {
+#if !SILVERLIGHT && !NETC
         private const string EnvironmentVariableTeamcityProjectName = "TEAMCITY_PROJECT_NAME";
+#endif
 
         public bool TeamCity
         {
-            get { return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableTeamcityProjectName)); }
+            get
+            {
+#if !SILVERLIGHT && !NETCF
+                return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableTeamcityProjectName));
+#else
+                return false;
+#endif
+            }
         }
     }
 }

--- a/src/Common/nunit/DefaultOptionsProvider.cs
+++ b/src/Common/nunit/DefaultOptionsProvider.cs
@@ -1,6 +1,6 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
-//
+// Copyright (c) 2015 Charlie Poole
+// 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -20,23 +20,17 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
+namespace NUnit.Common
+{
+    using System;
 
-using System.Reflection;
-using System.Runtime.CompilerServices;
+    internal sealed class DefaultOptionsProvider : IDefaultOptionsProvider
+    {
+        private const string EnvironmentVariableTeamcityProjectName = "TEAMCITY_PROJECT_NAME";
 
-#if NET_4_5
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.5")]
-#elif NET_4_0
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.0")]
-#elif NET_2_0
-[assembly: AssemblyTitle("NUnitLite Runner .NET 2.0")]
-#elif SL_5_0
-[assembly: AssemblyTitle("NUnitLite Runner Silverlight 5.0")]
-#elif NETCF_3_5
-[assembly: AssemblyTitle("NUnitLite Runner CF 3.5")]
-#else
-[assembly: AssemblyTitle("NUnitLite Runner")]
-#endif
-
-[assembly: AssemblyDescription("")]
-[assembly: InternalsVisibleTo("nunit.framework.tests")]
+        public bool TeamCity
+        {
+            get { return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableTeamcityProjectName)); }
+        }
+    }
+}

--- a/src/Common/nunit/IDefaultOptionsProvider.cs
+++ b/src/Common/nunit/IDefaultOptionsProvider.cs
@@ -1,6 +1,6 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
-//
+// Copyright (c) 2015 Charlie Poole
+// 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -21,22 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Reflection;
-using System.Runtime.CompilerServices;
-
-#if NET_4_5
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.5")]
-#elif NET_4_0
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.0")]
-#elif NET_2_0
-[assembly: AssemblyTitle("NUnitLite Runner .NET 2.0")]
-#elif SL_5_0
-[assembly: AssemblyTitle("NUnitLite Runner Silverlight 5.0")]
-#elif NETCF_3_5
-[assembly: AssemblyTitle("NUnitLite Runner CF 3.5")]
-#else
-[assembly: AssemblyTitle("NUnitLite Runner")]
-#endif
-
-[assembly: AssemblyDescription("")]
-[assembly: InternalsVisibleTo("nunit.framework.tests")]
+namespace NUnit.Common
+{
+    internal interface IDefaultOptionsProvider
+    {
+        bool TeamCity { get; }
+    }
+}

--- a/src/Common/tests/DefaultOptionsProviderTests.cs
+++ b/src/Common/tests/DefaultOptionsProviderTests.cs
@@ -1,0 +1,73 @@
+﻿// ***********************************************************************
+// Copyright (c) 2011 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Common;
+using NUnit.Framework;
+    
+namespace NUnit.ConsoleRunner.Tests
+{
+
+    [TestFixture]
+    public sealed class DefaultOptionsProviderTests
+    {
+        private const string EnvironmentVariableTeamcityProjectName = "TEAMCITY_PROJECT_NAME";
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableTeamcityProjectName, null);
+        }
+
+        [Test]
+        public void ShouldRetTeamCityAsTrueWhenHasEnvironmentVariable_TEAMCITY_PROJECT_NAME()
+        {
+            // Given
+            var provider = CreateInstance();
+
+            // When
+            Environment.SetEnvironmentVariable(EnvironmentVariableTeamcityProjectName, "Abc");
+
+            // Then
+            Assert.True(provider.TeamCity);
+        }
+
+        [Test]
+        public void ShouldRetTeamCityAsFalseWhenHasNotEnvironmentVariable_TEAMCITY_PROJECT_NAME()
+        {
+            // Given
+            var provider = CreateInstance();
+
+            // When
+            Environment.SetEnvironmentVariable(EnvironmentVariableTeamcityProjectName, string.Empty);
+
+            // Then
+            Assert.False(provider.TeamCity);
+        }
+
+        private static DefaultOptionsProvider CreateInstance()
+        {
+            return new DefaultOptionsProvider();
+        }
+    }
+}

--- a/src/Common/tests/DefaultOptionsProviderTests.cs
+++ b/src/Common/tests/DefaultOptionsProviderTests.cs
@@ -24,10 +24,10 @@
 using System;
 using NUnit.Common;
 using NUnit.Framework;
-    
+
+#if !SILVERLIGHT && !NETC
 namespace NUnit.ConsoleRunner.Tests
 {
-
     [TestFixture]
     public sealed class DefaultOptionsProviderTests
     {
@@ -71,3 +71,4 @@ namespace NUnit.ConsoleRunner.Tests
         }
     }
 }
+#endif

--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -29,6 +29,7 @@ using NUnit.Common;
 
 namespace NUnit.ConsoleRunner.Tests
 {
+    using System.Collections.Generic;
     using Engine;
     using Framework;
 
@@ -470,6 +471,39 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);
         }
 
+        [Test]
+        [TestCase(true, null, true)]
+        [TestCase(false, null, false)]
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, true)]
+        [TestCase(false, true, true)]
+        public void ShouldSetTeamCityFlagAccordingToArgsAndDefauls(bool hasTeamcityInCmd, bool? defaultTeamcity, bool expectedTeamCity)
+        {
+            // Given
+            List<string> args = new List<string> { "tests.dll" };
+            if (hasTeamcityInCmd)
+            {
+                args.Add("--teamcity");
+            }
+
+            ConsoleOptions options;
+            if (defaultTeamcity.HasValue)
+            {
+                options = new ConsoleOptions(new DefaultOptionsProviderStub(defaultTeamcity.Value), args.ToArray());
+            }
+            else
+            {
+                options = new ConsoleOptions(args.ToArray());
+            }
+
+            // When
+            var actualTeamCity = options.TeamCity;
+
+            // Then
+            Assert.AreEqual(actualTeamCity, expectedTeamCity);
+        }
+
         #endregion
 
         #region Helper Methods
@@ -489,5 +523,15 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         #endregion
+
+        internal sealed class DefaultOptionsProviderStub : IDefaultOptionsProvider
+        {
+            public DefaultOptionsProviderStub(bool teamCity)
+            {
+                TeamCity = teamCity;
+            }
+
+            public bool TeamCity { get; private set; }
+        }
     }
 }

--- a/src/NUnitConsole/nunit-console.tests/nunit-console.tests.csproj
+++ b/src/NUnitConsole/nunit-console.tests/nunit-console.tests.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\tests\DefaultOptionsProviderTests.cs">
+      <Link>DefaultOptionsProviderTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\tests\ExtendedTextWrapperTests.cs">
       <Link>ExtendedTextWrapperTests.cs</Link>
     </Compile>

--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -21,15 +21,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using System.IO;
+using System.Reflection;
+using Mono.Options;
+using NUnit.Common;
+using NUnit.Engine;
+
 namespace NUnit.ConsoleRunner
 {
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using Common;
-    using Engine;
-    using Mono.Options;
-
     /// <summary>
     /// This class provides the entry point for the console runner.
     /// </summary>

--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -21,16 +21,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.IO;
-using System.Reflection;
-using Mono.Options;
-using NUnit.Common;
-using NUnit.Engine;
-
 namespace NUnit.ConsoleRunner
 {
-    using Utilities;
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using Common;
+    using Engine;
+    using Mono.Options;
 
     /// <summary>
     /// This class provides the entry point for the console runner.
@@ -38,7 +36,7 @@ namespace NUnit.ConsoleRunner
     public class Program
     {
         //static Logger log = InternalTrace.GetLogger(typeof(Runner));
-        static ConsoleOptions Options = new ConsoleOptions();
+        static ConsoleOptions Options = new ConsoleOptions(new DefaultOptionsProvider());
         static ExtendedTextWriter OutWriter = new ColorConsoleWriter(!Options.NoColor);
 
         [STAThread]

--- a/src/NUnitConsole/nunit-console/Properties/AssemblyInfo.cs
+++ b/src/NUnitConsole/nunit-console/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -14,3 +15,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b2dfdf79-289b-4b45-ab40-8d461b7d56d7")]
+[assembly: InternalsVisibleTo("nunit-console.tests")]

--- a/src/NUnitConsole/nunit-console/nunit-console.csproj
+++ b/src/NUnitConsole/nunit-console/nunit-console.csproj
@@ -62,6 +62,9 @@
     <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
       <Link>ConsoleOptions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
+      <Link>DefaultOptionsProvider.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\nunit\Env.cs">
       <Link>Env.cs</Link>
     </Compile>
@@ -70,6 +73,9 @@
     </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWriter.cs">
       <Link>ExtendedTextWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\nunit\IDefaultOptionsProvider.cs">
+      <Link>IDefaultOptionsProvider.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\Options.cs">
       <Link>Options.cs</Link>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
@@ -53,11 +53,17 @@
     <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
       <Link>Runner\ConsoleOptions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
+      <Link>Runner\DefaultOptionsProvider.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWrapper.cs">
       <Link>Runner\ExtendedTextWrapper.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWriter.cs">
       <Link>Runner\ExtendedTextWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\nunit\IDefaultOptionsProvider.cs">
+      <Link>Runner\IDefaultOptionsProvider.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\Options.cs">
       <Link>Runner\Options.cs</Link>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
@@ -54,11 +54,17 @@
     <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
       <Link>Runner\ConsoleOptions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
+      <Link>Runner\DefaultOptionsProvider.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWrapper.cs">
       <Link>Runner\ExtendedTextWrapper.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWriter.cs">
       <Link>Runner\ExtendedTextWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\nunit\IDefaultOptionsProvider.cs">
+      <Link>Runner\IDefaultOptionsProvider.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\Options.cs">
       <Link>Runner\Options.cs</Link>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
@@ -56,11 +56,17 @@
     <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
       <Link>Runner\ConsoleOptions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
+      <Link>Runner\DefaultOptionsProvider.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWrapper.cs">
       <Link>Runner\ExtendedTextWrapper.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\ExtendedTextWriter.cs">
       <Link>Runner\ExtendedTextWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\nunit\IDefaultOptionsProvider.cs">
+      <Link>Runner\IDefaultOptionsProvider.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\Options.cs">
       <Link>Runner\Options.cs</Link>

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -30,6 +30,8 @@ using NUnit.Framework;
 
 namespace NUnit.Common.Tests
 {
+    using System.Collections.Generic;
+
     [TestFixture]
     public class CommandLineTests
     {
@@ -481,6 +483,39 @@ namespace NUnit.Common.Tests
             Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);
         }
 
+        [Test]
+        [TestCase(true, null, true)]
+        [TestCase(false, null, false)]
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, true)]
+        [TestCase(false, true, true)]
+        public void ShouldSetTeamCityFlagAccordingToArgsAndDefauls(bool hasTeamcityInCmd, bool? defaultTeamcity, bool expectedTeamCity)
+        {
+            // Given
+            List<string> args = new List<string> { "tests.dll" };
+            if (hasTeamcityInCmd)
+            {
+                args.Add("--teamcity");
+            }
+
+            ConsoleOptions options;
+            if (defaultTeamcity.HasValue)
+            {
+                options = new ConsoleOptions(new DefaultOptionsProviderStub(defaultTeamcity.Value), args.ToArray());
+            }
+            else
+            {
+                options = new ConsoleOptions(args.ToArray());
+            }
+
+            // When
+            var actualTeamCity = options.TeamCity;
+
+            // Then
+            Assert.AreEqual(actualTeamCity, expectedTeamCity);
+        }
+        
         #endregion
 
         #region Helper Methods
@@ -500,6 +535,16 @@ namespace NUnit.Common.Tests
         }
 
         #endregion
+
+        internal sealed class DefaultOptionsProviderStub : IDefaultOptionsProvider
+        {
+            public DefaultOptionsProviderStub(bool teamCity)
+            {
+                TeamCity = teamCity;
+            }
+
+            public bool TeamCity { get; private set; }
+        }
     }
 }
 #endif

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -53,6 +53,9 @@
     <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
       <Link>Internal\AssemblyHelperTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\tests\DefaultOptionsProviderTests.cs">
+      <Link>Runner\DefaultOptionsProviderTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\tests\ExtendedTextWrapperTests.cs">
       <Link>Runner\ExtendedTextWrapperTests.cs</Link>
     </Compile>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
       <Link>Internal\AssemblyHelperTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\tests\DefaultOptionsProviderTests.cs">
+      <Link>Runner\DefaultOptionsProviderTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\tests\ExtendedTextWrapperTests.cs">
       <Link>Runner\ExtendedTextWrapperTests.cs</Link>
     </Compile>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
       <Link>Internal\AssemblyHelperTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\tests\DefaultOptionsProviderTests.cs">
+      <Link>Runner\DefaultOptionsProviderTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\tests\ExtendedTextWrapperTests.cs">
       <Link>Runner\ExtendedTextWrapperTests.cs</Link>
     </Compile>


### PR DESCRIPTION
When this environment variable exists nunit works similar as for "--teamcity" command line argument. I am from JetBrains . I would like to verify that nunit 3.0 is well integrated to the TeamCity