### PR TITLE
Use correct config file. Fixes #646.

### DIFF
--- a/src/NUnitEngine/nunit.core.engine.tests/nunit.core.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.core.engine.tests/nunit.core.engine.tests.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Data" />

--- a/src/NUnitEngine/nunit.core.engine.tests/nunit.core.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.core.engine.tests/nunit.core.engine.tests.csproj
@@ -131,6 +131,11 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\nunit.engine.tests\App.config">
+      <Link>App.config</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/NUnitEngine/nunit.engine.tests/App.config
+++ b/src/NUnitEngine/nunit.engine.tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?> 
+<configuration>
+  <appSettings>
+    <add key="test.setting" value="54321"/>
+  </appSettings>
+</configuration>

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -87,7 +87,12 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public static void ProperConfigFileIsUsed()
         {
-            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "nunit.engine.tests.dll.config");
+#if CORE_ENGINE
+            var configFileName = "nunit.core.engine.tests.dll.config";
+#else
+            var configFileName = "nunit.engine.tests.dll.config";
+#endif
+            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, configFileName);
             Assert.That(expectedPath, Is.EqualTo(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile));
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using System.Configuration;
 using System.IO;
 using NUnit.Framework;
 
@@ -80,6 +82,19 @@ namespace NUnit.Engine.Services.Tests
             Assert.AreEqual(
                 TestPath("/test"),
                 DomainManager.GetCommonAppBase(assemblies));
+        }
+
+        [Test]
+        public static void ProperConfigFileIsUsed()
+        {
+            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "nunit.engine.tests.dll.config");
+            Assert.That(expectedPath, Is.EqualTo(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile));
+        }
+
+        [Test]
+        public static void CanReadConfigFile()
+        {
+            Assert.That(ConfigurationManager.AppSettings.Get("test.setting"), Is.EqualTo("54321"));
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Data" />
@@ -123,6 +124,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -88,6 +88,9 @@ namespace NUnit.Engine.Services
         {
             AppDomainSetup setup = new AppDomainSetup();
 
+            if (package.SubPackages.Count == 1)
+                package = package.SubPackages[0];
+
             //For parallel tests, we need to use distinct application name
             setup.ApplicationName = "Tests" + "_" + Environment.TickCount;
 
@@ -105,13 +108,15 @@ namespace NUnit.Engine.Services
                     appBase = testFile.DirectoryName;
 
                 if (configFile == null || configFile == string.Empty)
-                    //configFile = Services.ProjectService.CanLoadProject(testFile.Name)
-                    //    ? Path.GetFileNameWithoutExtension(testFile.Name) + ".config"
-                    //    : testFile.Name + ".config";
                     configFile = testFile.Name + ".config";
             }
-            else if (appBase == null || appBase == string.Empty)
-                appBase = GetCommonAppBase(package.SubPackages);
+            else
+            {
+                if (appBase == null || appBase == string.Empty)
+                    appBase = GetCommonAppBase(package.SubPackages);
+
+                // TODO: What about config file for multiple assemblies?
+            }
 
             char lastChar = appBase[appBase.Length - 1];
             if (lastChar != Path.DirectorySeparatorChar && lastChar != Path.AltDirectorySeparatorChar)


### PR DESCRIPTION
Fixes a problem whereby the domain is not set up to use the config file for an assembly entered on the command line.

NOTE - multiple assemblies run in the same AppDomain still don't get a default config since we have no way to know what config should be used.