### PR TITLE
Standardize disposal of engine objects. Fixes #673

### DIFF
--- a/src/NUnitEngine/nunit.core.engine/nunit.core.engine.csproj
+++ b/src/NUnitEngine/nunit.core.engine/nunit.core.engine.csproj
@@ -177,6 +177,9 @@
     <Compile Include="..\nunit.engine\Services\DriverService.cs">
       <Link>Services\DriverService.cs</Link>
     </Compile>
+    <Compile Include="..\nunit.engine\Services\Service.cs">
+      <Link>Services\Service.cs</Link>
+    </Compile>
     <Compile Include="..\nunit.engine\Services\ServiceManager.cs">
       <Link>Services\ServiceManager.cs</Link>
     </Compile>

--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
@@ -38,12 +38,6 @@ namespace NUnit.Engine.Internal.Tests
             settings = new SettingsGroup();
         }
 
-        [TearDown]
-        public void AfterEachTest()
-        {
-            settings.Dispose();
-        }
-
         [Test]
         public void WhenSettingIsNotInitialized_NullIsReturned()
         {

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -109,12 +109,27 @@ namespace NUnit.Engine.Agents
         #endregion
 
         #region IDisposable Members
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+
+        private bool _disposed = false;
+
         /// <summary>
         /// Dispose is overridden to stop the agent
         /// </summary>
-        public void Dispose()
+        protected virtual void Dispose(bool disposing)
         {
-            this.Stop();
+            if (!_disposed)
+            {
+                if (disposing)
+                    Stop();
+
+                _disposed = true;
+            }
         }
         #endregion
 

--- a/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
@@ -120,7 +120,21 @@ namespace NUnit.Engine.Internal
 
         public void Dispose()
         {
-            this.Stop();
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+
+        private bool _disposed = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                    Stop();
+
+                _disposed = true;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Internal
     /// SettingsGroup is the base class representing a group
     /// of user or system settings.
     /// </summary>
-    public class SettingsGroup : ISettings, IDisposable
+    public class SettingsGroup : ISettings
     {
         static Logger log = InternalTrace.GetLogger("SettingsGroup");
 
@@ -147,20 +147,6 @@ namespace NUnit.Engine.Internal
                 Changed(this, new SettingsEventArgs(settingName));
         }
 
-        #endregion
-
-        #region IDisposable Members
-        /// <summary>
-        /// Dispose of this group by disposing of it's settings
-        /// </summary>
-        public void Dispose()
-        {
-            if (_settings != null)
-            {
-                //_settings.Dispose();
-                _settings = null;
-            }
-        }
         #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -152,12 +152,6 @@ namespace NUnit.Engine.Runners
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
         public abstract void StopRun(bool force);
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-                Unload();
-        }
-
         #endregion
 
         #region ITestEngineRunner Members
@@ -255,6 +249,19 @@ namespace NUnit.Engine.Runners
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        protected bool _disposed = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                    Unload();
+
+                _disposed = true;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -134,8 +134,13 @@ namespace NUnit.Engine.Runners
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && _realRunner != null)
-                _realRunner.Dispose();
+            if (!_disposed)
+            {
+                base.Dispose(disposing);
+
+                if (disposing && _realRunner != null)
+                    _realRunner.Dispose();
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -37,6 +37,8 @@ namespace NUnit.Engine.Services
     {
         private IProjectService _projectService;
 
+        #region Service Overrides
+
         public override void StartService()
         {
             // TestRunnerFactory requires the ProjectService
@@ -48,6 +50,10 @@ namespace NUnit.Engine.Services
                 : ServiceStatus.Error;
         }
 
+        #endregion
+
+        #region InProcessTestRunnerFactory Overrides
+        
         /// <summary>
         /// Returns a test runner based on the settings in a TestPackage.
         /// Any setting that is "consumed" by the factory is removed, so
@@ -131,11 +137,17 @@ namespace NUnit.Engine.Services
             }
         }
 
+        #endregion
+
+        #region Helper Methods
+
         private ProcessModel GetTargetProcessModel(TestPackage package)
         {
             return (ProcessModel)System.Enum.Parse(
                 typeof(ProcessModel),
                 package.GetSetting(PackageSettings.ProcessModel, "Default"));
         }
+
+        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -40,7 +40,7 @@ namespace NUnit.Engine.Services
     /// The DomainManager class handles the creation and unloading
     /// of domains as needed and keeps track of all existing domains.
     /// </summary>
-    public class DomainManager : IService
+    public class DomainManager : Service
     {
         static Logger log = InternalTrace.GetLogger(typeof(DomainManager));
 
@@ -357,19 +357,9 @@ namespace NUnit.Engine.Services
         }
         #endregion
 
-        #region IService Members
+        #region Service Overrides
 
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StopService()
-        {
-            // TODO:  Add DomainManager.UnloadService implementation
-            Status = ServiceStatus.Stopped;
-        }
-
-        public void StartService() 
+        public override void StartService() 
         {
             try
             {

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Services
     /// The DriverService provides drivers able to load and run tests
     /// using various frameworks.
     /// </summary>
-    public class DriverService : IDriverService, IService
+    public class DriverService : Service, IDriverService
     {
         IList<IDriverFactory> _factories = new List<IDriverFactory>();
 
@@ -104,13 +104,9 @@ namespace NUnit.Engine.Services
 
         #endregion
  
-        #region IService Members
+        #region Service Overrides
 
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        public override void StartService()
         {
             try
             {
@@ -128,11 +124,6 @@ namespace NUnit.Engine.Services
                 Status = ServiceStatus.Error;
                 throw;
             }
-        }
-
-        public void StopService()
-        {
-            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -33,7 +33,7 @@ namespace NUnit.Engine.Services
     /// runner for a given package to be loaded and run within the
     /// same process.
     /// </summary>
-    public class InProcessTestRunnerFactory : ITestRunnerFactory, IService
+    public class InProcessTestRunnerFactory : Service, ITestRunnerFactory
     {
         #region ITestRunnerFactory Members
 
@@ -75,24 +75,6 @@ namespace NUnit.Engine.Services
         public virtual bool CanReuse(ITestEngineRunner runner, TestPackage package)
         {
             return false;
-        }
-
-        #endregion
-
-        #region IService Members
-
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; protected set; }
-
-        public virtual void StartService()
-        {
-            Status = ServiceStatus.Started;
-        }
-
-        public void StopService()
-        {
-            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Services
     /// <summary>
     /// Summary description for ProjectService.
     /// </summary>
-    public class ProjectService : IProjectService, IService
+    public class ProjectService : Service, IProjectService
     {
         /// <summary>
         /// List of all installed ProjectLoaders
@@ -80,13 +80,9 @@ namespace NUnit.Engine.Services
 
         #endregion
 
-        #region IService Members
+        #region Service Overrides
 
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        public override void StartService()
         {
             if (Status == ServiceStatus.Stopped)
             {
@@ -104,12 +100,6 @@ namespace NUnit.Engine.Services
                     throw;
                 }
             }
-        }
-
-        public void StopService()
-        {
-            // TODO:  Add ProjectLoader.UnloadService implementation
-            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Services
     /// <summary>
     /// Summary description for RecentFilesService.
     /// </summary>
-    public class RecentFilesService : IRecentFiles, IService
+    public class RecentFilesService : Service, IRecentFiles
     {
         private IList<string> _fileEntries = new List<string>();
         private ISettings _userSettings;
@@ -131,13 +131,9 @@ namespace NUnit.Engine.Services
         }
         #endregion
 
-        #region IService Members
+        #region Service Overrides
 
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StopService()
+        public override void StopService()
         {
             try
             {
@@ -149,7 +145,7 @@ namespace NUnit.Engine.Services
             }
         }
 
-        public void StartService()
+        public override void StartService()
         {
             try
             {

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -31,7 +31,7 @@ using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services
 {
-    public class ResultService : IResultService, IService
+    public class ResultService : Service, IResultService
     {
         IList<IResultWriterFactory> _factories = new List<IResultWriterFactory>();
 
@@ -68,11 +68,7 @@ namespace NUnit.Engine.Services
 
         #region IService Members
 
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
+        public override void StartService()
         {
             try
             {
@@ -90,11 +86,6 @@ namespace NUnit.Engine.Services
                 Status = ServiceStatus.Error;
                 throw;
             }
-        }
-
-        public void StopService()
-        {
-            Status = ServiceStatus.Stopped;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -28,7 +28,7 @@ using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
 {
-    public class RuntimeFrameworkService : IRuntimeFrameworkService, IService
+    public class RuntimeFrameworkService : Service, IRuntimeFrameworkService
     {
         static Logger log = InternalTrace.GetLogger(typeof(RuntimeFrameworkService));
 
@@ -161,23 +161,5 @@ namespace NUnit.Engine.Services
 
             return targetFramework.ToString();
         }
-
-        #region IService Members
-
-        public ServiceContext ServiceContext { get; set; }
-
-        public ServiceStatus Status { get; private set; }
-
-        public void StartService()
-        {
-            Status = ServiceStatus.Started;
-        }
-
-        public void StopService()
-        {
-            Status = ServiceStatus.Stopped;
-        }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/Service.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Service.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,53 +22,60 @@
 // ***********************************************************************
 
 using System;
-using System.IO;
-using NUnit.Engine.Internal;
+using System.Collections.Generic;
+using System.Text;
 
 namespace NUnit.Engine.Services
 {
     /// <summary>
-    /// Summary description for UserSettingsService.
+    /// Abstract base class for services that can use it. Some Services
+    /// already inherit from a different class and can't use this, which
+    /// is why we define the IService interface as well.
     /// </summary>
-    public class SettingsService : SettingsStore, IService
+    public abstract class Service : IService, IDisposable
     {
-        private const string SETTINGS_FILE = "Nunit30Settings.xml";
+        #region IService Default Implementation
 
-        public SettingsService(bool writeable)
-            : base(Path.Combine(NUnitConfiguration.ApplicationDirectory, SETTINGS_FILE), writeable) { }
-
-        #region IService Implementation
-
+        /// <summary>
+        /// The ServiceContext
+        /// </summary>
         public ServiceContext ServiceContext { get; set; }
 
-        public ServiceStatus Status { get; private set; }
+        /// <summary>
+        /// Gets the ServiceStatus of this service
+        /// </summary>
+        public ServiceStatus Status { get; protected set;  }
 
-        public void StartService()
+        /// <summary>
+        /// Initialize the Service
+        /// </summary>
+        public virtual void StartService()
         {
-            try
-            {
-                LoadSettings();
-
-                Status = ServiceStatus.Started;
-            }
-            catch
-            {
-                Status = ServiceStatus.Error;
-                throw;
-            }
+            Status = ServiceStatus.Started;
         }
 
-        public void StopService()
+        /// <summary>
+        /// Do any cleanup needed before terminating the service
+        /// </summary>
+        public virtual void StopService()
         {
-            try
-            {
-                SaveSettings();
-            }
-            finally
-            {
-                Status = ServiceStatus.Stopped;
-            }
+            Status = ServiceStatus.Stopped;
         }
+
+        #endregion
+
+        #region IDisposable Default Implementation
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+
+        protected bool _disposed = false;
+
+        protected virtual void Dispose(bool disposing) { }
+
         #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Services
     /// ServiceManager handles access to all services - global
     /// facilities shared by all instances of TestEngine.
     /// </summary>
-    public class ServiceManager
+    public class ServiceManager : IDisposable
     {
         private List<IService> _services = new List<IService>();
         private Dictionary<Type, IService> _serviceIndex = new Dictionary<Type, IService>();
@@ -128,6 +128,36 @@ namespace NUnit.Engine.Services
         {
             log.Info("Clearing Service list");
             _services.Clear();
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        private bool _disposed = false;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                StopServices();
+
+                if (disposing)
+                    foreach (IService service in _services)
+                    {
+                        IDisposable disposable = service as IDisposable;
+                        if (disposable != null)
+                            disposable.Dispose();
+                    }
+
+                _disposed = true;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -145,9 +145,24 @@ namespace NUnit.Engine
 
         #region IDisposable Members
 
+        private bool _disposed = false;
+
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
             Services.ServiceManager.StopServices();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                    Services.ServiceManager.Dispose();
+
+                _disposed = true;
+            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />
     <Compile Include="Services\ResultWriters\XmlTransformResultWriter.cs" />
     <Compile Include="Services\ResultService.cs" />
+    <Compile Include="Services\Service.cs" />
     <Compile Include="TestRun.cs" />
     <Compile Include="RunTestsCallbackHandler.cs" />
     <Compile Include="RuntimeFramework.cs" />


### PR DESCRIPTION
Engine, Runners, ServiceManager and Services now implement IDisposable as described in #673.

I introduced abstract class Service to provide a default implementation of both IService and IDisposable for all services. Services must override Dispose(bool disposing) if they actually need to dispose of something.

Note that I kept the IService interface even though this is not normal practice when there is an abstract base class. In this case, some existing services already inherit from a different type, which is not itself a service. Such services must implement IService directly. As time allows, we should try to migrate such services to use aggregation rather than inheritance.

I only used the basic Disposal pattern, without Finalizers. I'm open to advice on any classes that really need a finalizer. Microsoft best practice advice is to avoid Finalizers if possible.