### PR TITLE
Fix various problems introduced into the CF build

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -89,7 +89,7 @@ namespace NUnit.Framework.Constraints
                 return string.Format(Fmt_ValueType, val);
 
 #if NETCF
-            var vi = val as MethodInfo;
+            var vi = val as System.Reflection.MethodInfo;
             if (vi != null && vi.IsGenericMethodDefinition)
                 return string.Format(Fmt_Default, vi.Name + "<>");
 #endif

--- a/src/NUnitFramework/framework/Internal/RandomGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/RandomGenerator.cs
@@ -188,7 +188,9 @@ namespace NUnit.Framework.Internal
         /// Default characters for random functions.
         /// </summary>
         /// <remarks>Default characters are the English alphabet (uppercase &amp; lowercase), arabic numerals, and underscore</remarks>
-        public const string DefaultStringChars = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ0123456789_";        
+        public const string DefaultStringChars = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ0123456789_";
+
+        private const int DefaultStringLength = 25;
                 
         /// <summary>
         /// Generate a random string based on the characters from the input string.
@@ -208,18 +210,28 @@ namespace NUnit.Framework.Internal
         
             return sb.ToString();
         }
-        
+
         /// <summary>
         /// Generate a random string based on the characters from the input string.
         /// </summary>
-        /// <param name="outputLength">desired length of output string. The default is 20 characters.</param>
+        /// <param name="outputLength">desired length of output string.</param>
         /// <returns>A random string of arbitrary length</returns>
         /// <remarks>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set </remarks>
-        public string GetString(int outputLength=20)
+        public string GetString(int outputLength)
         {
             return GetString(outputLength, DefaultStringChars);
         }
-        
+
+        /// <summary>
+        /// Generate a random string based on the characters from the input string.
+        /// </summary>
+        /// <returns>A random string of the default length</returns>
+        /// <remarks>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set </remarks>
+        public string GetString()
+        {
+            return GetString(DefaultStringLength, DefaultStringChars);
+        }
+
         #endregion
         
     }

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-netcf-3.5.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-netcf-3.5.csproj
@@ -20,6 +20,8 @@
     </FormFactorID>
     <StartupObject>
     </StartupObject>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
@@ -19,6 +19,8 @@
     <FormFactorID>
     </FormFactorID>
     <IntermediateOutputPath>obj\$(Configuration)\netcf-3.5\</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NUnitFramework/testdata/nunit.testdata-netcf-3.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netcf-3.5.csproj
@@ -19,6 +19,8 @@
     <FormFactorID>
     </FormFactorID>
     <IntermediateOutputPath>obj\$(Configuration)\netcf-3.5\</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -483,7 +483,7 @@ namespace NUnit.Common.Tests
             Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);
         }
 
-        [Test]
+#if !SILVERLIGHT && !NETCF
         [TestCase(true, null, true)]
         [TestCase(false, null, false)]
         [TestCase(true, false, true)]
@@ -515,6 +515,7 @@ namespace NUnit.Common.Tests
             // Then
             Assert.AreEqual(actualTeamCity, expectedTeamCity);
         }
+#endif
         
         #endregion
 

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -19,6 +19,8 @@
     <FormFactorID>
     </FormFactorID>
     <IntermediateOutputPath>obj\$(Configuration)\netcf-3.5\</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\framework\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -163,7 +165,9 @@
     <Compile Include="Constraints\InstanceOfTypeConstraintTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
-    <Compile Include="Constraints\MsgUtilTests.cs" />
+    <Compile Include="Constraints\MsgUtilTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Constraints\NotConstraintTests.cs" />
     <Compile Include="Constraints\NumericsTest.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />


### PR DESCRIPTION
This started out as a fix to an error in CF created by PR #143 but I discovered additional problems so this takes care of a number of discrete errors:

* As pointed out by @oznetmaster PR #143 used a default parameter value on one method, which won't compile using C# 3.0 / VS 2008.

* PR #636 introduced signing to a number of assemblies but didn't include the CF build. However, the InternalsVisibleTo entry in two shared AssemblyInfo.cs files made signing necessary.

* PRs #607 and #633 left a test of the default TeamCity setting active in the CF build - although the setting is not available in that build.

I'd like to get the fixes in as quickly as possible, so please review and merge.

I think we need to follow up with some discussion about how we can do a better job of keeping the CF build clean.