### PR TITLE
Unit tests that proves #809 is fixed

### DIFF
--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace NUnit.TestData.OneTimeSetUpTearDownData
@@ -52,6 +53,73 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
 
         [Test]
         public void EvenMoreSuccess(){}
+    }
+
+    [TestFixture]
+    public class SetUpAndTearDownFixtureWithTestCases
+    {
+        public int setUpCount = 0;
+        public int tearDownCount = 0;
+
+        [OneTimeSetUp]
+        public virtual void Init()
+        {
+            setUpCount++;
+        }
+
+        [OneTimeTearDown]
+        public virtual void Destroy()
+        {
+            tearDownCount++;
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void Success(int i)
+        {
+            Assert.Pass("Passed with test case {0}", i);
+        }
+    }
+
+    [TestFixture]
+    public class SetUpAndTearDownFixtureWithTheories
+    {
+        public int setUpCount = 0;
+        public int tearDownCount = 0;
+
+        [OneTimeSetUp]
+        public virtual void Init()
+        {
+            setUpCount++;
+        }
+
+        [OneTimeTearDown]
+        public virtual void Destroy()
+        {
+            tearDownCount++;
+        }
+
+        public struct Data
+        {
+            public int Id { get; set; }
+        }
+
+        [DatapointSource]
+        public IEnumerable<Data> fetchAllRows()
+        {
+            yield return new Data { Id = 1 };
+            yield return new Data { Id = 2 };
+            yield return new Data { Id = 3 };
+            yield return new Data { Id = 4 };
+        }
+
+        [Theory]
+        public void TheoryTest(Data entry)
+        {
+            Assert.Pass("Passed with theory id {0}", entry.Id);
+        }
     }
 
     [TestFixture,Explicit]

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -42,7 +42,27 @@ namespace NUnit.Framework.Attributes
         {
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
+            
+            Assert.AreEqual(1, fixture.setUpCount, "SetUp");
+            Assert.AreEqual(1, fixture.tearDownCount, "TearDown");
+        }
 
+        [Test]
+        public void MakeSureSetUpAndTearDownAreCalledOnFixtureWithTestCases()
+        {
+            var fixture = new SetUpAndTearDownFixtureWithTestCases();
+            TestBuilder.RunTestFixture(fixture);
+            
+            Assert.AreEqual(1, fixture.setUpCount, "SetUp");
+            Assert.AreEqual(1, fixture.tearDownCount, "TearDown");
+        }
+
+        [Test]
+        public void MakeSureSetUpAndTearDownAreCalledOnFixtureWithTheories()
+        {
+            var fixture = new SetUpAndTearDownFixtureWithTheories();
+            TestBuilder.RunTestFixture(fixture);
+            
             Assert.AreEqual(1, fixture.setUpCount, "SetUp");
             Assert.AreEqual(1, fixture.tearDownCount, "TearDown");
         }


### PR DESCRIPTION
I simplified the proof of the sample given in issue #809, but I am pretty sure that this shows that this is no longer an issue in the current codebase. I tested it with Theories and with TestCases to be sure. Instead of creating a database connection, I just yield return the data.

If others agree that this properly tests the issue, we can merge to make sure it doesn't happen again and close the issue.