### PR TITLE
Fixes dispose being called twice on TestFixtures with TestCases

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/IDisposableFixture.cs
+++ b/src/NUnitFramework/framework/Interfaces/IDisposableFixture.cs
@@ -22,7 +22,7 @@
 // 
 // **********************************************************************************
 
-namespace NUnit.Interfaces
+namespace NUnit.Framework.Interfaces
 {
     /// <summary>
     /// Any ITest that implements this interface is at a level that the implementing

--- a/src/NUnitFramework/framework/Interfaces/IDisposableFixture.cs
+++ b/src/NUnitFramework/framework/Interfaces/IDisposableFixture.cs
@@ -1,0 +1,34 @@
+﻿// **********************************************************************************
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015 Charlie Poole
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// **********************************************************************************
+
+namespace NUnit.Interfaces
+{
+    /// <summary>
+    /// Any ITest that implements this interface is at a level that the implementing
+    /// class should be disposed at the end of the test run
+    /// </summary>
+    internal interface IDisposableFixture
+    {
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -23,8 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using NUnit.Interfaces;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using NUnit.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {
@@ -69,7 +70,7 @@ namespace NUnit.Framework.Internal.Commands
                         item.RunTearDown(context);
 
                 IDisposable disposable = context.TestObject as IDisposable;
-                if (disposable != null && Test is TestFixture)
+                if (disposable != null && Test is IDisposableFixture)
                     disposable.Dispose();
             }
             catch (Exception ex)

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Internal.Commands
                         item.RunTearDown(context);
 
                 IDisposable disposable = context.TestObject as IDisposable;
-                if (disposable != null)
+                if (disposable != null && Test is TestFixture)
                     disposable.Dispose();
             }
             catch (Exception ex)

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using NUnit.Framework.Interfaces;
-using NUnit.Interfaces;
 
 namespace NUnit.Framework.Internal
 {

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
+using NUnit.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// SetUpFixture extends TestSuite and supports
     /// Setup and TearDown methods.
     /// </summary>
-    public class SetUpFixture : TestSuite
+    public class SetUpFixture : TestSuite, IDisposableFixture
     {
         #region Constructor
 

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using NUnit.Framework.Interfaces;
-using NUnit.Interfaces;
 
 namespace NUnit.Framework.Internal
 {

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
+using NUnit.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// TestFixture is a surrogate for a user test fixture class,
     /// containing one or more tests.
     /// </summary>
-    public class TestFixture : TestSuite
+    public class TestFixture : TestSuite, IDisposableFixture
     {
         #region Constructor
 

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Assert.Conditions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IReflectionInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -296,6 +296,7 @@
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{D6FBBB3A-F6B8-45BB-B657-A7226AB96624}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NUnit</RootNamespace>
+    <RootNamespace>NUnit.Framework</RootNamespace>
     <AssemblyName>nunit.framework</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Interfaces\ICommandWrapper.cs" />
+    <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IFixtureBuilder.cs" />
     <Compile Include="Interfaces\IImplyFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -9,7 +9,7 @@
     <ProjectTypeGuids>{A1591282-1198-4647-A2B1-27E5FF5F6F3B};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NUnit</RootNamespace>
+    <RootNamespace>NUnit.Framework</RootNamespace>
     <AssemblyName>nunit.framework</AssemblyName>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -360,14 +360,31 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
     [TestFixture]
     public class DisposableFixture : IDisposable
     {
-        public bool disposeCalled = false;
+        public int disposeCalled = 0;
 
         [Test]
         public void OneTest() { }
 
         public void Dispose()
         {
-            disposeCalled = true;
+            disposeCalled++;
+        }
+    }
+
+    [TestFixture]
+    public class DisposableFixtureWithTestCases : IDisposable
+    {
+        public int disposeCalled = 0;
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void TestCaseTest(int data) { }
+        
+        public void Dispose()
+        {
+            disposeCalled++;
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -338,11 +338,19 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void DisposeCalledWhenFixtureImplementsIDisposable()
+        public void DisposeCalledOnceWhenFixtureImplementsIDisposable()
         {
-            DisposableFixture fixture = new DisposableFixture();
+            var fixture = new DisposableFixture();
             TestBuilder.RunTestFixture(fixture);
-            Assert.IsTrue(fixture.disposeCalled);
+            Assert.That(fixture.disposeCalled, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DisposeCalledOnceWhenFixtureImplementsIDisposableAndHasTestCases()
+        {
+            var fixture = new DisposableFixtureWithTestCases();
+            TestBuilder.RunTestFixture(fixture);
+            Assert.That(fixture.disposeCalled, Is.EqualTo(1));
         }
     }
 


### PR DESCRIPTION
Fixes #801 by ensuring that the `Test` is a `TestFixture` before disposing it because the `context.TestObject` is set for the `ParameterizedMethodSuite` for the `TestCases`. We don't want children of a `TestFixture` disposing the parent.