### PR TITLE
Don't run explicit tests when categories are only excluded. Fixes #741

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -32,35 +32,19 @@ namespace NUnit.Framework.Internal.Filters
     [Serializable]
     public class NotFilter : TestFilter
     {
-        ITestFilter baseFilter;
-        bool topLevel = false;
-
         /// <summary>
         /// Construct a not filter on another filter
         /// </summary>
         /// <param name="baseFilter">The filter to be negated</param>
         public NotFilter( ITestFilter baseFilter)
         {
-            this.baseFilter = baseFilter;
-        }
-
-        /// <summary>
-        /// Indicates whether this is a top-level NotFilter,
-        /// requiring special handling of Explicit
-        /// </summary>
-        public bool TopLevel
-        {
-            get { return topLevel; }
-            set { topLevel = value; }
+            BaseFilter = baseFilter;
         }
 
         /// <summary>
         /// Gets the base filter
         /// </summary>
-        public ITestFilter BaseFilter
-        {
-            get { return baseFilter; }
-        }
+        public ITestFilter BaseFilter { get; private set; }
 
         /// <summary>
         /// Check whether the filter matches a test
@@ -69,10 +53,10 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if it matches, otherwise false</returns>
         public override bool Match( ITest test )
         {
-            if (topLevel && test.RunState == RunState.Explicit)
+            if (TopLevel && test.RunState == RunState.Explicit)
                 return false;
 
-            return !baseFilter.Pass( test );
+            return !BaseFilter.Pass( test );
         }
 
         /// <summary>
@@ -82,7 +66,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if at least one descendant matches the filter criteria</returns>
         protected override bool MatchDescendant(ITest test)
         {
-            if (!test.HasChildren || test.Tests == null || topLevel && test.RunState == RunState.Explicit)
+            if (!test.HasChildren || test.Tests == null || TopLevel && test.RunState == RunState.Explicit)
                 return false;
 
             foreach (ITest child in test.Tests)

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -50,6 +50,12 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Indicates whether this is a top-level filter,
+        /// not contained in any other filter.
+        /// </summary>
+        public bool TopLevel { get; set; }
+
+        /// <summary>
         /// Determine if a particular test passes the filter criteria. The default 
         /// implementation checks the test itself, its parents and any descendants.
         /// 
@@ -111,24 +117,21 @@ namespace NUnit.Framework.Internal
         public static TestFilter FromXml(string xmlText)
         {
             TNode topNode = TNode.FromXml(xmlText);
-            //XmlDocument doc = new System.Xml.XmlDocument();
-            //doc.LoadXml(xmlText);
-            //XmlNode topNode = doc.FirstChild;
 
             if (topNode.Name != "filter")
                 throw new Exception("Expected filter element at top level");
 
-            switch (topNode.ChildNodes.Count)
-            {
-                case 0:
-                    return TestFilter.Empty;
+            int count = topNode.ChildNodes.Count;
 
-                case 1:
-                    return FromXml(topNode.FirstChild);
+            TestFilter filter = count == 0
+                ? TestFilter.Empty
+                : count == 1
+                    ? FromXml(topNode.FirstChild)
+                    : FromXml(topNode);
 
-                default:
-                    return FromXml(topNode);
-            }
+            filter.TopLevel = true;
+
+            return filter;
         }
 
         private static TestFilter FromXml(TNode node)

--- a/src/NUnitFramework/tests/Internal/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFilterTests.cs
@@ -226,6 +226,7 @@ namespace NUnit.Framework.Internal
 
             Assert.False(filter.IsEmpty);
             Assert.That(filter.Match(dummyFixture));
+            Assert.False(filter.Match(dummyFixture.Tests[0]));
             Assert.That(filter.Match(anotherFixture));
             Assert.False(filter.Match(yetAnotherFixture));
         }
@@ -269,6 +270,9 @@ namespace NUnit.Framework.Internal
         [Category("Dummy")]
         private class DummyFixture
         {
+            [Test, Explicit]
+            public void ExplicitTest() { }
+
         }
 
         [Category("Another")]
@@ -291,6 +295,19 @@ namespace NUnit.Framework.Internal
 
             Assert.False(filter.IsEmpty);
             Assert.False(filter.Match(dummyFixture));
+            Assert.True(filter.Match(dummyFixture.Tests[0]));
+            Assert.True(filter.Match(anotherFixture));
+        }
+
+        [Test]
+        public void NotFilter_Constructor_TopLevel()
+        {
+            var filter = new NotFilter(new CategoryFilter("Dummy"));
+            filter.TopLevel = true;
+
+            Assert.False(filter.IsEmpty);
+            Assert.False(filter.Match(dummyFixture));
+            Assert.False(filter.Match(dummyFixture.Tests[0]));
             Assert.True(filter.Match(anotherFixture));
         }
 
@@ -301,6 +318,7 @@ namespace NUnit.Framework.Internal
                 "<filter><not><cat>Dummy</cat></not></filter>");
 
             Assert.That(filter, Is.TypeOf<NotFilter>());
+            Assert.That(filter, Has.Property("TopLevel").EqualTo(true));
             Assert.False(filter.Match(dummyFixture));
             Assert.True(filter.Match(anotherFixture));
         }


### PR DESCRIPTION
Sets the TopLevel property on the topmost filter to true. This causes NotFilter to work as it should.