### PR TITLE
Modify IService interface; simplify ServiceContext; add tests

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
@@ -7,34 +30,24 @@ namespace NUnit.Engine.Api.Tests
 {
     public class ServiceLocatorTests
     {
-        private ITestEngine testEngine;
+        private ITestEngine _testEngine;
 
-        [SetUp]
+        [OneTimeSetUp]
         public void CreateEngine()
         {
-            testEngine = new TestEngine();
-            testEngine.InternalTraceLevel = InternalTraceLevel.Off;
-        }
-
-        private void CheckAccessToService(Type serviceType)
-        {
-            object service = testEngine.Services.GetService(serviceType);
-            Assert.NotNull(service, "GetService(Type) returned null");
-            Assert.That(service, Is.InstanceOf(serviceType));
-        }
-
-        private void CheckAccessToService<T>() where T: class
-        {
-            T service = testEngine.Services.GetService<T>();
-            Assert.NotNull(service, "GetService<T>() returned null");
+            _testEngine = new TestEngine();
+            _testEngine.InternalTraceLevel = InternalTraceLevel.Off;
         }
 
         [TestCase(typeof(ISettings))]
         [TestCase(typeof(IRecentFiles))]
         [TestCase(typeof(ITestAgency))]
-        public void CanAccessUserSettings(Type serviceType)
+        public void CanAccessService(Type serviceType)
         {
-            CheckAccessToService(serviceType);
+            IService service = _testEngine.Services.GetService(serviceType) as IService;
+            Assert.NotNull(service, "GetService(Type) returned null");
+            Assert.That(service, Is.InstanceOf(serviceType));
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Started));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -44,6 +44,12 @@ namespace NUnit.Engine.Services.Tests
             _services.ServiceManager.InitializeServices();
         }
 
+        [Test]
+        public void ServiceIsStarted()
+        {
+            Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started));
+        }
+
         // Single file
         [TestCase("EngineTests.nunit", null,        typeof(ProcessRunner))] // Needs to exist because contents are checked
         [TestCase("x.dll",             null,        typeof(ProcessRunner))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Services.Tests
             _services.Add(new ProjectService());
             _factory = new DefaultTestRunnerFactory();
             _services.Add(_factory);
-            _services.ServiceManager.InitializeServices();
+            _services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -1,0 +1,102 @@
+﻿// ***********************************************************************
+// Copyright (c) 2011-2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Services.Tests
+{
+    public static class DomainManagerStaticTests
+    {
+        static string path1 = TestPath("/test/bin/debug/test1.dll");
+        static string path2 = TestPath("/test/bin/debug/test2.dll");
+        static string path3 = TestPath("/test/utils/test3.dll");
+
+        [Test]
+        public static void GetPrivateBinPath()
+        {
+            string[] assemblies = new string[] { path1, path2, path3 };
+
+            Assert.AreEqual(
+                TestPath("bin/debug") + Path.PathSeparator + TestPath("utils"),
+                DomainManager.GetPrivateBinPath(TestPath("/test"), assemblies));
+        }
+
+        [Test]
+        public static void GetCommonAppBase_OneElement()
+        {
+            string[] assemblies = new string[] { path1 };
+
+            Assert.AreEqual(
+                TestPath("/test/bin/debug"),
+                DomainManager.GetCommonAppBase(assemblies));
+        }
+
+        [Test]
+        public static void GetCommonAppBase_TwoElements_SameDirectory()
+        {
+            string[] assemblies = new string[] { path1, path2 };
+
+            Assert.AreEqual(
+                TestPath("/test/bin/debug"),
+                DomainManager.GetCommonAppBase(assemblies));
+        }
+
+        [Test]
+        public static void GetCommonAppBase_TwoElements_DifferentDirectories()
+        {
+            string[] assemblies = new string[] { path1, path3 };
+
+            Assert.AreEqual(
+                TestPath("/test"),
+                DomainManager.GetCommonAppBase(assemblies));
+        }
+
+        [Test]
+        public static void GetCommonAppBase_ThreeElements_DifferentDirectories()
+        {
+            string[] assemblies = new string[] { path1, path2, path3 };
+
+            Assert.AreEqual(
+                TestPath("/test"),
+                DomainManager.GetCommonAppBase(assemblies));
+        }
+
+        /// <summary>
+        /// Take a valid Linux filePath and make a valid windows filePath out of it
+        /// if we are on Windows. Change slashes to backslashes and, if the
+        /// filePath starts with a slash, add C: in front of it.
+        /// </summary>
+        private static string TestPath(string path)
+        {
+            if (Path.DirectorySeparatorChar != '/')
+            {
+                path = path.Replace('/', Path.DirectorySeparatorChar);
+                if (path[0] == Path.DirectorySeparatorChar)
+                    path = "C:" + path;
+            }
+
+            return path;
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Engine.Services.Tests
             var context = new ServiceContext();
             _domainManager = new DomainManager();
             context.Add(_domainManager);
-            context.ServiceManager.InitializeServices();
+            context.ServiceManager.StartServices();
 
             _domain = _domainManager.CreateDomain(new TestPackage(MockAssembly.AssemblyPath));
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -38,10 +38,5 @@ namespace NUnit.Engine.Services.Tests.Fakes
         {
             return Path.GetExtension(path) == ".nunit";
         }
-
-        IProject IProjectService.LoadFrom(string path)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,53 +23,25 @@
 
 using System;
 using System.IO;
-using NUnit.Engine.Internal;
+using NUnit.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace NUnit.Engine.Services.Tests.Fakes
 {
-    /// <summary>
-    /// Summary description for UserSettingsService.
-    /// </summary>
-    public class SettingsService : SettingsStore, IService
+    public class FakeProjectService : FakeService, IProjectService
     {
-        private const string SETTINGS_FILE = "Nunit30Settings.xml";
-
-        public SettingsService(bool writeable)
-            : base(Path.Combine(NUnitConfiguration.ApplicationDirectory, SETTINGS_FILE), writeable) { }
-
-        #region IService Implementation
-
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        void IProjectService.ExpandProjectPackage(TestPackage package)
         {
-            try
-            {
-                LoadSettings();
-
-                Status = ServiceStatus.Started;
-            }
-            catch
-            {
-                Status = ServiceStatus.Error;
-                throw;
-            }
+            throw new NotImplementedException();
         }
 
-        public void StopService()
+        bool IProjectService.CanLoadFrom(string path)
         {
-            try
-            {
-                SaveSettings();
-            }
-            finally
-            {
-                Status = ServiceStatus.Stopped;
-                Dispose();
-            }
+            return Path.GetExtension(path) == ".nunit";
         }
-        #endregion
+
+        IProject IProjectService.LoadFrom(string path)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,53 +23,20 @@
 
 using System;
 using System.IO;
-using NUnit.Engine.Internal;
+using NUnit.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace NUnit.Engine.Services.Tests.Fakes
 {
-    /// <summary>
-    /// Summary description for UserSettingsService.
-    /// </summary>
-    public class SettingsService : SettingsStore, IService
+    public class FakeRuntimeService : FakeService, IRuntimeFrameworkService
     {
-        private const string SETTINGS_FILE = "Nunit30Settings.xml";
-
-        public SettingsService(bool writeable)
-            : base(Path.Combine(NUnitConfiguration.ApplicationDirectory, SETTINGS_FILE), writeable) { }
-
-        #region IService Implementation
-
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        bool IRuntimeFrameworkService.IsAvailable(string framework)
         {
-            try
-            {
-                LoadSettings();
-
-                Status = ServiceStatus.Started;
-            }
-            catch
-            {
-                Status = ServiceStatus.Error;
-                throw;
-            }
+            throw new NotImplementedException();
         }
 
-        public void StopService()
+        string IRuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
         {
-            try
-            {
-                SaveSettings();
-            }
-            finally
-            {
-                Status = ServiceStatus.Stopped;
-                Dispose();
-            }
+            throw new NotImplementedException();
         }
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeService.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,44 +21,32 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine.Services;
-
-namespace NUnit.Engine.Runners
+namespace NUnit.Engine.Services.Tests.Fakes
 {
-    /// <summary>
-    /// TestDomainRunner loads and runs tests in a separate
-    /// domain whose lifetime it controls.
-    /// </summary>
-    public class TestDomainRunner : DirectTestRunner
+    public class FakeService : IService
     {
-        private DomainManager _domainManager;
+        ServiceContext IService.ServiceContext { get; set; }
 
-        public TestDomainRunner(ServiceContext services, TestPackage package) : base(services, package) 
+        private ServiceStatus _status;
+        ServiceStatus IService.Status
         {
-            _domainManager = Services.GetService<DomainManager>();
+            get { return _status; }
         }
 
-        #region DirectTestRunner Overrides
-
-        protected override TestEngineResult LoadPackage()
+        void IService.StartService()
         {
-            TestDomain = _domainManager.CreateDomain(TestPackage);
-
-            return base.LoadPackage();
+            _status = FailToStart
+                ? ServiceStatus.Error
+                : ServiceStatus.Started;
         }
 
-        /// <summary>
-        /// Unload any loaded TestPackage as well as the AppDomain.
-        /// </summary>
-        public override void UnloadPackage()
+        void IService.StopService()
         {
-            if (this.TestDomain != null)
-            {
-                _domainManager.Unload(this.TestDomain);
-                this.TestDomain = null;
-            }
+            _status = ServiceStatus.Stopped;
         }
 
-        #endregion
+        // Set to true to cause the service to give
+        // an error result when started
+        public bool FailToStart { get; set; }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeSettingsService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeSettingsService.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,55 +21,32 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.IO;
 using NUnit.Engine.Internal;
 
-namespace NUnit.Engine.Services
+namespace NUnit.Engine.Services.Tests.Fakes
 {
-    /// <summary>
-    /// Summary description for UserSettingsService.
-    /// </summary>
-    public class SettingsService : SettingsStore, IService
+    public class FakeSettingsService : SettingsStore, IService
     {
-        private const string SETTINGS_FILE = "Nunit30Settings.xml";
+        ServiceContext IService.ServiceContext { get; set; }
 
-        public SettingsService(bool writeable)
-            : base(Path.Combine(NUnitConfiguration.ApplicationDirectory, SETTINGS_FILE), writeable) { }
-
-        #region IService Implementation
-
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        private ServiceStatus _status;
+        ServiceStatus IService.Status
         {
-            try
-            {
-                LoadSettings();
-
-                Status = ServiceStatus.Started;
-            }
-            catch
-            {
-                Status = ServiceStatus.Error;
-                throw;
-            }
+            get { return _status; }
         }
 
-        public void StopService()
+        void IService.StartService()
         {
-            try
-            {
-                SaveSettings();
-            }
-            finally
-            {
-                Status = ServiceStatus.Stopped;
-                Dispose();
-            }
+            _status = FailToStart
+                ? ServiceStatus.Error
+                : ServiceStatus.Started;
         }
-        #endregion
+
+        void IService.StopService()
+        {
+            _status = ServiceStatus.Stopped;
+        }
+
+        public bool FailToStart { get; set; }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Services.Tests
             var services = new ServiceContext();
             _factory = new InProcessTestRunnerFactory();
             services.Add(_factory);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014-2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,50 +24,27 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Engine.Runners;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Services.Tests
 {
-    using Fakes;
-
-    public class InProcessTestRunnerFactoryTests
+    public class ProjectServiceTests
     {
-        private InProcessTestRunnerFactory _factory;
+        private ProjectService _projectService;
 
         [SetUp]
         public void CreateServiceContext()
         {
             var services = new ServiceContext();
-            _factory = new InProcessTestRunnerFactory();
-            services.Add(_factory);
+            _projectService = new ProjectService();
+            services.Add(_projectService);
             services.ServiceManager.InitializeServices();
         }
 
         [Test]
         public void ServiceIsStarted()
         {
-            Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
-        }
-
-        // Single file
-        [TestCase("x.dll",  null,      typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Two files
-        [TestCase("x.dll y.dll",  null,     typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Three files
-        [TestCase("x.dll y.dll z.dll", null,       typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        public void CorrectRunnerIsUsed(string files, string domainUsage, Type expectedType)
-        {
-            var package = new TestPackage(files.Split(new char[] { ' ' }));
-            if (domainUsage != null)
-                package.Settings["DomainUsage"] = domainUsage;
-            Assert.That(_factory.MakeTestRunner(package), Is.TypeOf(expectedType));
+            Assert.That(_projectService.Status, Is.EqualTo(ServiceStatus.Started));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Services.Tests
             var services = new ServiceContext();
             _projectService = new ProjectService();
             services.Add(_projectService);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -21,13 +21,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using NUnit.Framework;
+
 namespace NUnit.Engine.Services.Tests
 {
-    using System;
-    using System.Collections;
-    using Microsoft.Win32;
-    using NUnit.Engine.Internal;
-    using NUnit.Framework;
+    using Fakes;
     
     /// <summary>
     /// This fixture is used to test both RecentProjects and
@@ -41,97 +40,63 @@ namespace NUnit.Engine.Services.Tests
         private const int MIN = 0;
         private const int DEFAULT = 5;
 
-        RecentFilesService recentFiles;
+        RecentFilesService _recentFiles;
 
         [SetUp]
         public void SetUp()
         {
             var services = new ServiceContext();
-            services.Add(new Services.SettingsService());
-            recentFiles = new RecentFilesService();
-            services.Add(recentFiles);
+            services.Add(new FakeSettingsService());
+            _recentFiles = new RecentFilesService();
+            services.Add(_recentFiles);
+            services.ServiceManager.InitializeServices();
         }
 
-        #region Helper Methods
-        // Set RecentFiles to a list of known values up
-        // to a maximum. Most recent will be "1", next 
-        // "2", and so on...
-        private void SetMockValues( int count )
+        [Test]
+        public void ServiceIsStarted()
         {
-            for( int num = count; num > 0; --num )
-                recentFiles.SetMostRecent( num.ToString() );			
+            Assert.That(_recentFiles.Status, Is.EqualTo(ServiceStatus.Started));
         }
-
-        // Check that the list is set right: 1, 2, ...
-        private void CheckMockValues( int count )
-        {
-            var files = recentFiles.Entries;
-            Assert.AreEqual( count, files.Count, "Count" );
-            
-            for( int index = 0; index < count; index++ )
-                Assert.AreEqual( (index + 1).ToString(), files[index], "Item" ); 
-        }
-
-        // Check that we can add count items correctly
-        private void CheckAddItems( int count )
-        {
-            SetMockValues( count );
-            Assert.AreEqual( "1", recentFiles.Entries[0], "RecentFile" );
-
-            CheckMockValues( Math.Min( count, recentFiles.MaxFiles ) );
-        }
-
-        // Check that the list contains a set of entries
-        // in the order given and nothing else.
-        private void CheckListContains( params int[] item )
-        {
-            var files = recentFiles.Entries;
-            Assert.AreEqual( item.Length, files.Count, "Count" );
-
-            for( int index = 0; index < files.Count; index++ )
-                Assert.AreEqual( item[index].ToString(), files[index], "Item" );
-        }
-        #endregion
 
         [Test]
         public void CountDefault()
         {
-            Assert.AreEqual( DEFAULT, recentFiles.MaxFiles );
+            Assert.AreEqual( DEFAULT, _recentFiles.MaxFiles );
         }
 
         [Test]
         public void CountOverMax()
         {
-            recentFiles.MaxFiles = MAX + 1;
-            Assert.AreEqual( MAX, recentFiles.MaxFiles );
+            _recentFiles.MaxFiles = MAX + 1;
+            Assert.AreEqual( MAX, _recentFiles.MaxFiles );
         }
 
         [Test]
         public void CountUnderMin()
         {
-            recentFiles.MaxFiles = MIN - 1;
-            Assert.AreEqual( MIN, recentFiles.MaxFiles );
+            _recentFiles.MaxFiles = MIN - 1;
+            Assert.AreEqual( MIN, _recentFiles.MaxFiles );
         }
 
         [Test]
         public void CountAtMax()
         {
-            recentFiles.MaxFiles = MAX;
-            Assert.AreEqual( MAX, recentFiles.MaxFiles );
+            _recentFiles.MaxFiles = MAX;
+            Assert.AreEqual( MAX, _recentFiles.MaxFiles );
         }
 
         [Test]
         public void CountAtMin()
         {
-            recentFiles.MaxFiles = MIN;
-            Assert.AreEqual( MIN, recentFiles.MaxFiles );
+            _recentFiles.MaxFiles = MIN;
+            Assert.AreEqual( MIN, _recentFiles.MaxFiles );
         }
 
         [Test]
         public void EmptyList()
         {
-            Assert.IsNotNull(  recentFiles.Entries, "Entries should never be null" );
-            Assert.AreEqual( 0, recentFiles.Entries.Count );
+            Assert.IsNotNull(  _recentFiles.Entries, "Entries should never be null" );
+            Assert.AreEqual( 0, _recentFiles.Entries.Count );
         }
 
         [Test]
@@ -155,14 +120,14 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public void IncreaseSize()
         {
-            recentFiles.MaxFiles = 10;
+            _recentFiles.MaxFiles = 10;
             CheckAddItems( 10 );
         }
 
         [Test]
         public void ReduceSize()
         {
-            recentFiles.MaxFiles = 3;
+            _recentFiles.MaxFiles = 3;
             CheckAddItems( 10 );
         }
 
@@ -170,10 +135,10 @@ namespace NUnit.Engine.Services.Tests
         public void IncreaseSizeAfterAdd()
         {
             SetMockValues(5);
-            recentFiles.MaxFiles = 7;
-            recentFiles.SetMostRecent( "30" );
-            recentFiles.SetMostRecent( "20" );
-            recentFiles.SetMostRecent( "10" );
+            _recentFiles.MaxFiles = 7;
+            _recentFiles.SetMostRecent( "30" );
+            _recentFiles.SetMostRecent( "20" );
+            _recentFiles.SetMostRecent( "10" );
             CheckListContains( 10, 20, 30, 1, 2, 3, 4 );
         }
 
@@ -181,7 +146,7 @@ namespace NUnit.Engine.Services.Tests
         public void ReduceSizeAfterAdd()
         {
             SetMockValues( 5 );
-            recentFiles.MaxFiles = 3;
+            _recentFiles.MaxFiles = 3;
             CheckMockValues( 3 );
         }
 
@@ -189,7 +154,7 @@ namespace NUnit.Engine.Services.Tests
         public void ReorderLastProject()
         {
             SetMockValues( 5 );
-            recentFiles.SetMostRecent( "5" );
+            _recentFiles.SetMostRecent( "5" );
             CheckListContains( 5, 1, 2, 3, 4 );
         }
 
@@ -197,7 +162,7 @@ namespace NUnit.Engine.Services.Tests
         public void ReorderSingleProject()
         {
             SetMockValues( 5 );
-            recentFiles.SetMostRecent( "3" );
+            _recentFiles.SetMostRecent( "3" );
             CheckListContains( 3, 1, 2, 4, 5 );
         }
 
@@ -205,9 +170,9 @@ namespace NUnit.Engine.Services.Tests
         public void ReorderMultipleProjects()
         {
             SetMockValues( 5 );
-            recentFiles.SetMostRecent( "3" );
-            recentFiles.SetMostRecent( "5" );
-            recentFiles.SetMostRecent( "2" );
+            _recentFiles.SetMostRecent( "3" );
+            _recentFiles.SetMostRecent( "5" );
+            _recentFiles.SetMostRecent( "2" );
             CheckListContains( 2, 5, 3, 1, 4 );
         }
 
@@ -215,7 +180,7 @@ namespace NUnit.Engine.Services.Tests
         public void ReorderSameProject()
         {
             SetMockValues( 5 );
-            recentFiles.SetMostRecent( "1" );
+            _recentFiles.SetMostRecent( "1" );
             CheckListContains( 1, 2, 3, 4, 5 );
         }
 
@@ -223,7 +188,7 @@ namespace NUnit.Engine.Services.Tests
         public void ReorderWithListNotFull()
         {
             SetMockValues( 3 );
-            recentFiles.SetMostRecent( "3" );
+            _recentFiles.SetMostRecent( "3" );
             CheckListContains( 3, 1, 2 );
         }
 
@@ -231,7 +196,7 @@ namespace NUnit.Engine.Services.Tests
         public void RemoveFirstProject()
         {
             SetMockValues( 3 );
-            recentFiles.Remove("1");
+            _recentFiles.Remove("1");
             CheckListContains( 2, 3 );
         }
 
@@ -239,7 +204,7 @@ namespace NUnit.Engine.Services.Tests
         public void RemoveOneProject()
         {
             SetMockValues( 4 );
-            recentFiles.Remove("2");
+            _recentFiles.Remove("2");
             CheckListContains( 1, 3, 4 );
         }
 
@@ -247,9 +212,9 @@ namespace NUnit.Engine.Services.Tests
         public void RemoveMultipleProjects()
         {
             SetMockValues( 5 );
-            recentFiles.Remove( "3" );
-            recentFiles.Remove( "1" );
-            recentFiles.Remove( "4" );
+            _recentFiles.Remove( "3" );
+            _recentFiles.Remove( "1" );
+            _recentFiles.Remove( "4" );
             CheckListContains( 2, 5 );
         }
         
@@ -257,8 +222,51 @@ namespace NUnit.Engine.Services.Tests
         public void RemoveLastProject()
         {
             SetMockValues( 5 );
-            recentFiles.Remove("5");
+            _recentFiles.Remove("5");
             CheckListContains( 1, 2, 3, 4 );
         }
+
+        #region Helper Methods
+
+        // Set RecentFiles to a list of known values up
+        // to a maximum. Most recent will be "1", next 
+        // "2", and so on...
+        private void SetMockValues(int count)
+        {
+            for (int num = count; num > 0; --num)
+                _recentFiles.SetMostRecent(num.ToString());
+        }
+
+        // Check that the list is set right: 1, 2, ...
+        private void CheckMockValues(int count)
+        {
+            var files = _recentFiles.Entries;
+            Assert.AreEqual(count, files.Count, "Count");
+
+            for (int index = 0; index < count; index++)
+                Assert.AreEqual((index + 1).ToString(), files[index], "Item");
+        }
+
+        // Check that we can add count items correctly
+        private void CheckAddItems(int count)
+        {
+            SetMockValues(count);
+            Assert.AreEqual("1", _recentFiles.Entries[0], "RecentFile");
+
+            CheckMockValues(Math.Min(count, _recentFiles.MaxFiles));
+        }
+
+        // Check that the list contains a set of entries
+        // in the order given and nothing else.
+        private void CheckListContains(params int[] item)
+        {
+            var files = _recentFiles.Entries;
+            Assert.AreEqual(item.Length, files.Count, "Count");
+
+            for (int index = 0; index < files.Count; index++)
+                Assert.AreEqual(item[index].ToString(), files[index], "Item");
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -49,7 +49,7 @@ namespace NUnit.Engine.Services.Tests
             services.Add(new FakeSettingsService());
             _recentFiles = new RecentFilesService();
             services.Add(_recentFiles);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -38,7 +38,13 @@ namespace NUnit.Engine.Services.Tests
         public void CreateService()
         {
             _resultService = new ResultService();
-            _resultService.InitializeService();
+            _resultService.StartService();
+        }
+
+        [Test]
+        public void ServiceIsStarted()
+        {
+            Assert.That(_resultService.Status, Is.EqualTo(ServiceStatus.Started));
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
@@ -43,7 +43,7 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
         {
             StringBuilder sb = new StringBuilder();
             ResultService service = new ResultService();
-            service.InitializeService();
+            service.StartService();
             using (StringWriter writer = new StringWriter(sb))
             {
                 service.GetResultWriter("nunit2", null).WriteResultFile(EngineResult.Xml, writer);

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlValidationTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlValidationTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
             StringBuilder output = new StringBuilder();
 
             ResultService service = new ResultService();
-            service.InitializeService();
+            service.StartService();
             service.GetResultWriter("nunit2", null).WriteResultFile(this.EngineResult.Xml, new StringWriter(output));
 
             if (!validator.Validate(new StringReader(output.ToString())))

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Services.Tests
             var services = new ServiceContext();
             _runtimeService = new RuntimeFrameworkService();
             services.Add(_runtimeService);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014-2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,50 +24,27 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Engine.Runners;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Services.Tests
 {
-    using Fakes;
-
-    public class InProcessTestRunnerFactoryTests
+    public class RuntimeFrameworkServiceTests
     {
-        private InProcessTestRunnerFactory _factory;
+        private RuntimeFrameworkService _runtimeService;
 
         [SetUp]
         public void CreateServiceContext()
         {
             var services = new ServiceContext();
-            _factory = new InProcessTestRunnerFactory();
-            services.Add(_factory);
+            _runtimeService = new RuntimeFrameworkService();
+            services.Add(_runtimeService);
             services.ServiceManager.InitializeServices();
         }
 
         [Test]
         public void ServiceIsStarted()
         {
-            Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
-        }
-
-        // Single file
-        [TestCase("x.dll",  null,      typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Two files
-        [TestCase("x.dll y.dll",  null,     typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Three files
-        [TestCase("x.dll y.dll z.dll", null,       typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        public void CorrectRunnerIsUsed(string files, string domainUsage, Type expectedType)
-        {
-            var package = new TestPackage(files.Split(new char[] { ' ' }));
-            if (domainUsage != null)
-                package.Settings["DomainUsage"] = domainUsage;
-            Assert.That(_factory.MakeTestRunner(package), Is.TypeOf(expectedType));
+            Assert.That(_runtimeService.Status, Is.EqualTo(ServiceStatus.Started));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
@@ -1,0 +1,107 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Services.Tests
+{
+    using Fakes;
+
+    public class ServiceDependencyTests
+    {
+        private ServiceContext _services;
+
+        [SetUp]
+        public void CreateServiceContext()
+        {
+            _services = new ServiceContext();
+        }
+
+        [Test]
+        public void RecentFilesService_SettingsServiceError()
+        {
+            var fake = new FakeSettingsService();
+            fake.FailToStart = true;
+            _services.Add(fake);
+            var service = new RecentFilesService();
+            _services.Add(service);
+            ((IService)fake).StartService();
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void RecentFilesService_SettingsServiceMissing()
+        {
+            var service = new RecentFilesService();
+            _services.Add(service);
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void DefaultTestRunnerFactory_ProjectServiceError()
+        {
+            var fake = new FakeProjectService();
+            fake.FailToStart = true;
+            _services.Add(fake);
+            var service = new RecentFilesService();
+            _services.Add(service);
+            ((IService)fake).StartService();
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void DefaultTestRunnerFactory_ProjectServiceMissing()
+        {
+            var service = new DefaultTestRunnerFactory();
+            _services.Add(service);
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void TestAgency_RuntimeFrameworkServiceError()
+        {
+            var fake = new FakeRuntimeService();
+            fake.FailToStart = true;
+            _services.Add(fake);
+            var service = new TestAgency();
+            _services.Add(service);
+            ((IService)fake).StartService();
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void TestAgency_RuntimeFrameworkServiceMissing()
+        {
+            var service = new TestAgency();
+            _services.Add(service);
+            service.StartService();
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
@@ -1,0 +1,84 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Services.Tests
+{
+    using Fakes;
+
+    public class ServiceManagerTests
+    {
+        private IService _settingsService;
+        private IService _projectService;
+        private ServiceManager _serviceManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _serviceManager = new ServiceManager();
+
+            _settingsService = new FakeSettingsService();
+            _serviceManager.AddService(_settingsService);
+
+            _projectService = new FakeProjectService();
+            _serviceManager.AddService(_projectService);
+        }
+
+        [Test]
+        public void InitializeServices()
+        {
+            _serviceManager.InitializeServices();
+
+            IService service = _serviceManager.GetService(typeof(IProjectService));
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Started));
+            service = _serviceManager.GetService(typeof(ISettings));
+            Assert.That(service.Status, Is.EqualTo(ServiceStatus.Started));
+        }
+
+        [Test]
+        public void InitializationFailure()
+        {
+            ((FakeSettingsService)_settingsService).FailToStart = true;
+            Assert.That(() => _serviceManager.InitializeServices(), 
+                Throws.InstanceOf<InvalidOperationException>().And.Message.Contains("FakeSettingsService"));
+        }
+
+        [Test]
+        public void AccessServiceByClass()
+        {
+            IService service = _serviceManager.GetService(typeof(FakeProjectService));
+            Assert.That(service, Is.SameAs(_projectService));
+        }
+
+        [Test]
+        public void AccessServiceByInterface()
+        {
+            IService service = _serviceManager.GetService(typeof(IProjectService));
+            Assert.That(service, Is.SameAs(_projectService));
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public void InitializeServices()
         {
-            _serviceManager.InitializeServices();
+            _serviceManager.StartServices();
 
             IService service = _serviceManager.GetService(typeof(IProjectService));
             Assert.That(service.Status, Is.EqualTo(ServiceStatus.Started));
@@ -63,7 +63,7 @@ namespace NUnit.Engine.Services.Tests
         public void InitializationFailure()
         {
             ((FakeSettingsService)_settingsService).FailToStart = true;
-            Assert.That(() => _serviceManager.InitializeServices(), 
+            Assert.That(() => _serviceManager.StartServices(), 
                 Throws.InstanceOf<InvalidOperationException>().And.Message.Contains("FakeSettingsService"));
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014-2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,50 +24,27 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Engine.Runners;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Services.Tests
 {
-    using Fakes;
-
-    public class InProcessTestRunnerFactoryTests
+    public class SettingsServiceTests
     {
-        private InProcessTestRunnerFactory _factory;
+        private SettingsService _settingsService;
 
         [SetUp]
         public void CreateServiceContext()
         {
             var services = new ServiceContext();
-            _factory = new InProcessTestRunnerFactory();
-            services.Add(_factory);
+            _settingsService = new SettingsService(false);
+            services.Add(_settingsService);
             services.ServiceManager.InitializeServices();
         }
 
         [Test]
         public void ServiceIsStarted()
         {
-            Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
-        }
-
-        // Single file
-        [TestCase("x.dll",  null,      typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Two files
-        [TestCase("x.dll y.dll",  null,     typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Three files
-        [TestCase("x.dll y.dll z.dll", null,       typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        public void CorrectRunnerIsUsed(string files, string domainUsage, Type expectedType)
-        {
-            var package = new TestPackage(files.Split(new char[] { ' ' }));
-            if (domainUsage != null)
-                package.Settings["DomainUsage"] = domainUsage;
-            Assert.That(_factory.MakeTestRunner(package), Is.TypeOf(expectedType));
+            Assert.That(_settingsService.Status, Is.EqualTo(ServiceStatus.Started));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Services.Tests
             var services = new ServiceContext();
             _settingsService = new SettingsService(false);
             services.Add(_settingsService);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Engine.Services.Tests
             // Use a different URI to avoid conflicting with the "real" TestAgency
             _testAgency = new TestAgency("TestAgencyTest", 0);
             services.Add(_testAgency);
-            services.ServiceManager.InitializeServices();
+            services.ServiceManager.StartServices();
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2014-2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,53 +21,31 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Engine.Runners;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Services.Tests
 {
     using Fakes;
 
-    public class InProcessTestRunnerFactoryTests
+    public class TestAgencyTests
     {
-        private InProcessTestRunnerFactory _factory;
+        private TestAgency _testAgency;
 
         [SetUp]
         public void CreateServiceContext()
         {
             var services = new ServiceContext();
-            _factory = new InProcessTestRunnerFactory();
-            services.Add(_factory);
+            services.Add(new FakeRuntimeService());
+            // Use a different URI to avoid conflicting with the "real" TestAgency
+            _testAgency = new TestAgency("TestAgencyTest", 0);
+            services.Add(_testAgency);
             services.ServiceManager.InitializeServices();
         }
 
         [Test]
         public void ServiceIsStarted()
         {
-            Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
-        }
-
-        // Single file
-        [TestCase("x.dll",  null,      typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Two files
-        [TestCase("x.dll y.dll",  null,     typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        // Three files
-        [TestCase("x.dll y.dll z.dll", null,       typeof(MultipleTestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll y.dll z.dll", "Multiple", typeof(MultipleTestDomainRunner))]
-        public void CorrectRunnerIsUsed(string files, string domainUsage, Type expectedType)
-        {
-            var package = new TestPackage(files.Split(new char[] { ' ' }));
-            if (domainUsage != null)
-                package.Settings["DomainUsage"] = domainUsage;
-            Assert.That(_factory.MakeTestRunner(package), Is.TypeOf(expectedType));
+            Assert.That(_testAgency.Status, Is.EqualTo(ServiceStatus.Started));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -70,9 +70,19 @@
     <Compile Include="Internal\SettingsGroupTests.cs" />
     <Compile Include="ResultHelperTests.cs" />
     <Compile Include="RuntimeFrameworkTests.cs" />
+    <Compile Include="Services\Fakes\FakeRuntimeService.cs" />
+    <Compile Include="Services\ServiceManagerTests.cs" />
+    <Compile Include="Services\TestAgencyTests.cs" />
+    <Compile Include="Services\SettingsServiceTests.cs" />
+    <Compile Include="Services\RuntimeFrameworkServiceTests.cs" />
+    <Compile Include="Services\DomainManagerStaticTests.cs" />
+    <Compile Include="Services\Fakes\FakeService.cs" />
+    <Compile Include="Services\Fakes\FakeProjectService.cs" />
+    <Compile Include="Services\Fakes\FakeSettingsService.cs" />
     <Compile Include="Services\InProcessTestRunnerFactoryTests.cs" />
     <Compile Include="Services\DomainManagerTests.cs" />
     <Compile Include="Services\DriverServiceTests.cs" />
+    <Compile Include="Services\ProjectServiceTests.cs" />
     <Compile Include="Services\ResultServiceTests.cs" />
     <Compile Include="Services\ResultWriters\NUnit2XmlResultWriterTests.cs" />
     <Compile Include="Services\ResultWriters\NUnit2XmlValidationTests.cs" />
@@ -81,6 +91,7 @@
     <Compile Include="Services\ResultWriters\XmlOutputTest.cs" />
     <Compile Include="Services\ResultWriters\XmlTransformResultWriterTests.cs" />
     <Compile Include="Services\DefaultTestRunnerFactoryTests.cs" />
+    <Compile Include="Services\ServiceDependencyTests.cs" />
     <Compile Include="TempResourceFile.cs" />
     <Compile Include="TestEngineResultTests.cs" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -131,7 +131,7 @@ namespace NUnit.Engine.Agents
         {
             //System.Diagnostics.Debug.Assert(false, "Attach debugger if desired");
 
-            _runner = Services.TestRunnerFactory.MakeTestRunner(_package);
+            _runner = Services.GetService<ITestRunnerFactory>().MakeTestRunner(_package);
             return _runner.Load();
         }
 

--- a/src/NUnitEngine/nunit.engine/IProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/IProjectService.cs
@@ -41,13 +41,6 @@ namespace NUnit.Engine.Services
         bool CanLoadFrom(string path);
 
         /// <summary>
-        /// Loads a project of a known format.
-        /// </summary>
-        /// <param name="path">The path of the project file</param>
-        /// <returns>An IProject interface to the loaded project or null if the project cannot be loaded</returns>
-        IProject LoadFrom(string path);
-
-        /// <summary>
         /// Expands a TestPackage based on a known project format, populating it
         /// with the project contents and any settings the project provides. 
         /// Note that the package file path must be checked to ensure that it is

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -22,10 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Xml;
-using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 
 namespace NUnit.Engine.Runners

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -25,11 +25,11 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml;
+using NUnit.Engine.Internal;
+using NUnit.Engine.Services;
 
 namespace NUnit.Engine.Runners
 {
-    using Internal;
-
     /// <summary>
     /// AbstractTestRunner is the base class for all runners
     /// within the NUnit Engine. It implements the ITestRunner
@@ -45,6 +45,8 @@ namespace NUnit.Engine.Runners
         {
             this.Services = services;
             this.TestPackage = package;
+            ProjectService = Services.GetService<IProjectService>();
+            TestRunnerFactory = Services.GetService<ITestRunnerFactory>();
         }
 
         #region Properties
@@ -53,6 +55,10 @@ namespace NUnit.Engine.Runners
         /// Our Service Context
         /// </summary>
         protected ServiceContext Services { get; private set; }
+
+        protected IProjectService ProjectService { get; private set; }
+
+        protected ITestRunnerFactory TestRunnerFactory { get; private set; }
 
         /// <summary>
         /// The TestPackage for which this is the runner
@@ -259,7 +265,7 @@ namespace NUnit.Engine.Runners
             return package != null
                 && package.FullName != null
                 && package.FullName != string.Empty
-                && Services.ProjectService.CanLoadFrom(package.FullName);
+                && ProjectService.CanLoadFrom(package.FullName);
         }
 
         private void EnsurePackageIsLoaded()

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -71,8 +71,8 @@ namespace NUnit.Engine.Runners
 
             foreach (var subPackage in TestPackage.SubPackages)
             {
-                if (Services.ProjectService.CanLoadFrom(subPackage.FullName))
-                    Services.ProjectService.ExpandProjectPackage(subPackage);
+                if (ProjectService.CanLoadFrom(subPackage.FullName))
+                    ProjectService.ExpandProjectPackage(subPackage);
 
                 var runner = CreateRunner(subPackage);
                 _runners.Add(runner);
@@ -165,7 +165,7 @@ namespace NUnit.Engine.Runners
 
         protected virtual ITestEngineRunner CreateRunner(TestPackage package)
         {
-            return Services.TestRunnerFactory.MakeTestRunner(package);
+            return TestRunnerFactory.MakeTestRunner(package);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -80,10 +80,12 @@ namespace NUnit.Engine.Runners
             if (packages.Count == 0)
                 packages.Add(TestPackage);
 
+            var driverService = Services.GetService<IDriverService>();
+
             foreach (var subPackage in packages)
             {
                 var testFile = subPackage.FullName;
-                IFrameworkDriver driver = Services.DriverService.GetDriver(TestDomain, testFile);
+                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile);
                 driver.ID = TestPackage.ID;
                 result.Add(driver.Load(testFile, subPackage.Settings));
                 _drivers.Add(driver);

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -61,7 +61,7 @@ namespace NUnit.Engine.Runners
             // in case the client runner missed them.
             ValidatePackageSettings();
 
-            _realRunner = Services.TestRunnerFactory.MakeTestRunner(TestPackage);
+            _realRunner = TestRunnerFactory.MakeTestRunner(TestPackage);
 
             return _realRunner.Load().Aggregate(TEST_RUN_ELEMENT, TestPackage.Name, TestPackage.FullName);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -23,6 +23,7 @@
 
 using System;
 using NUnit.Engine.Internal;
+using NUnit.Engine.Services;
 
 namespace NUnit.Engine.Runners
 {
@@ -35,8 +36,12 @@ namespace NUnit.Engine.Runners
 
         private ITestAgent _agent;
         private ITestEngineRunner _remoteRunner;
+        private TestAgency _agency;
 
-        public ProcessRunner(ServiceContext services, TestPackage package) : base(services, package) { }
+        public ProcessRunner(ServiceContext services, TestPackage package) : base(services, package) 
+        {
+            _agency = Services.GetService<TestAgency>();
+        }
 
         #region Properties
 
@@ -70,7 +75,7 @@ namespace NUnit.Engine.Runners
             {
                 if (_agent == null)
                 {
-                    _agent = Services.TestAgency.GetAgent(TestPackage, 30000);
+                    _agent = _agency.GetAgent(TestPackage, 30000);
 
                     if (_agent == null)
                         throw new Exception("Unable to acquire remote process agent");

--- a/src/NUnitEngine/nunit.engine/ServiceContext.cs
+++ b/src/NUnitEngine/nunit.engine/ServiceContext.cs
@@ -30,9 +30,6 @@ namespace NUnit.Engine
     /// The ServiceContext is used by services, runners and
     /// external clients to locate the services they need through
     /// the IServiceLocator interface.
-    /// 
-    /// For internal use by runners and other services, individual
-    /// properties are provided for common services as well.
     /// </summary>
     public class ServiceContext : IServiceLocator
     {
@@ -45,143 +42,13 @@ namespace NUnit.Engine
 
         #endregion
 
-        #region Service Properties
-
-        #region ServiceManager
+        #region Properties
 
         public ServiceManager ServiceManager { get; private set; }
 
         #endregion
 
-        #region DomainManager
-
-        private DomainManager _domainManager;
-        public DomainManager DomainManager
-        {
-            get
-            {
-                if (_domainManager == null)
-                    _domainManager = GetService<DomainManager>();
-
-                return _domainManager;
-            }
-        }
-
-        #endregion
-
-        #region UserSettings
-
-        private ISettings _userSettings;
-        public ISettings UserSettings
-        {
-            get
-            {
-                if (_userSettings == null)
-                    _userSettings = GetService<ISettings>();
-
-                return _userSettings;
-            }
-        }
-
-        #endregion
-
-        #region RecentFilesService
-        private IRecentFiles _recentFiles;
-        public IRecentFiles RecentFiles
-        {
-            get
-            {
-                if ( _recentFiles == null )
-                    _recentFiles = GetService<IRecentFiles>();
-
-                return _recentFiles;
-            }
-        }
-        #endregion
-
-        #region RuntimeFrameworkSelector
-
-        // Note: the engine uses the RuntimeFrameworkService directly
-        // while runners only have access to IRuntimeFrameworkService.
-        private RuntimeFrameworkService _runtimeService;
-        public RuntimeFrameworkService RuntimeFrameworkService
-        {
-            get
-            {
-                if (_runtimeService == null)
-                    _runtimeService = GetService<RuntimeFrameworkService>();
-
-                return _runtimeService;
-            }
-        }
-
-        #endregion
-
-        #region DriverService
-
-        private IDriverService _driverService;
-        public IDriverService DriverService
-        {
-            get
-            {
-                if (_driverService == null)
-                    _driverService = GetService<IDriverService>();
-
-                return _driverService;
-            }
-        }
-
-        #endregion
-
-        #region TestRunnerFactory
-
-        private ITestRunnerFactory _testRunnerFactory;
-        public ITestRunnerFactory TestRunnerFactory
-        {
-            get
-            {
-                if (_testRunnerFactory == null)
-                    _testRunnerFactory = GetService<ITestRunnerFactory>();
-
-                return _testRunnerFactory;
-            }
-        }
-
-        #endregion
-
-        #region TestAgency
-
-        private TestAgency _agency;
-        public TestAgency TestAgency
-        {
-            get
-            {
-                if (_agency == null)
-                    _agency = GetService<TestAgency>();
-
-                return _agency;
-            }
-        }
-
-        #endregion
-
-        #region ProjectService
-        private ProjectService _projectService;
-        public ProjectService ProjectService
-        {
-            get
-            {
-                if (_projectService == null)
-                    _projectService = GetService<ProjectService>();
-
-                return _projectService;
-            }
-        }
-        #endregion
-
-        #endregion
-
-        #region Add Method
+        #region Methods
 
         public void Add(IService service)
         {

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -39,7 +39,10 @@ namespace NUnit.Engine.Services
 
         public override void StartService()
         {
+            // TestRunnerFactory requires the ProjectService
             _projectService = ServiceContext.GetService<IProjectService>();
+
+            // Anything returned from ServiceContext is known to be an IService
             Status = _projectService != null && ((IService)_projectService).Status == ServiceStatus.Started
                 ? ServiceStatus.Started
                 : ServiceStatus.Error;

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -35,6 +35,16 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class DefaultTestRunnerFactory : InProcessTestRunnerFactory, ITestRunnerFactory
     {
+        private IProjectService _projectService;
+
+        public override void StartService()
+        {
+            _projectService = ServiceContext.GetService<IProjectService>();
+            Status = _projectService != null && ((IService)_projectService).Status == ServiceStatus.Started
+                ? ServiceStatus.Started
+                : ServiceStatus.Error;
+        }
+
         /// <summary>
         /// Returns a test runner based on the settings in a TestPackage.
         /// Any setting that is "consumed" by the factory is removed, so
@@ -55,7 +65,7 @@ namespace NUnit.Engine.Services
 
                 if (PathUtils.IsAssemblyFileType(testFile))
                     assemblyCount++;
-                else if (ServiceContext.ProjectService.CanLoadFrom(testFile))
+                else if (_projectService.CanLoadFrom(testFile))
                     projectCount++;
             }
 
@@ -71,7 +81,7 @@ namespace NUnit.Engine.Services
             {
                 var p = package.SubPackages[0];
 
-                ServiceContext.ProjectService.ExpandProjectPackage(p);
+                _projectService.ExpandProjectPackage(p);
 
                 package = p;
             }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -44,8 +44,7 @@ namespace NUnit.Engine.Services
     {
         static Logger log = InternalTrace.GetLogger(typeof(DomainManager));
 
-        static Type[] DEPENDENCIES = new[] { typeof(ISettings) };
-
+        // Default settings used if SettingsService is unavailable
         private string _shadowCopyPath = Path.Combine(NUnitConfiguration.NUnitBinDirectory, "ShadowCopyCache");
         private PrincipalPolicy _principalPolicy = PrincipalPolicy.UnauthenticatedPrincipal;
         private bool _setPrincipalPolicy = false;
@@ -75,39 +74,11 @@ namespace NUnit.Engine.Services
 
             log.Info("Creating AppDomain " + domainName);
 
-            AppDomain runnerDomain;
-            
-            // TODO: Find an approach that works across all platforms
-          
-            //// TODO: Try to eliminate this test. Currently, running on
-            //// Linux with the permission set specified causes an
-            //// unexplained crash when unloading the domain.
-            //if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            //{
-            //    PermissionSet permissionSet = new PermissionSet( PermissionState.Unrestricted );	
-            //    runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup, permissionSet, null);
-            //}
-            //else
-                runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup);
+            AppDomain runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup);
             
             // Set PrincipalPolicy for the domain if called for in the settings
-                if (_setPrincipalPolicy)
-                    runnerDomain.SetPrincipalPolicy(_principalPolicy);
-
-            //// HACK: Only pass down our AddinRegistry one level so that tests of NUnit
-            //// itself start without any addins defined.
-            //if ( !IsTestDomain( AppDomain.CurrentDomain ) )
-            //    runnerDomain.SetData("AddinRegistry", Services.AddinRegistry);
-
-            //// Inject DomainInitializer into the remote domain - there are other
-            //// approaches, but this works for all CLR versions.
-            //DomainInitializer initializer = DomainInitializer.CreateInstance(runnerDomain);
-
-            //// HACK: Under nunit-console, direct use of the enum fails
-            //int traceLevel = IsTestDomain(AppDomain.CurrentDomain)
-            //    ? (int)InternalTraceLevel.Off : (int)InternalTrace.Level;
-
-            //initializer.InitializeDomain(traceLevel);
+            if (_setPrincipalPolicy)
+                runnerDomain.SetPrincipalPolicy(_principalPolicy);
 
             return runnerDomain;
         }

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -78,23 +78,31 @@ namespace NUnit.Engine.Services
  
         #region IService Members
 
-        private ServiceContext services;
-        public ServiceContext ServiceContext 
+        public ServiceContext ServiceContext { get; set; }
+
+        public ServiceStatus Status { get; private set; }
+
+        public void StartService()
         {
-            get { return services; }
-            set { services = value; }
+            try
+            {
+                _factories.Add(new NUnit3DriverFactory());
+
+                foreach (IDriverFactory factory in AddinManager.GetExtensionObjects<IDriverFactory>())
+                    _factories.Add(factory);
+
+                Status = ServiceStatus.Started;
+            }
+            catch
+            {
+                Status = ServiceStatus.Error;
+                throw;
+            }
         }
 
-        public void InitializeService()
+        public void StopService()
         {
-            _factories.Add(new NUnit3DriverFactory());
-
-            foreach (IDriverFactory factory in AddinManager.GetExtensionObjects<IDriverFactory>())
-                _factories.Add(factory);
-        }
-
-        public void UnloadService()
-        {
+            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/IProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/IProjectService.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2011 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,46 +21,39 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
+using NUnit.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace NUnit.Engine.Services
 {
     /// <summary>
-    /// Enumeration representing the status of a service
+    /// The IProjectService interface is implemented by ProjectService.
+    /// It knows how to load projects in a specific format and can expand
+    /// TestPackages based on projects.
     /// </summary>
-    public enum ServiceStatus
-    {
-        /// <summary>Service was never started or has been stopped</summary>
-        Stopped,
-        /// <summary>Started successfully</summary>
-        Started,
-        /// <summary>Service failed to start and is unavailable</summary>
-        Error
-    }
-
-    /// <summary>
-    /// The IService interface is implemented by all Services.
-    /// </summary>
-    public interface IService
+    public interface IProjectService
     {
         /// <summary>
-        /// The ServiceContext
+        /// Returns true if the file indicated is one that this
+        /// loader knows how to load.
         /// </summary>
-        ServiceContext ServiceContext { get; set; }
+        /// <param name="path">The path of the project file</param>
+        /// <returns>True if the loader knows how to load this file, otherwise false</returns>
+        bool CanLoadFrom(string path);
 
         /// <summary>
-        /// Gets the ServiceStatus of this service
+        /// Loads a project of a known format.
         /// </summary>
-        ServiceStatus Status { get;  }
+        /// <param name="path">The path of the project file</param>
+        /// <returns>An IProject interface to the loaded project or null if the project cannot be loaded</returns>
+        IProject LoadFrom(string path);
 
         /// <summary>
-        /// Initialize the Service
+        /// Expands a TestPackage based on a known project format, populating it
+        /// with the project contents and any settings the project provides. 
+        /// Note that the package file path must be checked to ensure that it is
+        /// a known project format before calling this method.
         /// </summary>
-        void StartService();
-
-        /// <summary>
-        /// Do any cleanup needed before terminating the service
-        /// </summary>
-        void StopService();
+        /// <param name="package">The TestPackage to be expanded</param>
+        void ExpandProjectPackage(TestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Runners;
@@ -80,19 +81,18 @@ namespace NUnit.Engine.Services
 
         #region IService Members
 
-        private ServiceContext services;
-        public ServiceContext ServiceContext 
+        public ServiceContext ServiceContext { get; set; }
+
+        public ServiceStatus Status { get; protected set; }
+
+        public virtual void StartService()
         {
-            get { return services; }
-            set { services = value; }
+            Status = ServiceStatus.Started;
         }
 
-        public void InitializeService()
+        public void StopService()
         {
-        }
-
-        public void UnloadService()
-        {
+            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -49,15 +49,6 @@ namespace NUnit.Engine.Services
             return false;
         }
 
-        public IProject LoadFrom(string path)
-        {
-            foreach (IProjectLoader loader in _loaders)
-                if (loader.CanLoadFrom(path))
-                    return loader.LoadFrom(path);
-
-            return null;
-        }
-
         /// <summary>
         /// Expands a TestPackage based on a known project format, populating it
         /// with the project contents and any settings the project provides. 
@@ -119,6 +110,19 @@ namespace NUnit.Engine.Services
         {
             // TODO:  Add ProjectLoader.UnloadService implementation
             Status = ServiceStatus.Stopped;
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private IProject LoadFrom(string path)
+        {
+            foreach (IProjectLoader loader in _loaders)
+                if (loader.CanLoadFrom(path))
+                    return loader.LoadFrom(path);
+
+            return null;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
@@ -153,9 +153,10 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                // RecentFilesService depends on SettingsService. If it's
-                // not available, then an error results.
+                // RecentFilesService requires SettingsService
                 _userSettings = ServiceContext.GetService<ISettings>();
+
+                // Anything returned from ServiceContext is an IService
                 if (_userSettings != null && ((IService)_userSettings).Status == ServiceStatus.Started)
                 {
                     LoadEntriesFromSettings();

--- a/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
@@ -32,6 +32,7 @@ namespace NUnit.Engine.Services
     public class RecentFilesService : IRecentFiles, IService
     {
         private IList<string> _fileEntries = new List<string>();
+        private ISettings _userSettings;
 
         private const int MinSize = 0;
         private const int MaxSize = 24;
@@ -39,13 +40,11 @@ namespace NUnit.Engine.Services
 
         #region Properties
 
-        public ServiceContext ServiceContext { get; set; }
-
         public int MaxFiles
         {
             get 
             { 
-                int size = ServiceContext.UserSettings.GetSetting("Gui.RecentProjects.MaxFiles", DefaultSize );
+                int size = _userSettings.GetSetting("Gui.RecentProjects.MaxFiles", DefaultSize );
                 
                 if ( size < MinSize ) size = MinSize;
                 if ( size > MaxSize ) size = MaxSize;
@@ -60,7 +59,7 @@ namespace NUnit.Engine.Services
                 if ( newSize < MinSize ) newSize = MinSize;
                 if ( newSize > MaxSize ) newSize = MaxSize;
 
-                ServiceContext.UserSettings.SaveSetting( "Gui.RecentProjects.MaxFiles", newSize );
+                _userSettings.SaveSetting( "Gui.RecentProjects.MaxFiles", newSize );
                 if ( newSize < oldSize ) SaveEntriesToSettings();
             }
         }
@@ -101,7 +100,7 @@ namespace NUnit.Engine.Services
             {
                 if (_fileEntries.Count >= MaxFiles) break;
 
-                string fileSpec = ServiceContext.UserSettings.GetSetting(GetRecentFileKey(prefix, index)) as string;
+                string fileSpec = _userSettings.GetSetting(GetRecentFileKey(prefix, index)) as string;
                 if (fileSpec != null) _fileEntries.Add(fileSpec);
             }
         }
@@ -109,7 +108,6 @@ namespace NUnit.Engine.Services
         private void SaveEntriesToSettings()
         {
             string prefix = "Gui.RecentProjects";
-            ISettings settings = ServiceContext.UserSettings;
 
             while( _fileEntries.Count > MaxFiles )
                 _fileEntries.RemoveAt( _fileEntries.Count - 1 );
@@ -118,13 +116,13 @@ namespace NUnit.Engine.Services
             {
                 string keyName = GetRecentFileKey( prefix, index + 1 );
                 if ( index < _fileEntries.Count )
-                    settings.SaveSetting( keyName, _fileEntries[index] );
+                    _userSettings.SaveSetting( keyName, _fileEntries[index] );
                 else
-                    settings.RemoveSetting( keyName );
+                    _userSettings.RemoveSetting( keyName );
             }
 
             // Remove legacy entries here
-            settings.RemoveGroup("RecentProjects");
+            _userSettings.RemoveGroup("RecentProjects");
         }
 
         private string GetRecentFileKey( string prefix, int index )
@@ -135,14 +133,44 @@ namespace NUnit.Engine.Services
 
         #region IService Members
 
-        public void UnloadService()
+        public ServiceContext ServiceContext { get; set; }
+
+        public ServiceStatus Status { get; private set; }
+
+        public void StopService()
         {
-            SaveEntriesToSettings();
+            try
+            {
+                SaveEntriesToSettings();
+            }
+            finally
+            {
+                Status = ServiceStatus.Stopped;
+            }
         }
 
-        public void InitializeService()
+        public void StartService()
         {
-            LoadEntriesFromSettings();
+            try
+            {
+                // RecentFilesService depends on SettingsService. If it's
+                // not available, then an error results.
+                _userSettings = ServiceContext.GetService<ISettings>();
+                if (_userSettings != null && ((IService)_userSettings).Status == ServiceStatus.Started)
+                {
+                    LoadEntriesFromSettings();
+                    Status = ServiceStatus.Started;
+                }
+                else
+                {
+                    Status = ServiceStatus.Error;
+                }
+            }
+            catch
+            {
+                Status = ServiceStatus.Error;
+                throw;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -70,18 +70,31 @@ namespace NUnit.Engine.Services
 
         public ServiceContext ServiceContext { get; set; }
 
-        public void InitializeService()
-        {
-            _factories.Add(new NUnit3ResultWriterFactory());
-            _factories.Add(new TestCaseResultWriterFactory());
-            _factories.Add(new XmlTransformResultWriterFactory());
+        public ServiceStatus Status { get; private set; }
 
-            foreach (var factory in AddinManager.GetExtensionObjects<IResultWriterFactory>())
-                _factories.Add(factory);
+        public void StartService()
+        {
+            try
+            {
+                _factories.Add(new NUnit3ResultWriterFactory());
+                _factories.Add(new TestCaseResultWriterFactory());
+                _factories.Add(new XmlTransformResultWriterFactory());
+
+                foreach (var factory in AddinManager.GetExtensionObjects<IResultWriterFactory>())
+                    _factories.Add(factory);
+
+                Status = ServiceStatus.Started;
+            }
+            catch
+            {
+                Status = ServiceStatus.Error;
+                throw;
+            }
         }
 
-        public void UnloadService()
+        public void StopService()
         {
+            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using NUnit.Common;
 using NUnit.Engine.Internal;
@@ -103,52 +102,47 @@ namespace NUnit.Engine.Services
 
             if (targetVersion == RuntimeFramework.DefaultVersion)
             {
-                if (ServiceContext.UserSettings.GetSetting("Options.TestLoader.RuntimeSelectionEnabled", true))
+                foreach (var subPackage in package.SubPackages)
                 {
-                    foreach (var subPackage in package.SubPackages)
+                    var assembly = subPackage.FullName;
+
+                    // If the file is not an assembly or doesn't exist, then it can't
+                    // contribute any information to the decision, so we skip it.
+                    if (PathUtils.IsAssemblyFileType(assembly) && File.Exists(assembly))
                     {
-                        var assembly = subPackage.FullName;
-
-                        // If the file is not an assembly or doesn't exist, then it can't
-                        // contribute any information to the decision, so we skip it.
-                        if (PathUtils.IsAssemblyFileType(assembly) && File.Exists(assembly))
+                        using (var reader = new AssemblyReader(assembly))
                         {
-                            using (var reader = new AssemblyReader(assembly))
+                            if (!reader.IsValidPeFile)
+                                log.Debug("{0} is not a valid PE file", assembly);
+                            else if (!reader.IsDotNetFile)
+                                log.Debug("{0} is not a managed assembly", assembly);
+                            else
                             {
-                                if (!reader.IsValidPeFile)
-                                    log.Debug("{0} is not a valid PE file", assembly);
-                                else if (!reader.IsDotNetFile)
-                                    log.Debug("{0} is not a managed assembly", assembly);
-                                else
+                                if (reader.ShouldRun32Bit)
                                 {
-                                    if (reader.ShouldRun32Bit)
-                                    {
-                                        package.Settings[PackageSettings.RunAsX86] = true;
-                                        log.Debug("Assembly {0} will be run x86", assembly);
-                                    }
+                                    package.Settings[PackageSettings.RunAsX86] = true;
+                                    log.Debug("Assembly {0} will be run x86", assembly);
+                                }
 
-                                    var imageRuntimeVersion = reader.ImageRuntimeVersion;
-                                    if (imageRuntimeVersion != null)
-                                    {
-                                        var v = new Version(imageRuntimeVersion.Substring(1));
-                                        log.Debug("Assembly {0} uses version {1}", assembly, v);
+                                var imageRuntimeVersion = reader.ImageRuntimeVersion;
+                                if (imageRuntimeVersion != null)
+                                {
+                                    var v = new Version(imageRuntimeVersion.Substring(1));
+                                    log.Debug("Assembly {0} uses version {1}", assembly, v);
 
-                                        // TODO: We are doing two jobs here: (1) getting the
-                                        // target version and (2) applying a policy that says
-                                        // we run under the highest version of all assemblies.
-                                        // We should implement the policy at a higher level.
-                                        if (v > targetVersion) targetVersion = v;
-                                    }
+                                    // TODO: We are doing two jobs here: (1) getting the
+                                    // target version and (2) applying a policy that says
+                                    // we run under the highest version of all assemblies.
+                                    // We should implement the policy at a higher level.
+                                    if (v > targetVersion) targetVersion = v;
                                 }
                             }
                         }
                     }
                 }
-                else
-                    targetVersion = RuntimeFramework.CurrentFramework.ClrVersion;
-
+                
                 RuntimeFramework checkFramework = new RuntimeFramework(targetRuntime, targetVersion);
-                if (!checkFramework.IsAvailable || !ServiceContext.TestAgency.IsRuntimeVersionSupported(targetVersion))
+                if (!checkFramework.IsAvailable)
                 {
                     log.Debug("Preferred version {0} is not installed or this NUnit installation does not support it", targetVersion);
                     if (targetVersion < currentFramework.FrameworkVersion)
@@ -166,19 +160,18 @@ namespace NUnit.Engine.Services
 
         #region IService Members
 
-        private ServiceContext services;
-        public ServiceContext ServiceContext
+        public ServiceContext ServiceContext { get; set; }
+
+        public ServiceStatus Status { get; private set; }
+
+        public void StartService()
         {
-            get { return services; }
-            set { services = value; }
+            Status = ServiceStatus.Started;
         }
 
-        public void InitializeService()
+        public void StopService()
         {
-        }
-
-        public void UnloadService()
-        {
+            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -33,8 +33,8 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class ServiceManager
     {
-        private List<IService> services = new List<IService>();
-        private Dictionary<Type, IService> serviceIndex = new Dictionary<Type, IService>();
+        private List<IService> _services = new List<IService>();
+        private Dictionary<Type, IService> _serviceIndex = new Dictionary<Type, IService>();
 
         static Logger log = InternalTrace.GetLogger(typeof(ServiceManager));
 
@@ -46,15 +46,14 @@ namespace NUnit.Engine.Services
         {
             IService theService = null;
 
-            if (serviceIndex.ContainsKey(serviceType))
-                theService = serviceIndex[serviceType];
+            if (_serviceIndex.ContainsKey(serviceType))
+                theService = _serviceIndex[serviceType];
             else
-                foreach( IService service in services )
+                foreach( IService service in _services )
                 {
-                    // TODO: Does this work on Mono?
                     if( serviceType.IsInstanceOfType( service ) )
                     {
-                        serviceIndex[serviceType] = service;
+                        _serviceIndex[serviceType] = service;
                         theService = service;
                         break;
                     }
@@ -70,23 +69,31 @@ namespace NUnit.Engine.Services
 
         public void AddService(IService service)
         {
-            services.Add(service);
+            _services.Add(service);
             log.Debug("Added " + service.GetType().Name);
         }
 
         public void InitializeServices()
         {
-            foreach( IService service in services )
+            foreach( IService service in _services )
             {
-                log.Info( "Initializing " + service.GetType().Name );
-                try
+                if (service.Status == ServiceStatus.Stopped)
                 {
-                    service.InitializeService();
-                }
-                catch (Exception ex)
-                {
-                    // TODO: Should we pass this exception through?
-                    log.Error("Failed to initialize service", ex);
+                    string name = service.GetType().Name;
+                    log.Info("Initializing " + name);
+                    try
+                    {
+                        service.StartService();
+                        if (service.Status == ServiceStatus.Error)
+                            throw new InvalidOperationException("Service failed to initialize " + name);
+                    }
+                    catch (Exception ex)
+                    {
+                        // TODO: Should we pass this exception through?
+                        log.Error("Failed to initialize " + name );
+                        log.Error(ex.ToString());
+                        throw;
+                    }
                 }
             }
 
@@ -96,19 +103,23 @@ namespace NUnit.Engine.Services
         public void StopAllServices()
         {
             // Stop services in reverse of initialization order
-            // TODO: Deal with dependencies explicitly
-            int index = services.Count;
+            int index = _services.Count;
             while (--index >= 0)
             {
-                IService service = services[index];
-                log.Info("Stopping " + service.GetType().Name);
-                try
+                IService service = _services[index];
+                if (service.Status == ServiceStatus.Started)
                 {
-                    service.UnloadService();
-                }
-                catch (Exception ex)
-                {
-                    log.Error("Failure stopping service", ex);
+                    string name = service.GetType().Name;
+                    log.Info("Stopping " + name);
+                    try
+                    {
+                        service.StopService();
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error("Failure stopping service " + name);
+                        log.Error(ex.ToString());
+                    }
                 }
             }
         }
@@ -116,7 +127,7 @@ namespace NUnit.Engine.Services
         public void ClearServices()
         {
             log.Info("Clearing Service list");
-            services.Clear();
+            _services.Clear();
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -73,7 +73,7 @@ namespace NUnit.Engine.Services
             log.Debug("Added " + service.GetType().Name);
         }
 
-        public void InitializeServices()
+        public void StartServices()
         {
             foreach( IService service in _services )
             {
@@ -100,7 +100,7 @@ namespace NUnit.Engine.Services
             this.ServicesInitialized = true;
         }
 
-        public void StopAllServices()
+        public void StopServices()
         {
             // Stop services in reverse of initialization order
             int index = _services.Count;

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -364,9 +364,10 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                // TestAgency depends on the RuntimeFrameworkService.
-                // If it isn't available it will not start.
+                // TestAgency requires on the RuntimeFrameworkService.
                 _runtimeService = ServiceContext.GetService<IRuntimeFrameworkService>();
+
+                // Any object returned from ServiceContext is an IService
                 if (_runtimeService != null && ((IService)_runtimeService).Status == ServiceStatus.Started)
                 {
                     try

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -57,7 +57,11 @@ namespace NUnit.Engine.Services
         static Logger log = InternalTrace.GetLogger(typeof(TestAgency));
 
         #region Private Fields
-        private AgentDataBase agentData = new AgentDataBase();
+
+        private AgentDataBase _agentData = new AgentDataBase();
+
+        private IRuntimeFrameworkService _runtimeService;
+
         #endregion
 
         #region Constructors
@@ -95,7 +99,7 @@ namespace NUnit.Engine.Services
         #region Public Methods - Called by Agents
         public void Register( ITestAgent agent )
         {
-            AgentRecord r = agentData[agent.Id];
+            AgentRecord r = _agentData[agent.Id];
             if ( r == null )
                 throw new ArgumentException(
                     string.Format("Agent {0} is not in the agency database", agent.Id),
@@ -105,7 +109,7 @@ namespace NUnit.Engine.Services
 
         public void ReportStatus( Guid agentId, AgentStatus status )
         {
-            AgentRecord r = agentData[agentId];
+            AgentRecord r = _agentData[agentId];
 
             if ( r == null )
                 throw new ArgumentException(
@@ -118,22 +122,6 @@ namespace NUnit.Engine.Services
 
         #region Public Methods - Called by Clients
 
-        /// <summary>
-        /// Returns true if NUnit support for the runtime specified 
-        /// is installed, independent of whether the runtime itself
-        /// is installed on the system.
-        /// 
-        /// In the current implementation, only .NET 1.x requires
-        /// special handling, since all higher runtimes are 
-        /// supported normally.
-        /// </summary>
-        /// <param name="version">The desired runtime version</param>
-        /// <returns>True if NUnit support is installed</returns>
-        public bool IsRuntimeVersionSupported(Version version)
-        {
-            return GetNUnitBinDirectory(version) != null;
-        }
-
         public ITestAgent GetAgent(TestPackage package, int waitTime)
         {
             // TODO: Decide if we should reuse agents
@@ -145,7 +133,7 @@ namespace NUnit.Engine.Services
 
         public void ReleaseAgent( ITestAgent agent )
         {
-            AgentRecord r = agentData[agent.Id];
+            AgentRecord r = _agentData[agent.Id];
             if (r == null)
                 log.Error(string.Format("Unable to release agent {0} - not in database", agent.Id));
             else
@@ -174,7 +162,7 @@ namespace NUnit.Engine.Services
             RuntimeFramework targetRuntime = RuntimeFramework.Parse(
                 runtimeSetting != ""
                     ? runtimeSetting
-                    : ServiceContext.RuntimeFrameworkService.SelectRuntimeFramework(package));
+                    : _runtimeService.SelectRuntimeFramework(package));
 
             bool useX86Agent = package.GetSetting(PackageSettings.RunAsX86, false);
             bool enableDebug = package.GetSetting("AgentDebug", false);
@@ -234,7 +222,7 @@ namespace NUnit.Engine.Services
             log.Info("Launched Agent process {0} - see nunit-agent_{0}.log", p.Id);
             log.Info("Command line: \"{0}\" {1}", p.StartInfo.FileName, p.StartInfo.Arguments);
 
-            agentData.Add( new AgentRecord( agentId, p, null, AgentStatus.Starting ) );
+            _agentData.Add( new AgentRecord( agentId, p, null, AgentStatus.Starting ) );
             return agentId;
         }
 
@@ -271,7 +259,7 @@ namespace NUnit.Engine.Services
             {
                 Thread.Sleep( pollTime );
                 if ( !infinite ) waitTime -= pollTime;
-                ITestAgent agent = agentData[agentId].Agent;
+                ITestAgent agent = _agentData[agentId].Agent;
                 if ( agent != null )
                 {
                     log.Debug( "Returning new agent {0}", agentId.ToString("B") );
@@ -341,7 +329,7 @@ namespace NUnit.Engine.Services
 
         private static string GetTestAgentExePath(Version v, bool requires32Bit)
         {
-            string binDir = GetNUnitBinDirectory(v);
+            string binDir = NUnitConfiguration.NUnitBinDirectory;
             if (binDir == null) return null;
 
             string agentName = v.Major > 1 && requires32Bit
@@ -356,21 +344,52 @@ namespace NUnit.Engine.Services
 
         #region IService Members
 
-        private ServiceContext services;
-        public ServiceContext ServiceContext 
+        public ServiceContext ServiceContext { get; set; }
+
+        public ServiceStatus Status { get; private set; }
+
+        public void StopService()
         {
-            get { return services; }
-            set { services = value; }
+            try
+            {
+                Stop();
+            }
+            finally
+            {
+                Status = ServiceStatus.Stopped;
+            }
         }
 
-        public void UnloadService()
+        public void StartService()
         {
-            this.Stop();
-        }
-
-        public void InitializeService()
-        {
-            this.Start();
+            try
+            {
+                // TestAgency depends on the RuntimeFrameworkService.
+                // If it isn't available it will not start.
+                _runtimeService = ServiceContext.GetService<IRuntimeFrameworkService>();
+                if (_runtimeService != null && ((IService)_runtimeService).Status == ServiceStatus.Started)
+                {
+                    try
+                    {
+                        Start();
+                        Status = ServiceStatus.Started;
+                    }
+                    catch (Exception ex)
+                    {
+                        Status = ServiceStatus.Error;
+                        throw;
+                    }
+                }
+                else
+                {
+                    Status = ServiceStatus.Error;
+                }
+            }
+            catch
+            {
+                Status = ServiceStatus.Error;
+                throw;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -114,7 +114,7 @@ namespace NUnit.Engine
             this.Services.Add(new TestAgency());
             this.Services.Add(new ResultService());
 
-            this.Services.ServiceManager.InitializeServices();
+            this.Services.ServiceManager.StartServices();
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace NUnit.Engine
 
         public void Dispose()
         {
-            Services.ServiceManager.StopAllServices();
+            Services.ServiceManager.StopServices();
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -107,7 +107,7 @@
     <Compile Include="Runners\MultipleTestProcessRunner.cs" />
     <Compile Include="Runners\ProcessRunner.cs" />
     <Compile Include="Runners\TestDomainRunner.cs" />
-    <Compile Include="Services\IProjectService.cs" />
+    <Compile Include="IProjectService.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />
     <Compile Include="Services\ResultWriters\XmlTransformResultWriter.cs" />

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Runners\MultipleTestProcessRunner.cs" />
     <Compile Include="Runners\ProcessRunner.cs" />
     <Compile Include="Runners\TestDomainRunner.cs" />
+    <Compile Include="Services\IProjectService.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />
     <Compile Include="Services\ResultWriters\XmlTransformResultWriter.cs" />


### PR DESCRIPTION
Working on the experimental mini- and core-engine branches, I found it useful to do some refactoring of the service subsystem. This PR incorporates those changes, taken from my current core-engine working branch, and includes the following changes:

* IService interface now includes a Status property. It indicates whether the service is Started or Stopped or if an error has occurred making it unusable.

* Services now check  for the existence of any other services they depend on in their initialization and verify that they have been started. If the other service is not available, they must either manage without it or set an Error status.

* ServiceManager now throws an exception if any service initialization fails. This was being hidden in the log and leading to other failures down the line.

* Properties that cached various services have been removed from the ServiceContext. Callers need to use the GetService interface instead. This makes it easier to support various service configurations in different builds of the engine.

* Tests have been added.

I'm continuing to work on the core-engine on a separate branch.