### PR TITLE
Issue 47 - Extensions to Range Attribute

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -124,7 +124,7 @@ namespace NUnit.Framework
         #region Unsigned Longs
 
         /// <summary>
-        /// Construct a range of unsigned ints using default step of 1
+        /// Construct a range of unsigned longs using default step of 1
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
@@ -132,7 +132,7 @@ namespace NUnit.Framework
         public RangeAttribute(ulong from, ulong to) : this(from, to, 1ul) { }
 
         /// <summary>
-        /// Construct a range of unsigned ints specifying the step size 
+        /// Construct a range of unsigned longs specifying the step size 
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -32,6 +32,8 @@ namespace NUnit.Framework
     /// </summary>
     public class RangeAttribute : ValuesAttribute
     {
+        #region Ints
+
         /// <summary>
         /// Construct a range of ints using default step of 1
         /// </summary>
@@ -57,6 +59,17 @@ namespace NUnit.Framework
                 this.data[index++] = val;
         }
 
+        #endregion
+
+        #region Longs
+
+        /// <summary>
+        /// Construct a range of longs using a default step of 1
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public RangeAttribute(long from, long to) : this(from, to, from > to ? -1L : 1L) { }
+
         /// <summary>
         /// Construct a range of longs
         /// </summary>
@@ -75,6 +88,10 @@ namespace NUnit.Framework
                 this.data[index++] = val;
         }
 
+        #endregion
+
+        #region Doubles
+
         /// <summary>
         /// Construct a range of doubles
         /// </summary>
@@ -86,13 +103,18 @@ namespace NUnit.Framework
             Guard.ArgumentValid(step > 0.0D && to >= from || step < 0.0D && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", "step");
 
-            double tol = step / 1000;
-            int count = (int)((to - from) / step + tol + 1);
+            double aStep = Math.Abs(step);
+            double tol = aStep / 1000;
+            int count = (int)(Math.Abs(to - from) / aStep + tol + 1);
             this.data = new object[count];
             int index = 0;
             for (double val = from; index < count; val += step)
                 this.data[index++] = val;
         }
+
+        #endregion
+
+        #region Floats
 
         /// <summary>
         /// Construct a range of floats
@@ -105,12 +127,15 @@ namespace NUnit.Framework
             Guard.ArgumentValid(step > 0.0F && to >= from || step < 0.0F && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", "step");
 
-            float tol = step / 1000;
-            int count = (int)((to - from) / step + tol + 1);
+            float aStep = Math.Abs(step);
+            float tol = aStep / 1000;
+            int count = (int)(Math.Abs(to - from) / aStep + tol + 1);
             this.data = new object[count];
             int index = 0;
             for (float val = from; index < count; val += step)
                 this.data[index++] = val;
         }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -61,6 +61,37 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region Unsigned Ints
+
+        /// <summary>
+        /// Construct a range of unsigned ints using default step of 1
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        [CLSCompliant(false)]
+        public RangeAttribute(uint from, uint to) : this(from, to, 1u) { }
+
+        /// <summary>
+        /// Construct a range of unsigned ints specifying the step size 
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="step"></param>
+        [CLSCompliant(false)]
+        public RangeAttribute(uint from, uint to, uint step)
+        {
+            Guard.ArgumentValid(step > 0, "Step must be greater than zero", "step");
+            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", "to");
+
+            uint count = (to - from) / step + 1;
+            this.data = new object[count];
+            uint index = 0;
+            for (uint val = from; index < count; val += step)
+                this.data[index++] = val;
+        }
+
+        #endregion
+
         #region Longs
 
         /// <summary>
@@ -85,6 +116,37 @@ namespace NUnit.Framework
             this.data = new object[count];
             int index = 0;
             for (long val = from; index < count; val += step)
+                this.data[index++] = val;
+        }
+
+        #endregion
+
+        #region Unsigned Longs
+
+        /// <summary>
+        /// Construct a range of unsigned ints using default step of 1
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        [CLSCompliant(false)]
+        public RangeAttribute(ulong from, ulong to) : this(from, to, 1ul) { }
+
+        /// <summary>
+        /// Construct a range of unsigned ints specifying the step size 
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="step"></param>
+        [CLSCompliant(false)]
+        public RangeAttribute(ulong from, ulong to, ulong step)
+        {
+            Guard.ArgumentValid(step > 0, "Step must be greater than zero", "step");
+            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", "to");
+
+            ulong count = (to - from) / step + 1;
+            this.data = new object[count];
+            ulong index = 0;
+            for (ulong val = from; index < count; val += step)
                 this.data[index++] = val;
         }
 

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -96,6 +96,58 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
+        #region Unsigned Ints
+
+        [Test]
+        public void UintRange()
+        {
+            CheckValues("MethodWithUintRange", 11u, 12u, 13u, 14u, 15u);
+        }
+
+        private void MethodWithUintRange([Range(11u, 15u)] uint x) { }
+
+        [Test]
+        public void UintRange_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRange_Reversed", 15u, 14u, 13u, 12u, 11u));
+        }
+
+        private void MethodWithUintRange_Reversed([Range(15u, 11u)] uint x) { }
+
+        [Test]
+        public void UintRange_FromEqualsTo()
+        {
+            CheckValues("MethodWithUintRange_FromEqualsTo", 11u);
+        }
+
+        private void MethodWithUintRange_FromEqualsTo([Range(11u, 11u)] uint x) { }
+
+        [Test]
+        public void UintRangeAndStep()
+        {
+            CheckValues("MethodWithUintRangeAndStep", 11u, 13u, 15u);
+        }
+
+        private void MethodWithUintRangeAndStep([Range(11u, 15u, 2u)] uint x) { }
+
+        [Test]
+        public void UintRangeAndZeroStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRangeAndZeroStep", 11u, 12u, 13u));
+        }
+
+        private void MethodWithUintRangeAndZeroStep([Range(11u, 15u, 0u)] uint x) { }
+
+        [Test]
+        public void UintRangeAndStep_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRangeAndStep_Reversed", 11u, 13u, 15u));
+        }
+
+        private void MethodWithUintRangeAndStep_Reversed([Range(15u, 11u, 2u)] uint x) { }
+
+        #endregion
+
         #region Longs
 
         [Test]
@@ -161,6 +213,58 @@ namespace NUnit.Framework.Attributes
         }
 
         private void MethodWithLongRangeAndNegativeStep_Reversed([Range(15L, 11L, -2L)] long x) { }
+
+        #endregion
+
+        #region Unsigned Longs
+
+        [Test]
+        public void UlongRange()
+        {
+            CheckValues("MethodWithUlongRange", 11ul, 12ul, 13ul, 14ul, 15ul);
+        }
+
+        private void MethodWithUlongRange([Range(11ul, 15ul)] ulong x) { }
+
+        [Test]
+        public void UlongRange_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRange_Reversed", 15ul, 14ul, 13ul, 12ul, 11ul));
+        }
+
+        private void MethodWithUlongRange_Reversed([Range(15ul, 11ul)] ulong x) { }
+
+        [Test]
+        public void UlongRange_FromEqualsTo()
+        {
+            CheckValues("MethodWithUlongRange_FromEqualsTo", 11ul);
+        }
+
+        private void MethodWithUlongRange_FromEqualsTo([Range(11ul, 11ul)] ulong x) { }
+
+        [Test]
+        public void UlongRangeAndStep()
+        {
+            CheckValues("MethodWithUlongRangeAndStep", 11ul, 13ul, 15ul);
+        }
+
+        private void MethodWithUlongRangeAndStep([Range(11ul, 15ul, 2ul)] ulong x) { }
+
+        [Test]
+        public void UlongRangeAndZeroStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRangeAndZeroStep", 11ul, 12ul, 13ul));
+        }
+
+        private void MethodWithUlongRangeAndZeroStep([Range(11ul, 15ul, 0ul)] ulong x) { }
+
+        [Test]
+        public void UlongRangeAndStep_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRangeAndStep_Reversed", 11ul, 13ul, 15ul));
+        }
+
+        private void MethodWithUlongRangeAndStep_Reversed([Range(15ul, 11ul, 2ul)] ulong x) { }
 
         #endregion
 

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -28,6 +28,8 @@ namespace NUnit.Framework.Attributes
 {
     public class RangeAttributeTests
     {
+        #region Ints
+
         [Test]
         public void IntRange()
         {
@@ -92,6 +94,34 @@ namespace NUnit.Framework.Attributes
 
         private void MethodWithIntRangeAndNegativeStep_Reversed([Range(15, 11, -2)] int x) { }
 
+        #endregion
+
+        #region Longs
+
+        [Test]
+        public void LongRange()
+        {
+            CheckValues("MethodWithLongRange", 11L, 12L, 13L, 14L, 15L);
+        }
+
+        private void MethodWithLongRange([Range(11L, 15L)] long x) { }
+
+        [Test]
+        public void LongRange_Reversed()
+        {
+            CheckValues("MethodWithLongRange_Reversed", 15L, 14L, 13L, 12L, 11L);
+        }
+
+        private void MethodWithLongRange_Reversed([Range(15L, 11L)] long x) { }
+
+        [Test]
+        public void LongRange_FromEqualsTo()
+        {
+            CheckValues("MethodWithLongRange_FromEqualsTo", 11L);
+        }
+
+        private void MethodWithLongRange_FromEqualsTo([Range(11L, 11L)] long x) { }
+
         [Test]
         public void LongRangeAndStep()
         {
@@ -99,6 +129,42 @@ namespace NUnit.Framework.Attributes
         }
 
         private void MethodWithLongRangeAndStep([Range(11L, 15L, 2)] long x) { }
+
+        [Test]
+        public void LongRangeAndZeroStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndZeroStep", 11L, 12L, 13L));
+        }
+
+        private void MethodWithLongRangeAndZeroStep([Range(11L, 15L, 0L)] long x) { }
+
+        [Test]
+        public void LongRangeAndStep_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndStep_Reversed", 11L, 13L, 15L));
+        }
+
+        private void MethodWithLongRangeAndStep_Reversed([Range(15L, 11L, 2L)] long x) { }
+
+        [Test]
+        public void LongRangeAndNegativeStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndNegativeStep", 11L, 13L, 15L));
+        }
+
+        private void MethodWithLongRangeAndNegativeStep([Range(11L, 15L, -2L)] long x) { }
+
+        [Test]
+        public void LongRangeAndNegativeStep_Reversed()
+        {
+            CheckValues("MethodWithLongRangeAndNegativeStep_Reversed", 15L, 13L, 11L);
+        }
+
+        private void MethodWithLongRangeAndNegativeStep_Reversed([Range(15L, 11L, -2L)] long x) { }
+
+        #endregion
+
+        #region Doubles
 
         [Test]
         public void DoubleRangeAndStep()
@@ -109,12 +175,84 @@ namespace NUnit.Framework.Attributes
         private void MethodWithDoubleRangeAndStep([Range(0.7, 1.2, 0.2)] double x) { }
 
         [Test]
+        public void DoubleRangeAndZeroStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndZeroStep", 0.7, 0.9, 1.1));
+        }
+
+        private void MethodWithDoubleRangeAndZeroStep([Range(0.7, 1.2, 0.0)] double x) { }
+
+        [Test]
+        public void DoubleRangeAndStep_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndStep_Reversed", 0.7, 0.9, 1.1));
+        }
+
+        private void MethodWithDoubleRangeAndStep_Reversed([Range(1.2, 0.7, 0.2)] double x) { }
+
+        [Test]
+        public void DoubleRangeAndNegativeStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndNegativeStep", 0.7, 0.9, 1.1));
+        }
+
+        private void MethodWithDoubleRangeAndNegativeStep([Range(0.7, 1.2, -0.2)] double x) { }
+
+        [Test]
+        public void DoubleRangeAndNegativeStep_Reversed()
+        {
+            CheckValuesWithinTolerance("MethodWithDoubleRangeAndNegativeStep_Reversed", 1.2, 1.0, 0.8);
+        }
+
+        private void MethodWithDoubleRangeAndNegativeStep_Reversed([Range(1.2, 0.7, -0.2)] double x) { }
+
+        #endregion
+
+        #region Floats
+
+        [Test]
         public void FloatRangeAndStep()
         {
             CheckValuesWithinTolerance("MethodWithFloatRangeAndStep", 0.7f, 0.9f, 1.1f);
         }
 
         private void MethodWithFloatRangeAndStep([Range(0.7f, 1.2f, 0.2f)] float x) { }
+
+        [Test]
+        public void FloatRangeAndZeroStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndZeroStep", 0.7f, 0.9f, 1.1f));
+        }
+
+        private void MethodWithFloatRangeAndZeroStep([Range(0.7f, 1.2f, 0.0f)] float x) { }
+
+        [Test]
+        public void FloatRangeAndStep_Reversed()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndStep_Reversed", 0.7f, 0.9f, 1.1f));
+        }
+
+        private void MethodWithFloatRangeAndStep_Reversed([Range(1.2f, 0.7, 0.2f)] float x) { }
+
+        [Test]
+        public void FloatRangeAndNegativeStep()
+        {
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndNegativeStep", 0.7f, 0.9f, 1.1f));
+        }
+
+        private void MethodWithFloatRangeAndNegativeStep([Range(0.7f, 1.2f, -0.2f)] float x) { }
+
+        [Test]
+        public void FloatRangeAndNegativeStep_Reversed()
+        {
+            CheckValuesWithinTolerance("MethodWithFloatRangeAndNegativeStep_Reversed", 1.2f, 1.0f, 0.8f);
+        }
+
+        private void MethodWithFloatRangeAndNegativeStep_Reversed([Range(1.2f, 0.7, -0.2f)] float x) { }
+
+        #endregion
+
+        #region Conversions
 
         [Test]
         public void CanConvertIntRangeToShort([Range(1, 3)] short x) { }
@@ -131,7 +269,10 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertDoubleRangeToDecimal([Range(1.0, 1.3, 0.1)] decimal x) { }
 
+        #endregion
+
         #region Helper Methods
+        
         private void CheckValues(string methodName, params object[] expected)
         {
             MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
@@ -147,6 +288,7 @@ namespace NUnit.Framework.Attributes
             ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
             Assert.That(attr.GetData(param), Is.EqualTo(expected).Within(0.000001));
         }
+        
         #endregion
     }
 }

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Attributes\PairwiseTests.cs" />
     <Compile Include="Attributes\ParameterizedTestFixtureTests.cs" />
     <Compile Include="Attributes\PropertyAttributeTests.cs" />
+    <Compile Include="Attributes\RangeAttributeTests.cs" />
     <Compile Include="Attributes\RepeatedTestTests.cs" />
     <Compile Include="Attributes\RequiresThreadAttributeTests.cs" />
     <Compile Include="Attributes\SetCultureAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Attributes\PairwiseTests.cs" />
     <Compile Include="Attributes\ParameterizedTestFixtureTests.cs" />
     <Compile Include="Attributes\PropertyAttributeTests.cs" />
+    <Compile Include="Attributes\RangeAttributeTests.cs" />
     <Compile Include="Attributes\RepeatedTestTests.cs" />
     <Compile Include="Attributes\RequiresThreadAttributeTests.cs" />
     <Compile Include="Attributes\SetCultureAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Attributes\PairwiseTests.cs" />
     <Compile Include="Attributes\ParameterizedTestFixtureTests.cs" />
     <Compile Include="Attributes\PropertyAttributeTests.cs" />
+    <Compile Include="Attributes\RangeAttributeTests.cs" />
     <Compile Include="Attributes\RepeatedTestTests.cs" />
     <Compile Include="Attributes\RequiresThreadAttributeTests.cs" />
     <Compile Include="Attributes\SetCultureAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable-sl-5.0.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Attributes\PairwiseTests.cs" />
     <Compile Include="Attributes\ParameterizedTestFixtureTests.cs" />
     <Compile Include="Attributes\PropertyAttributeTests.cs" />
+    <Compile Include="Attributes\RangeAttributeTests.cs" />
     <Compile Include="Attributes\RepeatedTestTests.cs" />
     <Compile Include="Attributes\RequiresThreadAttributeTests.cs" />
     <Compile Include="Attributes\SetCultureAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Attributes\PairwiseTests.cs" />
     <Compile Include="Attributes\ParameterizedTestFixtureTests.cs" />
     <Compile Include="Attributes\PropertyAttributeTests.cs" />
+    <Compile Include="Attributes\RangeAttributeTests.cs" />
     <Compile Include="Attributes\RepeatedTestTests.cs" />
     <Compile Include="Attributes\RequiresThreadAttributeTests.cs" />
     <Compile Include="Attributes\SetCultureAttributeTests.cs" />


### PR DESCRIPTION
This implements some of the extensions requested in #47. Specifically, we now have a constructor without Step specified for long values, and new constructors for unsigned int and long.

Some other requested extensions are not being implemented...

Range of DateTime values cannot be done because of limitations in C# Attribute constructors.

Selection of a Range of values from a TestCaseSource is essentially a different meaning of Range and would not be done as part of the same change even if we intended to do it.

Extensions to RandomAttribute, requested originally in the same issue are being handled separately so this PR fixes #47.