### PR TITLE
WIP: Issue #575 (do not merge)

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -75,10 +75,12 @@ namespace NUnit.Framework
         /// Construct one or more TestMethods from a given MethodInfo,
         /// using available parameter data.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(Type fixtureType, MethodInfo method, Test suite)
         {
             List<TestMethod> tests = new List<TestMethod>();
 
@@ -123,10 +125,10 @@ namespace NUnit.Framework
             {
                 IEnumerable[] sources = new IEnumerable[parameters.Length];
                 for (int i = 0; i < parameters.Length; i++)
-                    sources[i] = _dataProvider.GetDataFor(parameters[i]);
+                    sources[i] = _dataProvider.GetDataFor(fixtureType, parameters[i]);
 
                 foreach (var parms in _strategy.GetTestCases(sources))
-                    tests.Add(_builder.BuildTestMethod(method, suite, (ParameterSet)parms));
+                    tests.Add(_builder.BuildTestMethod(fixtureType, method, suite, (ParameterSet)parms));
             }
 
             return tests;

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -91,7 +91,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of _values to be used as arguments
         /// </summary>
-        public new IEnumerable GetData(ParameterInfo parameter)
+        public new IEnumerable GetData(Type fixtureType, ParameterInfo parameter)
         {
             Randomizer r = Randomizer.GetRandomizer(parameter);
             IList values;
@@ -120,7 +120,7 @@ namespace NUnit.Framework
             for (int i = 0; i < values.Count; i++)
                 this.data[i] = values[i];
  
-            return base.GetData(parameter);
+            return base.GetData(fixtureType, parameter);
         }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -121,10 +121,12 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a TestMethod from a given MethodInfo.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo for which a test is to be constructed.</param>
         /// <param name="suite">The suite to which the test will be added.</param>
         /// <returns>A TestMethod</returns>
-        public TestMethod BuildFrom(MethodInfo method, Test suite)
+        public TestMethod BuildFrom(Type fixtureType, MethodInfo method, Test suite)
         {
             ParameterSet parms = null;
 
@@ -134,7 +136,7 @@ namespace NUnit.Framework
                 parms.ExpectedResult = this.ExpectedResult;
             }
 
-            return _builder.BuildTestMethod(method, suite, parms);
+            return _builder.BuildTestMethod(fixtureType, method, suite, parms);
         }
         
         #endregion

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -394,12 +394,14 @@ namespace NUnit.Framework
         /// Construct one or more TestMethods from a given MethodInfo,
         /// using available parameter data.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(Type fixtureType, MethodInfo method, Test suite)
         {
-            TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
+            TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(fixtureType, method, suite, GetParametersForTestCase(method));
             
 #if !PORTABLE
             if (test.RunState != RunState.NotRunnable && 

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -94,12 +94,14 @@ namespace NUnit.Framework
         /// Returns a set of ITestCaseDataItems for use as arguments
         /// to a parameterized test method.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method for which data is needed.</param>
         /// <returns></returns>
-        public IEnumerable<ITestCaseData> GetTestCasesFor(MethodInfo method)
+        public IEnumerable<ITestCaseData> GetTestCasesFor(Type fixtureType, MethodInfo method)
         {
             List<ITestCaseData> data = new List<ITestCaseData>();
-            IEnumerable source = GetTestCaseSource(method);
+            IEnumerable source = GetTestCaseSource(fixtureType);
 
             if (source != null)
             {
@@ -190,11 +192,11 @@ namespace NUnit.Framework
             return data;
         }
 
-        private IEnumerable GetTestCaseSource(MethodInfo method)
+        private IEnumerable GetTestCaseSource(Type fixtureType)
         {
             Type sourceType = this.SourceType;
             if (sourceType == null)
-                sourceType = method.ReflectedType;
+                sourceType = fixtureType;
 
             if (SourceName == null)
                 return Reflect.Construct(sourceType, _sourceConstructorParameters) as IEnumerable;
@@ -232,12 +234,12 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(Type fixtureType, MethodInfo method, Test suite)
         {
             List<TestMethod> tests = new List<TestMethod>();
 
-            foreach (ParameterSet parms in GetTestCasesFor(method))
-                tests.Add(_builder.BuildTestMethod(method, suite, parms));
+            foreach (ParameterSet parms in GetTestCasesFor(fixtureType, method))
+                tests.Add(_builder.BuildTestMethod(fixtureType, method, suite, parms));
 
             return tests;
         }

--- a/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
@@ -64,10 +64,12 @@ namespace NUnit.Framework
         /// Construct one or more TestMethods from a given MethodInfo,
         /// using available parameter data.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Internal.Test suite)
+        public IEnumerable<TestMethod> BuildFrom(Type fixtureType, MethodInfo method, Internal.Test suite)
         {
             ParameterInfo[] parameters = method.GetParameters();
 
@@ -77,10 +79,10 @@ namespace NUnit.Framework
             {
                 IEnumerable[] sources = new IEnumerable[parameters.Length];
                 for (int i = 0; i < parameters.Length; i++)
-                    sources[i] = _dataProvider.GetDataFor(parameters[i]);
+                    sources[i] = _dataProvider.GetDataFor(fixtureType, parameters[i]);
 
                 foreach (var parms in new CombinatorialStrategy().GetTestCases(sources))
-                    tests.Add(_builder.BuildTestMethod(method, suite, (ParameterSet)parms));
+                    tests.Add(_builder.BuildTestMethod(fixtureType, method, suite, (ParameterSet)parms));
             }
 
             return tests;

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -83,24 +83,26 @@ namespace NUnit.Framework
         /// Gets an enumeration of data items for use as arguments
         /// for a test method parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">The parameter for which data is needed</param>
         /// <returns>
         /// An enumeration containing individual data items
         /// </returns>
-        public IEnumerable GetData(ParameterInfo parameter)
+        public IEnumerable GetData(Type fixtureType, ParameterInfo parameter)
         {
-            return GetDataSource(parameter);
+            return GetDataSource(fixtureType);
         }
 
         #endregion
 
         #region Helper Methods
 
-        private IEnumerable GetDataSource(ParameterInfo parameter)
+        private IEnumerable GetDataSource(Type fixtureType)
         {
             Type sourceType = this.sourceType;
             if (sourceType == null)
-                sourceType = parameter.Member.ReflectedType;
+                sourceType = fixtureType;
 
             // TODO: Test this
             if (sourceName == null)

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -96,7 +96,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of _values to be used as arguments
         /// </summary>
-        public IEnumerable GetData(ParameterInfo parameter)
+        public IEnumerable GetData(Type fixtureType, ParameterInfo parameter)
         {
             Type targetType = parameter.ParameterType;
 

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Reflection;
 
@@ -35,18 +36,22 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Determine whether any data is available for a parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>True if any data is available, otherwise false.</returns>
-        bool HasDataFor(ParameterInfo parameter);
+        bool HasDataFor(Type fixtureType, ParameterInfo parameter);
 
         /// <summary>
         /// Return an IEnumerable providing data for use with the
         /// supplied parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>An IEnumerable providing the required data</returns>
-        IEnumerable GetDataFor(ParameterInfo parameter);
+        IEnumerable GetDataFor(Type fixtureType, ParameterInfo parameter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Reflection;
 
@@ -36,8 +37,10 @@ namespace NUnit.Framework.Interfaces
         /// Gets an enumeration of data items for use as arguments
         /// for a test method parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">The parameter for which data is needed</param>
         /// <returns>An enumeration containing individual data items</returns>
-        IEnumerable GetData(ParameterInfo parameter);
+        IEnumerable GetData(Type fixtureType, ParameterInfo parameter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Internal; // TODO: We shouldn't reference this in the interface
@@ -38,9 +39,11 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Build a TestMethod from the provided MethodInfo.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method to be used as a test</param>
         /// <param name="suite">The TestSuite to which the method will be added</param>
         /// <returns>A TestMethod object</returns>
-        TestMethod BuildFrom(MethodInfo method, Test suite);
+        TestMethod BuildFrom(Type fixtureType, MethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Internal; // TODO: We shouldn't reference this in the interface
@@ -38,9 +39,11 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Build one or more TestMethods from the provided MethodInfo.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method to be used as a test</param>
         /// <param name="suite">The TestSuite to which the method will be added</param>
         /// <returns>A TestMethod object</returns>
-        IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite);
+        IEnumerable<TestMethod> BuildFrom(Type fixtureType, MethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Reflection;
 using NUnit.Framework.Internal;
 
@@ -49,15 +50,17 @@ namespace NUnit.Framework.Interfaces
         /// <param name="method">The test method to examine</param>
         /// <param name="suite">The suite being populated</param>
         /// <returns>True is the builder can use this method</returns>
-        bool CanBuildFrom(MethodInfo method, Test suite);
+        bool CanBuildFrom(Type fixtureType, MethodInfo method, Test suite);
 
         /// <summary>
         /// Build a TestCase from the provided MethodInfo for
         /// inclusion in the suite being constructed.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method to be used as a test case</param>
         /// <param name="suite">The test suite being populated, or null</param>
         /// <returns>A TestCase or null</returns>
-        Test BuildFrom(MethodInfo method, Test suite);
+        Test BuildFrom(Type fixtureType, MethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -39,16 +39,17 @@ namespace NUnit.Framework.Internal.Builders
         /// <summary>
         /// Determine whether any data is available for a parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>
         /// True if any data is available, otherwise false.
         /// </returns>
-        public bool HasDataFor(System.Reflection.ParameterInfo parameter)
+        public bool HasDataFor(Type fixtureType, System.Reflection.ParameterInfo parameter)
         {
             Type parameterType = parameter.ParameterType;
             MemberInfo method = parameter.Member;
-            Type fixtureType = method.ReflectedType;
 
             if (!method.IsDefined(typeof(TheoryAttribute), true))
                 return false;
@@ -73,17 +74,17 @@ namespace NUnit.Framework.Internal.Builders
         /// Return an IEnumerable providing data for use with the
         /// supplied parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>
         /// An IEnumerable providing the required data
         /// </returns>
-        public System.Collections.IEnumerable GetDataFor(System.Reflection.ParameterInfo parameter)
+        public System.Collections.IEnumerable GetDataFor(Type fixtureType, System.Reflection.ParameterInfo parameter)
         {
             var datapoints = new List<object>();
-
             Type parameterType = parameter.ParameterType;
-            Type fixtureType = parameter.Member.ReflectedType;
 
             foreach (MemberInfo member in fixtureType.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             {

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -42,18 +42,20 @@ namespace NUnit.Framework.Internal.Builders
         /// Builds a single NUnitTestMethod, either as a child of the fixture
         /// or as one of a set of test cases under a ParameterizedTestMethodSuite.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo from which to construct the TestMethod</param>
         /// <param name="parentSuite">The suite or fixture to which the new test will be added</param>
         /// <param name="parms">The ParameterSet to be used, or null</param>
         /// <returns></returns>
-        public TestMethod BuildTestMethod(MethodInfo method, Test parentSuite, ParameterSet parms)
+        public TestMethod BuildTestMethod(Type fixtureType, MethodInfo method, Test parentSuite, ParameterSet parms)
         {
-            var testMethod = new TestMethod(method, parentSuite)
+            var testMethod = new TestMethod(fixtureType, method, parentSuite)
             {
                 Seed = randomizer.Next()
             };
 
-            string prefix = method.ReflectedType.FullName;
+            string prefix = fixtureType.FullName;
 
             // Needed to give proper fullname to test in a parameterized fixture.
             // Without this, the arguments to the fixture are not included.

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -181,7 +181,7 @@ namespace NUnit.Framework.Internal.Builders
 
             foreach (MethodInfo method in methods)
             {
-                Test test = BuildTestCase(method, this.fixture);
+                Test test = BuildTestCase(fixtureType, method, this.fixture);
 
                 if (test != null)
                 {
@@ -201,13 +201,15 @@ namespace NUnit.Framework.Internal.Builders
         /// Derived classes should add builders to the collection
         /// in their constructor.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The MethodInfo for which a test is to be created</param>
         /// <param name="suite">The test suite being built.</param>
         /// <returns>A newly constructed Test</returns>
-        private Test BuildTestCase(MethodInfo method, TestSuite suite)
+        private Test BuildTestCase(Type fixtureType, MethodInfo method, TestSuite suite)
         {
-            return testBuilder.CanBuildFrom(method, suite)
-                ? testBuilder.BuildFrom(method, suite)
+            return testBuilder.CanBuildFrom(fixtureType, method, suite)
+                ? testBuilder.BuildFrom(fixtureType, method, suite)
                 : null;
         }
 

--- a/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
@@ -40,12 +40,14 @@ namespace NUnit.Framework.Internal.Builders
         /// <summary>
         /// Determine whether any data is available for a parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>
         /// True if any data is available, otherwise false.
         /// </returns>
-        public bool HasDataFor(ParameterInfo parameter)
+        public bool HasDataFor(Type fixtureType, ParameterInfo parameter)
         {
             return parameter.IsDefined(typeof(IParameterDataSource), false);
         }
@@ -54,18 +56,20 @@ namespace NUnit.Framework.Internal.Builders
         /// Return an IEnumerable providing data for use with the
         /// supplied parameter.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>
         /// An IEnumerable providing the required data
         /// </returns>
-        public IEnumerable GetDataFor(ParameterInfo parameter)
+        public IEnumerable GetDataFor(Type fixtureType, ParameterInfo parameter)
         {
             var data = new List<object>();
 
             foreach (IParameterDataSource source in parameter.GetCustomAttributes(typeof(IParameterDataSource), false))
             {
-                foreach (object item in source.GetData(parameter))
+                foreach (object item in source.GetData(fixtureType, parameter))
                 data.Add(item);
             }
 

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Reflection;
 using NUnit.Framework.Internal.Commands;
 
@@ -37,9 +38,10 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Construct from a MethodInfo
         /// </summary>
+        /// <param name="fixtureType"></param>
         /// <param name="method"></param>
-        public ParameterizedMethodSuite(MethodInfo method)
-            : base(method.ReflectedType.FullName, method.Name)
+        public ParameterizedMethodSuite(Type fixtureType, MethodInfo method)
+            : base(fixtureType.FullName, method.Name)
         {
             Method = method;
 #if PORTABLE

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -97,9 +97,10 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Construct a test from a MethodInfo
         /// </summary>
+        /// <param name="fixtureType"></param>
         /// <param name="method"></param>
-        protected Test(MethodInfo method)
-            : this(method.ReflectedType)
+        protected Test(Type fixtureType, MethodInfo method)
+            : this(fixtureType)
         {
             this.Name = method.Name;
             this.FullName += "." + this.Name;

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
@@ -48,16 +49,20 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Initializes a new instance of the <see cref="TestMethod"/> class.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method to be used as a test.</param>
-        public TestMethod(MethodInfo method) : this(method, null) { }
+        public TestMethod(Type fixtureType, MethodInfo method) : this(fixtureType, method, null) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestMethod"/> class.
         /// </summary>
+        /// <param name="fixtureType">The parameter containing type of the test fixture class. 
+        /// This may be different from the reflected member info</param>
         /// <param name="method">The method to be used as a test.</param>
         /// <param name="parentSuite">The suite or fixture to which the new test will be added</param>
-        public TestMethod(MethodInfo method, Test parentSuite) 
-            : base( method ) 
+        public TestMethod(Type fixtureType, MethodInfo method, Test parentSuite)
+            : base(fixtureType, method) 
         {
             // Disambiguate call to base class methods
             // TODO: This should not be here - it's a presentation issue
@@ -66,7 +71,7 @@ namespace NUnit.Framework.Internal
 
             // Needed to give proper fullname to test in a parameterized fixture.
             // Without this, the arguments to the fixture are not included.
-            string prefix = method.ReflectedType.FullName;
+            string prefix = fixtureType.FullName;
             if (parentSuite != null)
             {
                 prefix = parentSuite.FullName;

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Attributes
         public void TestAttribute_NoArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            TestMethod test = new TestAttribute().BuildFrom(method, null);
+            TestMethod test = new TestAttribute().BuildFrom(GetType(), method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Attributes
         public void TestAttribute_WithArgs_NotRunnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            TestMethod test = new TestAttribute().BuildFrom(method, null);
+            TestMethod test = new TestAttribute().BuildFrom(GetType(), method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseAttribute_NoArgs_NotRunnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseAttribute_RightArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseAttribute_WrongArgs_NotRunnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42, 99).BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42, 99).BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseSourceAttribute_NoArgs_NotRunnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseSourceAttribute_RightArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Attributes
         public void TestCaseSourceAttribute_WrongArgs_NotRunnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("BadData").BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("BadData").BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Attributes
         public void TheoryAttribute_NoArgs_NoCases()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
 
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Attributes
         public void TheoryAttribute_WithArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(9));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Attributes
         public void CombinatorialAttribute_NoArgs_NoCases()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
 
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Attributes
         public void CombinatorialAttribute_WithArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntValues");
-            List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(6));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Attributes
         public void PairwiseAttribute_NoArgs_NoCases()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
 
@@ -153,7 +153,7 @@ namespace NUnit.Framework.Attributes
         public void PairwiseAttribute_WithArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntValues");
-            List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(6));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
@@ -163,7 +163,7 @@ namespace NUnit.Framework.Attributes
         public void SequentialAttribute_NoArgs_NoCases()
         {
             MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
 
@@ -171,7 +171,7 @@ namespace NUnit.Framework.Attributes
         public void SequentialAttribute_WithArgs_Runnable()
         {
             MethodInfo method = GetType().GetMethod("MethodWithIntValues");
-            List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
+            List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(GetType(), method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -139,18 +139,22 @@ namespace NUnit.Framework.Attributes
         #region Helper Methods
         private void CheckValues(string methodName, params object[] expected)
         {
-            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Type type = GetType();
+
+            MethodInfo method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             ParameterInfo param = method.GetParameters()[0];
             ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-            Assert.That(attr.GetData(param), Is.EqualTo(expected));
+            Assert.That(attr.GetData(type, param), Is.EqualTo(expected));
         }
 
         private void CheckValuesWithinTolerance(string methodName, params object[] expected)
         {
-            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Type type = GetType();
+
+            MethodInfo method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             ParameterInfo param = method.GetParameters()[0];
             ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-            Assert.That(attr.GetData(param), Is.EqualTo(expected).Within(0.000001));
+            Assert.That(attr.GetData(type, param), Is.EqualTo(expected).Within(0.000001));
         }
         #endregion
     }

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Internal
         public void Setup()
         {
             _testObject = new AsyncSetupTearDownFixture();
-            _context = new TestExecutionContext {TestObject = _testObject, CurrentResult = new TestCaseResult(new TestMethod(Success.ElementAt(0)))};
+            _context = new TestExecutionContext {TestObject = _testObject, CurrentResult = new TestCaseResult(new TestMethod(_testObject.GetType(), Success.ElementAt(0)))};
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -1,4 +1,5 @@
-﻿#if NET_4_0 || NET_4_5
+﻿using System;
+#if NET_4_0 || NET_4_5
 using System.Collections;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
@@ -27,41 +28,41 @@ namespace NUnit.Framework.Internal
         {
             get
             {
-                yield return GetTestCase(Method("AsyncVoid"), ResultState.NotRunnable, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncVoid"), ResultState.NotRunnable, 0, false);
 
-                yield return GetTestCase(Method("AsyncTaskSuccess"), ResultState.Success, 1, true);
-                yield return GetTestCase(Method("AsyncTaskFailure"), ResultState.Failure, 1, true);
-                yield return GetTestCase(Method("AsyncTaskError"), ResultState.Error, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskSuccess"), ResultState.Success, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskFailure"), ResultState.Failure, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskError"), ResultState.Error, 0, false);
 
-                yield return GetTestCase(Method("TaskSuccess"), ResultState.Success, 1, true);
-                yield return GetTestCase(Method("TaskFailure"), ResultState.Failure, 1, true);
-                yield return GetTestCase(Method("TaskError"), ResultState.Error, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskSuccess"), ResultState.Success, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskFailure"), ResultState.Failure, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskError"), ResultState.Error, 0, false);
 
-                yield return GetTestCase(Method("AsyncTaskResult"), ResultState.NotRunnable, 0, false);
-                yield return GetTestCase(Method("TaskResult"), ResultState.NotRunnable, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskResult"), ResultState.NotRunnable, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskResult"), ResultState.NotRunnable, 0, false);
 
-                yield return GetTestCase(Method("AsyncTaskResultCheckSuccess"), ResultState.Success, 1, false);
-                yield return GetTestCase(Method("AsyncTaskResultCheckFailure"), ResultState.ChildFailure, 1, false);
-                yield return GetTestCase(Method("AsyncTaskResultCheckError"), ResultState.ChildFailure, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskResultCheckSuccess"), ResultState.Success, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskResultCheckFailure"), ResultState.ChildFailure, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskResultCheckError"), ResultState.ChildFailure, 0, false);
 
-                yield return GetTestCase(Method("TaskResultCheckSuccess"), ResultState.Success, 1, false);
-                yield return GetTestCase(Method("TaskResultCheckFailure"), ResultState.ChildFailure, 1, false);
-                yield return GetTestCase(Method("TaskResultCheckError"), ResultState.ChildFailure, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskResultCheckSuccess"), ResultState.Success, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskResultCheckFailure"), ResultState.ChildFailure, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskResultCheckError"), ResultState.ChildFailure, 0, false);
 
-                yield return GetTestCase(Method("AsyncTaskTestCaseWithParametersSuccess"), ResultState.Success, 1, true);
-                yield return GetTestCase(Method("AsyncTaskResultCheckSuccessReturningNull"), ResultState.Success, 1, false);
-                yield return GetTestCase(Method("TaskResultCheckSuccessReturningNull"), ResultState.Success, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskTestCaseWithParametersSuccess"), ResultState.Success, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskResultCheckSuccessReturningNull"), ResultState.Success, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskResultCheckSuccessReturningNull"), ResultState.Success, 1, false);
                 
-                yield return GetTestCase(Method("NestedAsyncTaskSuccess"), ResultState.Success, 1, false);
-                yield return GetTestCase(Method("NestedAsyncTaskFailure"), ResultState.Failure, 1, true);
-                yield return GetTestCase(Method("NestedAsyncTaskError"), ResultState.Error, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("NestedAsyncTaskSuccess"), ResultState.Success, 1, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("NestedAsyncTaskFailure"), ResultState.Failure, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("NestedAsyncTaskError"), ResultState.Error, 0, false);
 
-                yield return GetTestCase(Method("AsyncTaskMultipleSuccess"), ResultState.Success, 1, true);
-                yield return GetTestCase(Method("AsyncTaskMultipleFailure"), ResultState.Failure, 1, true);
-                yield return GetTestCase(Method("AsyncTaskMultipleError"), ResultState.Error, 0, false);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskMultipleSuccess"), ResultState.Success, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskMultipleFailure"), ResultState.Failure, 1, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("AsyncTaskMultipleError"), ResultState.Error, 0, false);
 
-                yield return GetTestCase(Method("TaskCheckTestContextAcrossTasks"), ResultState.Success, 2, true);
-                yield return GetTestCase(Method("TaskCheckTestContextWithinTestBody"), ResultState.Success, 2, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskCheckTestContextAcrossTasks"), ResultState.Success, 2, true);
+                yield return GetTestCase(typeof(AsyncRealFixture), Method("TaskCheckTestContextWithinTestBody"), ResultState.Success, 2, true);
             }
         }
 
@@ -69,9 +70,9 @@ namespace NUnit.Framework.Internal
         /// Private method to return a test case, optionally ignored on the Linux platform.
         /// We use this since the Platform attribute is not supported on TestCaseData.
         /// </summary>
-        private TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
+        private TestCaseData GetTestCase(Type fixtureType, MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
         {
-            var data = new TestCaseData(method, resultState, assertionCount);
+            var data = new TestCaseData(fixtureType, method, resultState, assertionCount);
             if (ON_LINUX && ignoreOnLinux)
                 data = data.Ignore("Intermittent failure on Linux");
             return data;
@@ -79,9 +80,9 @@ namespace NUnit.Framework.Internal
 
         [Test]
         [TestCaseSource("TestCases")]
-        public void RunTests(MethodInfo method, ResultState resultState, int assertionCount)
+        public void RunTests(Type fixtureType, MethodInfo method, ResultState resultState, int assertionCount)
         {
-            var test = _builder.BuildFrom(method);
+            var test = _builder.BuildFrom(fixtureType, method);
             var result = TestBuilder.RunTest(test, _testObject);
 
             Assert.That(result.ResultState, Is.EqualTo(resultState), "Wrong result state");

--- a/src/NUnitFramework/tests/Internal/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestResultTests.cs
@@ -48,13 +48,15 @@ namespace NUnit.Framework.Internal
             expectedStart = new DateTime(1968, 4, 8, 15, 05, 30, 250, DateTimeKind.Utc);
             expectedEnd = expectedStart.AddSeconds(expectedDuration);
 
-            test = new TestMethod(typeof(DummySuite).GetMethod("DummyMethod"));
+            Type fixtureType = typeof(DummySuite);
+
+            test = new TestMethod(fixtureType, fixtureType.GetMethod("DummyMethod"));
             test.Properties.Set(PropertyNames.Description, "Test description");
             test.Properties.Add(PropertyNames.Category, "Dubious");
             test.Properties.Set("Priority", "low");
             testResult = test.MakeTestResult();
 
-            TestSuite suite = new TestSuite(typeof(DummySuite));
+            TestSuite suite = new TestSuite(fixtureType);
             suite.Properties.Set(PropertyNames.Description, "Suite description");
             suite.Properties.Add(PropertyNames.Category, "Fast");
             suite.Properties.Add("Value", 3);

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -14,19 +14,20 @@ namespace NUnit.Framework.Internal
         [SetUp]
         public void SetUp()
         {
-            testMethod = new TestMethod(typeof(DummyFixture).GetMethod("DummyMethod"));
+            Type fixtureType = typeof(DummyFixture);
+            testMethod = new TestMethod(fixtureType, fixtureType.GetMethod("DummyMethod"));
             testMethod.Properties.Set(PropertyNames.Description, "Test description");
             testMethod.Properties.Add(PropertyNames.Category, "Dubious");
             testMethod.Properties.Set("Priority", "low");
 
-            testFixture = new TestFixture(typeof(DummyFixture));
+            testFixture = new TestFixture(fixtureType);
             testFixture.Properties.Set(PropertyNames.Description, "Fixture description");
             testFixture.Properties.Add(PropertyNames.Category, "Fast");
             testFixture.Properties.Add("Value", 3);
 
             testFixture.Tests.Add(testMethod);
 
-            testSuite = new TestSuite(typeof(DummyFixture));
+            testSuite = new TestSuite(fixtureType);
             testSuite.Properties.Set(PropertyNames.Description, "Suite description");
         }
 
@@ -41,11 +42,12 @@ namespace NUnit.Framework.Internal
                 Is.EqualTo("TestSuite"));
             Assert.That(new TestAssembly("junk").TestType, 
                 Is.EqualTo("Assembly"));
-            Assert.That(new ParameterizedMethodSuite(typeof(DummyFixture).GetMethod("GenericMethod")).TestType,
+            Type type = typeof(DummyFixture);
+            Assert.That(new ParameterizedMethodSuite(type, type.GetMethod("GenericMethod")).TestType,
                 Is.EqualTo("GenericMethod"));
-            Assert.That(new ParameterizedMethodSuite(typeof(DummyFixture).GetMethod("ParameterizedMethod")).TestType,
+            Assert.That(new ParameterizedMethodSuite(type, type.GetMethod("ParameterizedMethod")).TestType,
                 Is.EqualTo("ParameterizedMethod"));
-            Assert.That(new ParameterizedFixtureSuite(typeof(DummyFixture)).TestType,
+            Assert.That(new ParameterizedFixtureSuite(type).TestType,
                 Is.EqualTo("ParameterizedFixture"));
             Type genericType = typeof(DummyGenericFixture<int>).GetGenericTypeDefinition();
             Assert.That(new ParameterizedFixtureSuite(genericType).TestType,

--- a/src/NUnitFramework/tests/TestUtilities/Fakes.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Fakes.cs
@@ -94,7 +94,7 @@ namespace NUnit.TestUtilities
             : this(obj.GetType(), name) { }
 
         public FakeTestMethod(Type type, string name)
-            : base(type.GetMethod(name, BF.Public | BF.NonPublic | BF.Static | BF.Instance)) { }
+            : base(type, type.GetMethod(name, BF.Public | BF.NonPublic | BF.Static | BF.Instance)) { }
     }
 
     #endregion

--- a/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
@@ -82,7 +82,7 @@ namespace NUnit.TestUtilities
             MethodInfo method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (method == null)
                 Assert.Fail("Method not found: " + methodName);
-            return new DefaultTestCaseBuilder().BuildFrom(method);
+            return new DefaultTestCaseBuilder().BuildFrom(type, method);
         }
 
         #endregion


### PR DESCRIPTION
@rprouse / @CharliePoole 

* This is the proposal how to remove usage of MemberInfo.ReflectedType in order to be ready support CoreCLR
* I was considering also reflection abstraction (like introduce IMemberInfo, IParameterInfo etc.) but it grew up very quickly and the changes were even larger and less obvious.
* Let me know if you have some better suggestion