### PR TITLE
Include test in NETCF build. Fixes #789.

### DIFF
--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -131,7 +131,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Does.Contain("100ms"));
         }
-#if !NETCF
+
         [Test]
         public void TestTimeOutTestCaseWithOutElapsed()
         {
@@ -143,7 +143,6 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.Children[0].ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Children[1].ResultState, Is.EqualTo(ResultState.Failure));
         }
-#endif
     }
 }
 #endif


### PR DESCRIPTION
I have tested this with the test included in both the Windows Mobile 5.0 Pocket PC R2 and the Pocket PC 2003 SE emulators and the test passes.

I had a bit of trouble getting it to load in the 2003 emulator at first, but after I did a hard reset it worked OK. You (@rprouse) might retest it and see what happens on your system. It could be that I fixed this bug unawares with the latest changes to the CF build.