### PR TITLE
Issue #622: [NUnit 3.0 beta 1] nunit-console fails when use --output

### DIFF
--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -37,7 +37,18 @@ namespace NUnit.ConsoleRunner
     {
         //static Logger log = InternalTrace.GetLogger(typeof(Runner));
         static ConsoleOptions Options = new ConsoleOptions(new DefaultOptionsProvider());
-        static ExtendedTextWriter OutWriter = new ColorConsoleWriter(!Options.NoColor);
+        private static ExtendedTextWriter _outWriter;
+
+        // This has to be lazy otherwise NoColor command line option is not applied correctly
+        private static ExtendedTextWriter OutWriter
+        {
+            get
+            {
+                if (_outWriter == null) _outWriter = new ColorConsoleWriter(!Options.NoColor);
+
+                return _outWriter;
+            }
+        }
 
         [STAThread]
         public static int Main(string[] args)


### PR DESCRIPTION
This is probably one of the options. I kept the scope of redirected output. The lifetime is managed just locally via a decorated with optional disposal based on the configuration.

Fixes #622 