### PR TITLE
Issue 794

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -112,7 +112,9 @@ namespace NUnit.Common
 
         public bool WaitBeforeExit { get; private set; }
 
-        public bool Debug { get; private set; }
+        public bool DebugTests { get; private set; }
+
+        public bool DebugAgent { get; private set; }
 
         // Output Control
 
@@ -331,8 +333,13 @@ namespace NUnit.Common
             this.Add("shadowcopy", "Shadow copy test files",
                 v => ShadowCopyFiles = v != null);
 
-            this.Add("debug", "Launch debugger when tests start.",
-                v => Debug = v != null);
+            this.Add("debug", "Launch debugger to debug tests.",
+                v => DebugTests = v != null);
+
+#if DEBUG
+            this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",
+                v => DebugAgent = v != null);
+#endif
 #endif
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",

--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -112,7 +112,7 @@ namespace NUnit.Common
 
         public bool WaitBeforeExit { get; private set; }
 
-        public bool PauseBeforeRun { get; private set; }
+        public bool Debug { get; private set; }
 
         // Output Control
 
@@ -347,8 +347,8 @@ namespace NUnit.Common
             this.Add("wait", "Wait for input before closing console window.",
                 v => WaitBeforeExit = v != null);
 
-            this.Add("pause", "Pause before run to allow debugging.",
-                v => PauseBeforeRun = v != null);
+            this.Add("debug", "Launch debugger when tests start.",
+                v => Debug = v != null);
 
             // Output Control
             this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",

--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -330,6 +330,9 @@ namespace NUnit.Common
 
             this.Add("shadowcopy", "Shadow copy test files",
                 v => ShadowCopyFiles = v != null);
+
+            this.Add("debug", "Launch debugger when tests start.",
+                v => Debug = v != null);
 #endif
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
@@ -346,9 +349,6 @@ namespace NUnit.Common
 
             this.Add("wait", "Wait for input before closing console window.",
                 v => WaitBeforeExit = v != null);
-
-            this.Add("debug", "Launch debugger when tests start.",
-                v => Debug = v != null);
 
             // Output Control
             this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",

--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -54,6 +54,11 @@ namespace NUnit.Common
         public const string ConfigurationFile = "ConfigurationFile";
 
         /// <summary>
+        /// Indicates whether a debugger should be launched at agent startup.
+        /// </summary>
+        public const string DebugAgent = "DebugAgent";
+
+        /// <summary>
         /// Indicates how to load tests across AppDomains
         /// </summary>
         public const string DomainUsage = "DomainUsage";
@@ -91,6 +96,11 @@ namespace NUnit.Common
         #endregion
 
         #region Settings taken from DriverSettings in the framework
+
+        /// <summary>
+        /// Indicates whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
 
         /// <summary>
         /// Integer value in milliseconds for the default timeout value

--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -61,7 +61,10 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("DisposeRunners", "dispose-runners")]
         [TestCase("ShadowCopyFiles", "shadowcopy")]
         [TestCase("TeamCity", "teamcity")]
-        [TestCase("Debug", "debug")]
+        [TestCase("DebugTests", "debug")]
+#if DEBUG
+        [TestCase("DebugAgent", "debug-agent")]
+#endif
         public void CanRecognizeBooleanOptions(string propertyName, string pattern)
         {
             string[] prototypes = pattern.Split('|');

--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -56,12 +56,12 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("ShowHelp", "help|h")]
         [TestCase("StopOnError", "stoponerror")]
         [TestCase("WaitBeforeExit", "wait")]
-        [TestCase("PauseBeforeRun", "pause")]
         [TestCase("NoHeader", "noheader|noh")]
         [TestCase("RunAsX86", "x86")]
         [TestCase("DisposeRunners", "dispose-runners")]
         [TestCase("ShadowCopyFiles", "shadowcopy")]
         [TestCase("TeamCity", "teamcity")]
+        [TestCase("Debug", "debug")]
         public void CanRecognizeBooleanOptions(string propertyName, string pattern)
         {
             string[] prototypes = pattern.Split('|');

--- a/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
@@ -67,7 +67,10 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--seed=1234", "RandomSeed", 1234)]
         [TestCase("--workers=3", "NumberOfTestWorkers", 3)]
         [TestCase("--workers=0", "NumberOfTestWorkers", 0)]
-        [TestCase("--debug", "Debug", true)]
+        [TestCase("--debug", "DebugTests", true)]
+#if DEBUG
+        [TestCase("--debug-agent", "DebugAgent", true)]
+#endif
         public void WhenOptionIsSpecified_PackageIncludesSetting(string option, string key, object val)
         {
             var options = new ConsoleOptions("test.dll", option);
@@ -83,7 +86,7 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions("test.dll", "--debug");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.That(package.Settings["Debug"], Is.EqualTo(true));
+            Assert.That(package.Settings["DebugTests"], Is.EqualTo(true));
             Assert.That(package.Settings["NumberOfTestWorkers"], Is.EqualTo(0));
         }
 
@@ -93,7 +96,7 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions("test.dll", "--debug", "--workers=3");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.That(package.Settings["Debug"], Is.EqualTo(true));
+            Assert.That(package.Settings["DebugTests"], Is.EqualTo(true));
             Assert.That(package.Settings["NumberOfTestWorkers"], Is.EqualTo(3));
         }
 

--- a/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/MakeTestPackageTests.cs
@@ -67,6 +67,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--seed=1234", "RandomSeed", 1234)]
         [TestCase("--workers=3", "NumberOfTestWorkers", 3)]
         [TestCase("--workers=0", "NumberOfTestWorkers", 0)]
+        [TestCase("--debug", "Debug", true)]
         public void WhenOptionIsSpecified_PackageIncludesSetting(string option, string key, object val)
         {
             var options = new ConsoleOptions("test.dll", option);
@@ -74,6 +75,26 @@ namespace NUnit.ConsoleRunner.Tests
 
             Assert.That(package.Settings.ContainsKey(key), "Setting not included for {0}", option);
             Assert.AreEqual(val, package.Settings[key], "NumberOfTestWorkers not set correctly for {0}", option);
+        }
+
+        [Test]
+        public void WhenDebugging_NumberOfTestWorkersDefaultsToZero()
+        {
+            var options = new ConsoleOptions("test.dll", "--debug");
+            var package = ConsoleRunner.MakeTestPackage(options);
+
+            Assert.That(package.Settings["Debug"], Is.EqualTo(true));
+            Assert.That(package.Settings["NumberOfTestWorkers"], Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WhenDebugging_NumberOfTestWorkersMayBeOverridden()
+        {
+            var options = new ConsoleOptions("test.dll", "--debug", "--workers=3");
+            var package = ConsoleRunner.MakeTestPackage(options);
+
+            Assert.That(package.Settings["Debug"], Is.EqualTo(true));
+            Assert.That(package.Settings["NumberOfTestWorkers"], Is.EqualTo(3));
         }
 
         //[Test]

--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -302,15 +302,18 @@ namespace NUnit.ConsoleRunner
             if (options.Verbose)
                 package.AddSetting("Verbose", true);
 
-            if (options.Debug)
+            if (options.DebugTests)
             {
-                package.AddSetting("Debug", true);
+                package.AddSetting(PackageSettings.DebugTests, true);
 
                 if (options.NumWorkers < 0)
                     package.AddSetting(PackageSettings.NumberOfTestWorkers, 0);
             }
 
 #if DEBUG
+            if (options.DebugAgent)
+                package.AddSetting(PackageSettings.DebugAgent, true);
+
             //foreach (KeyValuePair<string, object> entry in package.Settings)
             //    if (!(entry.Value is string || entry.Value is int || entry.Value is bool))
             //        throw new Exception(string.Format("Package setting {0} is not a valid type", entry.Key));

--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -302,6 +302,14 @@ namespace NUnit.ConsoleRunner
             if (options.Verbose)
                 package.AddSetting("Verbose", true);
 
+            if (options.Debug)
+            {
+                package.AddSetting("Debug", true);
+
+                if (options.NumWorkers < 0)
+                    package.AddSetting(PackageSettings.NumberOfTestWorkers, 0);
+            }
+
 #if DEBUG
             //foreach (KeyValuePair<string, object> entry in package.Settings)
             //    if (!(entry.Value is string || entry.Value is int || entry.Value is bool))

--- a/src/NUnitConsole/nunit-console/Program.cs
+++ b/src/NUnitConsole/nunit-console/Program.cs
@@ -77,12 +77,6 @@ namespace NUnit.ConsoleRunner
             //log.Info("NUnit-console.exe starting");
             try
             {
-                if (Options.PauseBeforeRun)
-                {
-                    OutWriter.WriteLine(ColorStyle.Warning, "Press any key to continue . . .");
-                    Console.ReadKey(true);
-                }
-
                 if (!Options.NoHeader)
                     WriteHeader();
 

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -62,6 +62,10 @@ namespace NUnit.Agent
             for (int i = 2; i < args.Length; i++)
                 switch (args[i])
                 {
+                    case "--debug-agent":
+                        if (!System.Diagnostics.Debugger.IsAttached)
+                            System.Diagnostics.Debugger.Launch();
+                        break;
                     case "--verbose":
                         verbose = true;
                         break;

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -58,26 +58,14 @@ namespace NUnit.Agent
             AgentId = new Guid(args[0]);
             AgencyUrl = args[1];
             
-#if DEBUG
-            bool pause = false;
-#endif
             bool verbose = false;
             for (int i = 2; i < args.Length; i++)
                 switch (args[i])
                 {
-#if DEBUG
-                    case "--pause":
-                        pause = true;
-                        break;
-#endif
                     case "--verbose":
                         verbose = true;
                         break;
                 }
-#if DEBUG
-            if (pause)
-                System.Windows.Forms.MessageBox.Show("Attach debugger if desired, then press OK", "NUnit-Agent");
-#endif
 
             // Create SettingsService early so we know the trace level right at the start
             SettingsService settingsService = new SettingsService(false);

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -168,9 +168,12 @@ namespace NUnit.Engine.Services
                 targetRuntime = new RuntimeFramework(RuntimeFramework.CurrentFramework.Runtime, targetRuntime.ClrVersion);
 
             bool useX86Agent = package.GetSetting(PackageSettings.RunAsX86, false);
-            bool enableDebug = package.GetSetting("Debug", false);
+            bool debugTests = package.GetSetting(PackageSettings.DebugTests, false);
+            bool debugAgent = package.GetSetting(PackageSettings.DebugAgent, false);
             bool verbose = package.GetSetting("Verbose", false);
+
             string agentArgs = string.Empty;
+            if (debugAgent) agentArgs += " --debug-agent";
             if (verbose) agentArgs += " --verbose";
 
             log.Info("Getting {0} agent for use under {1}", useX86Agent ? "x86" : "standard", targetRuntime);
@@ -199,7 +202,7 @@ namespace NUnit.Engine.Services
                 case RuntimeType.Mono:
                     p.StartInfo.FileName = NUnitConfiguration.MonoExePath;
                     string monoOptions = "--runtime=v" + targetRuntime.ClrVersion.ToString(3);
-                    if (enableDebug) monoOptions += " --debug";
+                    if (debugTests || debugAgent) monoOptions += " --debug";
                     p.StartInfo.Arguments = string.Format("{0} \"{1}\" {2}", monoOptions, agentExePath, arglist);
                     break;
                 case RuntimeType.Net:

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -168,10 +168,9 @@ namespace NUnit.Engine.Services
                 targetRuntime = new RuntimeFramework(RuntimeFramework.CurrentFramework.Runtime, targetRuntime.ClrVersion);
 
             bool useX86Agent = package.GetSetting(PackageSettings.RunAsX86, false);
-            bool enableDebug = package.GetSetting("AgentDebug", false);
+            bool enableDebug = package.GetSetting("Debug", false);
             bool verbose = package.GetSetting("Verbose", false);
             string agentArgs = string.Empty;
-            if (enableDebug) agentArgs += " --pause";
             if (verbose) agentArgs += " --verbose";
 
             log.Info("Getting {0} agent for use under {1}", useX86Agent ? "x86" : "standard", targetRuntime);

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -244,6 +244,10 @@ namespace NUnit.Framework.Api
             Context.Dispatcher = new SimpleWorkItemDispatcher();
 #endif
 
+            if (Settings.Contains("Debug") && (bool)Settings["Debug"])
+                if (!System.Diagnostics.Debugger.IsAttached)
+                    System.Diagnostics.Debugger.Launch();
+
             Context.Dispatcher.Dispatch(TopLevelWorkItem);
         }
 

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -244,9 +244,12 @@ namespace NUnit.Framework.Api
             Context.Dispatcher = new SimpleWorkItemDispatcher();
 #endif
 
-            if (Settings.Contains("Debug") && (bool)Settings["Debug"])
-                if (!System.Diagnostics.Debugger.IsAttached)
-                    System.Diagnostics.Debugger.Launch();
+            if (!System.Diagnostics.Debugger.IsAttached &&
+                Settings.Contains(PackageSettings.DebugTests) &&
+                (bool)Settings[PackageSettings.DebugTests])
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
 
             Context.Dispatcher.Dispatch(TopLevelWorkItem);
         }

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -55,7 +55,6 @@ namespace NUnit.Common.Tests
         [TestCase("ShowHelp", "help|h")]
         [TestCase("StopOnError", "stoponerror")]
         [TestCase("WaitBeforeExit", "wait")]
-        [TestCase("PauseBeforeRun", "pause")]
         [TestCase("NoHeader", "noheader|noh")]
         [TestCase("Full", "full")]
 #if !NUNITLITE


### PR DESCRIPTION
I added two different options...

--debug is for users debugging tests. It launches the debugger before the tests are starting. It works in the release build of NUnit, so long as the tests being run are a debug build. If running in a separate agent process, it is launched there rather than in the main process. It has the side effect of setting workers to zero if you have not specified the --workers option yourself.

--debug-agent is available in debug builds only and allows us to debug the engine. It launches the debugger in the agent Main. It has no other side effects, since it is intended for our use only.

If you are already running under the debugger, the options don't do anything.