### PR TITLE
Override ToString() for MethodWrapper and TypeWrapper. Fixes #821

### DIFF
--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -187,6 +187,14 @@ namespace NUnit.Framework.Internal
             return Reflect.InvokeMethod(MethodInfo, fixture, args);
         }
 
+        /// <summary>
+        /// Override ToString() so that error messages in NUnit's own tests make sense
+        /// </summary>
+        public override string ToString()
+        {
+            return MethodInfo.Name;
+        }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -244,5 +244,12 @@ namespace NUnit.Framework.Internal
             return Reflect.Construct(Type, args);
         }
 
+        /// <summary>
+        /// Override ToString() so that error messages in NUnit's own tests make sense
+        /// </summary>
+        public override string ToString()
+        {
+            return Type.ToString() + "()";
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -249,7 +249,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override string ToString()
         {
-            return Type.ToString() + "()";
+            return Type.ToString();
         }
     }
 }


### PR DESCRIPTION
This fixes the problem of tests not displaying the name of the method called. Note that this only impacts our own tests, not those of users, since the above are internal classes.