### PR TITLE
Issue 670

### DIFF
--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -417,9 +417,12 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void DirectoryInfoEqual()
         {
-            var one = new DirectoryInfo(Env.DocumentFolder);
-            var two = new DirectoryInfo(Env.DocumentFolder);
-            Assert.AreEqual(one, two);
+            using (var testDir = new TestDirectory())
+            {
+                var one = new DirectoryInfo(testDir.Directory.FullName);
+                var two = new DirectoryInfo(testDir.Directory.FullName);
+                Assert.AreEqual(one, two);
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -88,9 +88,12 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void SameDirectoriesAreEqual()
         {
-            var one = new DirectoryInfo(Env.DocumentFolder);
-            var two = new DirectoryInfo(Env.DocumentFolder);
-            Assert.That(comparer.AreEqual(one, two, ref tolerance));
+            using (var testDir = new TestDirectory())
+            {
+                var one = new DirectoryInfo(testDir.Directory.FullName);
+                var two = new DirectoryInfo(testDir.Directory.FullName);
+                Assert.That(comparer.AreEqual(one, two, ref tolerance));
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/TestUtilities/TestDirectory.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestDirectory.cs
@@ -42,6 +42,7 @@ namespace NUnit.TestUtilities
             Assume.That(_testDir.Exists, Is.False, _testDir + " should not already exist");
 
             _testDir.Create();
+            _testDir.Refresh();
             Assume.That(_testDir.Exists, Is.True, "Failed to create test dir " + _testDir);
         }
 


### PR DESCRIPTION
Fixes #670 

The tests that were using TestDirectory probably were always ignored due to an issue in TestDirectory creation.