### PR TITLE
Fix typo in --domain parameter help

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -315,7 +315,7 @@ namespace NUnit.Common
             this.Add("process=", "{PROCESS} isolation for test assemblies.\nValues: Single, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
                 v => ProcessModel = RequiredValue(v, "--process", "Single", "Separate", "Multiple"));
 
-            this.Add("domain=", "{DOMAIN} isolation for test assemblies.\nValues: None, Single, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
+            this.Add("domain=", "{DOMAIN} isolation for test assemblies.\nValues: None, Single, Multiple. If not specified, defaults to Single for a single assembly or Multiple for more than one.",
                 v => DomainUsage = RequiredValue(v, "--domain", "None", "Single", "Multiple"));
 
             // How to Run Tests


### PR DESCRIPTION
This is just trivial typo fix in help for --domain parameter