### PR TITLE
Issue #611: Remove unused --teamcity option from CF build of NUnitLite

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -382,8 +382,10 @@ namespace NUnit.Common
             this.Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
                 v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
 
+#if !NETCF
             this.Add("teamcity", "Turns on use of TeamCity service messages.",
                 v => TeamCity = v != null);
+#endif
 
             this.Add("noheader|noh", "Suppress display of program information at start of run.",
                 v => NoHeader = v != null);


### PR DESCRIPTION
I attempted to review the related stuff and haven't found any other options not being compiled. Though - feel free to suggest any additional areas to be reviewed. Fixes #611