### PR TITLE
664: Fix Invalid "id" attribute in the report for case "test started"

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/TestEventAdapter.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/TestEventAdapter.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using NUnit.Core;
 
@@ -135,8 +136,9 @@ namespace NUnit.Engine.Drivers
         private void OnTestStarted(TestName testName, bool isSuite)
         {
             string report = string.Format(
-                "<{0} id=\"{1}\" name=\"{2}\" fullname=\"{3}\"/>",
+                "<{0} id=\"{1}-{2}\" name=\"{3}\" fullname=\"{4}\"/>",
                 isSuite ? "start-suite" : "start-test",
+                testName.RunnerID,
                 testName.TestID,
                 FormatAttributeValue(testName.Name),
                 FormatAttributeValue(testName.FullName));


### PR DESCRIPTION
fixes #664