### PR TITLE
Add separate commands for CF packages; remove .git directory after zipping

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -12,6 +12,7 @@
     <PackageModifier>-beta-1</PackageModifier>
     <DisplayVersion>3.0 Beta 1</DisplayVersion>
     <PackageName>$(ProjectName)-$(PackageVersion)$(PackageModifier)</PackageName>
+    <PackageNameCF>$(ProjectName)CF-$(PackageVersion)$(PackageModifier)</PackageNameCF>
   </PropertyGroup>
 
   <PropertyGroup Label="Platform-specific properties">
@@ -369,7 +370,7 @@
   <!--   creates the package to first make sure that the build is up to date.  -->
   <!-- *********************************************************************** -->
   
-  <Target Name="Package" Label="Packages the source code and binaries already built"
+  <Target Name="Package" Label="Packages the source code and standard binaries. Excludes CF."
     DependsOnTargets="@(AllPackages)">
   </Target>
 
@@ -388,18 +389,21 @@
 
     <Exec Command='git init "$(CurrentImageDir)"' />
     <Exec WorkingDirectory='$(CurrentImageDir)' Command='git add -A' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git rm --cached bin\netcf-3.5\*' />
     <Exec WorkingDirectory='$(CurrentImageDir)' Command='git config user.name "temp"' />
     <Exec WorkingDirectory='$(CurrentImageDir)' Command='git config user.email "temp@temp.com"' />
     <Exec WorkingDirectory='$(CurrentImageDir)' Command='git commit -m "Export"' /> 
     <Exec WorkingDirectory='$(CurrentImageDir)' 
       Command='git archive -o "$(ProjectPackageDir)\$(PackageName)$(ConfigSuffix).zip" HEAD'></Exec>
+    <Exec Command="$(RemoveDir) $(CurrentImageDir)\.git" />
   </Target>
 
-  <Target Name="PackageNuGet" Label="Creates all NuGet packages"
+  <Target Name="PackageNuGet" Label="Creates all standard NuGet packages"
     DependsOnTargets="PackageNuGetNUnit;PackageNuGetNUnitLite;PackageNuGetConsole" />
-  
+
   <Target Name="PackageNuGetNUnit" Label="Creates the NUnit Framework NuGet package"
       DependsOnTargets="_CreateImageIfNotPresent">
+
     <Message Text="******************************************************************" />
     <Message Text="* Creating the nunit Nuget $(Configuration) package" />
     <Message Text="******************************************************************" />
@@ -408,9 +412,10 @@
         Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunit.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
 
   </Target>
-  
+
   <Target Name="PackageNuGetNUnitLite" Label="Creates the NUnitlite NuGet package"
       DependsOnTargets="_CreateImageIfNotPresent">
+
     <Message Text="******************************************************************" />
     <Message Text="* Creating the nunitlite Nuget $(Configuration) package" />
     <Message Text="******************************************************************" />
@@ -419,7 +424,7 @@
         Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitlite.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
 
   </Target>
-  
+
   <Target Name="PackageNuGetConsole" Label="Creates the NUnit.Console NuGet package"
       DependsOnTargets="_CreateImageIfNotPresent">
     <Message Text="******************************************************************" />
@@ -452,7 +457,51 @@
   <Target Name="PackageAllMsis" Label="Creates all of the MSI installers for NUnit"
       DependsOnTargets="PackageMasterMsi;PackageFrameworkMsi;PackageConsoleMsi">
   </Target>
-  
+
+  <!-- Packaging for the Compact framework -->
+  <Target Name="PackageCF" Label="Creates all packages for the compact framework"
+    DependsOnTargets="PackageBinariesCF;PackageNuGetNUnitCF;PackageNuGetNUnitLiteCF" />
+
+  <Target Name="PackageBinariesCF" Label="Packages the CF binaries as a zip" DependsOnTargets="_CreateImageIfNotPresent">
+    <Message Text="******************************************************************" />
+    <Message Text="* Creating the binary $(Configuration) package as $(PackageNameCF)$(ConfigSuffix).zip" />
+    <Message Text="******************************************************************" />
+
+    <Exec Command='git init "$(CurrentImageDir)"' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git add *.txt nunit.ico' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git add bin\netcf-3.5\*' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git config user.name "temp"' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git config user.email "temp@temp.com"' />
+    <Exec WorkingDirectory='$(CurrentImageDir)' Command='git commit -m "Export"' />
+    <Exec WorkingDirectory='$(CurrentImageDir)'
+      Command='git archive -o "$(ProjectPackageDir)\$(PackageNameCF)$(ConfigSuffix).zip" HEAD'></Exec>
+    <Exec Command="$(RemoveDir) $(CurrentImageDir)\.git" />
+  </Target>
+
+  <Target Name="PackageNuGetNUnitCF" Label="Creates the NUnit Framework NuGet package for compact framework"
+      DependsOnTargets="_CreateImageIfNotPresent">
+
+    <Message Text="******************************************************************" />
+    <Message Text="* Creating the nunit Nuget $(Configuration) package" />
+    <Message Text="******************************************************************" />
+
+    <Exec WorkingDirectory="$(ProjectBaseDir)"
+        Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitcf.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
+
+  </Target>
+
+  <Target Name="PackageNuGetNUnitLiteCF" Label="Creates the NUnitlite NuGet package for compact framework"
+      DependsOnTargets="_CreateImageIfNotPresent">
+
+    <Message Text="******************************************************************" />
+    <Message Text="* Creating the nunitlite Nuget $(Configuration) package" />
+    <Message Text="******************************************************************" />
+
+    <Exec WorkingDirectory="$(ProjectBaseDir)"
+        Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitlitecf.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
+
+  </Target>
+
   <Target Name="CreateImage" DependsOnTargets="_CleanCurrentImageDir">
 
     <!-- Copy root txt files to root -->
@@ -519,6 +568,10 @@
     <!-- Include pdp files for Debug -->
     <BinFiles Include="$(ConfigurationBuildDir)\**\*.pdb"
       Condition="'$(Configuration)' == 'Debug'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ZipFiles Include="*.*" />
   </ItemGroup>
 
   <ItemGroup Label="Supported Frameworks">

--- a/nuget/nunitCF.nuspec
+++ b/nuget/nunitCF.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>NUnitCF</id>
+    <title>NUnit Version 3 for Compact Framework</title>
+    <version>$version$</version>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
+    <projectUrl>http://nunit.org</projectUrl>
+    <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
+    <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible. A number of runners, both from the NUnit project and by third parties, are able to execute NUnit tests.&#10;&#13;&#10;&#13;This package includes the NUnit 3.0 framework assembly, which is referenced by your tests. You will need to install version 3.0 of the nunit-console program or a third-party runner that supports NUnit 3.0 in order to execute tests. Runners intended for use with NUnit 2.x will not run 3.0 tests correctly.&#10;&#13;&#10;&#13;This is an beta release, but is ready for production use for people with prior NUnit experience.</description>
+    <releaseNotes>This package includes the NUnit 3.0 framework assembly for .NET Compact Framework 3.5, which is referenced by your tests. You will need to install the NUnitLiteCF package in order to run the tests. Two separate packages are used because future versions will be supported by additional runners.</releaseNotes>
+    <language>en-US</language>
+    <tags>nunit test testing tdd framework fluent assert theory plugin addin cf compact framework</tags>
+    <copyright>Copyright (c) 2015 Charlie Poole</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin\netcf-3.5\nunit.framework.dll" target="lib\net35-cf" />
+    <file src="bin\netcf-3.5\nunit.framework.xml" target="lib\net35-cf" />
+  </files>
+</package>

--- a/nuget/nunitliteCF.nuspec
+++ b/nuget/nunitliteCF.nuspec
@@ -6,30 +6,29 @@
     <version>$version$</version>
     <authors>Charlie Poole</authors>
     <owners>Charlie Poole</owners>
-    <licenseUrl>http://nunit.org/nuget/nunitlite-license.txt</licenseUrl>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
     <projectUrl>http://nunit.org</projectUrl>
-    <iconUrl>http://nunit.org/nuget/nunit_32x32.png</iconUrl>
+    <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>NUnitlite is a lightweight runner for tests that use the NUnit testing framework.</summary>
-    <description>NUnitLite provides a simple way to run NUnit tests, without the overhead of a full NUnit installation. It is suitable for projects that want to have a quick way to run tests using a console runner and don't need all the features of the NUnit engine and console runner. This package contains the NUnitLite runner and the NUnit framework built for versuib 3.5 of the .NET Compact Framework.&#10;&#13;&#10;&#13;How to use this package:&#10;&#13;&#10;&#13;1. Create a console application for your tests and delete the generated class containing Main().&#10;&#13;2. Install the NUnitLiteCF package, which creates a new Main() as well as adding references to NUnitLite and the NUnit Framework.&#10;&#13;3. Add your tests to the test project and simply start the project to execute them.</description>
-    <releaseNotes>This is an alpha release and is not intended for production use.</releaseNotes>
+    <description>NUnitLite provides a simple way to run NUnit tests, without the overhead of a full NUnit installation. It is suitable for projects that want to have a quick way to run tests using a console runner and don't need all the features of the NUnit engine and console runner. This package contains a build of the NUnitLite runner for the .NET compact framework 3.5.&#10;&#13;&#10;&#13;How to use this package:&#10;&#13;&#10;&#13;1. Create a console application for your tests and delete the generated class containing Main().&#10;&#13;2. Install the NUnitLite package, which creates a new Main() as well as adding a reference to NUnitLite. This will also bring in the NUnit package, which adds a reference to the nunit framework to your project.&#10;&#13;3. Add your tests to the test project and simply start the project to execute them.</description>
+    <releaseNotes>This is an beta release, but is ready for production use for people with prior NUnit experience.</releaseNotes>
     <language>en-US</language>
-    <tags>test unit testing tdd framework fluent assert device phone embedded</tags>
-    <copyright>Copyright (c) 2014 Charlie Poole</copyright>			    <dependencies>
-      <group targetFramework="net40">
-        <dependency id="Microsoft.Bcl.Async" version="1.0.165" />
+    <tags>test unit testing tdd framework fluent assert device phone embedded cf compact</tags>
+    <copyright>Copyright (c) 2015 Charlie Poole</copyright>
+    <dependencies>
+      <group>
+        <dependency id="NUnitCF" version="[$version$]" />
       </group>
-      <!-- This is required otherwise 4.5 will pull in the 4.0 dependencies -->
-      <group targetFramework="net45" />
     </dependencies>
   </metadata>
   <files>
     <file src="LICENSE.txt" />
-    <file src="README.txt" />
+    <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="$builddir$\netcf-3.5\nunitlite.dll"  target="lib/net35-cf" />
-    <file src="$builddir$\netcf-3.5\nunit.framework.dll"  target="lib/net35-cf" />
-    <file src="$builddir$\netcf-3.5\nunit.framework.xml"  target="lib/net35-cf" />
-    <file src="src\tests\Program.cs" target="content" />
+    <file src="bin\netcf-3.5\nunitlite.dll" target="lib\net35-cf" />
+    <file src="..\..\nuget\Program.cs" target="content" />
+    <file src="..\..\nuget\Program.vb" target="content" />
+    <file src="..\..\nuget\install.ps1" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
This PR fixes #631. Packaging changes are made as follows:

* The binary zip no longer includes the CF build

* Separate targets are used to create a zip and two nuget packages for the compact framework

* The general Package target does not create any CF packages.

* The PackageCF target creates the three CF packages.

* The images directory continues to hold all binaries, including the CF builds

* The .git file created in the images directory by the PackageBinaries and PackageBinariesCF targets is removed once the zips are created.

That last point deserves some further examination. The approach we are using to create zip files through the git archive command has the advantage of not requiring any additional software for zipping. It's disadvantage is that it is invasive, modifying the content of the image directory. It would fail if we tried to use an image directory without write access. We should (in future) find another approach to zipping - possibly via a programmatic task using embedded C#.