### PR TITLE
Issue #196: Compare DateTimeOffsets including the offset in the comparison

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -164,6 +163,21 @@ namespace NUnit.Framework.Constraints
 
             _tolerance = new Tolerance(amount);
             return this;
+        }
+
+        /// <summary>
+        /// Flags the constraint to include <see cref="DateTimeOffset.Offset"/>
+        /// property in comparison of two <see cref="DateTimeOffset"/> values.
+        /// </summary>
+        /// <remarks>
+        /// Using this modifier does not allow to use the <see cref="Within"/>
+        /// constraint modifier.
+        /// </remarks>
+        public EqualConstraint WithSameOffset
+        {
+            get { _comparer.WithSameOffset = true;
+                return this;
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -175,7 +175,9 @@ namespace NUnit.Framework.Constraints
         /// </remarks>
         public EqualConstraint WithSameOffset
         {
-            get { _comparer.WithSameOffset = true;
+            get 
+            { 
+                _comparer.WithSameOffset = true;
                 return this;
             }
         }

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -112,6 +112,17 @@ namespace NUnit.Framework.Constraints
         {
             get { return failurePoints; }
         }
+
+        /// <summary>
+        /// Flags the comparer to include <see cref="DateTimeOffset.Offset"/>
+        /// property in comparison of two <see cref="DateTimeOffset"/> values.
+        /// </summary>
+        /// <remarks>
+        /// Using this modifier does not allow to use the <see cref="Tolerance"/>
+        /// modifier.
+        /// </remarks>
+        public bool WithSameOffset { get; set; }
+
         #endregion
 
         #region Public Methods
@@ -186,6 +197,16 @@ namespace NUnit.Framework.Constraints
 
             if (Numerics.IsNumericType(x) && Numerics.IsNumericType(y))
                 return Numerics.AreEqual(x, y, ref tolerance);
+
+#if !NETCF
+            if (x is DateTimeOffset && y is DateTimeOffset && WithSameOffset)
+            {
+                DateTimeOffset xAsOffset = (DateTimeOffset)x;
+                DateTimeOffset yAsOffset = (DateTimeOffset)y;
+
+                return InvokeFirstIEquatableEqualsSecond(x, y) && InvokeFirstIEquatableEqualsSecond(xAsOffset.Offset, yAsOffset.Offset);
+            }
+#endif
 
             if (tolerance != null && tolerance.Value is TimeSpan)
             {

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -199,12 +199,29 @@ namespace NUnit.Framework.Constraints
                 return Numerics.AreEqual(x, y, ref tolerance);
 
 #if !NETCF
-            if (x is DateTimeOffset && y is DateTimeOffset && WithSameOffset)
+            if (x is DateTimeOffset && y is DateTimeOffset)
             {
+                bool result;
+
                 DateTimeOffset xAsOffset = (DateTimeOffset)x;
                 DateTimeOffset yAsOffset = (DateTimeOffset)y;
 
-                return InvokeFirstIEquatableEqualsSecond(x, y) && InvokeFirstIEquatableEqualsSecond(xAsOffset.Offset, yAsOffset.Offset);
+                if (tolerance != null && tolerance.Value is TimeSpan)
+                {
+                    TimeSpan amount = (TimeSpan)tolerance.Value;
+                    result = (xAsOffset - yAsOffset).Duration() <= amount;
+                }
+                else
+                {
+                    result = xAsOffset == yAsOffset;
+                }
+
+                if (result && WithSameOffset)
+                {
+                    result = xAsOffset.Offset == yAsOffset.Offset;
+                }
+
+                return result;
             }
 #endif
 
@@ -214,11 +231,6 @@ namespace NUnit.Framework.Constraints
 
                 if (x is DateTime && y is DateTime)
                     return ((DateTime)x - (DateTime)y).Duration() <= amount;
-
-#if !NETCF
-                if (x is DateTimeOffset && y is DateTimeOffset)
-                    return ((DateTimeOffset)x - (DateTimeOffset)y).Duration() <= amount;
-#endif
 
                 if (x is TimeSpan && y is TimeSpan)
                     return ((TimeSpan)x - (TimeSpan)y).Duration() <= amount;

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -180,24 +180,81 @@ namespace NUnit.Framework.Constraints
         #region DateTimeOffsetEquality
 
 #if !NETCF
-        public class DateTimeOffSetEquality
+
+        public class DateTimeOffsetShouldBeSame
         {
-            [Test]
-            public void ShouldBeEqualWhenOffsetIsNotIncluded()
+      
+            [Datapoints]
+            public static readonly DateTimeOffset[] sameDateTimeOffsets = 
+                {
+                    new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0)), 
+                    new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0)),
+                    new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 1, 0)),
+                    new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 55), new TimeSpan(3, 0, 0)),
+                    new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 55), new TimeSpan(3, 50, 0))
+                };
+
+            [Theory]
+            public void PositiveEqualityTest(DateTimeOffset value1, DateTimeOffset value2)
             {
-                DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
-                DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
+                Assume.That(value1 == value2);
+
                 Assert.That(value1, Is.EqualTo(value2));
             }
 
-            [Test]
-            public void ShouldNotBeEqualWhenOffsetIsIncluded()
+            [Theory]
+            public void NegativeEqualityTest(DateTimeOffset value1, DateTimeOffset value2)
             {
-                DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
-                DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
-                Assert.That(value1, Is.Not.EqualTo(value2).WithSameOffset);
+                Assume.That(value1 != value2);
+
+                Assert.That(value1, Is.Not.EqualTo(value2));
             }
 
+            [Theory]
+            public void PositiveEqualityTestWithTolerance(DateTimeOffset value1, DateTimeOffset value2)
+            {
+                Assume.That((value1 - value2).Duration() <= new TimeSpan(0, 1, 0));
+
+                Assert.That(value1, Is.EqualTo(value2).Within(1).Minutes);
+            }
+
+            [Theory]
+            public void NegativeEqualityTestWithTolerance(DateTimeOffset value1, DateTimeOffset value2)
+            {
+                Assume.That((value1 - value2).Duration() > new TimeSpan(0, 1, 0));
+                
+                Assert.That(value1, Is.Not.EqualTo(value2).Within(1).Minutes);
+            }
+
+            [Theory]
+            public void NegativeEqualityTestWithToleranceAndWithSameOffset(DateTimeOffset value1, DateTimeOffset value2)
+            {
+                Assume.That((value1 - value2).Duration() > new TimeSpan(0, 1, 0));
+                
+                Assert.That(value1, Is.Not.EqualTo(value2).Within(1).Minutes.WithSameOffset);
+            }
+
+            [Theory]
+            public void PositiveEqualityTestWithToleranceAndWithSameOffset(DateTimeOffset value1, DateTimeOffset value2)
+            {
+                Assume.That((value1 - value2).Duration() <= new TimeSpan(0, 1, 0));
+                Assume.That(value1.Offset == value2.Offset);
+
+                Assert.That(value1, Is.EqualTo(value2).Within(1).Minutes.WithSameOffset);
+            }
+
+            [Theory]
+            public void NegativeEqualityTestWithinToleranceAndWithSameOffset(DateTimeOffset value1, DateTimeOffset value2)
+            {
+                Assume.That((value1 - value2).Duration() <= new TimeSpan(0, 1, 0));
+                Assume.That(value1.Offset != value2.Offset);
+
+                Assert.That(value1, Is.Not.EqualTo(value2).Within(1).Minutes.WithSameOffset);
+            }
+        }
+
+        public class DateTimeOffSetEquality
+        {
             [Test]
             public void CanMatchDates()
             {

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -183,6 +183,22 @@ namespace NUnit.Framework.Constraints
         public class DateTimeOffSetEquality
         {
             [Test]
+            public void ShouldBeEqualWhenOffsetIsNotIncluded()
+            {
+                DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
+                DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
+                Assert.That(value1, Is.EqualTo(value2));
+            }
+
+            [Test]
+            public void ShouldNotBeEqualWhenOffsetIsIncluded()
+            {
+                DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
+                DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
+                Assert.That(value1, Is.Not.EqualTo(value2).WithSameOffset);
+            }
+
+            [Test]
             public void CanMatchDates()
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1));

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -84,6 +84,28 @@ namespace NUnit.Framework.Constraints
             Assert.That(comparer.AreEqual(x, y, ref tolerance));
         }
 
+#if !NETCF
+        [Test]
+        public void TwoDateTimeOffsetsShouldBeEqualWhenOffsetIsNotIncludedInComparison()
+        {
+            DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
+            DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
+            
+            Assert.That(comparer.AreEqual(value1, value2, ref tolerance));
+        }
+
+        [Test]
+        public void DateTimeOffsetsShouldNotBeEqualWhenOffsetIsIncludedInComparison()
+        {
+            DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
+            DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
+            
+            comparer.WithSameOffset = true;
+
+            Assert.That(comparer.AreEqual(value1, value2, ref tolerance), Is.False);
+        }
+#endif
+
 #if !PORTABLE
         [Test]
         public void SameDirectoriesAreEqual()

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -84,28 +84,6 @@ namespace NUnit.Framework.Constraints
             Assert.That(comparer.AreEqual(x, y, ref tolerance));
         }
 
-#if !NETCF
-        [Test]
-        public void TwoDateTimeOffsetsShouldBeEqualWhenOffsetIsNotIncludedInComparison()
-        {
-            DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
-            DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
-            
-            Assert.That(comparer.AreEqual(value1, value2, ref tolerance));
-        }
-
-        [Test]
-        public void DateTimeOffsetsShouldNotBeEqualWhenOffsetIsIncludedInComparison()
-        {
-            DateTimeOffset value1 = new DateTimeOffset(new DateTime(2014, 1, 30, 12, 34, 56), new TimeSpan(6, 15, 0));
-            DateTimeOffset value2 = new DateTimeOffset(new DateTime(2014, 1, 30, 9, 19, 56), new TimeSpan(3, 0, 0));
-            
-            comparer.WithSameOffset = true;
-
-            Assert.That(comparer.AreEqual(value1, value2, ref tolerance), Is.False);
-        }
-#endif
-
 #if !PORTABLE
         [Test]
         public void SameDirectoriesAreEqual()


### PR DESCRIPTION
There is a lot of comments in the issue #196 notes and I am not familiar with DateTimeOffset so hopefully I got this correctly.

One thing I realized - if implemented this way it will not support Tolerance property. On the other hand I am a bit unsure how that could be supported if both parts will be used in comparison.

Fixes #196.