### PR TITLE
Removed the Microsoft.BCL.Async dependency from the NuGet Packages

### DIFF
--- a/nuget/nunit.nuspec
+++ b/nuget/nunit.nuspec
@@ -16,13 +16,6 @@
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory plugin addin</tags>
     <copyright>Copyright (c) 2015 Charlie Poole</copyright>
-    <dependencies>
-      <group targetFramework="net40">
-        <dependency id="Microsoft.Bcl.Async" version="1.0.165" />
-      </group>
-      <!-- This is required otherwise 4.5 will pull in the 4.0 dependencies -->
-      <group targetFramework="net45" />
-    </dependencies>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/nunitlite.nuspec
+++ b/nuget/nunitlite.nuspec
@@ -20,12 +20,6 @@
       <group>
         <dependency id="NUnit" version="[$version$]" />
       </group>
-
-      <group targetFramework="net40">
-        <dependency id="Microsoft.Bcl.Async" version="1.0.165" />
-      </group>
-      <!-- This is required otherwise 4.5 will pull in the 4.0 dependencies -->
-      <group targetFramework="net45" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Fixes #723 

The BCL.Async is not required for the 4.0 framework, so I removed it from the NuGet packages. If users want to create 4.0 tests that use async features will need to include it themselves.

It is currently not included in our installers, so no changes there. It is included in our Zip files. I left it there because it is required to run our tests that we distribute in the zip.