### PR TITLE
make package target work on Linux. Fixes #760

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -558,7 +558,7 @@
   <ItemGroup Label ="Targets for Packaging">
     <AllPackages Include="PackageSource" />
       <AllPackages Include="PackageBinaries" />
-      <AllPackages Include="PackageNuGet" />
+      <AllPackages Include="PackageNuGet" Condition="$(IsWindows)" />
       <AllPackages Include="PackageAllMsis" Condition="$(IsWindows)" />
   </ItemGroup>
 

--- a/nuget/nunit.console.nuspec
+++ b/nuget/nunit.console.nuspec
@@ -21,24 +21,24 @@
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="bin\nunit-agent.exe" target="tools" />
-    <file src="bin\nunit-agent.exe.config" target="tools" />
-    <file src="bin\nunit-agent-x86.exe" target="tools" />
-    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
-    <file src="bin\nunit-console.exe" target="tools" />
-    <file src="bin\nunit-console.exe.config" target="tools" />
-    <file src="bin\nunit.engine.api.dll" target="tools" />
-    <file src="bin\nunit.engine.api.xml" target="tools" />
-    <file src="bin\nunit.engine.dll" target="tools" />
-    <file src="bin\nunit.engine.addins" target="tools" />
-    <file src="bin\nunit.engine.addin.xml" target="tools" />
-    <file src="bin\Mono.Addins.dll" target="tools" />
-    <file src="bin\addins\nunit.v2.driver.dll" target="tools\addins" />
-    <file src="bin\addins\nunit.engine.api.dll" target="tools\addins" />
-    <file src="bin\addins\nunit.core.dll" target="tools\addins" />
-    <file src="bin\addins\nunit.core.interfaces.dll" target="tools\addins" />
-    <file src="bin\addins\nunit-v2-result-writer.dll" target="tools\addins" />
-    <file src="bin\addins\nunit-project-loader.dll" target="tools\addins" />
-    <file src="bin\addins\vs-project-loader.dll" target="tools\addins" />
+    <file src="bin/nunit-agent.exe" target="tools" />
+    <file src="bin/nunit-agent.exe.config" target="tools" />
+    <file src="bin/nunit-agent-x86.exe" target="tools" />
+    <file src="bin/nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin/nunit-console.exe" target="tools" />
+    <file src="bin/nunit-console.exe.config" target="tools" />
+    <file src="bin/nunit.engine.api.dll" target="tools" />
+    <file src="bin/nunit.engine.api.xml" target="tools" />
+    <file src="bin/nunit.engine.dll" target="tools" />
+    <file src="bin/nunit.engine.addins" target="tools" />
+    <file src="bin/nunit.engine.addin.xml" target="tools" />
+    <file src="bin/Mono.Addins.dll" target="tools" />
+    <file src="bin/addins/nunit.v2.driver.dll" target="tools/addins" />
+    <file src="bin/addins/nunit.engine.api.dll" target="tools/addins" />
+    <file src="bin/addins/nunit.core.dll" target="tools/addins" />
+    <file src="bin/addins/nunit.core.interfaces.dll" target="tools/addins" />
+    <file src="bin/addins/nunit-v2-result-writer.dll" target="tools/addins" />
+    <file src="bin/addins/nunit-project-loader.dll" target="tools/addins" />
+    <file src="bin/addins/vs-project-loader.dll" target="tools/addins" />
   </files>
 </package>

--- a/nuget/nunit.core.engine.nuspec
+++ b/nuget/nunit.core.engine.nuspec
@@ -21,6 +21,6 @@
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="bin\nunit.core.engine.dll" target="lib" />
+    <file src="bin/nunit.core.engine.dll" target="lib" />
   </files>
 </package>

--- a/nuget/nunitlite.nuspec
+++ b/nuget/nunitlite.nuspec
@@ -26,12 +26,12 @@
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="bin\net-2.0\nunitlite.dll" target="lib\net20" />
-    <file src="bin\net-4.0\nunitlite.dll" target="lib\net40" />
-    <file src="bin\net-4.5\nunitlite.dll" target="lib\net45" />
-    <file src="bin\sl-5.0\nunitlite.dll" target="lib\sl5" />
-    <file src="..\..\nuget\Program.cs" target="content" />
-    <file src="..\..\nuget\Program.vb" target="content" />
-    <file src="..\..\nuget\install.ps1" target="tools" />
+    <file src="bin/net-2.0/nunitlite.dll" target="lib/net20" />
+    <file src="bin/net-4.0/nunitlite.dll" target="lib/net40" />
+    <file src="bin/net-4.5/nunitlite.dll" target="lib/net45" />
+    <file src="bin/sl-5.0/nunitlite.dll" target="lib/sl5" />
+    <file src="../../nuget/Program.cs" target="content" />
+    <file src="../../nuget/Program.vb" target="content" />
+    <file src="../../nuget/install.ps1" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
This "fixes" the problem of Linux packaging by eliminating the NuGet packages.

It's a fix in the sense that the package target now works, producing source and binary zips.

It's incomplete in that we dont' produce nuget packages and the zip does not contain the same things as one packaged on Windows would contain.

Those problems can be fixed after we fix issues #783 and #784 