### PR TITLE
Windows 10 support

### DIFF
--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -433,9 +433,17 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Return true if the platform is Windows 8
+        /// Return true if the platform is Windows 8.1
         /// </summary>
         public bool IsWindows81
+        {
+            get { return IsNT63 && Product == ProductType.WorkStation; }
+        }
+
+        /// <summary>
+        /// Return true if the platform is Windows 10
+        /// </summary>
+        public bool IsWindows10
         {
             get { return IsNT63 && Product == ProductType.WorkStation; }
         }

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 #if !PORTABLE
+using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;
 
@@ -70,6 +71,8 @@ namespace NUnit.Framework.Internal
                         OSVERSIONINFOEX osvi = new OSVERSIONINFOEX();
                         osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
                         GetVersionEx(ref osvi);
+                        if (os.Version.Major == 6 && os.Version.Minor >= 2)
+                            os = new OperatingSystem(os.Platform, GetWindows81PlusVersion(os.Version));
                         currentPlatform = new OSPlatform(os.Platform, os.Version, (ProductType)osvi.ProductType);
                     }
                     else
@@ -80,6 +83,58 @@ namespace NUnit.Framework.Internal
                 return currentPlatform;
             }
         }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Gets the actual OS Version, not the incorrect value that might be 
+        /// returned for Win 8.1 and Win 10
+        /// </summary>
+        /// <remarks>
+        /// If an application is not manifested as Windows 8.1 or Windows 10,
+        /// the version returned from Environment.OSVersion will not be 6.3 and 10.0
+        /// respectively, but will be 6.2 and 6.3. The correct value can be found in
+        /// the registry.
+        /// </remarks>
+        /// <param name="version">The original version</param>
+        /// <returns>The correct OS version</returns>
+        private static Version GetWindows81PlusVersion(Version version)
+        {
+            try
+            {
+                using (var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion"))
+                {
+                    if (key != null)
+                    {
+                        var buildStr = key.GetValue("CurrentBuildNumber") as string;
+                        int build = 0;
+                        int.TryParse(buildStr, out build);
+
+                        // These two keys are in Windows 10 only and are DWORDS
+                        var major = key.GetValue("CurrentMajorVersionNumber") as int?;
+                        var minor = key.GetValue("CurrentMinorVersionNumber") as int?;
+                        if (major.HasValue && minor.HasValue)
+                        {
+                            return new Version(major.Value, minor.Value, build);
+                        }
+
+                        // If we get here, we are not Windows 10, so we are Windows 8
+                        // or 8.1. 8.1 might report itself as 6.2, but will have 6.3
+                        // in the registry. We can't do this earlier because for backwards
+                        // compatibility, Windows 10 also has 6.3 for this key.
+                        var currentVersion = key.GetValue("CurrentVersion") as string;
+                        if(currentVersion == "6.3")
+                        {
+                            return new Version(6, 3, build);
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+            return version;
+        }
+#endif
         #endregion
 
         #region Members used for Win32NT platform only
@@ -445,7 +500,16 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool IsWindows10
         {
-            get { return IsNT63 && Product == ProductType.WorkStation; }
+            get { return platform == PlatformID.Win32NT && version.Major == 10 && Product == ProductType.WorkStation; }
+        }
+
+        /// <summary>
+        /// Return true if the platform is Windows Server. This is named Windows
+        /// Server 10 to distinguish it from previous versions of Windows Server.
+        /// </summary>
+        public bool IsWindowsServer10
+        {
+            get { return platform == PlatformID.Win32NT && version.Major == 10 && Product == ProductType.Server; }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal
             "Win,Win32,Win32S,Win32NT,Win32Windows,WinCE,Win95,Win98,WinMe,NT3,NT4,NT5,NT6," +
             "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2," +
             "Win2K,WinXP,Win2003Server,Vista,Win7,Windows7,Win8,Windows8,"+
-            "Win8.1,Windows8.1,Win10,Windows10,Unix,Linux";
+            "Win8.1,Windows8.1,Win10,Windows10,WindowsServer,Unix,Linux";
 
         /// <summary>
         /// Comma-delimited list of all supported OS platform constants
@@ -249,6 +249,9 @@ namespace NUnit.Framework.Internal
                 case "WINDOWS10":
                 case "WIN10":
                     isSupported = os.IsWindows10;
+                    break;
+                case "WINDOWSSERVER":
+                    isSupported = os.IsWindowsServer10;
                     break;
                 case "UNIX":
                 case "LINUX":

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -40,7 +40,8 @@ namespace NUnit.Framework.Internal
         const string CommonOSPlatforms =
             "Win,Win32,Win32S,Win32NT,Win32Windows,WinCE,Win95,Win98,WinMe,NT3,NT4,NT5,NT6," +
             "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2," +
-            "Win2K,WinXP,Win2003Server,Vista,Win7,Windows7,Win8,Windows8,Win8.1,Windows8.1,Unix,Linux";
+            "Win2K,WinXP,Win2003Server,Vista,Win7,Windows7,Win8,Windows8,"+
+            "Win8.1,Windows8.1,Win10,Windows10,Unix,Linux";
 
         /// <summary>
         /// Comma-delimited list of all supported OS platform constants
@@ -244,6 +245,10 @@ namespace NUnit.Framework.Internal
                 case "WINDOWS8.1":
                 case "WIN8.1":
                     isSupported = os.IsWindows81;
+                    break;
+                case "WINDOWS10":
+                case "WIN10":
+                    isSupported = os.IsWindows10;
                     break;
                 case "UNIX":
                 case "LINUX":

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal
             "Win,Win32,Win32S,Win32NT,Win32Windows,WinCE,Win95,Win98,WinMe,NT3,NT4,NT5,NT6," +
             "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2," +
             "Win2K,WinXP,Win2003Server,Vista,Win7,Windows7,Win8,Windows8,"+
-            "Win8.1,Windows8.1,Win10,Windows10,WindowsServer,Unix,Linux";
+            "Win8.1,Windows8.1,Win10,Windows10,WindowsServer10,Unix,Linux";
 
         /// <summary>
         /// Comma-delimited list of all supported OS platform constants
@@ -250,7 +250,7 @@ namespace NUnit.Framework.Internal
                 case "WIN10":
                     isSupported = os.IsWindows10;
                     break;
-                case "WINDOWSSERVER":
+                case "WINDOWSSERVER10":
                     isSupported = os.IsWindowsServer10;
                     break;
                 case "UNIX":

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Internal
 
 #if !PORTABLE
         [Test]
-        [Platform(Exclude = "Windows10,WindowsServer", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
+        [Platform(Exclude = "Windows10,WindowsServer10", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
         public void SettingInvalidCultureOnFixtureGivesError()
         {
             ITestResult result = TestBuilder.RunTestFixture(typeof(FixtureWithInvalidSetCultureAttribute));
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
-        [Platform(Exclude = "Windows10,WindowsServer", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
+        [Platform(Exclude = "Windows10,WindowsServer10", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
         public void SettingInvalidCultureOnTestGivesError()
         {
             ITestResult result = TestBuilder.RunTestCase(typeof(FixtureWithInvalidSetCultureAttributeOnTest), "InvalidCultureSet");

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -151,6 +151,7 @@ namespace NUnit.Framework.Internal
 
 #if !PORTABLE
         [Test]
+        [Platform(Exclude = "Windows10,WindowsServer", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
         public void SettingInvalidCultureOnFixtureGivesError()
         {
             ITestResult result = TestBuilder.RunTestFixture(typeof(FixtureWithInvalidSetCultureAttribute));
@@ -164,6 +165,7 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        [Platform(Exclude = "Windows10,WindowsServer", Reason = "An unknown culture string creates a user defined culture in Windows 10")]
         public void SettingInvalidCultureOnTestGivesError()
         {
             ITestResult result = TestBuilder.RunTestCase(typeof(FixtureWithInvalidSetCultureAttributeOnTest), "InvalidCultureSet");

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -245,7 +245,7 @@ namespace NUnit.Framework.Internal
         {
             CheckOSPlatforms(
                 new OSPlatform(PlatformID.Win32NT, new Version(10, 0), OSPlatform.ProductType.Server),
-                "WindowsServer,Win32NT,Win32,Win");
+                "WindowsServer10,Win32NT,Win32,Win");
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -233,6 +233,22 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        public void DetectWindows10()
+        {
+            CheckOSPlatforms(
+                new OSPlatform(PlatformID.Win32NT, new Version(10, 0), OSPlatform.ProductType.WorkStation),
+                "Win10,Windows10,Win32NT,Win32,Win");
+        }
+
+        [Test]
+        public void DetectWindowsServer()
+        {
+            CheckOSPlatforms(
+                new OSPlatform(PlatformID.Win32NT, new Version(10, 0), OSPlatform.ProductType.Server),
+                "WindowsServer,Win32NT,Win32,Win");
+        }
+
+        [Test]
         public void DetectUnixUnderMicrosoftDotNet()
         {
             CheckOSPlatforms(


### PR DESCRIPTION
And fixes Windows 8.1. Windows misreports the version for Win 8.1 and Win 10 if the running app is not manifested for those OS's.

Also ignore the tests with the invalid culture string because on Windows 10, the call succeeds and creates a user defined culture.

See #679 for more info...