### PR TITLE
Issue 718 - Error in RangeConstraint when mixing types

### DIFF
--- a/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
         {
             // Issue #21 - https://github.com/nunit/nunit-framework/issues/21
             // from must be less than or equal to to
-            if ( from.CompareTo( to ) > 0 )
+            if (comparer.Compare(from, to) > 0)
                 throw new ArgumentException( "from must be less than to" );
 
             this.from = from;

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -359,19 +359,45 @@ namespace NUnit.Framework.Attributes
         #region Conversions
 
         [Test]
-        public void CanConvertIntRangeToShort([Range(1, 3)] short x) { }
+        public void CanConvertIntRangeToShort()
+        {
+            CheckValues("MethodWithIntRangeAndShortArgument", (short)1, (short)2, (short)3);
+        }
+
+        private void MethodWithIntRangeAndShortArgument([Range(1, 3)] short x) { }
 
         [Test]
-        public void CanConvertIntRangeToByte([Range(1, 3)] byte x) { }
+        public void CanConvertIntRangeToByte() 
+        {
+            CheckValues("MethodWithIntRangeAndByteArgument", (byte)1, (byte)2, (byte)3);
+        }
+        
+        private void MethodWithIntRangeAndByteArgument([Range(1, 3)] byte x) { }
 
         [Test]
-        public void CanConvertIntRangeToSByte([Range(1, 3)] sbyte x) { }
+        public void CanConvertIntRangeToSByte() 
+        {
+            CheckValues("MethodWithIntRangeAndSByteArgument", (sbyte)1, (sbyte)2, (sbyte)3);
+        }
+        
+        private void MethodWithIntRangeAndSByteArgument([Range(1, 3)] sbyte x) { }
 
         [Test]
-        public void CanConvertIntRangeToDecimal([Range(1, 3)] decimal x) { }
+        public void CanConvertIntRangeToDecimal()
+        {
+            CheckValues("MethodWithIntRangeAndDecimalArgument", 1M, 2M, 3M);
+        }
+        
+        private void MethodWithIntRangeAndDecimalArgument([Range(1, 3)] decimal x) { }
 
         [Test]
-        public void CanConvertDoubleRangeToDecimal([Range(1.0, 1.3, 0.1)] decimal x) { }
+        public void CanConvertDoubleRangeToDecimal() 
+        {
+            CheckValues("MethodWithDoubleRangeAndDecimalArgument", 1.0M, 1.1M, 1.2M);
+        }
+
+        // Use max of 1.21 rather than 1.3 so rounding won't give an extra value
+        private void MethodWithDoubleRangeAndDecimalArgument([Range(1.0, 1.21, 0.1)] decimal x) { }
 
         #endregion
 

--- a/src/NUnitFramework/tests/Constraints/RangeTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeTests.cs
@@ -92,5 +92,15 @@ namespace NUnit.Framework.Constraints
         {
             Assert.That( actual, Is.InRange(from, to) );
         }
+
+        [TestCase(5, (short)10, (short)7)]
+        [TestCase((short)5, 10, (short)7)]
+        [TestCase(5, 10.0, 7)]
+        [TestCase(5.0, 10, 7.0)]
+        public void MixedRangeTests<TMin, TMax, TVal>(TMin min, TMax max, TVal val) 
+            where TMin : IComparable where TMax : IComparable where TVal : IComparable
+        {
+            Assert.That(val, Is.InRange(min, max));
+        }
     }
 }


### PR DESCRIPTION
As explained on issue #718, I treated this as high priority because of I had just lost several hours trying to figure out what was wrong with my tests. Others might run into the same thing and it was an easy fix.

I included an unrelated commit to RangeTests as well - it's a test-only change that didn't make it into my last commit for RangeAttribute.