### PR TITLE
Allow NUnitComparer to compare IEquatable<T> where the second object is derived from T

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -272,7 +272,6 @@ namespace NUnit.Framework.Constraints
 
         private static bool InvokeFirstIEquatableEqualsSecond(object first, object second)
         {
-            //MethodInfo equals = typeof(IEquatable<>).MakeGenericType(second.GetType()).GetMethod("Equals");
             MethodInfo equals = GetCorrectGenericEqualsMethod(first.GetType(), second.GetType());
 
             return equals != null ? (bool)equals.Invoke(first, new object[] { second }) : false;

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -200,6 +200,23 @@ namespace NUnit.Framework.Constraints
             Assert.That(n.AreEqual(obj1, obj2, ref tolerance), Is.True);
             Assert.That(n.AreEqual(obj2, obj1, ref tolerance), Is.True);
         }
+
+        [Test]
+        public void CanHandleMultipleImplementationsOfIEquatable()
+        {
+            IEquatableObject obj1 = new InheritedEquatableObject { SomeProperty = 1 };
+            IEquatableObject obj2 = new MultipleIEquatables { SomeProperty = 1 };
+            var obj3 = new EquatableObject { SomeProperty = 1 };
+
+            var n = new NUnitEqualityComparer();
+            var tolerance = Tolerance.Exact;
+            Assert.That(n.AreEqual(obj1, obj2, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj2, obj1, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj1, obj3, ref tolerance), Is.False);
+            Assert.That(n.AreEqual(obj3, obj1, ref tolerance), Is.False);
+            Assert.That(n.AreEqual(obj2, obj3, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj3, obj2, ref tolerance), Is.True);
+        }
     }
 
     public class NeverEqualIEquatableWithOverriddenAlwaysTrueEquals : IEquatable<NeverEqualIEquatableWithOverriddenAlwaysTrueEquals>
@@ -288,4 +305,14 @@ namespace NUnit.Framework.Constraints
         }
     }
 
+    public class MultipleIEquatables : InheritedEquatableObject, IEquatable<EquatableObject>
+    {
+        public bool Equals(EquatableObject other)
+        {
+            if (other == null)
+                return false;
+
+            return SomeProperty == other.SomeProperty;
+        }
+    }
 }

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -168,55 +168,37 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void ImplementingIEquatableDirectlyOnTheClass()
         {
-            var listA = new List<EquatableObject>
-                {
-                    new EquatableObject {SomeProperty = 1},
-                    new EquatableObject {SomeProperty = 2},
-                    new EquatableObject {SomeProperty = 3},
-                    new EquatableObject {SomeProperty = 4},
-                    new EquatableObject {SomeProperty = 5},
-                };
-
-            var listB = new List<EquatableObject>
-                {
-                    new EquatableObject {SomeProperty = 1},
-                    new EquatableObject {SomeProperty = 2},
-                    new EquatableObject {SomeProperty = 3},
-                    new EquatableObject {SomeProperty = 4},
-                    new EquatableObject {SomeProperty = 5},
-                };
+            var obj1 = new EquatableObject { SomeProperty = 1 };
+            var obj2 = new EquatableObject { SomeProperty = 1 };
 
             var n = new NUnitEqualityComparer();
             var tolerance = Tolerance.Exact;
-            var actualResult = n.AreEqual(listA, listB, ref tolerance);
-            Assert.IsTrue(actualResult);
+            Assert.That(n.AreEqual(obj1, obj2, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj2, obj1, ref tolerance), Is.True);
         }
 
         [Test]
         public void ImplementingIEquatableOnABaseClassOrInterface()
         {
-            var listA = new List<InheritedEquatableObject>
-                {
-                    new InheritedEquatableObject {SomeProperty = 1},
-                    new InheritedEquatableObject {SomeProperty = 2},
-                    new InheritedEquatableObject {SomeProperty = 3},
-                    new InheritedEquatableObject {SomeProperty = 4},
-                    new InheritedEquatableObject {SomeProperty = 5},
-                };
-
-            var listB = new List<InheritedEquatableObject>
-                {
-                    new InheritedEquatableObject {SomeProperty = 1},
-                    new InheritedEquatableObject {SomeProperty = 2},
-                    new InheritedEquatableObject {SomeProperty = 3},
-                    new InheritedEquatableObject {SomeProperty = 4},
-                    new InheritedEquatableObject {SomeProperty = 5},
-                };
+            var obj1 = new InheritedEquatableObject { SomeProperty = 1 };
+            var obj2 = new InheritedEquatableObject { SomeProperty = 1 };
 
             var n = new NUnitEqualityComparer();
             var tolerance = Tolerance.Exact;
-            var actualResult = n.AreEqual(listA, listB, ref tolerance);
-            Assert.IsTrue(actualResult);
+            Assert.That(n.AreEqual(obj1, obj2, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj2, obj1, ref tolerance), Is.True);
+        }
+
+        [Test]
+        public void ImplementingIEquatableOnABaseClassOrInterfaceThroughInterface()
+        {
+            IEquatableObject obj1 = new InheritedEquatableObject { SomeProperty = 1 };
+            IEquatableObject obj2 = new InheritedEquatableObject { SomeProperty = 1 };
+
+            var n = new NUnitEqualityComparer();
+            var tolerance = Tolerance.Exact;
+            Assert.That(n.AreEqual(obj1, obj2, ref tolerance), Is.True);
+            Assert.That(n.AreEqual(obj2, obj1, ref tolerance), Is.True);
         }
     }
 
@@ -282,9 +264,8 @@ namespace NUnit.Framework.Constraints
         public bool Equals(EquatableObject other)
         {
             if (other == null)
-            {
                 return false;
-            }
+
             return SomeProperty == other.SomeProperty;
         }
     }
@@ -301,9 +282,8 @@ namespace NUnit.Framework.Constraints
         public bool Equals(IEquatableObject other)
         {
             if (other == null)
-            {
                 return false;
-            }
+
             return SomeProperty == other.SomeProperty;
         }
     }

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.TestUtilities;
 
@@ -163,6 +164,60 @@ namespace NUnit.Framework.Constraints
 
             Assert.IsFalse(comparer.AreEqual(x, y, ref tolerance));
         }
+
+        [Test]
+        public void ImplementingIEquatableDirectlyOnTheClass()
+        {
+            var listA = new List<EquatableObject>
+                {
+                    new EquatableObject {SomeProperty = 1},
+                    new EquatableObject {SomeProperty = 2},
+                    new EquatableObject {SomeProperty = 3},
+                    new EquatableObject {SomeProperty = 4},
+                    new EquatableObject {SomeProperty = 5},
+                };
+
+            var listB = new List<EquatableObject>
+                {
+                    new EquatableObject {SomeProperty = 1},
+                    new EquatableObject {SomeProperty = 2},
+                    new EquatableObject {SomeProperty = 3},
+                    new EquatableObject {SomeProperty = 4},
+                    new EquatableObject {SomeProperty = 5},
+                };
+
+            var n = new NUnitEqualityComparer();
+            var tolerance = Tolerance.Exact;
+            var actualResult = n.AreEqual(listA, listB, ref tolerance);
+            Assert.IsTrue(actualResult);
+        }
+
+        [Test]
+        public void ImplementingIEquatableOnABaseClassOrInterface()
+        {
+            var listA = new List<InheritedEquatableObject>
+                {
+                    new InheritedEquatableObject {SomeProperty = 1},
+                    new InheritedEquatableObject {SomeProperty = 2},
+                    new InheritedEquatableObject {SomeProperty = 3},
+                    new InheritedEquatableObject {SomeProperty = 4},
+                    new InheritedEquatableObject {SomeProperty = 5},
+                };
+
+            var listB = new List<InheritedEquatableObject>
+                {
+                    new InheritedEquatableObject {SomeProperty = 1},
+                    new InheritedEquatableObject {SomeProperty = 2},
+                    new InheritedEquatableObject {SomeProperty = 3},
+                    new InheritedEquatableObject {SomeProperty = 4},
+                    new InheritedEquatableObject {SomeProperty = 5},
+                };
+
+            var n = new NUnitEqualityComparer();
+            var tolerance = Tolerance.Exact;
+            var actualResult = n.AreEqual(listA, listB, ref tolerance);
+            Assert.IsTrue(actualResult);
+        }
     }
 
     public class NeverEqualIEquatableWithOverriddenAlwaysTrueEquals : IEquatable<NeverEqualIEquatableWithOverriddenAlwaysTrueEquals>
@@ -220,4 +275,37 @@ namespace NUnit.Framework.Constraints
             return value.Equals(other.value);
         }
     }
+    
+    public class EquatableObject : IEquatable<EquatableObject>
+    {
+        public int SomeProperty { get; set; }
+        public bool Equals(EquatableObject other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            return SomeProperty == other.SomeProperty;
+        }
+    }
+
+    public interface IEquatableObject : IEquatable<IEquatableObject>
+    {
+        int SomeProperty { get; set; }
+    }
+
+    public class InheritedEquatableObject : IEquatableObject
+    {
+        public int SomeProperty { get; set; }
+
+        public bool Equals(IEquatableObject other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            return SomeProperty == other.SomeProperty;
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #275 

Hopefully the unit tests speak for themselves :smile: 

We were using the T from an `IEquatable<T>`, which did not work if the second object was derived from T. I changed our logic to use `IsAssignableFrom`

