### PR TITLE
Eliminate use of ReflectedType in preparation for ASP .Net 5 support

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -163,11 +163,13 @@ namespace NUnit.Framework.Api
             int testcases = 0;
             foreach (Type testType in testTypes)
             {
+                var typeInfo = new TypeWrapper(testType);
+
                 try
                 {
-                    if (_defaultSuiteBuilder.CanBuildFrom(testType))
+                    if (_defaultSuiteBuilder.CanBuildFrom(typeInfo))
                     {
-                        Test fixture = _defaultSuiteBuilder.BuildFrom(testType);
+                        Test fixture = _defaultSuiteBuilder.BuildFrom(typeInfo);
                         fixtures.Add(fixture);
                         testcases += fixture.TestCaseCount;
                     }

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Api
             try
             {
                 IList fixtureNames = options[PackageSettings.LOAD] as IList;
-                IList fixtures = GetFixtures(assembly, fixtureNames);
+                var fixtures = GetFixtures(assembly, fixtureNames);
 
                 testAssembly = BuildTestAssembly(assembly, assemblyPath, fixtures);
             }
@@ -148,12 +148,12 @@ namespace NUnit.Framework.Api
 
         #region Helper Methods
 
-        private IList GetFixtures(Assembly assembly, IList names)
+        private IList<Test> GetFixtures(Assembly assembly, IList names)
         {
             var fixtures = new List<Test>();
             log.Debug("Examining assembly for test fixtures");
 
-            IList testTypes = GetCandidateFixtureTypes(assembly, names);
+            var testTypes = GetCandidateFixtureTypes(assembly, names);
 
             log.Debug("Found {0} classes to examine", testTypes.Count);
 #if LOAD_TIMING
@@ -187,9 +187,9 @@ namespace NUnit.Framework.Api
             return fixtures;
         }
 
-        private IList GetCandidateFixtureTypes(Assembly assembly, IList names)
+        private IList<Type> GetCandidateFixtureTypes(Assembly assembly, IList names)
         {
-            IList types = assembly.GetTypes();
+            var types = assembly.GetTypes();
 
             if (names == null || names.Count == 0)
                 return types;
@@ -214,7 +214,7 @@ namespace NUnit.Framework.Api
             return result;
         }
 
-        private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList fixtures)
+        private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList<Test> fixtures)
         {
             TestSuite testAssembly = new TestAssembly(assembly, assemblyName);
 

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -90,7 +90,7 @@ namespace NUnit.Framework
 
                 var o = new object();
                 var tryArgs = Enumerable.Repeat(o, numGenericParams).ToArray();
-                MethodInfo mi;
+                IMethodInfo mi;
 
                 try
                 {
@@ -106,6 +106,7 @@ namespace NUnit.Framework
                 }
 
                 var par = mi.GetParameters();
+
                 if (par.Length == 0)
                     return tests;
 

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             List<TestMethod> tests = new List<TestMethod>();
 
@@ -127,7 +127,7 @@ namespace NUnit.Framework
                 return tests;
             }
 #endif
-            ParameterInfo[] parameters = method.GetParameters();
+            IParameterInfo[] parameters = method.GetParameters();
 
             if (parameters.Length > 0)
             {

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -143,7 +143,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of _values to be used as arguments.
         /// </summary>
-        public IEnumerable GetData(ParameterInfo parameter)
+        public IEnumerable GetData(IParameterInfo parameter)
         {
             // Since a separate Randomizer is used for each parameter,
             // we can't fill in the data in the constructor of the
@@ -220,7 +220,7 @@ namespace NUnit.Framework
         {
             public Type DataType { get; protected set; }
 
-            public abstract IEnumerable GetData(ParameterInfo parameter);
+            public abstract IEnumerable GetData(IParameterInfo parameter);
         }
 
         abstract class RandomDataSource<T> : RandomDataSource
@@ -250,11 +250,11 @@ namespace NUnit.Framework
                 DataType = typeof(T);
             }
 
-            public override IEnumerable GetData(ParameterInfo parameter)
+            public override IEnumerable GetData(IParameterInfo parameter)
             {
                 //Guard.ArgumentValid(parameter.ParameterType == typeof(T), "Parameter type must be " + typeof(T).Name, "parameter");
 
-                _randomizer = Randomizer.GetRandomizer(parameter);
+                _randomizer = Randomizer.GetRandomizer(parameter.ParameterInfo);
 
                 for (int i = 0; i < _count; i++)
                     yield return _inRange
@@ -279,7 +279,7 @@ namespace NUnit.Framework
                 _source = source;
             }
 
-            public override IEnumerable GetData(ParameterInfo parameter)
+            public override IEnumerable GetData(IParameterInfo parameter)
             {
                 Type parmType = parameter.ParameterType;
 
@@ -533,11 +533,11 @@ namespace NUnit.Framework
                 DataType = typeof(Enum);
             }
 
-            public override IEnumerable GetData(ParameterInfo parameter)
+            public override IEnumerable GetData(IParameterInfo parameter)
             {
                 Guard.ArgumentValid(parameter.ParameterType.IsEnum, "EnumDataSource requires an enum parameter", "parameter");
 
-                Randomizer randomizer = Randomizer.GetRandomizer(parameter);
+                Randomizer randomizer = Randomizer.GetRandomizer(parameter.ParameterInfo);
                 DataType = parameter.ParameterType;
 
                 for (int i = 0; i < _count; i++ )

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework
             if (fixture.RunState != RunState.NotRunnable)
             {
                 string reason = null;
-                if (!IsValidFixtureType(typeInfo.Type, ref reason))
+                if (!IsValidFixtureType(typeInfo, ref reason))
                 {
                     fixture.RunState = RunState.NotRunnable;
                     fixture.Properties.Set(PropertyNames.SkipReason, reason);
@@ -65,17 +65,17 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        private bool IsValidFixtureType(Type fixtureType, ref string reason)
+        private bool IsValidFixtureType(ITypeInfo typeInfo, ref string reason)
         {
-            if (fixtureType.IsAbstract)
+            if (typeInfo.IsAbstract)
             {
-                reason = string.Format("{0} is an abstract class", fixtureType.FullName);
+                reason = string.Format("{0} is an abstract class", typeInfo.FullName);
                 return false;
             }
 
-            if (fixtureType.GetConstructor(new Type[0]) == null)
+            if (!typeInfo.HasConstructor(new Type[0]))
             {
-                reason = string.Format("{0} does not have a valid constructor", fixtureType.FullName);
+                reason = string.Format("{0} does not have a default constructor", typeInfo.FullName);
                 return false;
             }
 
@@ -88,7 +88,7 @@ namespace NUnit.Framework
 #pragma warning restore
 
             foreach (Type invalidType in invalidAttributes)
-                if (Reflect.HasMethodWithAttribute(fixtureType, invalidType))
+                if (typeInfo.HasMethodWithAttribute(invalidType))
                 {
                     reason = invalidType.Name + " attribute not allowed in a SetUpFixture";
                     return false;

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -42,16 +42,16 @@ namespace NUnit.Framework
         /// Build a SetUpFixture from type provided. Normally called for a Type
         /// on which the attribute has been placed.
         /// </summary>
-        /// <param name="type">The type of the fixture to be used.</param>
+        /// <param name="typeInfo">The type info of the fixture to be used.</param>
         /// <returns>A SetUpFixture object as a TestSuite.</returns>
-        public IEnumerable<TestSuite> BuildFrom(Type type)
+        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
-            SetUpFixture fixture = new SetUpFixture(type);
+            SetUpFixture fixture = new SetUpFixture(typeInfo);
 
             if (fixture.RunState != RunState.NotRunnable)
             {
                 string reason = null;
-                if (!IsValidFixtureType(type, ref reason))
+                if (!IsValidFixtureType(typeInfo.Type, ref reason))
                 {
                     fixture.RunState = RunState.NotRunnable;
                     fixture.Properties.Set(PropertyNames.SkipReason, reason);

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -119,12 +119,12 @@ namespace NUnit.Framework
         #region ISimpleTestBuilder Members
 
         /// <summary>
-        /// Construct a TestMethod from a given MethodInfo.
+        /// Construct a TestMethod from a given method.
         /// </summary>
-        /// <param name="method">The MethodInfo for which a test is to be constructed.</param>
+        /// <param name="method">The method for which a test is to be constructed.</param>
         /// <param name="suite">The suite to which the test will be added.</param>
         /// <returns>A TestMethod</returns>
-        public TestMethod BuildFrom(MethodInfo method, Test suite)
+        public TestMethod BuildFrom(IMethodInfo method, Test suite)
         {
             TestCaseParameters parms = null;
 

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -254,7 +254,7 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        private TestCaseParameters GetParametersForTestCase(MethodInfo method)
+        private TestCaseParameters GetParametersForTestCase(IMethodInfo method)
         {
             TestCaseParameters parms;
 
@@ -267,7 +267,7 @@ namespace NUnit.Framework
                 method = tmethod;
 #endif
 
-                ParameterInfo[] parameters = method.GetParameters();
+                IParameterInfo[] parameters = method.GetParameters();
                 int argsNeeded = parameters.Length;
                 int argsProvided = Arguments.Length;
 
@@ -276,11 +276,11 @@ namespace NUnit.Framework
                 // Special handling for params arguments
                 if (argsNeeded > 0 && argsProvided >= argsNeeded - 1)
                 {
-                    ParameterInfo lastParameter = parameters[argsNeeded - 1];
+                    IParameterInfo lastParameter = parameters[argsNeeded - 1];
                     Type lastParameterType = lastParameter.ParameterType;
                     Type elementType = lastParameterType.GetElementType();
 
-                    if (lastParameterType.IsArray && lastParameter.IsDefined(typeof(ParamArrayAttribute), false))
+                    if (lastParameterType.IsArray && lastParameter.IsDefined<ParamArrayAttribute>(false))
                     {
                         if (argsProvided == argsNeeded)
                         {
@@ -341,7 +341,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="arglist">The arguments to be converted</param>
         /// <param name="parameters">The ParameterInfo array for the method</param>
-        private static void PerformSpecialConversions(object[] arglist, ParameterInfo[] parameters)
+        private static void PerformSpecialConversions(object[] arglist, IParameterInfo[] parameters)
         {
             for (int i = 0; i < arglist.Length; i++)
             {
@@ -392,7 +392,7 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
             

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -99,10 +99,10 @@ namespace NUnit.Framework
         /// Construct one or more TestMethods from a given MethodInfo,
         /// using available parameter data.
         /// </summary>
-        /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
+        /// <param name="method">The IMethod for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite)
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             foreach (TestCaseParameters parms in GetTestCasesFor(method))
                 yield return _builder.BuildTestMethod(method, suite, parms);
@@ -118,7 +118,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="method">The method for which data is needed.</param>
         /// <returns></returns>
-        private IEnumerable<ITestCaseData> GetTestCasesFor(MethodInfo method)
+        private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
         {
             List<ITestCaseData> data = new List<ITestCaseData>();
 
@@ -129,9 +129,9 @@ namespace NUnit.Framework
                 if (source != null)
                 {
 #if NETCF
-                    ParameterInfo[] parameters = method.IsGenericMethodDefinition ? new ParameterInfo[0] : method.GetParameters();
+                    IParameterInfo[] parameters = method.IsGenericMethodDefinition ? new ParameterInfo[0] : method.GetParameters();
 #else
-                    ParameterInfo[] parameters = method.GetParameters();
+                    IParameterInfo[] parameters = method.GetParameters();
 #endif
 
                     foreach (object item in source)
@@ -210,11 +210,11 @@ namespace NUnit.Framework
             return data;
         }
 
-        private IEnumerable GetTestCaseSource(MethodInfo method)
+        private IEnumerable GetTestCaseSource(IMethodInfo method)
         {
             Type sourceType = this.SourceType;
             if (sourceType == null)
-                sourceType = method.ReflectedType;
+                sourceType = method.TypeInfo.Type;
 
             // Handle Type implementing IEnumerable separately
             if (SourceName == null)

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -129,10 +129,8 @@ namespace NUnit.Framework
                 if (source != null)
                 {
 #if NETCF
-                    //IParameterInfo[] parameters = method.IsGenericMethodDefinition ? new IParameterInfo[0] : method.GetParameters();
                     int numParameters = method.IsGenericMethodDefinition ? 0 : method.GetParameters().Length;
 #else
-                    //IParameterInfo[] parameters = method.GetParameters();
                     int numParameters = method.GetParameters().Length;
 #endif
 
@@ -149,17 +147,12 @@ namespace NUnit.Framework
                                 if (method.IsGenericMethodDefinition)
                                 {
                                     var mi = method.MakeGenericMethodEx(args);
-                                    //parameters = mi == null ? new ParameterInfo[0] : mi.GetParameters();
                                     numParameters = mi == null ? 0 : mi.GetParameters().Length;
                                 }
 #endif
                                 if (args.Length != numParameters)//parameters.Length)
                                     args = new object[] { item };
                             }
-                            // else if (parameters.Length == 1 && parameters[0].ParameterType.IsAssignableFrom(item.GetType()))
-                            // {
-                            //    args = new object[] { item };
-                            // }
                             else if (item is Array)
                             {
                                 Array array = item as Array;

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -212,9 +212,7 @@ namespace NUnit.Framework
 
         private IEnumerable GetTestCaseSource(IMethodInfo method)
         {
-            Type sourceType = this.SourceType;
-            if (sourceType == null)
-                sourceType = method.TypeInfo.Type;
+            Type sourceType = SourceType ?? method.TypeInfo.Type;
 
             // Handle Type implementing IEnumerable separately
             if (SourceName == null)

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -129,9 +129,11 @@ namespace NUnit.Framework
                 if (source != null)
                 {
 #if NETCF
-                    IParameterInfo[] parameters = method.IsGenericMethodDefinition ? new ParameterInfo[0] : method.GetParameters();
+                    //IParameterInfo[] parameters = method.IsGenericMethodDefinition ? new IParameterInfo[0] : method.GetParameters();
+                    int numParameters = method.IsGenericMethodDefinition ? 0 : method.GetParameters().Length;
 #else
-                    IParameterInfo[] parameters = method.GetParameters();
+                    //IParameterInfo[] parameters = method.GetParameters();
+                    int numParameters = method.GetParameters().Length;
 #endif
 
                     foreach (object item in source)
@@ -147,10 +149,11 @@ namespace NUnit.Framework
                                 if (method.IsGenericMethodDefinition)
                                 {
                                     var mi = method.MakeGenericMethodEx(args);
-                                    parameters = mi == null ? new ParameterInfo[0] : mi.GetParameters();
+                                    //parameters = mi == null ? new ParameterInfo[0] : mi.GetParameters();
+                                    numParameters = mi == null ? 0 : mi.GetParameters().Length;
                                 }
 #endif
-                                if (args.Length != parameters.Length)
+                                if (args.Length != numParameters)//parameters.Length)
                                     args = new object[] { item };
                             }
                             // else if (parameters.Length == 1 && parameters[0].ParameterType.IsAssignableFrom(item.GetType()))
@@ -162,9 +165,9 @@ namespace NUnit.Framework
                                 Array array = item as Array;
 
 #if NETCF
-                                if (array.Rank == 1 && (method.IsGenericMethodDefinition || array.Length == parameters.Length))
+                                if (array.Rank == 1 && (method.IsGenericMethodDefinition || array.Length == numParameters))//parameters.Length))
 #else
-                                if (array.Rank == 1 && array.Length == parameters.Length)
+                                if (array.Rank == 1 && array.Length == numParameters)//parameters.Length)
 #endif
                                 {
                                     args = new object[array.Length];

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -220,11 +220,11 @@ namespace NUnit.Framework
         /// Build a fixture from type provided. Normally called for a Type
         /// on which the attribute has been placed.
         /// </summary>
-        /// <param name="type">The type of the fixture to be used.</param>
+        /// <param name="typeInfo">The type info of the fixture to be used.</param>
         /// <returns>A an IEnumerable holding one TestFixture object.</returns>
-        public IEnumerable<TestSuite> BuildFrom(Type type)
+        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
-            yield return _builder.BuildFrom(type, this);
+            yield return _builder.BuildFrom(typeInfo, this);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -108,7 +108,9 @@ namespace NUnit.Framework
         /// <returns>One or more TestFixtures as TestSuite</returns>
         public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
-            foreach (TestFixtureParameters parms in GetParametersFor(typeInfo.Type))
+            Type sourceType = SourceType ?? typeInfo.Type;
+
+            foreach (TestFixtureParameters parms in GetParametersFor(sourceType))
                 yield return _builder.BuildFrom(typeInfo, parms);
         }
 
@@ -120,15 +122,15 @@ namespace NUnit.Framework
         /// Returns a set of ITestFixtureData items for use as arguments
         /// to a parameterized test fixture.
         /// </summary>
-        /// <param name="type">The type for which data is needed.</param>
+        /// <param name="sourceType">The type for which data is needed.</param>
         /// <returns></returns>
-        public IEnumerable<ITestFixtureData> GetParametersFor(Type type)
+        public IEnumerable<ITestFixtureData> GetParametersFor(Type sourceType)
         {
             List<ITestFixtureData> data = new List<ITestFixtureData>();
 
             try
             {
-                IEnumerable source = GetTestFixtureSource(type);
+                IEnumerable source = GetTestFixtureSource(sourceType);
 
                 if (source != null)
                 {
@@ -164,12 +166,8 @@ namespace NUnit.Framework
             return data;
         }
 
-        private IEnumerable GetTestFixtureSource(Type type)
+        private IEnumerable GetTestFixtureSource(Type sourceType)
         {
-            Type sourceType = this.SourceType;
-            if (sourceType == null)
-                sourceType = type;
-
             // Handle Type implementing IEnumerable separately
             if (SourceName == null)
                 return Reflect.Construct(sourceType) as IEnumerable;

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -104,12 +104,12 @@ namespace NUnit.Framework
         /// Construct one or more TestFixtures from a given Type,
         /// using available parameter data.
         /// </summary>
-        /// <param name="type">The Type for which fixures are to be constructed.</param>
+        /// <param name="typeInfo">The TypeInfo for which fixures are to be constructed.</param>
         /// <returns>One or more TestFixtures as TestSuite</returns>
-        public IEnumerable<TestSuite> BuildFrom(Type type)
+        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
-            foreach (TestFixtureParameters parms in GetParametersFor(type))
-                yield return _builder.BuildFrom(type, parms);
+            foreach (TestFixtureParameters parms in GetParametersFor(typeInfo.Type))
+                yield return _builder.BuildFrom(typeInfo, parms);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
@@ -67,9 +67,9 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(MethodInfo method, Internal.Test suite)
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Internal.Test suite)
         {
-            ParameterInfo[] parameters = method.GetParameters();
+            IParameterInfo[] parameters = method.GetParameters();
 
             List<TestMethod> tests = new List<TestMethod>();
 

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework
         /// <returns>
         /// An enumeration containing individual data items
         /// </returns>
-        public IEnumerable GetData(ParameterInfo parameter)
+        public IEnumerable GetData(IParameterInfo parameter)
         {
             return GetDataSource(parameter);
         }
@@ -96,11 +96,11 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        private IEnumerable GetDataSource(ParameterInfo parameter)
+        private IEnumerable GetDataSource(IParameterInfo parameter)
         {
             Type sourceType = SourceType;
             if (sourceType == null)
-                sourceType = parameter.Member.ReflectedType;
+                sourceType = parameter.Method.TypeInfo.Type;
 
             // TODO: Test this
             if (SourceName == null)

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -98,9 +98,7 @@ namespace NUnit.Framework
 
         private IEnumerable GetDataSource(IParameterInfo parameter)
         {
-            Type sourceType = SourceType;
-            if (sourceType == null)
-                sourceType = parameter.Method.TypeInfo.Type;
+            Type sourceType = SourceType ?? parameter.Method.TypeInfo.Type;
 
             // TODO: Test this
             if (SourceName == null)

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -97,7 +97,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of _values to be used as arguments
         /// </summary>
-        public IEnumerable GetData(ParameterInfo parameter)
+        public IEnumerable GetData(IParameterInfo parameter)
         {
             Type targetType = parameter.ParameterType;
 

--- a/src/NUnitFramework/framework/Interfaces/IFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/IFixtureBuilder.cs
@@ -43,9 +43,9 @@ namespace NUnit.Framework.Interfaces
         /// a fixture. If something prevents the fixture from being used, it
         /// will be returned nonetheless, labelled as non-runnable.
         /// </summary>
-        /// <param name="type">The type of the fixture to be used.</param>
+        /// <param name="typeInfo">The type info of the fixture to be used.</param>
         /// <returns>A TestSuite object or one derived from TestSuite.</returns>
         // TODO: This should really return a TestFixture, but that requires changes to the Test hierarchy.
-        IEnumerable<TestSuite> BuildFrom(Type type);
+        IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
@@ -83,6 +83,11 @@ namespace NUnit.Framework.Interfaces
         #region Methods
 
         /// <summary>
+        /// Get the display name for a method with arguments
+        /// </summary>
+        string GetDisplayName(object[] args);
+
+        /// <summary>
         /// Gets the parameters of the method.
         /// </summary>
         /// <returns></returns>

--- a/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
@@ -94,6 +94,11 @@ namespace NUnit.Framework.Interfaces
         IParameterInfo[] GetParameters();
 
         /// <summary>
+        /// Returns the Type arguments of a generic method or the Type parameters of a generic method definition.
+        /// </summary>
+        Type[] GetGenericArguments();
+
+        /// <summary>
         /// Replaces the type parameters of the method with the array of types provided and returns a new IMethodInfo.
         /// </summary>
         /// <param name="typeArguments">The type arguments to be used</param>

--- a/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Interfaces
     /// The IMethodInfo class is used to encapsulate information
     /// about a method in a platform-independent manner.
     /// </summary>
-    public interface IMethodInfo
+    public interface IMethodInfo : IReflectionInfo
     {
         #region Properties
 
@@ -94,16 +94,6 @@ namespace NUnit.Framework.Interfaces
         /// <param name="typeArguments">The type arguments to be used</param>
         /// <returns>A new IMethodInfo with the type arguments replaced</returns>
         IMethodInfo MakeGenericMethod(params Type[] typeArguments);
-
-        /// <summary>
-        /// Returns an array of custom attributes of the specified type applied to this method
-        /// </summary>
-        T[] GetCustomAttributes<T>(bool inherit) where T : class;
-
-        /// <summary>
-        /// Gets a value indicating whether one or more attributes of the specified type are defined on the method.
-        /// </summary>
-        bool IsDefined<T>(bool inherit);
 
         /// <summary>
         /// Invokes the method, converting any TargetInvocationException to an NUnitException.

--- a/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
@@ -1,0 +1,118 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+using System;
+using System.Reflection;
+
+namespace NUnit.Framework.Interfaces
+{
+    /// <summary>
+    /// The IMethodInfo class is used to encapsulate information
+    /// about a method in a platform-independent manner.
+    /// </summary>
+    public interface IMethodInfo
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the Type from which this method was reflected.
+        /// </summary>
+        ITypeInfo TypeInfo { get; }
+
+        /// <summary>
+        /// Gets the MethodInfo for this method.
+        /// </summary>
+        MethodInfo MethodInfo { get; }
+
+        /// <summary>
+        /// Gets the name of the method.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is abstract.
+        /// </summary>
+        bool IsAbstract { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is public.
+        /// </summary>
+        bool IsPublic { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the method contains unassigned generic type parameters.
+        /// </summary>
+        bool ContainsGenericParameters { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is a generic method.
+        /// </summary>
+        bool IsGenericMethod { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the MethodInfo represents the definition of a generic method.
+        /// </summary>
+        bool IsGenericMethodDefinition { get; }
+
+        /// <summary>
+        /// Gets the return Type of the method.
+        /// </summary>
+        ITypeInfo ReturnType { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the parameters of the method.
+        /// </summary>
+        /// <returns></returns>
+        IParameterInfo[] GetParameters();
+
+        /// <summary>
+        /// Replaces the type parameters of the method with the array of types provided and returns a new IMethodInfo.
+        /// </summary>
+        /// <param name="typeArguments">The type arguments to be used</param>
+        /// <returns>A new IMethodInfo with the type arguments replaced</returns>
+        IMethodInfo MakeGenericMethod(params Type[] typeArguments);
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this method
+        /// </summary>
+        T[] GetCustomAttributes<T>(bool inherit) where T : class;
+
+        /// <summary>
+        /// Gets a value indicating whether one or more attributes of the specified type are defined on the method.
+        /// </summary>
+        bool IsDefined<T>(bool inherit);
+
+        /// <summary>
+        /// Invokes the method, converting any TargetInvocationException to an NUnitException.
+        /// </summary>
+        /// <param name="fixture">The object on which to invoke the method</param>
+        /// <param name="args">The argument list for the method</param>
+        /// <returns>The return value from the invoked method</returns>
+        object Invoke(object fixture, params object[] args);
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
@@ -38,15 +38,15 @@ namespace NUnit.Framework.Interfaces
         /// <param name="parameter">A ParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>True if any data is available, otherwise false.</returns>
-        bool HasDataFor(ParameterInfo parameter);
+        bool HasDataFor(IParameterInfo parameter);
 
         /// <summary>
         /// Return an IEnumerable providing data for use with the
         /// supplied parameter.
         /// </summary>
-        /// <param name="parameter">A ParameterInfo representing one
+        /// <param name="parameter">An IParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>An IEnumerable providing the required data</returns>
-        IEnumerable GetDataFor(ParameterInfo parameter);
+        IEnumerable GetDataFor(IParameterInfo parameter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Determine whether any data is available for a parameter.
         /// </summary>
-        /// <param name="parameter">A ParameterInfo representing one
+        /// <param name="parameter">An IParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>True if any data is available, otherwise false.</returns>
         bool HasDataFor(IParameterInfo parameter);

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
@@ -38,6 +38,6 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
         /// <param name="parameter">The parameter for which data is needed</param>
         /// <returns>An enumeration containing individual data items</returns>
-        IEnumerable GetData(ParameterInfo parameter);
+        IEnumerable GetData(IParameterInfo parameter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2009 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,49 +23,36 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework.Interfaces;
-using NUnit.Framework.Internal;
+using System.Reflection;
 
-namespace NUnit.Framework.Attributes
+namespace NUnit.Framework.Interfaces
 {
-    public class SetUpFixtureAttributeTests
+    public interface IParameterInfo
     {
-        [TestCase(typeof(Class1))]
-        [TestCase(typeof(Class2))]
-        [TestCase(typeof(Class3))]
-        [TestCase(typeof(Class4))]
-        public void CertainAttributesAreNotAllowed(Type type)
-        {
-            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeInfo(type));
-            foreach (var fixture in fixtures)
-                Assert.That(fixture.RunState, Is.EqualTo(RunState.NotRunnable));
-        }
+        #region Properties
 
-#pragma warning disable 618 // Obsolete Attributes
-        private class Class1
-        {
-            [TestFixtureSetUp]
-            public void SomeMethod() { }
-        }
+        bool IsOptional { get; }
 
-        private class Class2
-        {
-            [TestFixtureTearDown]
-            public void SomeMethod() { }
-        }
-#pragma warning restore
+        IMethodInfo Method { get; }
 
-        private class Class3
-        {
-            [SetUp]
-            public void SomeMethod() { }
-        }
+        ParameterInfo ParameterInfo { get; }
 
-        private class Class4
-        {
-            [TearDown]
-            public void SomeMethod() { }
-        }
+        Type ParameterType { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this method
+        /// </summary>
+        T[] GetCustomAttributes<T>(bool inherit) where T : class;
+
+        /// <summary>
+        /// Gets a value indicating whether one or more attributes of the specified type are defined on the parameter.
+        /// </summary>
+        bool IsDefined<T>(bool inherit);
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
@@ -27,31 +27,32 @@ using System.Reflection;
 
 namespace NUnit.Framework.Interfaces
 {
-    public interface IParameterInfo
+    /// <summary>
+    /// The IParameterInfo interface is an abstraction of a .NET parameter.
+    /// </summary>
+    public interface IParameterInfo : IReflectionInfo
     {
         #region Properties
 
+        /// <summary>
+        /// Gets a value indicating whether the parameter is optional
+        /// </summary>
         bool IsOptional { get; }
 
+        /// <summary>
+        /// Gets an IMethodInfo representing the method for which this is a parameter
+        /// </summary>
         IMethodInfo Method { get; }
 
+        /// <summary>
+        /// Gets the underlying .NET ParameterInfo
+        /// </summary>
         ParameterInfo ParameterInfo { get; }
 
+        /// <summary>
+        /// Gets the Type of the parameter
+        /// </summary>
         Type ParameterType { get; }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        /// Returns an array of custom attributes of the specified type applied to this method
-        /// </summary>
-        T[] GetCustomAttributes<T>(bool inherit) where T : class;
-
-        /// <summary>
-        /// Gets a value indicating whether one or more attributes of the specified type are defined on the parameter.
-        /// </summary>
-        bool IsDefined<T>(bool inherit);
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterInfo.cs
@@ -34,10 +34,12 @@ namespace NUnit.Framework.Interfaces
     {
         #region Properties
 
+#if !NETCF
         /// <summary>
         /// Gets a value indicating whether the parameter is optional
         /// </summary>
         bool IsOptional { get; }
+#endif
 
         /// <summary>
         /// Gets an IMethodInfo representing the method for which this is a parameter

--- a/src/NUnitFramework/framework/Interfaces/IReflectionInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IReflectionInfo.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,35 +21,21 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using NUnit.Framework.Internal;
-
 namespace NUnit.Framework.Interfaces
 {
     /// <summary>
-    /// The ISuiteBuilder interface is exposed by a class that knows how to
-    /// build a suite from one or more Types. 
+    /// The IReflectionInfo interface is implemented by NUnit wrapper objects that perform reflection.
     /// </summary>
-    public interface ISuiteBuilder
+    public interface IReflectionInfo
     {
         /// <summary>
-        /// Examine the type and determine if it is suitable for
-        /// this builder to use in building a TestSuite.
-        /// 
-        /// Note that returning false will cause the type to be ignored 
-        /// in loading the tests. If it is desired to load the suite
-        /// but label it as non-runnable, ignored, etc., then this
-        /// method must return true.
+        /// Returns an array of custom attributes of the specified type applied to this object
         /// </summary>
-        /// <param name="typeInfo">The type of the fixture to be used</param>
-        /// <returns>True if the type can be used to build a TestSuite</returns>
-        bool CanBuildFrom( ITypeInfo typeInfo );
+        T[] GetCustomAttributes<T>(bool inherit) where T : class;
 
         /// <summary>
-        /// Build a TestSuite from type provided.
+        /// Returns a value indicating whether an attribute of the specified type is defined on this object.
         /// </summary>
-        /// <param name="typeInfo">The type of the fixture to be used</param>
-        /// <returns>A TestSuite</returns>
-        TestSuite BuildFrom( ITypeInfo typeInfo );
+        bool IsDefined<T>(bool inherit);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
@@ -41,6 +41,6 @@ namespace NUnit.Framework.Interfaces
         /// <param name="method">The method to be used as a test</param>
         /// <param name="suite">The TestSuite to which the method will be added</param>
         /// <returns>A TestMethod object</returns>
-        TestMethod BuildFrom(MethodInfo method, Test suite);
+        TestMethod BuildFrom(IMethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
@@ -50,6 +50,6 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
         /// <param name="type">The type of the fixture to be used</param>
         /// <returns>A TestSuite</returns>
-        Test BuildFrom( Type type );
+        TestSuite BuildFrom( Type type );
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2007-2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -65,13 +65,13 @@ namespace NUnit.Framework.Interfaces
         /// Gets the Type of the test fixture, if applicable, or
         /// null if no fixture type is associated with this test.
         /// </summary>
-        Type FixtureType { get; }
+        ITypeInfo TypeInfo { get; }
 
         /// <summary>
-        /// Gets a MethodInfo for the method implementing this test.
+        /// Gets an IMethod for the method implementing this test.
         /// Returns null if the test is not implemented as a method.
         /// </summary>
-        MethodInfo Method { get; }
+        IMethodInfo Method { get; }
 
         /// <summary>
         /// Gets the RunState of the test, indicating whether it can be run.

--- a/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
@@ -41,6 +41,6 @@ namespace NUnit.Framework.Interfaces
         /// <param name="method">The method to be used as a test</param>
         /// <param name="suite">The TestSuite to which the method will be added</param>
         /// <returns>A TestMethod object</returns>
-        IEnumerable<TestMethod> BuildFrom(MethodInfo method, Test suite);
+        IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Interfaces
         /// <param name="method">The test method to examine</param>
         /// <param name="suite">The suite being populated</param>
         /// <returns>True is the builder can use this method</returns>
-        bool CanBuildFrom(MethodInfo method, Test suite);
+        bool CanBuildFrom(IMethodInfo method, Test suite);
 
         /// <summary>
         /// Build a TestCase from the provided MethodInfo for

--- a/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
@@ -58,6 +58,6 @@ namespace NUnit.Framework.Interfaces
         /// <param name="method">The method to be used as a test case</param>
         /// <param name="suite">The test suite being populated, or null</param>
         /// <returns>A TestCase or null</returns>
-        Test BuildFrom(MethodInfo method, Test suite);
+        Test BuildFrom(IMethodInfo method, Test suite);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -29,8 +29,10 @@ namespace NUnit.Framework.Interfaces
     /// <summary>
     /// The ITypeInfo interface is an abstraction of a .NET Type
     /// </summary>
-    public interface ITypeInfo
+    public interface ITypeInfo : IReflectionInfo
     {
+        #region Properties
+
         /// <summary>
         /// Gets the underlying Type on which this ITypeInfo is based
         /// </summary>
@@ -67,6 +69,11 @@ namespace NUnit.Framework.Interfaces
         string Namespace { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the type is abstract.
+        /// </summary>
+        bool IsAbstract { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the Type is a generic Type
         /// </summary>
         bool IsGenericType { get; }
@@ -82,19 +89,45 @@ namespace NUnit.Framework.Interfaces
         bool IsGenericTypeDefinition { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the type is sealed.
+        /// </summary>
+        bool IsSealed { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this type is a static class.
+        /// </summary>
+        bool IsStaticClass { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
         /// Returns a Type representing a generic type definition from which this Type can be constructed.
         /// </summary>
         Type GetGenericTypeDefinition();
 
         /// <summary>
-        /// Returns an array of custom attributes of the specified type applied to this type
+        /// Returns a value indicating whether this type has a method with a specified public attribute
         /// </summary>
-        T[] GetCustomAttributes<T>(bool inherit) where T : class;
+        bool HasMethodWithAttribute(Type attrType);
 
         /// <summary>
         /// Returns an array of IMethodInfos for methods of this Type
         /// that match the specified flags.
         /// </summary>
         IMethodInfo[] GetMethods(BindingFlags flags);
+
+        /// <summary>
+        /// Returns a value indicating whether this Type has a public constructor taking the specified argument Types.
+        /// </summary>
+        bool HasConstructor(Type[] argTypes);
+
+        /// <summary>
+        /// Construct an object of this Type, using the specified arguments.
+        /// </summary>
+        object Construct(object[] args);
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -103,6 +103,16 @@ namespace NUnit.Framework.Interfaces
         #region Methods
 
         /// <summary>
+        /// Get the display name for this typeInfo.
+        /// </summary>
+        string GetDisplayName();
+
+        /// <summary>
+        /// Get the display name for an oject of this type, constructed with specific arguments
+        /// </summary>
+        string GetDisplayName(object[] args);
+
+        /// <summary>
         /// Returns a Type representing a generic type definition from which this Type can be constructed.
         /// </summary>
         Type GetGenericTypeDefinition();

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -118,6 +118,11 @@ namespace NUnit.Framework.Interfaces
         Type GetGenericTypeDefinition();
 
         /// <summary>
+        /// Returns a new ITypeInfo representing an instance of this generic Type using the supplied Type arguments
+        /// </summary>
+        ITypeInfo MakeGenericType(Type[] typeArgs);
+
+        /// <summary>
         /// Returns a value indicating whether this type has a method with a specified public attribute
         /// </summary>
         bool HasMethodWithAttribute(Type attrType);

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -1,0 +1,100 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Framework.Interfaces
+{
+    /// <summary>
+    /// The ITypeInfo interface is an abstraction of a .NET Type
+    /// </summary>
+    public interface ITypeInfo
+    {
+        /// <summary>
+        /// Gets the underlying Type on which this ITypeInfo is based
+        /// </summary>
+        Type Type { get; }
+
+        /// <summary>
+        /// Gets the base type of this type as an ITypeInfo
+        /// </summary>
+        ITypeInfo BaseType { get; }
+
+        /// <summary>
+        /// Returns true if the Type wrapped is equal to the argument
+        /// </summary>
+        bool IsType(Type type);
+
+        /// <summary>
+        /// Gets the Name of the Type
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the FullName of the Type
+        /// </summary>
+        string FullName { get; }
+
+        /// <summary>
+        /// Gets the assembly in which the type is declared
+        /// </summary>
+        Assembly Assembly { get; }
+
+        /// <summary>
+        /// Gets the Namespace of the Type
+        /// </summary>
+        string Namespace { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type is a generic Type
+        /// </summary>
+        bool IsGenericType { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type has generic parameters that have not been replaced by specific Types.
+        /// </summary>
+        bool ContainsGenericParameters { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type is a generic Type definition
+        /// </summary>
+        bool IsGenericTypeDefinition { get; }
+
+        /// <summary>
+        /// Returns a Type representing a generic type definition from which this Type can be constructed.
+        /// </summary>
+        Type GetGenericTypeDefinition();
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this type
+        /// </summary>
+        T[] GetCustomAttributes<T>(bool inherit) where T : class;
+
+        /// <summary>
+        /// Returns an array of IMethodInfos for methods of this Type
+        /// that match the specified flags.
+        /// </summary>
+        IMethodInfo[] GetMethods(BindingFlags flags);
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -44,13 +44,13 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns>
         /// True if any data is available, otherwise false.
         /// </returns>
-        public bool HasDataFor(System.Reflection.ParameterInfo parameter)
+        public bool HasDataFor(IParameterInfo parameter)
         {
             Type parameterType = parameter.ParameterType;
-            MemberInfo method = parameter.Member;
-            Type fixtureType = method.ReflectedType;
+            var method = parameter.Method;
+            Type fixtureType = method.TypeInfo.Type;
 
-            if (!method.IsDefined(typeof(TheoryAttribute), true))
+            if (!method.IsDefined<TheoryAttribute>(true))
                 return false;
 
             if (parameterType == typeof(bool) || parameterType.IsEnum)
@@ -78,12 +78,12 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns>
         /// An IEnumerable providing the required data
         /// </returns>
-        public System.Collections.IEnumerable GetDataFor(System.Reflection.ParameterInfo parameter)
+        public System.Collections.IEnumerable GetDataFor(IParameterInfo parameter)
         {
             var datapoints = new List<object>();
 
             Type parameterType = parameter.ParameterType;
-            Type fixtureType = parameter.Member.ReflectedType;
+            Type fixtureType = parameter.Method.TypeInfo.Type;
 
             foreach (MemberInfo member in fixtureType.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             {

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -46,17 +46,16 @@ namespace NUnit.Framework.Internal.Builders
         /// </returns>
         public bool HasDataFor(IParameterInfo parameter)
         {
-            Type parameterType = parameter.ParameterType;
             var method = parameter.Method;
-            Type fixtureType = method.TypeInfo.Type;
-
             if (!method.IsDefined<TheoryAttribute>(true))
                 return false;
 
+            Type parameterType = parameter.ParameterType;
             if (parameterType == typeof(bool) || parameterType.IsEnum)
                 return true;
 
-            foreach (MemberInfo member in fixtureType.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            Type containingType = method.TypeInfo.Type;
+            foreach (MemberInfo member in containingType.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             {
                 if (member.IsDefined(typeof(DatapointAttribute), true) &&
                     GetTypeFromMemberInfo(member) == parameterType)

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -64,8 +64,10 @@ namespace NUnit.Framework.Internal.Builders
         }
 
         /// <summary>
-        /// Build a TestSuite from type provided.
+        /// Build a TestSuite from TypeInfo provided.
         /// </summary>
+        /// <param name="typeInfo">The fixture type to build</param>
+        /// <returns>A TestSuite built from that type</returns>
         public TestSuite BuildFrom(ITypeInfo typeInfo)
         {
             var fixtures = new List<TestSuite>();

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -72,9 +72,9 @@ namespace NUnit.Framework.Internal.Builders
         /// of test case data, this method may return a single test
         /// or a group of tests contained in a ParameterizedMethodSuite.
         /// </summary>
-        /// <param name="method">The MethodInfo for which a test is to be built</param>
+        /// <param name="method">The method for which a test is to be built</param>
         /// <returns>A Test representing one or more method invocations</returns>
-        public Test BuildFrom(MethodInfo method)
+        public Test BuildFrom(IMethodInfo method)
         {
             return BuildFrom(method, null);
         }
@@ -109,15 +109,15 @@ namespace NUnit.Framework.Internal.Builders
         /// of test case data, this method may return a single test
         /// or a group of tests contained in a ParameterizedMethodSuite.
         /// </summary>
-        /// <param name="method">The MethodInfo for which a test is to be built</param>
+        /// <param name="method">The method for which a test is to be built</param>
         /// <param name="parentSuite">The test fixture being populated, or null</param>
         /// <returns>A Test representing one or more method invocations</returns>
-        public Test BuildFrom(MethodInfo method, Test parentSuite)
+        public Test BuildFrom(IMethodInfo method, Test parentSuite)
         {
             var tests = new List<TestMethod>();
 
             List<ITestBuilder> builders = new List<ITestBuilder>(
-                (ITestBuilder[])method.GetCustomAttributes(typeof(ITestBuilder), false));
+                method.GetCustomAttributes<ITestBuilder>(false));
 
             // See if we need a CombinatorialAttribute added
             bool needCombinatorial = true;
@@ -154,13 +154,13 @@ namespace NUnit.Framework.Internal.Builders
         /// <summary>
         /// Builds a ParameterizedMethodSuite containing individual test cases.
         /// </summary>
-        /// <param name="method">The MethodInfo for which a test is to be built.</param>
+        /// <param name="method">The method for which a test is to be built.</param>
         /// <param name="tests">The list of test cases to include.</param>
         /// <returns>A ParameterizedMethodSuite populated with test cases</returns>
-        private Test BuildParameterizedMethodSuite(MethodInfo method, IEnumerable<TestMethod> tests)
+        private Test BuildParameterizedMethodSuite(IMethodInfo method, IEnumerable<TestMethod> tests)
         {
             ParameterizedMethodSuite methodSuite = new ParameterizedMethodSuite(method);
-            methodSuite.ApplyAttributesToTest(method);
+            methodSuite.ApplyAttributesToTest(method.MethodInfo);
 
             foreach (TestMethod test in tests)
                 methodSuite.Add(test);
@@ -174,9 +174,9 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="method">The MethodInfo for which a test is to be built</param>
         /// <param name="suite">The test suite for which the method is being built</param>
         /// <returns>A TestMethod.</returns>
-        private Test BuildSingleTestMethod(MethodInfo method, Test suite)
+        private Test BuildSingleTestMethod(IMethodInfo method, Test suite)
         {
-            var builders = (ISimpleTestBuilder[])method.GetCustomAttributes(typeof(ISimpleTestBuilder), false);
+            var builders = method.GetCustomAttributes<ISimpleTestBuilder>(false);
             return builders.Length > 0
                 ? builders[0].BuildFrom(method, suite)
                 : _nunitTestCaseBuilder.BuildTestMethod(method, suite, null);

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -58,12 +58,12 @@ namespace NUnit.Framework.Internal.Builders
         /// methods to be reported, the check for validity is made
         /// in BuildFrom rather than here.
         /// </summary>
-        /// <param name="method">A MethodInfo for the method being used as a test method</param>
+        /// <param name="method">An IMethodInfo for the method being used as a test method</param>
         /// <returns>True if the builder can create a test case from this method</returns>
-        public bool CanBuildFrom(MethodInfo method)
+        public bool CanBuildFrom(IMethodInfo method)
         {
-            return method.IsDefined(typeof(ITestBuilder), false)
-                || method.IsDefined(typeof(ISimpleTestBuilder), false);
+            return method.IsDefined<ITestBuilder>(false)
+                || method.IsDefined<ISimpleTestBuilder>(false);
         }
 
         /// <summary>
@@ -95,10 +95,10 @@ namespace NUnit.Framework.Internal.Builders
         /// methods to be reported, the check for validity is made
         /// in BuildFrom rather than here.
         /// </summary>
-        /// <param name="method">A MethodInfo for the method being used as a test method</param>
+        /// <param name="method">An IMethodInfo for the method being used as a test method</param>
         /// <param name="parentSuite">The test suite being built, to which the new test would be added</param>
         /// <returns>True if the builder can create a test case from this method</returns>
-        public bool CanBuildFrom(MethodInfo method, Test parentSuite)
+        public bool CanBuildFrom(IMethodInfo method, Test parentSuite)
         {
             return CanBuildFrom(method);
         }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal.Builders
                 }
                 else if (parms.OriginalArguments != null)
                 {
-                    string name = MethodHelper.GetDisplayName(method.MethodInfo, parms.OriginalArguments);
+                    string name = method.GetDisplayName(parms.OriginalArguments);
                     testMethod.Name = name;
                     testMethod.FullName = prefix + "." + name;
                 }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -46,24 +46,17 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="parentSuite">The suite or fixture to which the new test will be added</param>
         /// <param name="parms">The ParameterSet to be used, or null</param>
         /// <returns></returns>
-        public TestMethod BuildTestMethod(MethodInfo method, Test parentSuite, TestCaseParameters parms)
+        public TestMethod BuildTestMethod(IMethodInfo method, Test parentSuite, TestCaseParameters parms)
         {
             var testMethod = new TestMethod(method, parentSuite)
             {
                 Seed = randomizer.Next()
             };
 
-            string prefix = method.ReflectedType.FullName;
-
-            // Needed to give proper fullname to test in a parameterized fixture.
-            // Without this, the arguments to the fixture are not included.
-            if (parentSuite != null)
-                prefix = parentSuite.FullName;
-
             CheckTestMethodSignature(testMethod, parms);
 
             if (parms == null || parms.Arguments == null)
-                testMethod.ApplyAttributesToTest(method);
+                testMethod.ApplyAttributesToTest(method.MethodInfo);
 
             if (parms != null)
             {
@@ -72,6 +65,13 @@ namespace NUnit.Framework.Internal.Builders
                 // original MethodInfo, so we reassign it here.
                 method = testMethod.Method;
 
+                string prefix = method.TypeInfo.FullName;
+
+                // Needed to give proper fullname to test in a parameterized fixture.
+                // Without this, the arguments to the fixture are not included.
+                if (parentSuite != null)
+                    prefix = parentSuite.FullName;
+
                 if (parms.TestName != null)
                 {
                     testMethod.Name = parms.TestName;
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal.Builders
                 }
                 else if (parms.OriginalArguments != null)
                 {
-                    string name = MethodHelper.GetDisplayName(method, parms.OriginalArguments);
+                    string name = MethodHelper.GetDisplayName(method.MethodInfo, parms.OriginalArguments);
                     testMethod.Name = name;
                     testMethod.FullName = prefix + "." + name;
                 }
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal.Builders
             if (!testMethod.Method.IsPublic)
                 return MarkAsNotRunnable(testMethod, "Method is not public");
 
-            ParameterInfo[] parameters;
+            IParameterInfo[] parameters;
 #if NETCF
             if (testMethod.Method.IsGenericMethodDefinition)
             {
@@ -170,15 +170,15 @@ namespace NUnit.Framework.Internal.Builders
             }
 
 #if NETCF
-            Type returnType = testMethod.Method.IsGenericMethodDefinition && (parms == null || parms.Arguments == null) ? typeof(void) : (Type)testMethod.Method.ReturnType;
+            ITypeInfo returnType = testMethod.Method.IsGenericMethodDefinition && (parms == null || parms.Arguments == null) ? typeof(void) : (Type)testMethod.Method.ReturnType;
 #else
-            Type returnType = testMethod.Method.ReturnType;
+            ITypeInfo returnType = testMethod.Method.ReturnType;
 #endif
 
 #if NET_4_0 || NET_4_5 || PORTABLE
-            if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method))
+            if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
             {
-                if (returnType == typeof(void))
+                if (returnType.IsType(typeof(void)))
                     return MarkAsNotRunnable(testMethod, "Async test method must have non-void return type");
 
                 var returnsGenericTask = returnType.IsGenericType &&
@@ -194,7 +194,7 @@ namespace NUnit.Framework.Internal.Builders
             }
             else
 #endif
-            if (returnType == typeof(void))
+            if (returnType.IsType(typeof(void)))
             {
                 if (parms != null && parms.HasExpectedResult)
                     return MarkAsNotRunnable(testMethod, "Method returning void cannot have an expected result");
@@ -216,7 +216,7 @@ namespace NUnit.Framework.Internal.Builders
 
             if (testMethod.Method.IsGenericMethodDefinition && arglist != null)
             {
-                var typeArguments = new GenericMethodHelper(testMethod.Method).GetTypeArguments(arglist);
+                var typeArguments = new GenericMethodHelper(testMethod.Method.MethodInfo).GetTypeArguments(arglist);
                 foreach (Type o in typeArguments)
                     if (o == null || o == TypeHelper.NonmatchingType)
                         return MarkAsNotRunnable(testMethod, "Unable to determine type arguments for method");

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -132,14 +132,14 @@ namespace NUnit.Framework.Internal.Builders
                     parameters = testMethod.Method.GetParameters();
                 }
                 else
-                    parameters = new ParameterInfo[0];
+                    parameters = new IParameterInfo[0];
             }
             else
-#endif
+                parameters = testMethod.Method.GetParameters();
 
+            int minArgsNeeded = parameters.Length;
+#else
             parameters = testMethod.Method.GetParameters();
-
-#if !NETCF
             int minArgsNeeded = 0;
             foreach (var parameter in parameters)
             {
@@ -147,8 +147,6 @@ namespace NUnit.Framework.Internal.Builders
                 if (!parameter.IsOptional)
                     minArgsNeeded++;
             }
-#else
-            int minArgsNeeded = parameters.Length;
 #endif
             int maxArgsNeeded = parameters.Length;
 
@@ -170,7 +168,7 @@ namespace NUnit.Framework.Internal.Builders
             }
 
 #if NETCF
-            ITypeInfo returnType = testMethod.Method.IsGenericMethodDefinition && (parms == null || parms.Arguments == null) ? typeof(void) : (Type)testMethod.Method.ReturnType;
+            ITypeInfo returnType = testMethod.Method.IsGenericMethodDefinition && (parms == null || parms.Arguments == null) ? new TypeWrapper(typeof(void)) : testMethod.Method.ReturnType;
 #else
             ITypeInfo returnType = testMethod.Method.ReturnType;
 #endif

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Internal.Builders
             
             if (arguments != null && arguments.Length > 0)
             {
-                string name = fixture.Name = TypeHelper.GetDisplayName(typeInfo.Type, arguments);
+                string name = fixture.Name = typeInfo.GetDisplayName(arguments);
                 string nspace = typeInfo.Namespace;
                 fixture.FullName = nspace != null && nspace != ""
                     ? nspace + "." + name

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Internal.Builders
                 if (typeArgs.Length > 0 ||
                     TypeHelper.CanDeduceTypeArgsFromArgs(typeInfo.Type, arguments, ref typeArgs))
                 {
-                    typeInfo = new TypeWrapper(TypeHelper.MakeGenericType(typeInfo.Type, typeArgs));
+                    typeInfo = typeInfo.MakeGenericType(typeArgs);
                 }
             }
 

--- a/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal.Builders
         /// Adds the specified fixtures to the tree.
         /// </summary>
         /// <param name="fixtures">The fixtures to be added.</param>
-        public void Add( IList fixtures )
+        public void Add( IList<Test> fixtures )
         {
             foreach (TestSuite fixture in fixtures)
                 //if (fixture is SetUpFixture)
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Internal.Builders
         private static string GetNamespaceForFixture(TestSuite fixture)
         {
             string ns = fixture.FullName;
-            int index = ns.IndexOf("[");
+            int index = ns.IndexOfAny(new char[] { '[', '(' });
             if (index >= 0) ns = ns.Substring(0, index);
             index = ns.LastIndexOf('.');
             ns = index > 0 ? ns.Substring(0, index) : string.Empty;

--- a/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
@@ -45,25 +45,25 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns>
         /// True if any data is available, otherwise false.
         /// </returns>
-        public bool HasDataFor(ParameterInfo parameter)
+        public bool HasDataFor(IParameterInfo parameter)
         {
-            return parameter.IsDefined(typeof(IParameterDataSource), false);
+            return parameter.IsDefined<IParameterDataSource>(false);
         }
 
         /// <summary>
         /// Return an IEnumerable providing data for use with the
         /// supplied parameter.
         /// </summary>
-        /// <param name="parameter">A ParameterInfo representing one
+        /// <param name="parameter">An IParameterInfo representing one
         /// argument to a parameterized test</param>
         /// <returns>
         /// An IEnumerable providing the required data
         /// </returns>
-        public IEnumerable GetDataFor(ParameterInfo parameter)
+        public IEnumerable GetDataFor(IParameterInfo parameter)
         {
             var data = new List<object>();
 
-            foreach (IParameterDataSource source in parameter.GetCustomAttributes(typeof(IParameterDataSource), false))
+            foreach (IParameterDataSource source in parameter.GetCustomAttributes<IParameterDataSource>(false))
             {
                 foreach (object item in source.GetData(parameter))
                     data.Add(item);

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal.Commands
     public class OneTimeSetUpCommand : TestCommand
     {
         private readonly TestSuite _suite;
-        private readonly ITypeInfo _fixtureType;
+        private readonly ITypeInfo _typeInfo;
         private readonly object[] _arguments;
         private readonly List<SetUpTearDownItem> _setUpTearDown;
         private readonly List<TestActionItem> _actions;
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Internal.Commands
             : base(suite) 
         {
             _suite = suite;
-            _fixtureType = suite.TypeInfo;
+            _typeInfo = suite.TypeInfo;
             _arguments = suite.Arguments;
             _setUpTearDown = setUpTearDown;
             _actions = actions;
@@ -63,12 +63,12 @@ namespace NUnit.Framework.Internal.Commands
         /// <returns>A TestResult</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
-            if (_fixtureType != null)
+            if (_typeInfo != null)
             {
                 // Use pre-constructed fixture if available, otherwise construct it
-                if (!IsStaticClass(_fixtureType.Type))
+                if (!_typeInfo.IsStaticClass)
                 {
-                    context.TestObject = _suite.Fixture ?? Reflect.Construct(_fixtureType.Type, _arguments);
+                    context.TestObject = _suite.Fixture ?? _typeInfo.Construct(_arguments);
                     if (_suite.Fixture == null)
                     {
                         _suite.Fixture = context.TestObject;
@@ -85,11 +85,6 @@ namespace NUnit.Framework.Internal.Commands
                 _actions[i].BeforeTest(Test);
 
             return context.CurrentResult;
-        }
-
-        private static bool IsStaticClass(Type type)
-        {
-            return type.IsAbstract && type.IsSealed;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {
@@ -34,7 +35,7 @@ namespace NUnit.Framework.Internal.Commands
     public class OneTimeSetUpCommand : TestCommand
     {
         private readonly TestSuite _suite;
-        private readonly Type _fixtureType;
+        private readonly ITypeInfo _fixtureType;
         private readonly object[] _arguments;
         private readonly List<SetUpTearDownItem> _setUpTearDown;
         private readonly List<TestActionItem> _actions;
@@ -49,7 +50,7 @@ namespace NUnit.Framework.Internal.Commands
             : base(suite) 
         {
             _suite = suite;
-            _fixtureType = suite.FixtureType;
+            _fixtureType = suite.TypeInfo;
             _arguments = suite.Arguments;
             _setUpTearDown = setUpTearDown;
             _actions = actions;
@@ -65,9 +66,9 @@ namespace NUnit.Framework.Internal.Commands
             if (_fixtureType != null)
             {
                 // Use pre-constructed fixture if available, otherwise construct it
-                if (!IsStaticClass(_fixtureType))
+                if (!IsStaticClass(_fixtureType.Type))
                 {
-                    context.TestObject = _suite.Fixture ?? Reflect.Construct(_fixtureType, _arguments);
+                    context.TestObject = _suite.Fixture ?? Reflect.Construct(_fixtureType.Type, _arguments);
                     if (_suite.Fixture == null)
                     {
                         _suite.Fixture = context.TestObject;

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
@@ -27,6 +27,7 @@ using System.Threading;
 
 namespace NUnit.Framework.Internal.Commands
 {
+    using Execution;
     using Interfaces;
 
     /// <summary>
@@ -45,9 +46,9 @@ namespace NUnit.Framework.Internal.Commands
             : base(innerCommand)
         {
             Guard.ArgumentValid(innerCommand.Test is TestMethod, "SetUpTearDownCommand may only apply to a TestMethod", "innerCommand");
-            Guard.OperationValid(Test.FixtureType != null, "TestMethod must have a non-null FixtureType");
+            Guard.OperationValid(Test.TypeInfo != null, "TestMethod must have a non-null TypeInfo");
 
-            _setUpTearDownItems = Execution.CommandBuilder.BuildSetUpTearDownList(Test.FixtureType, typeof(SetUpAttribute), typeof(TearDownAttribute));
+            _setUpTearDownItems = CommandBuilder.BuildSetUpTearDownList(Test.TypeInfo.Type, typeof(SetUpAttribute), typeof(TearDownAttribute));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Internal.Commands
                 _actions.Add(new TestActionItem(action));
             }
 
-            foreach (ITestAction action in ActionsHelper.GetActionsFromAttributeProvider(((TestMethod)Test).Method))
+            foreach (ITestAction action in ActionsHelper.GetActionsFromAttributeProvider(((TestMethod)Test).Method.MethodInfo))
                 if (action.Targets == ActionTargets.Default || (action.Targets & ActionTargets.Test) == ActionTargets.Test)
                     _actions.Add(new TestActionItem(action));
 

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Internal.Commands
         private object RunTestMethod(TestExecutionContext context)
         {
 #if NET_4_0 || NET_4_5 || PORTABLE
-            if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method))
+            if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
                 return RunAsyncTestMethod(context);
             else
 #endif
@@ -83,9 +83,9 @@ namespace NUnit.Framework.Internal.Commands
 #if NET_4_0 || NET_4_5 || PORTABLE
         private object RunAsyncTestMethod(TestExecutionContext context)
         {
-            using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(testMethod.Method))
+            using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(testMethod.Method.MethodInfo))
             {
-                object result = Reflect.InvokeMethod(testMethod.Method, context.TestObject, arguments);
+                object result = Reflect.InvokeMethod(testMethod.Method.MethodInfo, context.TestObject, arguments);
 
                 try
                 {
@@ -101,7 +101,8 @@ namespace NUnit.Framework.Internal.Commands
 
         private object RunNonAsyncTestMethod(TestExecutionContext context)
         {
-            return Reflect.InvokeMethod(testMethod.Method, context.TestObject, arguments);
+            //return Reflect.InvokeMethod(testMethod.Method.MethodInfo, context.TestObject, arguments);
+            return testMethod.Method.Invoke(context.TestObject, arguments);
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
@@ -51,15 +51,15 @@ namespace NUnit.Framework.Internal.Execution
             TestCommand command = new OneTimeSetUpCommand(suite, setUpTearDown, actions);
 
             // Prefix with any IApplyToContext items from attributes
-            if (suite.FixtureType != null)
+            if (suite.TypeInfo != null)
             {
-                IApplyToContext[] changes = (IApplyToContext[])suite.FixtureType.GetCustomAttributes(typeof(IApplyToContext), true);
+                IApplyToContext[] changes = suite.TypeInfo.GetCustomAttributes<IApplyToContext>(true);
                 if (changes.Length > 0)
                     command = new ApplyChangesToContextCommand(command, changes);
             }
             if (suite.Method!=null)
             {
-                IApplyToContext[] changes = (IApplyToContext[])suite.Method.GetCustomAttributes(typeof(IApplyToContext), true);
+                IApplyToContext[] changes = suite.Method.GetCustomAttributes<IApplyToContext>(true);
                 if (changes.Length > 0)
                     command = new ApplyChangesToContextCommand(command, changes);
             }
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal.Execution
             TestCommand command = new TestMethodCommand(test);
 
             // Add any wrappers to the TestMethodCommand
-            foreach (IWrapTestMethod wrapper in test.Method.GetCustomAttributes(typeof(IWrapTestMethod), true))
+            foreach (IWrapTestMethod wrapper in test.Method.GetCustomAttributes<IWrapTestMethod>(true))
                 command = wrapper.Wrap(command);
 
             // Wrap in TestActionCommand
@@ -104,11 +104,11 @@ namespace NUnit.Framework.Internal.Execution
             command = new SetUpTearDownCommand(command);
 
             // Add wrappers that apply before setup and after teardown
-            foreach (ICommandWrapper decorator in test.Method.GetCustomAttributes(typeof(IWrapSetUpTearDown), true))
+            foreach (ICommandWrapper decorator in test.Method.GetCustomAttributes<IWrapSetUpTearDown>(true))
                 command = decorator.Wrap(command);
 
             // Add command to set up context using attributes that implement IApplyToContext
-            IApplyToContext[] changes = (IApplyToContext[])test.Method.GetCustomAttributes(typeof(IApplyToContext), true);
+            IApplyToContext[] changes = test.Method.GetCustomAttributes<IApplyToContext>(true);
             if (changes.Length > 0)
                 command = new ApplyChangesToContextCommand(command, changes);
 
@@ -127,9 +127,9 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Builds the set up tear down list.
         /// </summary>
-        /// <param name="fixtureType">Type of the fixture.</param>
-        /// <param name="setUpType">Type of the set up.</param>
-        /// <param name="tearDownType">Type of the tear down.</param>
+        /// <param name="fixtureType">TypeInfo of the fixture.</param>
+        /// <param name="setUpType">Type of the set up attribute.</param>
+        /// <param name="tearDownType">Type of the tear down attribute.</param>
         /// <returns>A list of SetUpTearDownItems</returns>
         public static List<SetUpTearDownItem> BuildSetUpTearDownList(Type fixtureType, Type setUpType, Type tearDownType)
         {
@@ -138,7 +138,7 @@ namespace NUnit.Framework.Internal.Execution
 
             var list = new List<SetUpTearDownItem>();
 
-            while (fixtureType != null && fixtureType != typeof(object))
+            while (fixtureType != null && !fixtureType.Equals(typeof(object)))
             {
                 var node = BuildNode(fixtureType, setUpMethods, tearDownMethods);
                 if (node.HasMethods)

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -149,8 +149,8 @@ namespace NUnit.Framework.Internal.Execution
 
         private void InitializeSetUpAndTearDownCommands()
         {
-            List<SetUpTearDownItem> setUpTearDownItems = _suite.FixtureType != null
-                ? CommandBuilder.BuildSetUpTearDownList(_suite.FixtureType, typeof(OneTimeSetUpAttribute), typeof(OneTimeTearDownAttribute))
+            List<SetUpTearDownItem> setUpTearDownItems = _suite.TypeInfo != null
+                ? CommandBuilder.BuildSetUpTearDownList(_suite.TypeInfo.Type, typeof(OneTimeSetUpAttribute), typeof(OneTimeTearDownAttribute))
                 : new List<SetUpTearDownItem>();
 
             var actionItems = new List<TestActionItem>();

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal.Execution
             // 2. For now, if this represents a test case. This avoids issues of
             // tests that access the fixture state and allows handling ApartmentState
             // preferences set on the fixture.
-            else if (work is SimpleWorkItem || work.Test.FixtureType == null)
+            else if (work is SimpleWorkItem || work.Test.TypeInfo == null)
                 Execute(work);
             else
                 Enqueue(work);

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -107,9 +107,9 @@ namespace NUnit.Framework.Internal.Execution
             if (Test is TestAssembly)
                 _actions.AddRange(ActionsHelper.GetActionsFromAttributeProvider(((TestAssembly)Test).Assembly));
             else if (Test is ParameterizedMethodSuite)
-                _actions.AddRange(ActionsHelper.GetActionsFromAttributeProvider(((ParameterizedMethodSuite)Test).Method));
-            else if (Test.FixtureType != null)
-                _actions.AddRange(ActionsHelper.GetActionsFromTypesAttributes(Test.FixtureType));
+                _actions.AddRange(ActionsHelper.GetActionsFromAttributeProvider(Test.Method.MethodInfo));
+            else if (Test.TypeInfo != null)
+                _actions.AddRange(ActionsHelper.GetActionsFromTypesAttributes(Test.TypeInfo.Type));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -122,8 +122,6 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Returns the display name for the method, called with specific arguments.
         /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
         public string GetDisplayName(object[] args)
         {
             return MethodHelper.GetDisplayName(MethodInfo, args);
@@ -142,6 +140,14 @@ namespace NUnit.Framework.Internal
                 result[i] = new ParameterWrapper(this, parameters[i]);
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns the Type arguments of a generic method or the Type parameters of a generic method definition.
+        /// </summary>
+        public Type[] GetGenericArguments()
+        {
+            return MethodInfo.GetGenericArguments();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -120,6 +120,16 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Returns the display name for the method, called with specific arguments.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public string GetDisplayName(object[] args)
+        {
+            return MethodHelper.GetDisplayName(MethodInfo, args);
+        }
+
+        /// <summary>
         /// Gets the parameters of the method.
         /// </summary>
         /// <returns></returns>

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -1,0 +1,176 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// The MethodWrapper class wraps a MethodInfo so that it may
+    /// be used in a platform-independent manner.
+    /// </summary>
+    public class MethodWrapper : IMethodInfo
+    {
+        /// <summary>
+        /// Construct a MethodWrapper for a Type and a MethodInfo.
+        /// </summary>
+        public MethodWrapper(Type type, MethodInfo method)
+        {
+            TypeInfo = new TypeInfo(type);
+            MethodInfo = method;
+        }
+
+        /// <summary>
+        /// Construct a MethodInfo for a given Type and method name.
+        /// </summary>
+        public MethodWrapper(Type type, string methodName)
+        {
+            TypeInfo = new TypeInfo(type);
+            MethodInfo = type.GetMethod(methodName);
+        }
+
+        #region IMethod Implementation
+
+        /// <summary>
+        /// Gets the Type from which this method was reflected.
+        /// </summary>
+        public ITypeInfo TypeInfo { get; private set; }
+
+        /// <summary>
+        /// Gets the MethodInfo for this method.
+        /// </summary>
+        public MethodInfo MethodInfo { get; private set; }
+
+        /// <summary>
+        /// Gets the name of the method.
+        /// </summary>
+        public string Name
+        {
+            get { return MethodInfo.Name;  }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is abstract.
+        /// </summary>
+        public bool IsAbstract
+        {
+            get { return MethodInfo.IsAbstract; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is public.
+        /// </summary>
+        public bool IsPublic
+        {
+            get { return MethodInfo.IsPublic;  }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the method contains unassigned generic type parameters.
+        /// </summary>
+        public bool ContainsGenericParameters
+        {
+            get { return MethodInfo.ContainsGenericParameters; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the method is a generic method.
+        /// </summary>
+        public bool IsGenericMethod
+        {
+            get { return MethodInfo.IsGenericMethod; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the MethodInfo represents the definition of a generic method.
+        /// </summary>
+        public bool IsGenericMethodDefinition
+        {
+            get { return MethodInfo.IsGenericMethodDefinition; }
+        }
+
+        /// <summary>
+        /// Gets the return Type of the method.
+        /// </summary>
+        public ITypeInfo ReturnType
+        {
+            get { return new TypeInfo(MethodInfo.ReturnType); }
+        }
+
+        /// <summary>
+        /// Gets the parameters of the method.
+        /// </summary>
+        /// <returns></returns>
+        public IParameterInfo[] GetParameters()
+        {
+            var parameters = MethodInfo.GetParameters();
+            var result = new IParameterInfo[parameters.Length];
+
+            for (int i = 0; i < parameters.Length; i++)
+                result[i] = new ParameterWrapper(this, parameters[i]);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Replaces the type parameters of the method with the array of types provided and returns a new IMethodInfo.
+        /// </summary>
+        /// <param name="typeArguments">The type arguments to be used</param>
+        /// <returns>A new IMethodInfo with the type arguments replaced</returns>
+        public IMethodInfo MakeGenericMethod(params Type[] typeArguments)
+        {
+            return new MethodWrapper(TypeInfo.Type, MethodInfo.MakeGenericMethod(typeArguments));
+        }
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this method
+        /// </summary>
+        public T[] GetCustomAttributes<T>(bool inherit) where T : class
+        {
+            return (T[])MethodInfo.GetCustomAttributes(typeof(T), inherit);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether one or more attributes of the spcified type are defined on the method.
+        /// </summary>
+        public bool IsDefined<T>(bool inherit)
+        {
+            return MethodInfo.IsDefined(typeof(T), inherit);
+        }
+
+        /// <summary>
+        /// Invokes the method, converting any TargetInvocationException to an NUnitException.
+        /// </summary>
+        /// <param name="fixture">The object on which to invoke the method</param>
+        /// <param name="args">The argument list for the method</param>
+        /// <returns>The return value from the invoked method</returns>
+        public object Invoke(object fixture, params object[] args)
+        {
+            return Reflect.InvokeMethod(MethodInfo, fixture, args);
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public MethodWrapper(Type type, MethodInfo method)
         {
-            TypeInfo = new TypeInfo(type);
+            TypeInfo = new TypeWrapper(type);
             MethodInfo = method;
         }
 
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public MethodWrapper(Type type, string methodName)
         {
-            TypeInfo = new TypeInfo(type);
+            TypeInfo = new TypeWrapper(type);
             MethodInfo = type.GetMethod(methodName);
         }
 
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public ITypeInfo ReturnType
         {
-            get { return new TypeInfo(MethodInfo.ReturnType); }
+            get { return new TypeWrapper(MethodInfo.ReturnType); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/NetCFExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/NetCFExtensions.cs
@@ -4,11 +4,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Reflection;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
     static class NetCFExtensions
     {
+        public static IMethodInfo MakeGenericMethodEx(this IMethodInfo method, object[] arguments)
+        {
+            var newMi = method.MethodInfo.MakeGenericMethodEx(arguments);
+            if (newMi == null) return null;
+
+            return new MethodWrapper(method.TypeInfo.Type, newMi);
+        }
+
         public static MethodInfo MakeGenericMethodEx(this MethodInfo mi, object[] arguments)
         {
             return mi.MakeGenericMethodEx(arguments.Select(a => a == null ? typeof(object) : (a is Type ? typeof(Type) : a.GetType())).ToArray());

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2008 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,52 +21,57 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
-using NUnit.Framework.Internal.Commands;
 
 namespace NUnit.Framework.Internal
 {
-    /// <summary>
-    /// ParameterizedMethodSuite holds a collection of individual
-    /// TestMethods with their arguments applied.
-    /// </summary>
-    public class ParameterizedMethodSuite : TestSuite
+    public class ParameterWrapper : IParameterInfo
     {
-        private bool _isTheory;
-
-        /// <summary>
-        /// Construct from a MethodInfo
-        /// </summary>
-        /// <param name="method"></param>
-        public ParameterizedMethodSuite(IMethodInfo method)
-            : base(method.TypeInfo.FullName, method.Name)
+        public ParameterWrapper(IMethodInfo method, ParameterInfo parameterInfo)
         {
             Method = method;
-#if PORTABLE
-            _isTheory = false;
-#else
-            _isTheory = method.IsDefined<TheoryAttribute>(true);
-#endif
-            this.MaintainTestOrder = true;
+            ParameterInfo = parameterInfo;
+        }
+
+        #region Properties
+
+        public bool IsOptional
+        {
+            get { return ParameterInfo.IsOptional;  }
+        }
+
+        public IMethodInfo Method { get; private set; }
+
+        public ParameterInfo ParameterInfo { get; private set; }
+
+        public Type ParameterType
+        {
+            get { return ParameterInfo.ParameterType;  }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this method
+        /// </summary>
+        public T[] GetCustomAttributes<T>(bool inherit) where T : class
+        {
+            return (T[])ParameterInfo.GetCustomAttributes(typeof(T), inherit);
         }
 
         /// <summary>
-        /// Gets a string representing the type of test
+        /// Gets a value indicating whether one or more attributes of the specified type are defined on the parameter.
         /// </summary>
-        /// <value></value>
-        public override string TestType
+        public bool IsDefined<T>(bool inherit)
         {
-            get
-            {
-                if (_isTheory)
-                    return "Theory";
-
-                if (this.Method.ContainsGenericParameters)
-                    return "GenericMethod";
-                
-                return "ParameterizedMethod";
-            }
+            return ParameterInfo.IsDefined(typeof(T), inherit);
         }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -28,8 +28,17 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
+    /// <summary>
+    /// The ParameterWrapper class wraps a ParameterInfo so that it may
+    /// be used in a platform-independent manner.
+    /// </summary>
     public class ParameterWrapper : IParameterInfo
     {
+        /// <summary>
+        /// Construct a ParameterWrapper for a given method and parameter
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="parameterInfo"></param>
         public ParameterWrapper(IMethodInfo method, ParameterInfo parameterInfo)
         {
             Method = method;
@@ -38,15 +47,27 @@ namespace NUnit.Framework.Internal
 
         #region Properties
 
+        /// <summary>
+        /// Gets a value indicating whether the parameter is optional
+        /// </summary>
         public bool IsOptional
         {
             get { return ParameterInfo.IsOptional;  }
         }
 
+        /// <summary>
+        /// Gets an IMethodInfo representing the method for which this is a parameter.
+        /// </summary>
         public IMethodInfo Method { get; private set; }
 
+        /// <summary>
+        /// Gets the underlying ParameterInfo
+        /// </summary>
         public ParameterInfo ParameterInfo { get; private set; }
 
+        /// <summary>
+        /// Gets the Type of the parameter
+        /// </summary>
         public Type ParameterType
         {
             get { return ParameterInfo.ParameterType;  }

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -47,6 +47,7 @@ namespace NUnit.Framework.Internal
 
         #region Properties
 
+#if !NETCF
         /// <summary>
         /// Gets a value indicating whether the parameter is optional
         /// </summary>
@@ -54,6 +55,7 @@ namespace NUnit.Framework.Internal
         {
             get { return ParameterInfo.IsOptional;  }
         }
+#endif
 
         /// <summary>
         /// Gets an IMethodInfo representing the method for which this is a parameter.

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -210,18 +210,20 @@ namespace NUnit.Framework.Internal
                 {
                     return method.Invoke(fixture, args);
                 }
+#if !PORTABLE
+                catch (System.Threading.ThreadAbortException)
+                {
+                    // No need to wrap or rethrow ThreadAbortException
+                    return null;
+                }
+#endif
+                catch (TargetInvocationException e)
+                {
+                    throw new NUnitException("Rethrown", e.InnerException);
+                }
                 catch (Exception e)
                 {
-#if !PORTABLE
-                    // No need to wrap or rethrow ThreadAbortException
-                    if (!(e is System.Threading.ThreadAbortException))
-#endif
-                    {
-                        if (e is TargetInvocationException)
-                            throw new NUnitException("Rethrown", e.InnerException);
-                        else
-                            throw new NUnitException("Rethrown", e);
-                    }
+                    throw new NUnitException("Rethrown", e);
                 }
             }
 

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -36,10 +37,10 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterizedFixtureSuite"/> class.
         /// </summary>
-        /// <param name="type">The type.</param>
-        public ParameterizedFixtureSuite(Type type) : base(type.Namespace, TypeHelper.GetDisplayName(type)) 
+        /// <param name="typeInfo">The ITypeInfo for the type that represents the suite.</param>
+        public ParameterizedFixtureSuite(ITypeInfo typeInfo) : base(typeInfo.Namespace, TypeHelper.GetDisplayName(typeInfo.Type)) 
         {
-            _genericFixture = type.ContainsGenericParameters;
+            _genericFixture = typeInfo.ContainsGenericParameters;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class ParameterizedFixtureSuite : TestSuite
     {
-        private Type type;
+        private bool _genericFixture;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterizedFixtureSuite"/> class.
@@ -39,16 +39,7 @@ namespace NUnit.Framework.Internal
         /// <param name="type">The type.</param>
         public ParameterizedFixtureSuite(Type type) : base(type.Namespace, TypeHelper.GetDisplayName(type)) 
         {
-            this.type = type;
-        }
-
-        /// <summary>
-        /// Gets the Type represented by this suite.
-        /// </summary>
-        /// <value>A System.Type.</value>
-        public Type ParameterizedType
-        {
-            get { return type; }
+            _genericFixture = type.ContainsGenericParameters;
         }
 
         /// <summary>
@@ -59,10 +50,9 @@ namespace NUnit.Framework.Internal
         {
             get
             {
-                if (this.ParameterizedType.ContainsGenericParameters)
-                    return "GenericFixture";
-                
-                return "ParameterizedFixture";
+                return _genericFixture
+                    ? "GenericFixture"
+                    : "ParameterizedFixture";
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="ParameterizedFixtureSuite"/> class.
         /// </summary>
         /// <param name="typeInfo">The ITypeInfo for the type that represents the suite.</param>
-        public ParameterizedFixtureSuite(ITypeInfo typeInfo) : base(typeInfo.Namespace, TypeHelper.GetDisplayName(typeInfo.Type)) 
+        public ParameterizedFixtureSuite(ITypeInfo typeInfo) : base(typeInfo.Namespace, typeInfo.GetDisplayName()) 
         {
             _genericFixture = typeInfo.ContainsGenericParameters;
         }

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -37,7 +38,7 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="SetUpFixture"/> class.
         /// </summary>
         /// <param name="type">The type.</param>
-        public SetUpFixture( Type type ) : base( type )
+        public SetUpFixture( ITypeInfo type ) : base( type )
         {
             this.Name = type.Namespace;
             if (this.Name == null)

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal
         /// <param name="typeInfo"></param>
         protected Test(ITypeInfo typeInfo)
         {
-            Initialize(TypeHelper.GetDisplayName(typeInfo.Type));
+            Initialize(typeInfo.GetDisplayName());
 
             string nspace = typeInfo.Namespace;
             if (nspace != null && nspace != "")

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -37,7 +38,7 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="TestFixture"/> class.
         /// </summary>
         /// <param name="fixtureType">Type of the fixture.</param>
-        public TestFixture(Type fixtureType) : base(fixtureType)
+        public TestFixture(ITypeInfo fixtureType) : base(fixtureType)
         {
             CheckSetUpTearDownMethods(typeof(OneTimeSetUpAttribute));
             CheckSetUpTearDownMethods(typeof(OneTimeTearDownAttribute));

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -49,31 +49,19 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="TestMethod"/> class.
         /// </summary>
         /// <param name="method">The method to be used as a test.</param>
-        public TestMethod(MethodInfo method) : this(method, null) { }
+        public TestMethod(IMethodInfo method) : base (method) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestMethod"/> class.
         /// </summary>
         /// <param name="method">The method to be used as a test.</param>
         /// <param name="parentSuite">The suite or fixture to which the new test will be added</param>
-        public TestMethod(MethodInfo method, Test parentSuite) 
-            : base( method ) 
+        public TestMethod(IMethodInfo method, Test parentSuite) : base(method ) 
         {
-            // Disambiguate call to base class methods
-            // TODO: This should not be here - it's a presentation issue
-            //if( method.DeclaringType != method.ReflectedType)
-            //    this.Name = method.DeclaringType.Name + "." + method.Name;
-
             // Needed to give proper fullname to test in a parameterized fixture.
             // Without this, the arguments to the fixture are not included.
-            string prefix = method.ReflectedType.FullName;
             if (parentSuite != null)
-            {
-                prefix = parentSuite.FullName;
-                this.FullName = prefix + "." + this.Name;
-            }
-
-            //this.method = method;
+                FullName = parentSuite.FullName + "." + Name;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="fixtureType">Type of the fixture.</param>
         public TestSuite(Type fixtureType)
-            : base(new TypeInfo(fixtureType))
+            : base(new TypeWrapper(fixtureType))
         {
             Arguments = new object[0];
         }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -53,8 +53,7 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="TestSuite"/> class.
         /// </summary>
         /// <param name="name">The name of the suite.</param>
-        public TestSuite( string name ) 
-            : base( name ) 
+        public TestSuite( string name ) : base( name ) 
         {
             Arguments = new object[0];
         }
@@ -74,13 +73,19 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="TestSuite"/> class.
         /// </summary>
         /// <param name="fixtureType">Type of the fixture.</param>
-        public TestSuite(Type fixtureType) : base(fixtureType)
+        public TestSuite(ITypeInfo fixtureType)
+            : base(fixtureType)
         {
-            Name = TypeHelper.GetDisplayName(fixtureType);
-            string nspace = fixtureType.Namespace;
-            FullName = nspace != null && nspace != ""
-                ? nspace + "." + Name
-                : Name;
+            Arguments = new object[0];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestSuite"/> class.
+        /// </summary>
+        /// <param name="fixtureType">Type of the fixture.</param>
+        public TestSuite(Type fixtureType)
+            : base(new TypeInfo(fixtureType))
+        {
             Arguments = new object[0];
         }
 
@@ -244,7 +249,7 @@ namespace NUnit.Framework.Internal
         /// <param name="attrType">The attribute type to check for</param>
         protected void CheckSetUpTearDownMethods(Type attrType)
         {
-            foreach (MethodInfo method in Reflect.GetMethodsWithAttribute(FixtureType, attrType, true))
+            foreach (MethodInfo method in Reflect.GetMethodsWithAttribute(TypeInfo.Type, attrType, true))
                 if (method.IsAbstract ||
                      !method.IsPublic && !method.IsFamily ||
                      method.GetParameters().Length > 0 ||

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -27,6 +27,7 @@ using System.Linq;
 #endif
 using System.Reflection;
 using System.Text;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -222,7 +223,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="arglist">An array of args to be converted</param>
         /// <param name="parameters">A ParameterInfo[] whose types will be used as targets</param>
-        public static void ConvertArgumentList(object[] arglist, ParameterInfo[] parameters)
+        public static void ConvertArgumentList(object[] arglist, IParameterInfo[] parameters)
         {
             System.Diagnostics.Debug.Assert(arglist.Length <= parameters.Length);
 

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -260,18 +260,6 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Creates an instance of a generic Type using the supplied Type arguments
-        /// </summary>
-        /// <param name="type">The generic type to be specialized.</param>
-        /// <param name="typeArgs">The type args.</param>
-        /// <returns>An instance of the generic type.</returns>
-        public static Type MakeGenericType(Type type, Type[] typeArgs)
-        {
-            // TODO: Add error handling
-            return type.MakeGenericType(typeArgs);
-        }
-
-        /// <summary>
         /// Determines whether this instance can deduce type args for a generic type from the supplied arguments.
         /// </summary>
         /// <param name="type">The type to be examined.</param>

--- a/src/NUnitFramework/framework/Internal/TypeInfo.cs
+++ b/src/NUnitFramework/framework/Internal/TypeInfo.cs
@@ -1,0 +1,162 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// The TypeInfo class wraps a Type so it may be used in
+    /// a platform-independent manner.
+    /// </summary>
+    public class TypeInfo : ITypeInfo
+    {
+        /// <summary>
+        /// Construct a TypeWrapper for a specified Type.
+        /// </summary>
+        public TypeInfo(Type type)
+        {
+            Guard.ArgumentNotNull(type, "Type");
+
+            Type = type;
+        }
+
+        /// <summary>
+        /// Gets the underlying Type on which this TypeWrapper is based.
+        /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// Gets the base type of this type as an ITypeInfo
+        /// </summary>
+        public ITypeInfo BaseType 
+        {
+            get 
+            {
+                var baseType = Type.BaseType;
+
+                return baseType != null
+                    ? new TypeInfo(baseType)
+                    : null; 
+            }
+        }
+
+        /// <summary>
+        /// Gets the Name of the Type
+        /// </summary>
+        public string Name
+        {
+            get { return Type.Name; }
+        }
+
+        /// <summary>
+        /// Gets the FullName of the Type
+        /// </summary>
+        public string FullName
+        {
+            get { return Type.FullName;  }
+        }
+
+        /// <summary>
+        /// Gets the assembly in which the type is declared
+        /// </summary>
+        public Assembly Assembly
+        {
+            get { return Type.Assembly; }
+        }
+
+        /// <summary>
+        /// Gets the namespace of the Type
+        /// </summary>
+        public string Namespace
+        {
+            get { return Type.Namespace; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type is a generic Type
+        /// </summary>
+        public bool IsGenericType
+        {
+            get { return Type.IsGenericType; }
+        }
+
+        /// <summary>
+        /// Returns true if the Type wrapped is T
+        /// </summary>
+        public bool IsType(Type type)
+        {
+            return Type == type;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type has generic parameters that have not been replaced by specific Types.
+        /// </summary>
+        public bool ContainsGenericParameters
+        {
+            get { return Type.ContainsGenericParameters; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the Type is a generic Type definition
+        /// </summary>
+        public bool IsGenericTypeDefinition
+        {
+            get { return Type.IsGenericTypeDefinition; }
+        }
+
+        /// <summary>
+        /// Returns a Type representing a generic type definition from which this Type can be constructed.
+        /// </summary>
+        public Type GetGenericTypeDefinition()
+        {
+            return Type.GetGenericTypeDefinition();
+        }
+
+        /// <summary>
+        /// Returns an array of custom attributes of the specified type applied to this type
+        /// </summary>
+        public T[] GetCustomAttributes<T>(bool inherit) where T : class
+        {
+            return (T[])Type.GetCustomAttributes(typeof(T), inherit);
+        }
+
+        /// <summary>
+        /// Returns an array of IMethodInfos for methods of this Type
+        /// that match the specified flags.
+        /// </summary>
+        public IMethodInfo[] GetMethods(BindingFlags flags)
+        {
+            var methods = Type.GetMethods(flags);
+            var result = new MethodWrapper[methods.Length];
+
+            for (int i = 0; i < methods.Length; i++)
+                result[i] = new MethodWrapper(Type, methods[i]);
+
+            return result;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -153,6 +153,22 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Get the display name for this type
+        /// </summary>
+        public string GetDisplayName()
+        {
+            return TypeHelper.GetDisplayName(Type);
+        }
+
+        /// <summary>
+        /// Get the display name for an object of this type, constructed with the specified args.
+        /// </summary>
+        public string GetDisplayName(object[] args)
+        {
+            return TypeHelper.GetDisplayName(Type, args);
+        }
+
+        /// <summary>
         /// Returns a Type representing a generic type definition from which this Type can be constructed.
         /// </summary>
         public Type GetGenericTypeDefinition()
@@ -168,11 +184,22 @@ namespace NUnit.Framework.Internal
             return (T[])Type.GetCustomAttributes(typeof(T), inherit);
         }
 
+        /// <summary>
+        /// Returns a value indicating whether the type has an attribute of the specified type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="inherit"></param>
+        /// <returns></returns>
         public bool IsDefined<T>(bool inherit)
         {
             return Type.IsDefined(typeof(T), inherit);
         }
 
+        /// <summary>
+        /// Returns a flag indicating whether this type has a method with an attribute of the specified type.
+        /// </summary>
+        /// <param name="attributeType"></param>
+        /// <returns></returns>
         public bool HasMethodWithAttribute(Type attributeType)
         {
             return Reflect.HasMethodWithAttribute(Type, attributeType);

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -29,15 +29,15 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework.Internal
 {
     /// <summary>
-    /// The TypeInfo class wraps a Type so it may be used in
+    /// The TypeWrapper class wraps a Type so it may be used in
     /// a platform-independent manner.
     /// </summary>
-    public class TypeInfo : ITypeInfo
+    public class TypeWrapper : ITypeInfo
     {
         /// <summary>
         /// Construct a TypeWrapper for a specified Type.
         /// </summary>
-        public TypeInfo(Type type)
+        public TypeWrapper(Type type)
         {
             Guard.ArgumentNotNull(type, "Type");
 
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Internal
                 var baseType = Type.BaseType;
 
                 return baseType != null
-                    ? new TypeInfo(baseType)
+                    ? new TypeWrapper(baseType)
                     : null; 
             }
         }
@@ -97,6 +97,14 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Gets a value indicating whether the type is abstract.
+        /// </summary>
+        public bool IsAbstract
+        {
+            get { return Type.IsAbstract; }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the Type is a generic Type
         /// </summary>
         public bool IsGenericType
@@ -129,6 +137,22 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Gets a value indicating whether the type is sealed.
+        /// </summary>
+        public bool IsSealed
+        {
+            get { return Type.IsSealed; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this type represents a static class.
+        /// </summary>
+        public bool IsStaticClass
+        {
+            get { return Type.IsSealed && Type.IsAbstract; }
+        }
+
+        /// <summary>
         /// Returns a Type representing a generic type definition from which this Type can be constructed.
         /// </summary>
         public Type GetGenericTypeDefinition()
@@ -142,6 +166,16 @@ namespace NUnit.Framework.Internal
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
             return (T[])Type.GetCustomAttributes(typeof(T), inherit);
+        }
+
+        public bool IsDefined<T>(bool inherit)
+        {
+            return Type.IsDefined(typeof(T), inherit);
+        }
+
+        public bool HasMethodWithAttribute(Type attributeType)
+        {
+            return Reflect.HasMethodWithAttribute(Type, attributeType);
         }
 
         /// <summary>
@@ -158,5 +192,22 @@ namespace NUnit.Framework.Internal
 
             return result;
         }
+
+        /// <summary>
+        /// Returns a value indicating whether this Type has a public constructor taking the specified argument Types.
+        /// </summary>
+        public bool HasConstructor(Type[] argTypes)
+        {
+            return Type.GetConstructor(argTypes) != null;
+        }
+
+        /// <summary>
+        /// Construct an object of this Type, using the specified arguments.
+        /// </summary>
+        public object Construct(object[] args)
+        {
+            return Reflect.Construct(Type, args);
+        }
+
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -169,6 +169,14 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Returns a new ITypeInfo representing an instance of this generic Type using the supplied Type arguments
+        /// </summary>
+        public ITypeInfo MakeGenericType(Type[] typeArgs)
+        {
+            return new TypeWrapper(Type.MakeGenericType(typeArgs));
+        }
+
+        /// <summary>
         /// Returns a Type representing a generic type definition from which this Type can be constructed.
         /// </summary>
         public Type GetGenericTypeDefinition()

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -95,7 +95,7 @@ namespace NUnit.Framework
         /// </summary>
         public string TestDirectory
         {
-            get { return AssemblyHelper.GetDirectoryName(_testExecutionContext.CurrentTest.FixtureType.Assembly); }
+            get { return AssemblyHelper.GetDirectoryName(_testExecutionContext.CurrentTest.TypeInfo.Assembly); }
         }
 #endif
 

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -138,12 +138,13 @@
     </Compile>
     <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Internal\MethodWrapper.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Internal\ParameterWrapper.cs" />
-    <Compile Include="Internal\TypeInfo.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="TestFixtureData.cs" />
     <Compile Include="DirectoryAssert.cs" />
     <Compile Include="Does.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -136,6 +136,14 @@
     <Compile Include="Assert.Conditions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Interfaces\IMethodInfo.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
+    <Compile Include="Internal\MethodWrapper.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Internal\ParameterWrapper.cs" />
+    <Compile Include="Internal\TypeInfo.cs" />
     <Compile Include="TestFixtureData.cs" />
     <Compile Include="DirectoryAssert.cs" />
     <Compile Include="Does.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Interfaces\IParameterDataSource.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
     <Compile Include="Interfaces\ITest.cs" />
@@ -395,7 +396,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
-    <Compile Include="Internal\TypeInfo.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -281,11 +281,13 @@
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
+    <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\IParameterDataSource.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
@@ -298,6 +300,7 @@
     <Compile Include="Interfaces\ITestFixtureData.cs" />
     <Compile Include="Interfaces\ITestListener.cs" />
     <Compile Include="Interfaces\ITestResult.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
@@ -360,9 +363,11 @@
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
+    <Compile Include="Internal\MethodWrapper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\NUnitException.cs" />
     <Compile Include="Internal\OSPlatform.cs" />
+    <Compile Include="Internal\ParameterWrapper.cs" />
     <Compile Include="Internal\PlatformHelper.cs" />
     <Compile Include="Internal\PropertyBag.cs" />
     <Compile Include="Internal\PropertyNames.cs" />
@@ -390,6 +395,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
+    <Compile Include="Internal\TypeInfo.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -292,6 +292,7 @@
     <Compile Include="Interfaces\IParameterDataSource.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
     <Compile Include="Interfaces\ITest.cs" />
@@ -399,7 +400,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
-    <Compile Include="Internal\TypeInfo.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -287,8 +287,10 @@
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
+    <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
     <Compile Include="Interfaces\IParameterDataSource.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
@@ -301,6 +303,7 @@
     <Compile Include="Interfaces\ITestListener.cs" />
     <Compile Include="Interfaces\ITestBuilder.cs" />
     <Compile Include="Interfaces\ITestResult.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
@@ -364,9 +367,11 @@
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
+    <Compile Include="Internal\MethodWrapper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\NUnitException.cs" />
     <Compile Include="Internal\OSPlatform.cs" />
+    <Compile Include="Internal\ParameterWrapper.cs" />
     <Compile Include="Internal\PlatformHelper.cs" />
     <Compile Include="Internal\PropertyBag.cs" />
     <Compile Include="Internal\PropertyNames.cs" />
@@ -394,6 +399,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
+    <Compile Include="Internal\TypeInfo.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -299,9 +299,12 @@
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
+    <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
     <Compile Include="Interfaces\IParameterDataSource.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
     <Compile Include="Interfaces\ITest.cs" />
@@ -313,6 +316,7 @@
     <Compile Include="Interfaces\ITestFixtureData.cs" />
     <Compile Include="Interfaces\ITestListener.cs" />
     <Compile Include="Interfaces\ITestResult.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
@@ -375,9 +379,11 @@
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
+    <Compile Include="Internal\MethodWrapper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\NUnitException.cs" />
     <Compile Include="Internal\OSPlatform.cs" />
+    <Compile Include="Internal\ParameterWrapper.cs" />
     <Compile Include="Internal\PlatformHelper.cs" />
     <Compile Include="Internal\PropertyBag.cs" />
     <Compile Include="Internal\PropertyNames.cs" />
@@ -407,6 +413,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -283,8 +283,10 @@
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
+    <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
     <Compile Include="Interfaces\IParameterDataSource.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
@@ -297,6 +299,7 @@
     <Compile Include="Interfaces\ITestFixtureData.cs" />
     <Compile Include="Interfaces\ITestListener.cs" />
     <Compile Include="Interfaces\ITestResult.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
@@ -359,9 +362,11 @@
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
+    <Compile Include="Internal\MethodWrapper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\NUnitException.cs" />
     <Compile Include="Internal\OSPlatform.cs" />
+    <Compile Include="Internal\ParameterWrapper.cs" />
     <Compile Include="Internal\PlatformHelper.cs" />
     <Compile Include="Internal\PropertyBag.cs" />
     <Compile Include="Internal\PropertyNames.cs" />
@@ -391,6 +396,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
+    <Compile Include="Internal\TypeInfo.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Interfaces\IParameterDataSource.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
     <Compile Include="Interfaces\ITest.cs" />
@@ -396,7 +397,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
-    <Compile Include="Internal\TypeInfo.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -298,8 +298,10 @@
     <Compile Include="Interfaces\ICommandWrapper.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
+    <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterDataProvider.cs" />
     <Compile Include="Interfaces\IParameterDataSource.cs" />
+    <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
@@ -312,6 +314,7 @@
     <Compile Include="Interfaces\ITestFixtureData.cs" />
     <Compile Include="Interfaces\ITestListener.cs" />
     <Compile Include="Interfaces\ITestResult.cs" />
+    <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
@@ -374,9 +377,11 @@
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\MethodHelper.cs" />
+    <Compile Include="Internal\MethodWrapper.cs" />
     <Compile Include="Internal\NetCFExtensions.cs" />
     <Compile Include="Internal\NUnitException.cs" />
     <Compile Include="Internal\OSPlatform.cs" />
+    <Compile Include="Internal\ParameterWrapper.cs" />
     <Compile Include="Internal\PlatformHelper.cs" />
     <Compile Include="Internal\PropertyBag.cs" />
     <Compile Include="Internal\PropertyNames.cs" />
@@ -406,6 +411,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
+    <Compile Include="Internal\TypeInfo.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -303,6 +303,7 @@
     <Compile Include="Interfaces\IParameterDataSource.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IPropertyBag.cs" />
+    <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ISimpleTestBuilder.cs" />
     <Compile Include="Interfaces\ISuiteBuilder.cs" />
     <Compile Include="Interfaces\ITest.cs" />
@@ -411,7 +412,7 @@
     <Compile Include="Internal\Tests\TestSuite.cs" />
     <Compile Include="Internal\ThreadUtility.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
-    <Compile Include="Internal\TypeInfo.cs" />
+    <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Attributes
 {
@@ -405,18 +406,19 @@ namespace NUnit.Framework.Attributes
         
         private void CheckValues(string methodName, params object[] expected)
         {
-            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
-            ParameterInfo param = method.GetParameters()[0];
-            ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-            Assert.That(attr.GetData(param), Is.EqualTo(expected));
+            var method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            var param = method.GetParameters()[0];
+            var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
+            Assert.That(attr.GetData(new ParameterWrapper(new MethodWrapper(GetType(), method), param)), Is.EqualTo(expected));
         }
 
         private void CheckValuesWithinTolerance(string methodName, params object[] expected)
         {
-            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
-            ParameterInfo param = method.GetParameters()[0];
-            ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-            Assert.That(attr.GetData(param), Is.EqualTo(expected).Within(0.000001));
+            var method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            var param = method.GetParameters()[0];
+            var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
+            Assert.That(attr.GetData(new ParameterWrapper(new MethodWrapper(GetType(), method), param)), 
+                Is.EqualTo(expected).Within(0.000001));
         }
         
         #endregion

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(typeof(Class4))]
         public void CertainAttributesAreNotAllowed(Type type)
         {
-            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeInfo(type));
+            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeWrapper(type));
             foreach (var fixture in fixtures)
                 Assert.That(fixture.RunState, Is.EqualTo(RunState.NotRunnable));
         }

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestAttribute_NoArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             TestMethod test = new TestAttribute().BuildFrom(method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestAttribute_WithArgs_NotRunnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             TestMethod test = new TestAttribute().BuildFrom(method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseAttribute_NoArgs_NotRunnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseAttribute_RightArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.Runnable));
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseAttribute_WrongArgs_NotRunnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42, 99).BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
@@ -76,7 +76,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_NoArgs_NotRunnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_RightArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_WrongArgs_NotRunnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("BadData").BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TheoryAttribute_NoArgs_NoCases()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
@@ -115,7 +115,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TheoryAttribute_WithArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntArgs");
+            var method = GetMethod("MethodWithIntArgs");
             List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(9));
             foreach (var test in tests)
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CombinatorialAttribute_NoArgs_NoCases()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CombinatorialAttribute_WithArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntValues");
+            var method = GetMethod("MethodWithIntValues");
             List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(6));
             foreach (var test in tests)
@@ -144,7 +144,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void PairwiseAttribute_NoArgs_NoCases()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void PairwiseAttribute_WithArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntValues");
+            var method = GetMethod("MethodWithIntValues");
             List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(6));
             foreach (var test in tests)
@@ -162,7 +162,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SequentialAttribute_NoArgs_NoCases()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithoutArgs");
+            var method = GetMethod("MethodWithoutArgs");
             List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(0));
         }
@@ -170,11 +170,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SequentialAttribute_WithArgs_Runnable()
         {
-            MethodInfo method = GetType().GetMethod("MethodWithIntValues");
+            var method = GetMethod("MethodWithIntValues");
             List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
             Assert.That(tests.Count, Is.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
+        private IMethodInfo GetMethod(string methodName)
+        {
+            return new MethodWrapper(GetType(), methodName);
         }
 
         public static void MethodWithoutArgs() { }

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Attributes
 {
@@ -81,7 +82,7 @@ namespace NUnit.Framework.Attributes
             MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             ParameterInfo param = method.GetParameters()[0];
             ValuesAttribute attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-            Assert.That(attr.GetData(param), Is.EqualTo(expected));
+            Assert.That(attr.GetData(new ParameterWrapper(new MethodWrapper(GetType(), method), param)), Is.EqualTo(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -19,7 +19,8 @@ namespace NUnit.Framework.Internal
         public void Setup()
         {
             _testObject = new AsyncSetupTearDownFixture();
-            _context = new TestExecutionContext {TestObject = _testObject, CurrentResult = new TestCaseResult(new TestMethod(Success.ElementAt(0)))};
+            var method = new MethodWrapper(typeof(AsyncSetupTearDownFixture), Success.ElementAt(0));
+            _context = new TestExecutionContext {TestObject = _testObject, CurrentResult = new TestCaseResult(new TestMethod(method))};
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Internal
         /// Private method to return a test case, optionally ignored on the Linux platform.
         /// We use this since the Platform attribute is not supported on TestCaseData.
         /// </summary>
-        private static TestCaseData GetTestCase(MethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
+        private static TestCaseData GetTestCase(IMethodInfo method, ResultState resultState, int assertionCount, bool ignoreOnLinux)
         {
             var data = new TestCaseData(method, resultState, assertionCount);
             if (ON_LINUX && ignoreOnLinux)
@@ -83,7 +83,7 @@ namespace NUnit.Framework.Internal
 
         [Test]
         [TestCaseSource("TestCases")]
-        public void RunTests(MethodInfo method, ResultState resultState, int assertionCount)
+        public void RunTests(IMethodInfo method, ResultState resultState, int assertionCount)
         {
             var test = _builder.BuildFrom(method);
             var result = TestBuilder.RunTest(test, _testObject);
@@ -92,9 +92,9 @@ namespace NUnit.Framework.Internal
             Assert.That(result.AssertCount, Is.EqualTo(assertionCount), "Wrong assertion count");
         }
 
-        private static MethodInfo Method(string name)
+        private static IMethodInfo Method(string name)
         {
-            return typeof(AsyncRealFixture).GetMethod(name);
+            return new MethodWrapper(typeof(AsyncRealFixture), name);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -437,7 +437,7 @@ namespace NUnit.Framework.Internal
             {
                 Assert.That(test, Is.Not.Null, "ITest is null on a " + _location);
                 Assert.That(test.Fixture, Is.Not.Null, "ITest.Fixture is null on a " + _location);
-                Assert.That(test.Fixture.GetType(), Is.EqualTo(test.FixtureType), "ITest.Fixture is not the correct type on a " + _location);
+                Assert.That(test.Fixture.GetType(), Is.EqualTo(test.TypeInfo.Type), "ITest.Fixture is not the correct type on a " + _location);
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestResultTests.cs
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
             expectedStart = new DateTime(1968, 4, 8, 15, 05, 30, 250, DateTimeKind.Utc);
             expectedEnd = expectedStart.AddSeconds(expectedDuration);
 
-            test = new TestMethod(typeof(DummySuite).GetMethod("DummyMethod"));
+            test = new TestMethod(new MethodWrapper(typeof(DummySuite), "DummyMethod"));
             test.Properties.Set(PropertyNames.Description, "Test description");
             test.Properties.Add(PropertyNames.Category, "Dubious");
             test.Properties.Set("Priority", "low");

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Internal
             testMethod.Properties.Add(PropertyNames.Category, "Dubious");
             testMethod.Properties.Set("Priority", "low");
 
-            testFixture = new TestFixture(new TypeInfo(typeof(DummyFixture)));
+            testFixture = new TestFixture(new TypeWrapper(typeof(DummyFixture)));
             testFixture.Properties.Set(PropertyNames.Description, "Fixture description");
             testFixture.Properties.Add(PropertyNames.Category, "Fast");
             testFixture.Properties.Add("Value", 3);
@@ -45,10 +45,10 @@ namespace NUnit.Framework.Internal
                 Is.EqualTo("GenericMethod"));
             Assert.That(new ParameterizedMethodSuite(new MethodWrapper(typeof(DummyFixture), "ParameterizedMethod")).TestType,
                 Is.EqualTo("ParameterizedMethod"));
-            Assert.That(new ParameterizedFixtureSuite(typeof(DummyFixture)).TestType,
+            Assert.That(new ParameterizedFixtureSuite(new TypeWrapper(typeof(DummyFixture))).TestType,
                 Is.EqualTo("ParameterizedFixture"));
             Type genericType = typeof(DummyGenericFixture<int>).GetGenericTypeDefinition();
-            Assert.That(new ParameterizedFixtureSuite(genericType).TestType,
+            Assert.That(new ParameterizedFixtureSuite(new TypeWrapper(genericType)).TestType,
                 Is.EqualTo("GenericFixture"));
         }
 

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -14,12 +14,12 @@ namespace NUnit.Framework.Internal
         [SetUp]
         public void SetUp()
         {
-            testMethod = new TestMethod(typeof(DummyFixture).GetMethod("DummyMethod"));
+            testMethod = new TestMethod(new MethodWrapper(typeof(DummyFixture), "DummyMethod"));
             testMethod.Properties.Set(PropertyNames.Description, "Test description");
             testMethod.Properties.Add(PropertyNames.Category, "Dubious");
             testMethod.Properties.Set("Priority", "low");
 
-            testFixture = new TestFixture(typeof(DummyFixture));
+            testFixture = new TestFixture(new TypeInfo(typeof(DummyFixture)));
             testFixture.Properties.Set(PropertyNames.Description, "Fixture description");
             testFixture.Properties.Add(PropertyNames.Category, "Fast");
             testFixture.Properties.Add("Value", 3);
@@ -41,9 +41,9 @@ namespace NUnit.Framework.Internal
                 Is.EqualTo("TestSuite"));
             Assert.That(new TestAssembly("junk").TestType, 
                 Is.EqualTo("Assembly"));
-            Assert.That(new ParameterizedMethodSuite(typeof(DummyFixture).GetMethod("GenericMethod")).TestType,
+            Assert.That(new ParameterizedMethodSuite(new MethodWrapper(typeof(DummyFixture), "GenericMethod")).TestType,
                 Is.EqualTo("GenericMethod"));
-            Assert.That(new ParameterizedMethodSuite(typeof(DummyFixture).GetMethod("ParameterizedMethod")).TestType,
+            Assert.That(new ParameterizedMethodSuite(new MethodWrapper(typeof(DummyFixture), "ParameterizedMethod")).TestType,
                 Is.EqualTo("ParameterizedMethod"));
             Assert.That(new ParameterizedFixtureSuite(typeof(DummyFixture)).TestType,
                 Is.EqualTo("ParameterizedFixture"));
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Internal
             Assert.That(topNode.Attributes["id"], Is.EqualTo(test.Id.ToString()));
             Assert.That(topNode.Attributes["name"], Is.EqualTo(test.Name));
             Assert.That(topNode.Attributes["fullname"], Is.EqualTo(test.FullName));
-            if (test.FixtureType != null)
+            if (test.TypeInfo != null)
             {
                 Assert.NotNull(test.ClassName);
                 Assert.That(topNode.Attributes["classname"], Is.EqualTo(test.ClassName));

--- a/src/NUnitFramework/tests/TestUtilities/Fakes.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Fakes.cs
@@ -94,7 +94,7 @@ namespace NUnit.TestUtilities
             : this(obj.GetType(), name) { }
 
         public FakeTestMethod(Type type, string name)
-            : base(type.GetMethod(name, BF.Public | BF.NonPublic | BF.Static | BF.Instance)) { }
+            : base(new MethodWrapper(type, type.GetMethod(name, BF.Public | BF.NonPublic | BF.Static | BF.Instance))) { }
     }
 
     #endregion

--- a/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
@@ -79,10 +79,10 @@ namespace NUnit.TestUtilities
         // depending on whether the method takes arguments or not
         internal static Test MakeTestFromMethod(Type type, string methodName)
         {
-            MethodInfo method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (method == null)
                 Assert.Fail("Method not found: " + methodName);
-            return new DefaultTestCaseBuilder().BuildFrom(method);
+            return new DefaultTestCaseBuilder().BuildFrom(new MethodWrapper(type, method));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
@@ -42,7 +42,7 @@ namespace NUnit.TestUtilities
 
         public static TestSuite MakeFixture(Type type)
         {
-            return (TestSuite)new DefaultSuiteBuilder().BuildFrom(type);
+            return (TestSuite)new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(type));
         }
 
         public static TestSuite MakeFixture(object fixture)


### PR DESCRIPTION
I have used wrapper classes for Types, MethodInfos and ParameterInfos and managed to eliminate all use of RefelctedType. This is an alternate approach to what @voloda did in PR #658. This is a pretty large change. Let's review it and make sure this is the way we want to go.

What's Not Done: There could be more integration of the MethodHelper, GenericMethodHelper, TypeHelper and Reflect classes with the wrappers, possibly eliminating some of these. 

The CF build is now working.

I'd like to have @rprouse and @voloda review this, as well as anyone else who has the time. Then we can decide where to put in further effort.