### PR TITLE
Use Travis CI C# support instead of installing Mono from a PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
-before_install:
-  - sudo add-apt-repository ppa:directhex/monoxide -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install mono-devel -qq -y
-  - yes | sudo certmgr -ssl -m https://go.microsoft.com
-  - yes | sudo certmgr -ssl -m https://nugetgallery.blob.core.windows.net
-  - yes | sudo certmgr -ssl -m https://nuget.org
-  - sudo mozroots --import --machine --sync
+language: csharp
+sudo: false
+mono:
+  - latest
+  - 3.2.8
 
 before_script:
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework "/t:DumpSettings"
 
 script: 
-  - ./tools/nuget.exe restore nunit.sln
+  - mono ./tools/nuget.exe restore nunit.sln
   - xbuild NUnit.proj /p:Configuration=Release /p:Framework=$Framework /t:$Targets
   
 env:


### PR DESCRIPTION
I'm one of the maintainers of the [community-supported C# support](http://docs.travis-ci.com/user/languages/csharp/) for Travis CI and saw you weren't using it yet. This switches .travis.yml to take advantage of the C# support instead of installing Mono from a PPA.

The new config also uses the container-based Travis environment (`sudo: false`) which has better performance and startup time.

Since you were testing on Mono 3.2.8 before, I added that alongside latest Mono.

Let me know if you have questions :smile: 