### PR TITLE
Refactor framework driver so that no use of XmlNode remains, allowing…

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
@@ -93,13 +93,13 @@ namespace NUnit.Engine.Drivers
             return test.ToXml(false).OuterXml;
         }
 
-        public int CountTestCases(TestFilter filter)
+        public int CountTestCases(string filter)
         {
             ITestFilter v2Filter = CreateNUnit2TestFilter(filter);
             return _runner.CountTestCases(v2Filter);
         }
 
-        public string Run(ITestEventListener listener, TestFilter filter)
+        public string Run(ITestEventListener listener, string filter)
         {
             if (_runner.Test == null)
                 return String.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, "Error loading test");
@@ -111,7 +111,7 @@ namespace NUnit.Engine.Drivers
             return result.ToXml(true).OuterXml;
         }
 
-        public string Explore(TestFilter filter)
+        public string Explore(string filter)
         {
             if (_runner.Test == null)
                 return String.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, "Error loading test");
@@ -139,12 +139,14 @@ namespace NUnit.Engine.Drivers
             get { return string.IsNullOrEmpty(ID) ? "1" : ID + "-1";}
         }
 
-        private static ITestFilter CreateNUnit2TestFilter(TestFilter filter)
+        private static ITestFilter CreateNUnit2TestFilter(string filter)
         {
-            if (filter == null || filter.Xml == null)
+            if (string.IsNullOrEmpty(filter))
                 return Core.TestFilter.Empty;
 
-            var topNode = filter.Xml;
+            var doc = new XmlDocument();
+            doc.LoadXml(filter);
+            var topNode = doc.FirstChild;
             if (topNode.Name != "filter")
                 throw new Exception("Expected filter element at top level");
 

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IFrameworkDriver.cs
@@ -49,24 +49,24 @@ namespace NUnit.Engine.Extensibility
         /// <summary>
         /// Count the test cases that would be executed.
         /// </summary>
-        /// <param name="filter">A TestFilter to use in counting the tests</param>
+        /// <param name="filter">An XML string representing the TestFilter to use in counting the tests</param>
         /// <returns>The number of test cases counted</returns>
-        int CountTestCases(TestFilter filter);
+        int CountTestCases(string filter);
 
         /// <summary>
         /// Executes the tests in an assembly.
         /// </summary>
         /// <param name="listener">An ITestEventHandler that receives progress notices</param>
-        /// <param name="filter">A filter that controls which tests are executed</param>
+        /// <param name="filter">A XML string representing the filter that controls which tests are executed</param>
         /// <returns>An Xml string representing the result</returns>
-        string Run(ITestEventListener listener, TestFilter filter);
+        string Run(ITestEventListener listener, string filter);
 
         /// <summary>
         /// Returns information about the tests in an assembly.
         /// </summary>
-        /// <param name="filter">A filter indicating which tests to include</param>
+        /// <param name="filter">An XML string representing the filter that controls which tests are included</param>
         /// <returns>An Xml string representing the tests</returns>
-        string Explore(TestFilter filter);
+        string Explore(string filter);
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -86,7 +86,7 @@ namespace NUnit.Engine.Drivers.Tests
         public void Explore_AfterLoad_ReturnsRunnableSuite()
         {
             _driver.Load(_mockAssemblyPath, _settings);
-            var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty));
+            var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty.Text));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
@@ -98,7 +98,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void ExploreTestsAction_WithoutLoad_ThrowsInvalidOperationException()
         {
-            var ex = Assert.Catch(() => _driver.Explore(TestFilter.Empty));
+            var ex = Assert.Catch(() => _driver.Explore(TestFilter.Empty.Text));
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
@@ -111,13 +111,13 @@ namespace NUnit.Engine.Drivers.Tests
         public void CountTestsAction_AfterLoad_ReturnsCorrectCount()
         {
             _driver.Load(_mockAssemblyPath, _settings);
-            Assert.That(_driver.CountTestCases(TestFilter.Empty), Is.EqualTo(MockAssembly.Tests - MockAssembly.Explicit));
+            Assert.That(_driver.CountTestCases(TestFilter.Empty.Text), Is.EqualTo(MockAssembly.Tests - MockAssembly.Explicit));
         }
 
         [Test]
         public void CountTestsAction_WithoutLoad_ThrowsInvalidOperationException()
         {
-            var ex = Assert.Catch(() => _driver.CountTestCases(TestFilter.Empty));
+            var ex = Assert.Catch(() => _driver.CountTestCases(TestFilter.Empty.Text));
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
@@ -130,7 +130,7 @@ namespace NUnit.Engine.Drivers.Tests
         public void RunTestsAction_AfterLoad_ReturnsRunnableSuite()
         {
             _driver.Load(_mockAssemblyPath, _settings);
-            var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty));
+            var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty.Text));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
@@ -147,7 +147,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void RunTestsAction_WithoutLoad_ThrowsInvalidOperationException()
         {
-            var ex = Assert.Catch(() => _driver.Run(new NullListener(), TestFilter.Empty));
+            var ex = Assert.Catch(() => _driver.Run(new NullListener(), TestFilter.Empty.Text));
             if (ex is System.Reflection.TargetInvocationException)
                 ex = ex.InnerException;
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -68,7 +68,7 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void Explore_ReturnsNonRunnableSuite()
         {
-            var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty));
+            var result = XmlHelper.CreateXmlNode(_driver.Explore(TestFilter.Empty.Text));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
@@ -84,13 +84,13 @@ namespace NUnit.Engine.Drivers.Tests
         [Test]
         public void CountTestCases_ReturnsZero()
         {
-            Assert.That(_driver.CountTestCases(TestFilter.Empty), Is.EqualTo(0));
+            Assert.That(_driver.CountTestCases(TestFilter.Empty.Text), Is.EqualTo(0));
         }
 
         [Test]
         public void Run_ReturnsNonRunnableSuite()
         {
-            var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty));
+            var result = XmlHelper.CreateXmlNode(_driver.Run(new NullListener(), TestFilter.Empty.Text));
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
             Assert.That(result.GetAttribute("name"), Is.EqualTo(BAD_FILE));

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -83,13 +83,13 @@ namespace NUnit.Engine.Drivers
             return handler.Result;
         }
 
-        public int CountTestCases(TestFilter filter)
+        public int CountTestCases(string filter)
         {
             CheckLoadWasCalled();
 
             CallbackHandler handler = new CallbackHandler();
 
-            CreateObject(COUNT_ACTION, _frameworkController, filter.Text, handler);
+            CreateObject(COUNT_ACTION, _frameworkController, filter, handler);
 
             return int.Parse(handler.Result);
         }
@@ -100,14 +100,14 @@ namespace NUnit.Engine.Drivers
         /// <param name="listener">An ITestEventHandler that receives progress notices</param>
         /// <param name="filter">A filter that controls which tests are executed</param>
         /// <returns>An Xml string representing the result</returns>
-        public string Run(ITestEventListener listener, TestFilter filter)
+        public string Run(ITestEventListener listener, string filter)
         {
             CheckLoadWasCalled();
 
             CallbackHandler handler = new RunTestsCallbackHandler(listener);
 
             log.Info("Running {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
-            CreateObject(RUN_ACTION, _frameworkController, filter.Text, handler);
+            CreateObject(RUN_ACTION, _frameworkController, filter, handler);
 
             return handler.Result;
         }
@@ -126,14 +126,14 @@ namespace NUnit.Engine.Drivers
         /// </summary>
         /// <param name="filter">A filter indicating which tests to include</param>
         /// <returns>An Xml string representing the tests</returns>
-        public string Explore(TestFilter filter)
+        public string Explore(string filter)
         {
             CheckLoadWasCalled();
 
             CallbackHandler handler = new CallbackHandler();
 
             log.Info("Exploring {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
-            CreateObject(EXPLORE_ACTION, _frameworkController, filter.Text, handler);
+            CreateObject(EXPLORE_ACTION, _frameworkController, filter, handler);
 
             return handler.Result;
         }

--- a/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
@@ -65,17 +65,17 @@ namespace NUnit.Engine.Drivers
             return string.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }
 
-        public int CountTestCases(TestFilter filter)
+        public int CountTestCases(string filter)
         {
             return 0;
         }
 
-        public string Run(ITestEventListener listener, TestFilter filter)
+        public string Run(ITestEventListener listener, string filter)
         {
             return string.Format(RUN_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }
 
-        public string Explore(TestFilter filter)
+        public string Explore(string filter)
         {
             return string.Format(LOAD_RESULT_FORMAT, TestID, _name, _fullname, _message);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Runners
             var result = new TestEngineResult();
 
             foreach (IFrameworkDriver driver in _drivers)
-                result.Add(driver.Explore(filter));
+                result.Add(driver.Explore(filter.Text));
 
 #if NUNIT_ENGINE
             if (IsProjectPackage(TestPackage))
@@ -113,7 +113,7 @@ namespace NUnit.Engine.Runners
             int count = 0;
 
             foreach (IFrameworkDriver driver in _drivers)
-                count += driver.CountTestCases(filter);
+                count += driver.CountTestCases(filter.Text);
 
             return count;
         }
@@ -132,7 +132,7 @@ namespace NUnit.Engine.Runners
             var result = new TestEngineResult();
 
             foreach (IFrameworkDriver driver in _drivers)
-                result.Add(driver.Run(listener, filter));
+                result.Add(driver.Run(listener, filter.Text));
 
 #if NUNIT_ENGINE
             if (IsProjectPackage(TestPackage))


### PR DESCRIPTION
… portable use

Working on the portable engine, I realized that TestFilter is used in the IFrameworkDriver interface. Since TestFilter uses XmlNode, it makes the interface unusable in a portable library. However, use of XmlNode is really not needed since all the driver does is pass the text representation of the XML to the framework.

I refactored so that the text representation is extracted and passed into the framework driver. Everything works as before except that IFrameworkDriver is now usable in a portable library. One inconvenience is that the NUnit v2 framework driver has to recreate the XmlNode in order to use it, but it seems like a reasonable tradeoff.
