### PR TITLE
Use mono prefix for nuget.exe and exit if it fails. Fixes #778.

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,5 @@
 #!/bin/bash
-./tools/nuget.exe restore nunit.sln
+mono ./tools/nuget.exe restore nunit.linux.sln
+if [ "$?" -ne 0 ]; then echo "NuGet restore failed."; exit 1; fi
+
 xbuild "$@"

--- a/build.cmd
+++ b/build.cmd
@@ -2,6 +2,10 @@
 setlocal
 for %%a in (%*) do echo "%%a" | findstr /C:"mono">nul && set buildtool=xbuild.bat
 if not defined buildtool for /f %%i in ('dir /b /ad /on "%windir%\Microsoft.NET\Framework\v*"') do @if exist "%windir%\Microsoft.NET\Framework\%%i\msbuild".exe set buildtool=%windir%\Microsoft.NET\Framework\%%i\msbuild.exe
+
 if not defined buildtool (echo no MSBuild.exe or xbuild was found>&2 & exit /b 42)
+
 call "tools/nuget.exe" restore nunit.sln
+if %errorlevel% 1 (echo NuGet restore failed.>&2 & exit /b %errorlevel%)
+
 if defined buildtool "%buildtool%" %*


### PR DESCRIPTION
It turns out that nuget.exe is a managed executable and requires the mono prefix in some environments. In addition, this exits in case nuget fails.

Ideally, the nuget restore should not be in the build command scripts, which are only intended to find the correct version of msbuild or xbuild in the environment. However, it would take a bit more work to add it to the NUnti.proj file as a target and make sure all dependent targets include it as a dependency. We can make that change at a later time if someone wants to work on it. 

Note that nuget.exe will fail if the root certificates are not set up correctly. You can use 
   mozroots --import --sync
to make sure the build machine is set up correctly.

Although this is simple enough, let's follow our own rules and get an @nunit/core-team review before merging.