### PR TITLE
Fix processing of framework option. Fixes #687

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -230,8 +230,9 @@ namespace NUnit.Engine.Runners
                 var processModel = TestPackage.GetSetting(PackageSettings.ProcessModel, "Default");
                 if (processModel.ToLower() == "single")
                 {
-                    var currentFramework = RuntimeFramework.CurrentFramework.ToString();
-                    if (currentFramework != frameworkSetting)
+                    var currentFramework = RuntimeFramework.CurrentFramework;
+                    var requestedFramework = RuntimeFramework.Parse(frameworkSetting);
+                    if (!currentFramework.Supports(requestedFramework))
                         throw new NUnitEngineException(string.Format(
                             "Cannot run {0} framework in process already running {1}.", frameworkSetting, currentFramework));
                 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -164,6 +164,9 @@ namespace NUnit.Engine.Services
                     ? runtimeSetting
                     : _runtimeService.SelectRuntimeFramework(package));
 
+            if (targetRuntime.Runtime == RuntimeType.Any)
+                targetRuntime = new RuntimeFramework(RuntimeFramework.CurrentFramework.Runtime, targetRuntime.ClrVersion);
+
             bool useX86Agent = package.GetSetting(PackageSettings.RunAsX86, false);
             bool enableDebug = package.GetSetting("AgentDebug", false);
             bool verbose = package.GetSetting("Verbose", false);


### PR DESCRIPTION
Fixed the issue in TestAgency. It needed to pick a runtime in order to properly run the tests.  If no runtime is specified, we are now assuming the same one under which we are running: .NET or Mono.

At the same time, fixed a similar error that arises using --process:Single. The code in MasterTestRunner was comaring the option textually to the string representation of the current runtime. It needs to be more sophisticate than that and now uses the RuntimeFramework Type to do the comparison.