### PR TITLE
Require TestCaseSource and ValueSource named members to be static.

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -113,7 +113,7 @@ namespace NUnit.Engine.Tests
             return f1.Supports(f2);
         }
 
-        internal static TestCaseData[] matchData = new TestCaseData[] {
+        static TestCaseData[] matchData = new TestCaseData[] {
             new TestCaseData(
                 new RuntimeFramework(RuntimeType.Net, new Version(3,5)), 
                 new RuntimeFramework(RuntimeType.Net, new Version(2,0))) 
@@ -216,7 +216,7 @@ namespace NUnit.Engine.Tests
             }
         }
 
-        internal FrameworkData[] frameworkData = new FrameworkData[] {
+        static FrameworkData[] frameworkData = new FrameworkData[] {
             new FrameworkData(RuntimeType.Net, new Version(1,0), new Version(1,0,3705), "net-1.0", "Net 1.0"),
             //new FrameworkData(RuntimeType.Net, new Version(1,0,3705), new Version(1,0,3705), "net-1.0.3705", "Net 1.0.3705"),
             //new FrameworkData(RuntimeType.Net, new Version(1,0), new Version(1,0,3705), "net-1.0.3705", "Net 1.0.3705"),

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
+// Copyright (c) 2014-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -122,8 +122,20 @@ namespace NUnit.Framework
             if (parameters.Length > 0)
             {
                 IEnumerable[] sources = new IEnumerable[parameters.Length];
-                for (int i = 0; i < parameters.Length; i++)
-                    sources[i] = _dataProvider.GetDataFor(parameters[i]);
+
+                try
+                {
+                    for (int i = 0; i < parameters.Length; i++)
+                        sources[i] = _dataProvider.GetDataFor(parameters[i]);
+                }
+                catch (InvalidDataSourceException ex)
+                {
+                    var parms = new ParameterSet();
+                    parms.RunState = RunState.NotRunnable;
+                    parms.Properties.Set(PropertyNames.SkipReason, ex.Message);
+                    tests.Add(_builder.BuildTestMethod(method, suite, parms));
+                    return tests;
+                }
 
                 foreach (var parms in _strategy.GetTestCases(sources))
                     tests.Add(_builder.BuildTestMethod(method, suite, (ParameterSet)parms));

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct with the name of the method, property or field that will provide data
         /// </summary>
-        /// <param name="sourceName">The name of the method, property or field that will provide data</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestCaseSourceAttribute(string sourceName)
         {
             this.SourceName = sourceName;
@@ -55,7 +55,7 @@ namespace NUnit.Framework
         /// Construct with a Type and name
         /// </summary>
         /// <param name="sourceType">The Type that will provide data</param>
-        /// <param name="sourceName">The name of the method, property or field that will provide data</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestCaseSourceAttribute(Type sourceType, string sourceName)
         {
             this.SourceType = sourceType;
@@ -263,7 +263,7 @@ namespace NUnit.Framework
         {
             var parms = new ParameterSet();
             parms.RunState = RunState.NotRunnable;
-            parms.Properties.Set(PropertyNames.SkipReason, "The name specified on a TestCaseSourceAttribute must refer to a static field, property or method.");
+            parms.Properties.Set(PropertyNames.SkipReason, "The sourceName specified on a TestCaseSourceAttribute must refer to a static field, property or method.");
             return new ParameterSet[] { parms };
         }
 

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework
         /// Construct with the name of the factory - for use with languages
         /// that don't support params arrays.
         /// </summary>
-        /// <param name="sourceName">The name of the data source to be used</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public ValueSourceAttribute(string sourceName)
         {
             SourceName = sourceName;
@@ -54,7 +54,7 @@ namespace NUnit.Framework
         /// that don't support params arrays.
         /// </summary>
         /// <param name="sourceType">The Type that will provide data</param>
-        /// <param name="sourceName">The name of the method, property or field that will provide data</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public ValueSourceAttribute(Type sourceType, string sourceName)
         {
             SourceType = sourceType;
@@ -146,7 +146,7 @@ namespace NUnit.Framework
 
         private static void ThrowInvalidDataSourceException()
         {
-            throw new InvalidDataSourceException("The name specified on a ValueSourceAttribute must refer to a static field, property or method.");
+            throw new InvalidDataSourceException("The sourceName specified on a ValueSourceAttribute must refer to a static field, property or method.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework.Internal
+{
+    using System;
+#if !NETCF
+    using System.Runtime.Serialization;
+#endif
+
+    /// <summary>
+    /// InvalidTestFixtureException is thrown when an appropriate test
+    /// fixture constructor using the provided arguments cannot be found.
+    /// </summary>
+#if !NETCF
+    [Serializable]
+#endif
+    public class InvalidDataSourceException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidTestFixtureException"/> class.
+        /// </summary>
+        public InvalidDataSourceException() : base() {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidTestFixtureException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public InvalidDataSourceException(string message) : base(message)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidTestFixtureException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public InvalidDataSourceException(string message, Exception inner) : base(message, inner)
+        { }
+
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+        /// <summary>
+        /// Serialization Constructor
+        /// </summary>
+        protected InvalidDataSourceException(SerializationInfo info, 
+            StreamingContext context) : base(info,context){}
+#endif
+    }
+}

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal
                 {
                     OperatingSystem os = Environment.OSVersion;
 
-#if SILVERLIGHT
+#if SILVERLIGHT || NETCF
                     // TODO: Runtime silverlight detection?
                     currentPlatform = new OSPlatform(os.Platform, os.Version);
 #else
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Internal
             }
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETCF
         /// <summary>
         /// Gets the actual OS Version, not the incorrect value that might be 
         /// returned for Win 8.1 and Win 10

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Internal\Execution\WorkItemState.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\RandomGenerator.cs" />
     <Compile Include="Internal\StackFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -354,6 +354,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Internal\Commands\TestCommand.cs" />
     <Compile Include="Internal\Commands\TestMethodCommand.cs" />
     <Compile Include="Internal\Commands\TheoryResultCommand.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\CultureDetector.cs" />
     <Compile Include="Internal\ExceptionHelper.cs" />
     <Compile Include="Internal\Execution\CommandBuilder.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -369,6 +369,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -352,6 +352,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -368,6 +368,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />

--- a/src/NUnitFramework/testdata/CategoryAttributeData.cs
+++ b/src/NUnitFramework/testdata/CategoryAttributeData.cs
@@ -46,7 +46,7 @@ namespace NUnit.TestData.CategoryAttributeData
         public void Test4() { }
 
 #pragma warning disable 414
-        private TestCaseData[] Test3Data = new TestCaseData[] {
+        private static TestCaseData[] Test3Data = new TestCaseData[] {
             new TestCaseData(5).SetCategory("Bottom")
         };
 #pragma warning restore 414

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2009 Charlie Poole
+// Copyright (c) 2009-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -50,6 +50,36 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         public void MethodWithExplicitTestCases(int num)
         {
         }
+
+        [Test, TestCaseSource("InstanceProperty")]
+        public void MethodWithInstancePropertyAsSource(string source)
+        {
+            Assert.AreEqual("InstanceProperty", source);
+        }
+
+        IEnumerable InstanceProperty
+        {
+            get { return new object[] { new object[] { "InstanceProperty" } }; }
+        }
+
+        [Test, TestCaseSource("InstanceMethod")]
+        public void MethodWithInstanceMethodAsSource(string source)
+        {
+            Assert.AreEqual("InstanceMethod", source);
+        }
+
+        IEnumerable InstanceMethod()
+        {
+            return new object[] { new object[] { "InstanceMethod" } };
+        }
+
+        [Test, TestCaseSource("InstanceField")]
+        public void MethodWithInstanceFieldAsSource(string source)
+        {
+            Assert.AreEqual("InstanceField", source);
+        }
+
+        object[] InstanceField = { new object[] { "InstanceField" } };
 
         private static IEnumerable ignored_source
         {

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2009 Charlie Poole
+// Copyright (c) 2009-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -45,15 +45,11 @@ namespace NUnit.Framework.Attributes
             get { return new object[] { new object[] { "StaticProperty" } }; }
         }
 
-        [Test, TestCaseSource("InstanceProperty")]
-        public void SourceCanBeInstanceProperty(string source)
+        [Test]
+        public void SourceUsingInstancePropertyIsNotRunnable()
         {
-            Assert.AreEqual("InstanceProperty", source);
-        }
-
-        IEnumerable InstanceProperty
-        {
-            get { return new object[] { new object[] { "InstanceProperty" } }; }
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstancePropertyAsSource");
+            Assert.AreEqual(result.Children[0].ResultState, ResultState.NotRunnable);
         }
 
         [Test, TestCaseSource("StaticMethod")]
@@ -67,10 +63,11 @@ namespace NUnit.Framework.Attributes
             return new object[] { new object[] { "StaticMethod" } };
         }
 
-        [Test, TestCaseSource("InstanceMethod")]
-        public void SourceCanBeInstanceMethod(string source)
+        [Test]
+        public void SourceUsingInstanceMethodIsNotRunnable()
         {
-            Assert.AreEqual("InstanceMethod", source);
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstanceMethodAsSource");
+            Assert.AreEqual(result.Children[0].ResultState, ResultState.NotRunnable);
         }
 
         IEnumerable InstanceMethod()
@@ -87,25 +84,17 @@ namespace NUnit.Framework.Attributes
         static object[] StaticField =
             { new object[] { "StaticField" } };
 
-        [Test, TestCaseSource("InstanceField")]
-        public void SourceCanBeInstanceField(string source)
+        [Test]
+        public void SourceUsingInstanceFieldIsNotRunnable()
         {
-            Assert.AreEqual("InstanceField", source);
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstanceFieldAsSource");
+            Assert.AreEqual(result.Children[0].ResultState, ResultState.NotRunnable);
         }
-
-        static object[] InstanceField =
-            { new object[] { "InstanceField" } };
 
         [Test, TestCaseSource(typeof(DataSourceClass))]
         public void SourceCanBeInstanceOfIEnumerable(string source)
         {
             Assert.AreEqual("DataSourceClass", source);
-        }
-
-        [Test, TestCaseSource(typeof(DataSourceClass), null, "foo")]
-        public void SourceCanBeInstanceOfIEnumerableWithParameters(string source)
-        {
-            Assert.AreEqual("foo", source);
         }
 
         class DataSourceClass : IEnumerable
@@ -114,45 +103,9 @@ namespace NUnit.Framework.Attributes
             {
             }
 
-            private readonly string enumeratorOverride;
-
-            public DataSourceClass(string enumeratorOverride)
-            {
-                this.enumeratorOverride = enumeratorOverride;
-            }
-
             public IEnumerator GetEnumerator()
             {
-                yield return this.enumeratorOverride ?? "DataSourceClass";
-            }
-        }
-
-        [Test, TestCaseSource(typeof(DataSourceClassWithMethod), "GetStuff", "foo")]
-        public void SourceCanHaveMethodProducingIEnumerableWithParameters(string source)
-        {
-            string[] items = new[] { "foo1", "foo2", "foo3" };
-            bool found = false;
-            for (int i = 0; i < items.Length; i++)
-            {
-                if (items[i] == source)
-                {
-                    found = true;
-                }
-            }
-            Assert.IsTrue(found);
-        }
-
-        class DataSourceClassWithMethod
-        {
-            private readonly string enumeratorPrepend;
-
-            public DataSourceClassWithMethod(string enumeratorPrepend)
-            {
-                this.enumeratorPrepend = enumeratorPrepend;
-            }
-            public IEnumerable<string> GetStuff()
-            {
-                return new[] { enumeratorPrepend + "1", enumeratorPrepend + "2", enumeratorPrepend + "3" };
+                yield return "DataSourceClass";
             }
         }
 
@@ -271,7 +224,7 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(lhs, rhs);
         }
 
-        object[] testCases =
+        static object[] testCases =
         {
             new TestCaseData(
                 new string[] { "A" },

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -177,9 +177,9 @@ namespace NUnit.Framework.Attributes
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
-        public void MethodWithoutArgs() { }
-        public void MethodWithIntArgs(int x, int y) { }
-        public void MethodWithIntValues(
+        public static void MethodWithoutArgs() { }
+        public static void MethodWithIntArgs(int x, int y) { }
+        public static void MethodWithIntValues(
             [Values(1, 2, 3)]int x,
             [Values(10, 20)]int y) { }
 

--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -1,12 +1,31 @@
-﻿// ****************************************************************
-// Copyright 2009, Charlie Poole
-// This is free software licensed under the NUnit license. You may
-// obtain a copy of the license at http://nunit.org
-// ****************************************************************
+﻿// ***********************************************************************
+// Copyright (c) 2009-2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
@@ -29,7 +48,13 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void ValueSourceCanBeInstanceProperty(
+        public void ValueSourceMayNotBeInstanceProperty()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceProperty");
+            Assert.That(result.Children[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
+        }
+
+        public void MethodWithValueSourceInstanceProperty(
             [ValueSource("InstanceProperty")] string source)
         {
             Assert.AreEqual("InstanceProperty", source);
@@ -53,7 +78,13 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void ValueSourceCanBeInstanceMethod(
+        public void ValueSourceMayNotBeInstanceMethod()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceMethod");
+            Assert.That(result.Children[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
+        }
+
+        public void MethodWithValueSourceInstanceMethod(
             [ValueSource("InstanceMethod")] string source)
         {
             Assert.AreEqual("InstanceMethod", source);
@@ -74,13 +105,19 @@ namespace NUnit.Framework.Attributes
         internal static object[] StaticField = { "StaticField" };
 
         [Test]
-        public void ValueSourceCanBeInstanceField(
+        public void ValueSourceMayNotBeInstanceField()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceField");
+            Assert.That(result.Children[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
+        }
+
+        public void MethodWithValueSourceInstanceField(
             [ValueSource("InstanceField")] string source)
         {
             Assert.AreEqual("InstanceField", source);
         }
 
-        internal static object[] InstanceField = { "InstanceField" };
+        internal object[] InstanceField = { "InstanceField" };
 
         [Test, Sequential]
         public void MultipleArguments(
@@ -120,7 +157,7 @@ namespace NUnit.Framework.Attributes
 
         public class ValueProvider
         {
-            public IEnumerable<int> IntegerProvider()
+            public static IEnumerable<int> IntegerProvider()
             {
                 List<int> dataList = new List<int>();
 

--- a/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<and <greaterthan 40> <lessthan 50>>";
         }
 
-        object[] SuccessData = new object[] { 42 };
+        static object[] SuccessData = new object[] { 42 };
 
-        object[] FailureData = new object[] { new object[] { 37, "37" }, new object[] { 53, "53" } };
+        static object[] FailureData = new object[] { new object[] { 37, "37" }, new object[] { 53, "53" } };
 
         [Test]
         public void CanCombineTestsWithAndOperator()

--- a/src/NUnitFramework/tests/Constraints/AssignableFromConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AssignableFromConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = string.Format("<assignablefrom {0}>", typeof(D1));
         }
 
-        object[] SuccessData = new object[] { new D1(), new B() };
+        static object[] SuccessData = new object[] { new D1(), new B() };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( new D2(), "<" + typeof(D2).FullName + ">" ) };
 
         class B { }

--- a/src/NUnitFramework/tests/Constraints/AssignableToConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AssignableToConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = string.Format("<assignableto {0}>", typeof(D1));
         }
 
-        object[] SuccessData = new object[] { new D1(), new D2() };
+        static object[] SuccessData = new object[] { new D1(), new D2() };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( new B(), "<" + typeof(B).FullName + ">" ) };
 
         class B { }

--- a/src/NUnitFramework/tests/Constraints/AttributeExistsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AttributeExistsConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<attributeexists NUnit.Framework.TestFixtureAttribute>";
         }
 
-        object[] SuccessData = new object[] { typeof(AttributeExistsConstraintTests) };
+        static object[] SuccessData = new object[] { typeof(AttributeExistsConstraintTests) };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( typeof(D2), "<" + typeof(D2).FullName + ">" ) };
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/BasicConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/BasicConstraintTests.cs
@@ -39,9 +39,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<null>";
         }
         
-        object[] SuccessData = new object[] { null };
+        static object[] SuccessData = new object[] { null };
 
-        object[] FailureData = new object[] { new object[] { "hello", "\"hello\"" } };
+        static object[] FailureData = new object[] { new object[] { "hello", "\"hello\"" } };
     }
 
     [TestFixture]
@@ -55,9 +55,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<true>";
         }
         
-        object[] SuccessData = new object[] { true, 2+2==4 };
+        static object[] SuccessData = new object[] { true, 2+2==4 };
         
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new object[] { null, "null" }, new object[] { "hello", "\"hello\"" },
             new object[] { false, "False"}, new object[] { 2+2==5, "False" } };
     }
@@ -73,9 +73,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<false>";
         }
 
-        object[] SuccessData = new object[] { false, 2 + 2 == 5 };
+        static object[] SuccessData = new object[] { false, 2 + 2 == 5 };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( null, "null" ),
             new TestCaseData( "hello", "\"hello\"" ),
             new TestCaseData( true, "True" ),
@@ -93,9 +93,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<nan>";
         }
         
-        object[] SuccessData = new object[] { double.NaN, float.NaN };
+        static object[] SuccessData = new object[] { double.NaN, float.NaN };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( null, "null" ),
             new TestCaseData( "hello", "\"hello\"" ),
             new TestCaseData( 42, "42" ), 

--- a/src/NUnitFramework/tests/Constraints/BinarySerializableTest.cs
+++ b/src/NUnitFramework/tests/Constraints/BinarySerializableTest.cs
@@ -38,9 +38,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<binaryserializable>";
         }
 
-        object[] SuccessData = new object[] { 1, "a", new List<int>(), new InternalWithSerializableAttributeClass() };
+        static object[] SuccessData = new object[] { 1, "a", new List<int>(), new InternalWithSerializableAttributeClass() };
         
-        object[] FailureData = new object[] { new TestCaseData( new InternalClass(), "<NUnit.Framework.Constraints.InternalClass>" ) };
+        static object[] FailureData = new object[] { new TestCaseData( new InternalClass(), "<NUnit.Framework.Constraints.InternalClass>" ) };
 
         [Test]
         public void NullArgumentThrowsException()

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -39,8 +39,8 @@ namespace NUnit.Framework.Constraints
             expectedDescription = "subset of < 1, 2, 3, 4, 5 >";
         }
 
-        internal object[] SuccessData = new object[] { new int[] { 1, 3, 5 }, new int[] { 1, 2, 3, 4, 5 } };
-        internal object[] FailureData = new object[] { 
+        static object[] SuccessData = new object[] { new int[] { 1, 3, 5 }, new int[] { 1, 2, 3, 4, 5 } };
+        static object[] FailureData = new object[] { 
             new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" },
             new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" } };
 

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -55,16 +55,31 @@ namespace NUnit.Framework.Constraints
             //SetValueTrueAfterDelay(300);
         }
 
-        object[] SuccessData = new object[] { true };
-        object[] FailureData = new object[] { 
+        static object[] SuccessData = new object[] { true };
+        static object[] FailureData = new object[] { 
             new TestCaseData( false, "False" ),
             new TestCaseData( 0, "0" ),
             new TestCaseData( null, "null" ) };
 
-        object[] InvalidData = new object[] { InvalidDelegate };
+        static ActualValueDelegate DelegateReturningValue;
+        static ActualValueDelegate DelegateReturningFalse;
+        static ActualValueDelegate DelegateReturningZero;
 
-        ActualValueDelegate<object>[] SuccessDelegates = new ActualValueDelegate<object>[] { DelegateReturningValue };
-        ActualValueDelegate<object>[] FailureDelegates = new ActualValueDelegate<object>[] { DelegateReturningFalse, DelegateReturningZero };
+        static ActualValueDelegate<object>[] SuccessDelegates;
+        static ActualValueDelegate<object>[] FailureDelegates;
+
+        // Initialize static fields that are sensitive to order of initialization.
+        // Most compilers would probably intialize these in lexical order but it
+        // may not be guaranteed in all cases so we do it directly.
+        static DelayedConstraintTests()
+        {
+            DelegateReturningValue = new ActualValueDelegate(MethodReturningValue);
+            DelegateReturningFalse = new ActualValueDelegate(MethodReturningFalse);
+            DelegateReturningZero = new ActualValueDelegate(MethodReturningZero);
+
+            SuccessDelegates = new ActualValueDelegate<object>[] { DelegateReturningValue };
+            FailureDelegates = new ActualValueDelegate<object>[] { DelegateReturningFalse, DelegateReturningZero };
+        }
 
         [Test, TestCaseSource("SuccessDelegates")]
         public void SucceedsWithGoodDelegates(ActualValueDelegate<object> del)
@@ -227,16 +242,12 @@ namespace NUnit.Framework.Constraints
         private static int setValuesDelay;
 
         private static void MethodReturningVoid() { }
-        private static TestDelegate InvalidDelegate = new TestDelegate(MethodReturningVoid);
 
         private static object MethodReturningValue() { return boolValue; }
-        private static ActualValueDelegate DelegateReturningValue = new ActualValueDelegate(MethodReturningValue);
 
         private static object MethodReturningFalse() { return false; }
-        private static ActualValueDelegate DelegateReturningFalse = new ActualValueDelegate(MethodReturningFalse);
 
         private static object MethodReturningZero() { return 0; }
-        private static ActualValueDelegate DelegateReturningZero = new ActualValueDelegate(MethodReturningZero);
 
         private static AutoResetEvent waitEvent = new AutoResetEvent(false);
 

--- a/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<endswith \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "hello", "I said hello" };
+        static object[] SuccessData = new object[] { "hello", "I said hello" };
 
-        object[] FailureData = new object[] {
+        static object[] FailureData = new object[] {
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "hello there", "\"hello there\"" ),
             new TestCaseData( "say hello to Fred", "\"say hello to Fred\"" ),
@@ -58,9 +58,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<endswith \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "HELLO", "I said Hello" };
+        static object[] SuccessData = new object[] { "HELLO", "I said Hello" };
 
-        object[] FailureData = new object[] {
+        static object[] FailureData = new object[] {
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "What the hell?", "\"What the hell?\"" ),
             new TestCaseData( "hello there", "\"hello there\"" ),

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -40,9 +40,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<equal 4>";
         }
 
-        private object[] SuccessData = new object[] {4, 4.0f, 4.0d, 4.0000m};
+        static object[] SuccessData = new object[] {4, 4.0f, 4.0d, 4.0000m};
 
-        private object[] FailureData = new object[]
+        static object[] FailureData = new object[]
             {
                 new TestCaseData(5, "5"),
                 new TestCaseData(null, "null"),

--- a/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = string.Format("<typeof {0}>", typeof(D1));
         }
 
-        object[] SuccessData = new object[] { new D1() };
+        static object[] SuccessData = new object[] { new D1() };
         
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( new B(), "<" + typeof(B).FullName + ">" ),
             new TestCaseData( new D2(), "<" + typeof(D2).FullName + ">" )
         };

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -38,9 +38,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<greaterthan 5>";
         }
 
-        object[] SuccessData = new object[] { 6, 5.001 };
+        static object[] SuccessData = new object[] { 6, 5.001 };
 
-        object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { 5, "5" } };
+        static object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { 5, "5" } };
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -38,9 +38,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<greaterthanorequal 5>";
         }
 
-        object[] SuccessData = new object[] { 6, 5 };
+        static object[] SuccessData = new object[] { 6, 5 };
 
-        object[] FailureData = new object[] { new object[] { 4, "4" } };
+        static object[] FailureData = new object[] { new object[] { 4, "4" } };
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = string.Format("<instanceof {0}>", typeof(D1));
         }
 
-        object[] SuccessData = new object[] { new D1(), new D2() };
+        static object[] SuccessData = new object[] { new D1(), new D2() };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( new B(), "<" + typeof(B).FullName + ">" ) 
         };
 

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -38,9 +38,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<lessthan 5>";
         }
 
-        object[] SuccessData = new object[] { 4, 4.999 };
+        static object[] SuccessData = new object[] { 4, 4.999 };
 
-        object[] FailureData = new object[] { new object[] { 6, "6" }, new object[] { 5, "5" } };
+        static object[] FailureData = new object[] { new object[] { 6, "6" }, new object[] { 5, "5" } };
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -38,9 +38,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<lessthanorequal 5>";
         }
 
-        object[] SuccessData = new object[] { 4, 5 };
+        static object[] SuccessData = new object[] { 4, 5 };
 
-        object[] FailureData = new object[] { new object[] { 6, "6" } };
+        static object[] FailureData = new object[] { new object[] { 6, "6" } };
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
@@ -36,9 +36,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<not <equal null>>";
         }
 
-        object[] SuccessData = new object[] { 42, "Hello" };
+        static object[] SuccessData = new object[] { 42, "Hello" };
             
-        object[] FailureData = new object [] { new object[] { null, "null" } };
+        static object[] FailureData = new object [] { new object[] { null, "null" } };
 
         [Test]
         public void NotHonorsIgnoreCaseUsingConstructors()

--- a/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<or <equal 42> <equal 99>>";
         }
 
-        object[] SuccessData = new object[] { 99, 42 };
+        static object[] SuccessData = new object[] { 99, 42 };
 
-        object[] FailureData = new object[] { new object[] { 37, "37" } };
+        static object[] FailureData = new object[] { new object[] { 37, "37" } };
 
         [Test]
         public void CanCombineTestsWithOrOperator()

--- a/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<samepath \"C:\\folder1\\file.tmp\" ignorecase>";
         }
 
-        object[] SuccessData = new object[] 
+        static object[] SuccessData = new object[] 
             { 
                 @"C:\folder1\file.tmp", 
                 @"C:\Folder1\File.TMP",
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Constraints
                 @"C:\FOLDER1\.\folder2\..\File.TMP",
                 @"C:/folder1/file.tmp"
             };
-        object[] FailureData = new object[] 
+        static object[] FailureData = new object[] 
             { 
                 new TestCaseData( @"C:\folder2\file.tmp", "\"C:\\folder2\\file.tmp\"" ),
                 new TestCaseData( @"C:\folder1\.\folder2\..\file.temp", "\"C:\\folder1\\.\\folder2\\..\\file.temp\"" )
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = @"<samepath ""/folder1/folder2"" respectcase>";
         }
 
-        object[] SuccessData = new object[] 
+        static object[] SuccessData = new object[] 
             { 
                 @"/folder1/folder2", 
                 @"/folder1/folder2/",
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Constraints
                 @"\folder1\folder2",
                 @"\folder1\folder2\"
             };
-        object[] FailureData = new object[] 
+        static object[] FailureData = new object[] 
             { 
                 new TestCaseData( "folder1/folder2", "\"folder1/folder2\""),
                 new TestCaseData( "//folder1/folder2", "\"//folder1/folder2\""),
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = @"<subpath ""C:\folder1\folder2"" ignorecase>";
         }
 
-        internal object[] SuccessData = new object[]
+        static object[] SuccessData = new object[]
             {
                 @"C:\folder1\folder2\folder3",
                 @"C:\folder1\.\folder2\folder3",
@@ -122,7 +122,7 @@ namespace NUnit.Framework.Constraints
                 @"C:\FOLDER1\.\junk\..\Folder2\temp\..\Folder3",
                 @"C:/folder1/folder2/folder3",
             };
-        internal object[] FailureData = new object[]
+        static object[] FailureData = new object[]
             {
                 new TestCaseData(@"C:\folder1\folder3", "\"C:\\folder1\\folder3\""),
                 new TestCaseData(@"C:\folder1\.\folder2\..\file.temp", "\"C:\\folder1\\.\\folder2\\..\\file.temp\""),
@@ -152,14 +152,14 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = @"<subpath ""/folder1/folder2"" respectcase>";
         }
 
-        internal object[] SuccessData = new object[]
+        static object[] SuccessData = new object[]
             {
                 @"/folder1/folder2/folder3",
                 @"/folder1/./folder2/folder3",
                 @"/folder1/junk/../folder2/folder3",
                 @"\folder1\folder2\folder3",
             };
-        internal object[] FailureData = new object[]
+        static object[] FailureData = new object[]
             {
                 new TestCaseData("/Folder1/Folder2", "\"/Folder1/Folder2\""),
                 new TestCaseData("/FOLDER1/./junk/../Folder2", "\"/FOLDER1/./junk/../Folder2\""),
@@ -191,7 +191,7 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = @"<samepathorunder ""C:\folder1\folder2"" ignorecase>";
         }
 
-        object[] SuccessData = new object[]
+        static object[] SuccessData = new object[]
             {
                 @"C:\folder1\folder2",
                 @"C:\Folder1\Folder2",
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Constraints
                 @"C:\FOLDER1\.\junk\..\Folder2\temp\..\Folder3",
                 @"C:/folder1/folder2/folder3",
             };
-        object[] FailureData = new object[]
+        static object[] FailureData = new object[]
             {
                 new TestCaseData( @"C:\folder1\folder3", "\"C:\\folder1\\folder3\"" ),
                 new TestCaseData( @"C:\folder1\.\folder2\..\file.temp", "\"C:\\folder1\\.\\folder2\\..\\file.temp\"" )
@@ -223,7 +223,7 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = @"<samepathorunder ""/folder1/folder2"" respectcase>";
         }
 
-        object[] SuccessData = new object[]
+        static object[] SuccessData = new object[]
             {
                 @"/folder1/folder2",
                 @"/folder1/./folder2",
@@ -234,7 +234,7 @@ namespace NUnit.Framework.Constraints
                 @"/folder1/junk/../folder2/folder3",
                 @"\folder1\folder2\folder3",
             };
-        object[] FailureData = new object[]
+        static object[] FailureData = new object[]
             {
                 new TestCaseData( "/Folder1/Folder2", "\"/Folder1/Folder2\"" ),
                 new TestCaseData( "/FOLDER1/./junk/../Folder2", "\"/FOLDER1/./junk/../Folder2\"" ),

--- a/src/NUnitFramework/tests/Constraints/PredicateConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PredicateConstraintTests.cs
@@ -37,13 +37,13 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<predicate>";
         }
 
-        internal object[] SuccessData = new object[] 
+        static object[] SuccessData = new object[] 
         {
             0,
             -5
         };
 
-        internal object[] FailureData = new object[]
+        static object[] FailureData = new object[]
         {
             new TestCaseData(123, "123")
         };

--- a/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
@@ -39,9 +39,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<range 5 42>";
         }
 
-        object[] SuccessData = new object[] { 5, 23, 42 };
+        static object[] SuccessData = new object[] { 5, 23, 42 };
 
-        object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { 43, "43" } };
+        static object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { 43, "43" } };
         
         [TestCase(null)]
         [TestCase("xxx")]

--- a/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<startswith \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "hello", "hello there" };
+        static object[] SuccessData = new object[] { "hello", "hello there" };
 
-        object[] FailureData = new object[] {
+        static object[] FailureData = new object[] {
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "HELLO THERE", "\"HELLO THERE\"" ),
             new TestCaseData( "I said hello", "\"I said hello\"" ),
@@ -59,9 +59,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<startswith \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "Hello", "HELLO there" };
+        static object[] SuccessData = new object[] { "Hello", "HELLO there" };
 
-        object[] FailureData = new object[] {
+        static object[] FailureData = new object[] {
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "What the hell?", "\"What the hell?\"" ),
             new TestCaseData( "I said hello", "\"I said hello\"" ),

--- a/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<substring \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "hello", "hello there", "I said hello", "say hello to fred" };
+        static object[] SuccessData = new object[] { "hello", "hello there", "I said hello", "say hello to fred" };
         
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "HELLO", "\"HELLO\"" ),
             new TestCaseData( "What the hell?", "\"What the hell?\"" ),
@@ -58,9 +58,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<substring \"hello\">";
         }
 
-        object[] SuccessData = new object[] { "Hello", "HellO there", "I said HELLO", "say hello to fred" };
+        static object[] SuccessData = new object[] { "Hello", "HellO there", "I said HELLO", "say hello to fred" };
         
-        object[] FailureData = new object[] {
+        static object[] FailureData = new object[] {
             new TestCaseData( "goodbye", "\"goodbye\"" ), 
             new TestCaseData( "What the hell?", "\"What the hell?\"" ),
             new TestCaseData( string.Empty, "<string.Empty>" ),
@@ -77,9 +77,9 @@ namespace NUnit.Framework.Constraints
     //        Description = "\"Hello World!\", ignoring case";
     //    }
 
-    //    object[] SuccessData = new object[] { "hello world!", "Hello World!", "HELLO world!" };
+    //    static object[] SuccessData = new object[] { "hello world!", "Hello World!", "HELLO world!" };
             
-    //    object[] FailureData = new object[] { "goodbye", "Hello Friends!", string.Empty, null };
+    //    static object[] FailureData = new object[] { "goodbye", "Hello Friends!", string.Empty, null };
 
 
     //    string[] ActualValues = new string[] { "\"goodbye\"", "\"Hello Friends!\"", "<string.Empty>", "null" };

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -37,8 +37,8 @@ namespace NUnit.Framework.Constraints
             expectedDescription = "all items unique";
         }
 
-        internal object[] SuccessData = new object[] { new int[] { 1, 3, 17, -2, 34 }, new object[0] };
-        internal object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
+        static object[] SuccessData = new object[] { new int[] { 1, 3, 17, -2, 34 }, new object[0] };
+        static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
 
         [Test]
         [TestCaseSource( "IgnoreCaseData" )]

--- a/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
+++ b/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
@@ -39,9 +39,9 @@ namespace NUnit.Framework.Constraints
             stringRepresentation = "<xmlserializable>";
         }
 
-        object[] SuccessData = new object[] { 1, "a", new List<string>() };
+        static object[] SuccessData = new object[] { 1, "a", new List<string>() };
 
-        object[] FailureData = new object[] { 
+        static object[] FailureData = new object[] { 
             new TestCaseData( new Dictionary<string, string>(), "<System.Collections.Generic.Dictionary`2[System.String,System.String]>" ),
             new TestCaseData( new InternalClass(), "<" + typeof(InternalClass).FullName + ">" ),
             new TestCaseData( new InternalWithSerializableAttributeClass(), "<" + typeof(InternalWithSerializableAttributeClass).FullName + ">" )

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Internal
             _testObject = new AsyncRealFixture();
         }
 
-        public IEnumerable TestCases
+        public static IEnumerable TestCases
         {
             get
             {
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Internal
         /// Private method to return a test case, optionally ignored on the Linux platform.
         /// We use this since the Platform attribute is not supported on TestCaseData.
         /// </summary>
-        private TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
+        private static TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
         {
             var data = new TestCaseData(method, resultState, assertionCount);
             if (ON_LINUX && ignoreOnLinux)

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -34,10 +34,10 @@ namespace NUnit.Framework.Internal
             RuntimeType.Silverlight;
 #else
             Type.GetType("Mono.Runtime", false) != null
-				? RuntimeType.Mono
-				: Environment.OSVersion.Platform == PlatformID.WinCE
-					? RuntimeType.NetCF
-					: RuntimeType.Net;
+                ? RuntimeType.Mono
+                : Environment.OSVersion.Platform == PlatformID.WinCE
+                    ? RuntimeType.NetCF
+                    : RuntimeType.Net;
 #endif
 
         [Test]
@@ -210,7 +210,7 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        internal FrameworkData[] frameworkData = new FrameworkData[] {
+        internal static FrameworkData[] frameworkData = new FrameworkData[] {
             new FrameworkData(RuntimeType.Net, new Version(1,0), new Version(1,0,3705), "net-1.0", "Net 1.0"),
             // new FrameworkData(RuntimeType.Net, new Version(1,0,3705), new Version(1,0,3705), "net-1.0.3705", "Net 1.0.3705"),
             // new FrameworkData(RuntimeType.Net, new Version(1,0), new Version(1,0,3705), "net-1.0.3705", "Net 1.0.3705"),


### PR DESCRIPTION
This fiixes #698. It implements the proposal I made in #698, which has as yet not received any comments, so the review of this PR should encompass both design and code review.

Converting all our own tests to use statics for TestCaseSource and ValueSource was tedious but not difficult. The only unexpected issue is that it may require care in some cases to ensure that statics are initialized in the proper order. There was only one class where this came up, DelayedConstraintTests, and it was resolved using a class constructor.