### PR TITLE
Fix handling of generic test args. Fixes #693.

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -213,7 +213,7 @@ namespace NUnit.Framework.Internal.Builders
 
             if (testMethod.Method.IsGenericMethodDefinition && arglist != null)
             {
-                var typeArguments = GetTypeArgumentsForMethod(testMethod.Method, arglist);
+                var typeArguments = new GenericMethodHelper(testMethod.Method).GetTypeArguments(arglist);
                 foreach (Type o in typeArguments)
                     if (o == null || o == TypeHelper.NonmatchingType)
                         return MarkAsNotRunnable(testMethod, "Unable to determine type arguments for method");
@@ -227,34 +227,6 @@ namespace NUnit.Framework.Internal.Builders
                 TypeHelper.ConvertArgumentList(arglist, parameters);
 
             return true;
-        }
-
-        private static Type[] GetTypeArgumentsForMethod(MethodInfo method, object[] arglist)
-        {
-            Type[] typeParameters = method.GetGenericArguments();
-            Type[] typeArguments = new Type[typeParameters.Length];
-            ParameterInfo[] parameters = method.GetParameters();
-
-            for (int argIndex = 0; argIndex < parameters.Length; argIndex++)
-            {
-                var pi = parameters[argIndex];
-                var arg = arglist[argIndex];
-
-                if (pi.ParameterType.IsGenericParameter)
-                {
-                    // If a null arg is provided, pass null as the Type
-                    // BestCommonType knows how to deal with this
-#if NETCF
-                    var typeArgIndex = Array.IndexOf(typeParameters, pi.ParameterType);
-#else
-                    var typeArgIndex = pi.ParameterType.GenericParameterPosition;
-#endif
-                    var argType = arg != null ? arg.GetType() : null;
-                    typeArguments[typeArgIndex] = TypeHelper.BestCommonType(typeArguments[typeArgIndex], argType);
-                }
-            }
-
-            return typeArguments;
         }
 
         private static bool MarkAsNotRunnable(TestMethod testMethod, string reason)

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -240,7 +240,6 @@ namespace NUnit.Framework.Internal.Execution
 
         private void SkipChildren(TestSuite suite, ResultState resultState, string message)
         {
-            // TODO: Extend this to skip recursively?
             foreach (Test child in suite.Tests)
             {
                 if (_childFilter.Pass(child))

--- a/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
@@ -1,0 +1,155 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// GenericMethodHelper is able to deduce the Type arguments for
+    /// a generic method from the actual arguments provided.
+    /// </summary>
+    public class GenericMethodHelper
+    {
+        /// <summary>
+        /// Construct a GenericMethodHelper for a method
+        /// </summary>
+        /// <param name="method">MethodInfo for the method to examine</param>
+        public GenericMethodHelper(MethodInfo method)
+        {
+            Guard.ArgumentValid(method.IsGenericMethod, "Specified method must be generic", "method");
+
+            Method = method;
+
+            TypeParms = Method.GetGenericArguments();
+            TypeArgs = new Type[TypeParms.Length];
+
+            var parms = Method.GetParameters();
+            ParmTypes = new Type[parms.Length];
+            for (int i = 0; i < parms.Length; i++)
+                ParmTypes[i] = parms[i].ParameterType;
+        }
+
+        private MethodInfo Method { get; set; }
+
+        private Type[] TypeParms { get; set; }
+        private Type[] TypeArgs { get; set; }
+
+        private Type[] ParmTypes { get; set; }
+
+        /// <summary>
+        /// Return the type argments for the method, deducing them
+        /// from the arguments actually provided.
+        /// </summary>
+        /// <param name="argList">The arguments to the method</param>
+        /// <returns>An array of type arguments.</returns>
+        public Type[] GetTypeArguments(object[] argList)
+        {
+            Guard.ArgumentValid(argList.Length == ParmTypes.Length, "Supplied arguments do not match required method parameters", "argList");
+
+            for (int argIndex = 0; argIndex < ParmTypes.Length; argIndex++)
+            {
+                var arg = argList[argIndex];
+
+                if (arg != null)
+                {
+                    Type argType = arg.GetType();
+                    TryApplyArgType(ParmTypes[argIndex], argType);
+                }
+            }
+
+            return TypeArgs;
+        }
+
+        private void TryApplyArgType(Type parmType, Type argType)
+        {
+            if (parmType.IsGenericParameter)
+            {
+                ApplyArgType(parmType, argType);
+            }
+            else if (parmType.ContainsGenericParameters)
+            {
+                var genericArgTypes = parmType.GetGenericArguments();
+
+                if (argType.HasElementType)
+                {
+                    ApplyArgType(genericArgTypes[0], argType.GetElementType());
+                }
+                else if (argType.IsGenericType && IsAssignableToGenericType(argType, parmType))
+                {
+                    Type[] argTypes = argType.GetGenericArguments();
+
+                    if (argTypes.Length == genericArgTypes.Length)
+                        for (int i = 0; i < genericArgTypes.Length; i++)
+                            TryApplyArgType(genericArgTypes[i], argTypes[i]);
+                }
+            }
+        }
+
+        private void ApplyArgType(Type parmType, Type argType)
+        {
+            // Note: parmType must be generic parameter type - checked by caller
+#if NETCF
+            var index = Array.IndexOf(TypeParms, parmType);
+#else
+            var index = parmType.GenericParameterPosition;
+#endif
+            TypeArgs[index] = TypeHelper.BestCommonType(TypeArgs[index], argType);
+        }
+
+        // Simulates IsAssignableTo generics
+        private bool IsAssignableToGenericType(Type givenType, Type genericType)
+        {
+            var interfaceTypes = givenType.GetInterfaces();
+
+            foreach (var iterator in interfaceTypes)
+            {
+                if (iterator.IsGenericType)
+                {
+                    // The Type returned by GetGenericTyeDefinition may have the
+                    // FullName set to null, so we do our own comparison
+                    Type gtd = iterator.GetGenericTypeDefinition();
+                    if (gtd.Name == genericType.Name && gtd.Namespace == genericType.Namespace)
+                        return true;
+                }
+            }
+
+            if (givenType.IsGenericType)
+            {
+                // The Type returned by GetGenericTyeDefinition may have the
+                // FullName set to null, so we do our own comparison
+                Type gtd = givenType.GetGenericTypeDefinition();
+                if (gtd.Name == genericType.Name && gtd.Namespace == genericType.Namespace)
+                    return true;
+            }
+
+            Type baseType = givenType.BaseType;
+            if (baseType == null)
+                return false;
+
+            return IsAssignableToGenericType(baseType, genericType);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2008 Charlie Poole
+// Copyright (c) 2008-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Internal\Execution\WorkItemState.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\RandomGenerator.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -354,6 +354,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Internal\Commands\TestCommand.cs" />
     <Compile Include="Internal\Commands\TestMethodCommand.cs" />
     <Compile Include="Internal\Commands\TheoryResultCommand.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\CultureDetector.cs" />
     <Compile Include="Internal\ExceptionHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -369,6 +369,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -352,6 +352,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -368,6 +368,7 @@
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\SimpleNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -104,7 +104,11 @@ namespace NUnit.Framework.Api
             Assert.That(result.Name.ToString(), Is.EqualTo("test-suite"));
             Assert.That(result.Attributes["type"], Is.EqualTo("Assembly"));
             Assert.That(result.Attributes["id"], Is.Not.Null.And.StartWith("ID"));
+#if SILVERLIGHT
+            Assert.That(result.Attributes["name"], Is.EqualTo("mock-nunit-assembly"));
+#else
             Assert.That(result.Attributes["name"], Is.EqualTo(EXPECTED_NAME).IgnoreCase);
+#endif
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");

--- a/src/NUnitFramework/tests/Internal/GenericMethodHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericMethodHelperTests.cs
@@ -1,0 +1,142 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if !NETCF // Doesn't work under CF - But also isn't needed because we construct a closed method
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
+{
+    public class GenericMethodHelperTests
+    {
+        static TestCaseData[] TypeArgData = new TestCaseData[] {
+            new TestCaseData("MethodWithOneTypeAndOneParameter", 
+                ArgList(42), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithOneTypeAndTwoParameters", 
+                ArgList(42, 99), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithOneTypeAndTwoParameters", 
+                ArgList(42.0, 99.0), 
+                TypeArgs<double>()),
+            new TestCaseData("MethodWithOneTypeAndTwoParameters", 
+                ArgList(42, 99.0), 
+                TypeArgs<double>()),
+            new TestCaseData("MethodWithOneTypeAndTwoParameters", 
+                ArgList(42.0, 99), 
+                TypeArgs<double>()),
+            new TestCaseData("MethodWithOneTypeAndThreeParameters", 
+                ArgList(42, -1, 7), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithTwoTypesAndTwoParameters", 
+                ArgList(42, "Answer"), 
+                TypeArgs<int,string>()),
+            new TestCaseData("MethodWithTwoTypesAndTwoParameters_Reversed", 
+                ArgList("Answer", 42), 
+                TypeArgs<int,string>()),
+            new TestCaseData("MethodWithTwoTypesAndThreeParameters", 
+                ArgList(42, "Answer", 42), 
+                TypeArgs<int,string>()),
+            new TestCaseData("MethodWithTwoTypesAndFourParameters", 
+                ArgList("Question", 1, "Answer", 42), 
+                TypeArgs<int,string>()),
+            new TestCaseData("MethodWithThreeTypes_Order123", 
+                ArgList(42, 42.0, "forty-two"), 
+                TypeArgs<int,double,string>()),
+            new TestCaseData("MethodWithThreeTypes_Order132", 
+                ArgList(42, "forty-two", 42.0), 
+                TypeArgs<int,double,string>()),
+            new TestCaseData("MethodWithThreeTypes_Order321", 
+                ArgList("forty-two", 42.0, 42), 
+                TypeArgs<int,double,string>()),
+            new TestCaseData("MethodWithThreeTypes_Order213", 
+                ArgList(42.0, 42, "forty-two"), 
+                TypeArgs<int,double,string>()),
+            new TestCaseData("MethodWithOneTypeAndOneParameter", 
+                ArgList(new int[] { 1, 2, 3 }), 
+                TypeArgs<int[]>()),
+            new TestCaseData("MethodWithGenericListOfType", 
+                ArgList(new List<int>()),
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithGenericListOfType", 
+                ArgList(new LinkedList<int>()),
+                new Type[] { null } ),
+            new TestCaseData("MethodWithGenericListOfLists", 
+                ArgList(new List<List<int>>()), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithGenericEnumerableOfType", 
+                ArgList(new List<int>(new int[] { 1, 2, 3 })), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithGenericEnumerableOfType", 
+                ArgList(new int[] { 1, 2, 3 }), 
+                TypeArgs<int>()),
+            new TestCaseData("MethodWithGenericEnumerableOfTypeAsSecondArg", 
+                ArgList("X", new int[] { } ), 
+                TypeArgs<string,int>()),
+            new TestCaseData("MethodTakingDictionary",                       
+                ArgList(new Dictionary<string, object>()), 
+                TypeArgs<string,object>()),
+            new TestCaseData("MethodWithNestedTypes",                        
+                ArgList(new List<Dictionary<string, int>>(), new Dictionary<int, List<string[]>>() ), 
+                TypeArgs<string,int,string[]>()) 
+        };
+
+        [TestCaseSource("TypeArgData")]
+        public void GetTypeArgumentsForMethodTests(string methodName, object[] args, Type[] typeArgs)
+        {
+            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(new GenericMethodHelper(method).GetTypeArguments(args), Is.EqualTo(typeArgs), MethodHelper.GetDisplayName(method, args));
+        }
+
+        private static object[] ArgList(params object[] args) { return args; }
+
+        private static Type[] TypeArgs<T>() { return new Type[] { typeof(T) }; }
+        private static Type[] TypeArgs<T1, T2>() { return new Type[] { typeof(T1), typeof(T2) }; }
+        private static Type[] TypeArgs<T1, T2, T3>() { return new Type[] { typeof(T1), typeof(T2), typeof(T3) }; }
+
+        void MethodWithOneTypeAndOneParameter<T>(T x) { }
+        void MethodWithOneTypeAndTwoParameters<T>(T x, T y) { }
+        void MethodWithOneTypeAndThreeParameters<T>(T x, T y, T z) { }
+
+        void MethodWithTwoTypesAndTwoParameters<T, U>(T x, U y) { }
+        void MethodWithTwoTypesAndTwoParameters_Reversed<T, U>(U x, T y) { }
+        void MethodWithTwoTypesAndThreeParameters<T, U>(T x, U y, T z) { }
+        void MethodWithTwoTypesAndFourParameters<T, U>(U q, T x, U y, T z) { }
+
+        void MethodWithThreeTypes_Order123<T, U, V>(T x, U y, V z) { }
+        void MethodWithThreeTypes_Order132<T, U, V>(T x, V y, U z) { }
+        void MethodWithThreeTypes_Order321<T, U, V>(V x, U y, T z) { }
+        void MethodWithThreeTypes_Order213<T, U, V>(U x, T y, V z) { }
+
+        void MethodWithGenericListOfType<T>(List<T> c) { }
+        void MethodWithGenericListOfLists<T>(List<List<T>> c) { }
+        void MethodWithGenericEnumerableOfType<T>(IEnumerable<T> c) { }
+        void MethodWithGenericEnumerableOfTypeAsSecondArg<T, U>(T x, IEnumerable<U> c) { }
+
+        void MethodTakingDictionary<T, U>(Dictionary<T, U> d) { }
+        void MethodWithNestedTypes<T, U, V>(List<Dictionary<T, U>> x, Dictionary<U, List<V>> z) { }
+    }
+}
+#endif
+

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -156,5 +156,14 @@ namespace NUnit.Framework.Internal
             new object[] { 5, 2.0, "ABC" },
             new object[] { 5.0, 2L, "ABC" }
         };
+
+        //[TestCaseSource("SequenceCases")]
+        //public void SequenceEquality<TSource>(IEnumerable<TSource> left, IEnumerable<TSource> right)
+        //{
+        //    Assert.That(left, Is.EqualTo(right));
+        //}
+
+        //static ITestCaseData[] SequenceCases = {
+        //    new TestCaseData(new List<int> { 1, 2 }, new List<int> { 1, 2 }) };
     }
 }

--- a/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
@@ -1,8 +1,48 @@
-﻿namespace NUnit.Framework.Internal
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
 {
     [TestFixture]
     public class TypeHelperTests
     {
+        #region BestCommonType
+
+        [TestCase(typeof(TypeHelper.NonmatchingTypeClass), typeof(object), ExpectedResult = typeof(TypeHelper.NonmatchingTypeClass))]
+        [TestCase(typeof(object), typeof(TypeHelper.NonmatchingTypeClass), ExpectedResult = typeof(TypeHelper.NonmatchingTypeClass))]
+        [TestCase(typeof(A), typeof(B), ExpectedResult = typeof(A))]
+        [TestCase(typeof(B), typeof(A), ExpectedResult = typeof(A))]
+        [TestCase(typeof(A), typeof(string), ExpectedResult = typeof(TypeHelper.NonmatchingTypeClass))]
+        [TestCase(typeof(int[]), typeof(IEnumerable<int>), ExpectedResult=typeof(IEnumerable<int>))]
+        public Type BestCommonTypeTest(Type type1, Type type2)
+        {
+            return TypeHelper.BestCommonType(type1, type2);
+        }
+
         public class A
         {
         }
@@ -11,13 +51,26 @@
         {
         }
 
-        public void BestCommonTypeTest()
+        #endregion
+
+        #region GetDisplayName
+
+        [TestCase(typeof(int), ExpectedResult = "Int32")]
+        [TestCase(typeof(TypeHelperTests), ExpectedResult = "TypeHelperTests")]
+        [TestCase(typeof(int[]), ExpectedResult = "Int32[]")]
+        [TestCase(typeof(List<int>), ExpectedResult="List<Int32>")]
+        [TestCase(typeof(IList<string>), ExpectedResult = "IList<String>")]
+        [TestCase(typeof(Dictionary<string, object>), ExpectedResult = "Dictionary<String,Object>")]
+#if !NETCF // No Open Generics in CF
+        [TestCase(typeof(List<>), ExpectedResult = "List<T>")]
+        [TestCase(typeof(IList<>), ExpectedResult = "IList<T>")]
+        [TestCase(typeof(Dictionary<,>), ExpectedResult = "Dictionary<TKey,TValue>")]
+#endif
+        public string GetDisplayNameTests(Type type)
         {
-            Assert.That( new TestCaseData( TypeHelper.NonmatchingType, typeof( object ) ), Is.EqualTo( TypeHelper.NonmatchingType ) );
-            Assert.That( new TestCaseData( typeof( object ), TypeHelper.NonmatchingType ), Is.EqualTo( TypeHelper.NonmatchingType ) );
-            Assert.That( new TestCaseData( typeof( A ), typeof( B ) ), Is.EqualTo( typeof( A ) ) );
-            Assert.That( new TestCaseData( typeof( B ), typeof( A ) ), Is.EqualTo( typeof( A ) ) );
-            Assert.That( new TestCaseData( typeof( A ), typeof( string ) ), Is.EqualTo( TypeHelper.NonmatchingType ) );
+            return TypeHelper.GetDisplayName(type);
         }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -78,9 +78,11 @@
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />
     <Compile Include="Assertions\ArrayEqualsFixture.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs" />
     <Compile Include="Internal\GenericTestMethodTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
@@ -212,6 +213,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />
     <Compile Include="Internal\UnhandledExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
@@ -217,6 +218,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />
     <Compile Include="Internal\UnhandledExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -219,6 +220,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />
     <Compile Include="Internal\UnhandledExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs" />
     <Compile Include="Internal\GenericTestMethodTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
@@ -256,6 +257,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />
     <Compile Include="Internal\UnhandledExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs" />
     <Compile Include="Internal\GenericTestMethodTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
@@ -253,6 +254,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />
     <Compile Include="Internal\UnhandledExceptionTests.cs" />


### PR DESCRIPTION
This is a complete rewrite of NUnit's logic for deducing a method's Type arguments from the actual arguments supplied. The existing logic turned out not to work at all for anything beyond simple arguments that are exact matches for the parameters. 

Originally, this was pretty much untested at the unit level. Now there are 23 test cases. In reviewing, please look closely to see if I've missed anything that should be tested.