### PR TITLE
Issue-524 Char accepted as numeric + if both char then do a normal co…

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitComparer.cs
@@ -54,6 +54,9 @@ namespace NUnit.Framework.Constraints
             else if (y == null)
                 return +1;
 
+            if (x is char && y is char)
+                return (char)x == (char)y ? 0 : 1;
+
             if (Numerics.IsNumericType(x) && Numerics.IsNumericType(y))
                 return Numerics.Compare(x, y);
 

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -76,6 +76,7 @@ namespace NUnit.Framework.Constraints
                 if (obj is System.UInt64) return true;
                 if (obj is System.Int16) return true;
                 if (obj is System.UInt16) return true;
+                if (obj is System.Char) return true;
             }
             return false;
         }

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -1,4 +1,4 @@
-// ***********************************************************************
+﻿// ***********************************************************************
 // Copyright (c) 2004 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -55,7 +55,28 @@ namespace NUnit.Framework.Assertions
             int i32 = 0;
             Assert.AreEqual(i32, l64);
         }
-        
+
+        [Test]
+        public void Bug524CharIntComparision()
+        {
+            char c = '\u0000';
+            Assert.AreEqual(0, c);
+        }
+
+        [Test]
+        public void Bug524CharIntWithoutOverload()
+        {
+            char c = '\u0000';
+            Assert.That(c, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CharCharComparision()
+        {
+            char c = 'a';
+            Assert.That(c, Is.EqualTo('a'));
+        }
+
         [Test]
         public void IntegerLongComparison()
         {
@@ -281,6 +302,8 @@ namespace NUnit.Framework.Assertions
             long      l9 = 35;
             short    s10 = 35;
             ushort  us11 = 35;
+            char      c1 = '3';
+            char      c2 = 'a';
         
             System.Byte    b12  = 35;  
             System.SByte   sb13 = 35; 
@@ -293,6 +316,8 @@ namespace NUnit.Framework.Assertions
             System.UInt64  ui20 = 35; 
             System.Int16   i21  = 35; 
             System.UInt16  i22  = 35;
+            System.Char    c12 = '3';
+            System.Char    c22 = 'a';
 
             Assert.AreEqual(35, b1);
             Assert.AreEqual(35, sb2);
@@ -304,6 +329,8 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual(35, l9);
             Assert.AreEqual(35, s10);
             Assert.AreEqual(35, us11);
+            Assert.AreEqual('3', c1);
+            Assert.AreEqual('a', c2);
         
             Assert.AreEqual( 35, b12  );
             Assert.AreEqual( 35, sb13 );
@@ -316,6 +343,8 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual( 35, ui20 );
             Assert.AreEqual( 35, i21  );
             Assert.AreEqual( 35, i22  );
+            Assert.AreEqual('3', c12);
+            Assert.AreEqual('a', c22);
 
             byte? b23 = 35;
             sbyte? sb24 = 35;
@@ -327,6 +356,8 @@ namespace NUnit.Framework.Assertions
             long? l30 = 35;
             short? s31 = 35;
             ushort? us32 = 35;
+            char? c3 = '3';
+            char? c4 = 'a';
 
             Assert.AreEqual(35, b23);
             Assert.AreEqual(35, sb24);
@@ -338,6 +369,8 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual(35, l30);
             Assert.AreEqual(35, s31);
             Assert.AreEqual(35, us32);
+            Assert.AreEqual('3', c3);
+            Assert.AreEqual('a', c4);
         }
 
         [Test]


### PR DESCRIPTION
I have read the discussion -> #524 

> I think we should modify Numerics.IsFixedPointNumeric to add char and then modify NUnitComparer and NUnitEqualityComparer to do a specific character comparison if both arguments are char before it falls through to the numeric comparisons. I think this will address @CharliePoole's concerns with number 3?

I didn't modify NUnitEqualityComparer as there is already a logic handling (char, char) situation.
I tried to look for chars in different character sets with the same numeric value but couldn't find anything. Any ideas here ? Did i missed something ? Should i add more tests ? 