### PR TITLE
Send TestFinished event for child tests skipped because of the fixtur…

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -248,6 +248,10 @@ namespace NUnit.Framework.Internal.Execution
                     childResult.SetResult(resultState, message);
                     Result.AddResult(childResult);
 
+                    // Some runners may depend on getting the TestFinished event
+                    // even for tests that have been skipped at a higher level.
+                    Context.Listener.TestFinished(childResult);
+
                     if (child.IsSuite)
                         SkipChildren((TestSuite)child, resultState, message);
                 }


### PR DESCRIPTION
…e's runstate or an error in OneTimeSetUp

This fixes #746. It has been tested using the VS adapter with the temporary fix of PR #44 removed.