### PR TITLE
Return error code if any assembly is not found or invalid. Fixes #685

### DIFF
--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -41,7 +41,7 @@ namespace NUnit.ConsoleRunner
 
         public static readonly int OK = 0;
         public static readonly int INVALID_ARG = -1;
-        public static readonly int FILE_NOT_FOUND = -2;
+        public static readonly int INVALID_ASSEMBLY = -2;
         public static readonly int FIXTURE_NOT_FOUND = -3;
         public static readonly int UNEXPECTED_ERROR = -100;
 
@@ -175,7 +175,10 @@ namespace NUnit.ConsoleRunner
                 _outWriter.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
             }
 
-            return reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;
+            return reporter.Summary.InvalidAssemblies > 0
+                    ? ConsoleRunner.INVALID_ASSEMBLY
+                    : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;
+
         }
 
         private void WriteRuntimeEnvironment(ExtendedTextWriter OutWriter)

--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -130,12 +130,12 @@ namespace NUnit.ConsoleRunner
                     catch (FileNotFoundException ex)
                     {
                         OutWriter.WriteLine(ColorStyle.Error, ex.Message);
-                        return ConsoleRunner.FILE_NOT_FOUND;
+                        return ConsoleRunner.INVALID_ASSEMBLY;
                     }
                     catch (DirectoryNotFoundException ex)
                     {
                         OutWriter.WriteLine(ColorStyle.Error, ex.Message);
-                        return ConsoleRunner.FILE_NOT_FOUND;
+                        return ConsoleRunner.INVALID_ASSEMBLY;
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
I changed FILE_NOT_FOUND to INVALID_ASSEMBLY (-2). The value is now returned if __any__ assembly could not be found or could not be loaded. This change is solely in the console runner, not the engine, since we want the gui to be able to display the results for any assemblies that are found in addition to marking those not found as invalid.