### PR TITLE
Properly distinguish between .NET 4.0 and 4.5

### DIFF
--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -69,6 +69,7 @@ namespace NUnit.Framework.Internal
         }
 #elif NET_4_0
         [Test]
+        [Platform(Exclude = "Mono", Reason = "Mono does not run assemblies targeting 4.0 in compatibility mode")]
         public void RunsIn40CompatibilityModeWhenCompiled40()
         {
             var uri = new Uri("http://host.com/path./");

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -59,6 +59,24 @@ namespace NUnit.Framework.Internal
 #endif
         }
 
+#if NET_4_5
+        [Test]
+        public void DoesNotRunIn40CompatibilityModeWhenCompiled45()
+        {
+            var uri = new Uri( "http://host.com/path./" );
+            var uriStr = uri.ToString();
+            Assert.AreEqual( "http://host.com/path./", uriStr );
+        }
+#elif NET_4_0
+        [Test]
+        public void RunsIn40CompatibilityModeWhenCompiled40()
+        {
+            var uri = new Uri("http://host.com/path./");
+            var uriStr = uri.ToString();
+            Assert.AreEqual("http://host.com/path/", uriStr);
+        }
+#endif
+
         [Test]
         public void CurrentFrameworkHasBuildSpecified()
         {


### PR DESCRIPTION
Fixes #244 and fixes #237.

The code is complicated a bit by the fact that `AppDomain.TargetFrameworkName` and `TargetFrameworkAttribute` only exist if .NET 4.5 is installed, thus the need for reflection. 

I am not happy with the tests for this since they test the original issue, #237, not the actual code, but this code is very dependent on what version of the .NET Framework is installed on the test machine. In addition to the two tests, I stepped through the code in each version of the .NET framework. Suggestions are welcome.