### PR TITLE
Display help if no args entered. Fixes #734

### DIFF
--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -86,7 +86,7 @@ namespace NUnit.ConsoleRunner
                 if (!Options.NoHeader)
                     WriteHeader();
 
-                if (Options.ShowHelp)
+                if (Options.ShowHelp || args.Length == 0)
                 {
                     WriteHelpText();
                     return ConsoleRunner.OK;


### PR DESCRIPTION
When no args entered, help is displayed. If options are entered but no input files, the old behavior is followed.