### PR TITLE
Fix random unique values tests so they are more robust. Fixes #826

### DIFF
--- a/src/NUnitFramework/tests/Internal/RandomizerTests.cs
+++ b/src/NUnitFramework/tests/Internal/RandomizerTests.cs
@@ -43,13 +43,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomIntsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.Next(), 10);
+            UniqueValues.Check(() => _randomizer.Next(), 10, 100);
         }
 
         [Test]
         public void RandomIntsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.Next(-300, 300), 10);
+            UniqueValues.Check(() => _randomizer.Next(-300, 300), 10, 100);
         }
 
         #endregion
@@ -92,13 +92,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomUIntsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextUInt(), 10);
+            UniqueValues.Check(() => _randomizer.NextUInt(), 10, 100);
         }
 
         [Test]
         public void RandomUIntsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextUInt(27u, 777u), 10);
+            UniqueValues.Check(() => _randomizer.NextUInt(27u, 777u), 10, 100);
         }
 
         #endregion
@@ -148,13 +148,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomShortsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextShort(), 10);
+            UniqueValues.Check(() => _randomizer.NextShort(), 10, 100);
         }
 
         [Test]
         public void RandomShortsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextShort(-300, 300), 10);
+            UniqueValues.Check(() => _randomizer.NextShort(-300, 300), 10, 100);
         }
 
         #endregion
@@ -204,13 +204,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomUShortsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextUShort(), 10);
+            UniqueValues.Check(() => _randomizer.NextUShort(), 10, 100);
         }
 
         [Test]
         public void RandomUShortsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextUShort((ushort)27, (ushort)200), 10);
+            UniqueValues.Check(() => _randomizer.NextUShort((ushort)27, (ushort)200), 10, 100);
         }
 
         #endregion
@@ -255,13 +255,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomLongsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextLong(), 10);
+            UniqueValues.Check(() => _randomizer.NextLong(), 10, 100);
         }
 
         [Test]
         public void RandomLongsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextLong(1066L, 2010L), 10);
+            UniqueValues.Check(() => _randomizer.NextLong(1066L, 2010L), 10, 100);
         }
 
         #endregion
@@ -305,13 +305,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomULongsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextULong(), 10);
+            UniqueValues.Check(() => _randomizer.NextULong(), 10, 100);
         }
 
         [Test]
         public void RandomULongsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextULong(1066UL, 2010UL), 10);
+            UniqueValues.Check(() => _randomizer.NextULong(1066UL, 2010UL), 10, 100);
         }
 
         #endregion
@@ -360,13 +360,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomBytesAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextByte(), 10);
+            UniqueValues.Check(() => _randomizer.NextByte(), 10, 1000);
         }
 
         [Test]
         public void RandomBytesInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextByte(byte.MinValue, byte.MaxValue), 10);
+            UniqueValues.Check(() => _randomizer.NextByte(byte.MinValue, byte.MaxValue), 10, 1000);
         }
 
         #endregion
@@ -415,13 +415,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomSBytesAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextSByte(), 10);
+            UniqueValues.Check(() => _randomizer.NextSByte(), 10, 1000);
         }
 
         [Test]
         public void RandomSBytesInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextSByte(sbyte.MinValue, sbyte.MaxValue), 10);
+            UniqueValues.Check(() => _randomizer.NextSByte(sbyte.MinValue, sbyte.MaxValue), 10, 1000);
         }
 
         #endregion
@@ -431,39 +431,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomBool()
         {
-            bool haveTrue = false;
-            bool haveFalse = false;
-            int attempts = 0;
-            while (!haveTrue && !haveFalse)
-            {
-                if (attempts++ > 10000)
-                {
-                    Assert.Fail("No randomness in 10000 attempts");
-                }
-                if (_randomizer.NextBool())
-                    haveTrue = true;
-                else
-                    haveFalse = true;
-            }
+            UniqueValues.Check(() => _randomizer.NextBool(), 2, 100);
         }
 
         [Test]
         public void RandomBoolWithProbability()
         {
-            bool haveTrue = false;
-            bool haveFalse = false;
-            int attempts = 0;
-            while (!haveTrue && !haveFalse)
-            {
-                if (attempts++ > 10000)
-                {
-                    Assert.Fail("No randomness in 10000 attempts");
-                }
-                if (_randomizer.NextBool(.25))
-                    haveTrue = true;
-                else
-                    haveFalse = true;
-            }
+            UniqueValues.Check(() => _randomizer.NextBool(.25), 2, 200);
         }
 
         [Test]
@@ -526,13 +500,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomDoublesAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextDouble(), 10);
+            UniqueValues.Check(() => _randomizer.NextDouble(), 10, 100);
         }
 
         [Test]
         public void RandomDoublesInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextDouble(0.1, 0.7), 10);
+            UniqueValues.Check(() => _randomizer.NextDouble(0.1, 0.7), 10, 100);
         }
 
         #endregion
@@ -576,13 +550,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomFloatsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextFloat(), 10);
+            UniqueValues.Check(() => _randomizer.NextFloat(), 10, 100);
         }
 
         [Test]
         public void RandomFloatsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextFloat(0.5f, 1.5f), 10);
+            UniqueValues.Check(() => _randomizer.NextFloat(0.5f, 1.5f), 10, 100);
         }
 
         /// <summary>
@@ -666,13 +640,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomDecimalsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextDecimal(), 10);
+            UniqueValues.Check(() => _randomizer.NextDecimal(), 10, 100);
         }
 
         [Test]
         public void RandomDecimalsInRangeAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.NextDecimal(1066M, 2010M), 10);
+            UniqueValues.Check(() => _randomizer.NextDecimal(1066M, 2010M), 10, 100);
         }
 
         #endregion
@@ -683,7 +657,7 @@ namespace NUnit.Framework.Internal
         [Description("Test that all generated strings are unique")]
         public void RandomStringsAreUnique()
         {
-            UniqueValues.Check(() => _randomizer.GetString(), 10, 1.0);
+            UniqueValues.Check(() => _randomizer.GetString(), 10, 10);
         }
         
         [TestCase(30, "Tｈｅɋúｉｃｋƃｒòｗｎｆ߀хｊｕｍｐëԁoѵerｔհëｌａȥｙｄｏɢ")]
@@ -692,7 +666,7 @@ namespace NUnit.Framework.Internal
         [Description("Test that all generated strings are unique for varying output length")]
         public void RandomStringsAreUnique(int outputLength, string allowedChars)
         {
-            UniqueValues.Check(() => _randomizer.GetString(outputLength, allowedChars), 10, 1.0);
+            UniqueValues.Check(() => _randomizer.GetString(outputLength, allowedChars), 10, 10);
         }
         
         #endregion
@@ -702,14 +676,13 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RandomEnum()
         {
-            object e = _randomizer.NextEnum(typeof(AttributeTargets));
-            Assert.That(e, Is.TypeOf<AttributeTargets>());
+            UniqueValues.Check(() => _randomizer.NextEnum(typeof(AttributeTargets)), 5, 50);
         }
 
         [Test]
         public void RandomEnum_Generic()
         {
-            AttributeTargets at = _randomizer.NextEnum<AttributeTargets>();
+            UniqueValues.Check(() => _randomizer.NextEnum<AttributeTargets>(), 5, 50);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/UniqueValues.cs
+++ b/src/NUnitFramework/tests/TestUtilities/UniqueValues.cs
@@ -14,23 +14,29 @@ namespace NUnit.TestUtilities
     public class UniqueValues
     {
         /// <summary>
-        /// Call a delegate a specified number of times and check that
-        /// the returned values are more or less unique.
+        /// Call a delegate until a certain number of unique values are returned,
+        /// up to a maximum number of tries. Assert that the target was reached.
         /// </summary>
-        public static void Check<T>(ActualValueDelegate<T> del, int count, double successRatio)
+        /// <typeparam name="T"></typeparam>
+        /// <param name="del"></param>
+        /// <param name="unique"></param>
+        /// <param name="maxTries"></param>
+        public static void Check<T>(ActualValueDelegate<T> del, int targetCount, int maxTries)
         {
-            int minExpected = (int)(count * successRatio);
+            var lookup = new Dictionary<T, int>();
 
-            int unique = CountUniqueValues(del, count);
-            Assert.That(unique, Is.Not.EqualTo(1), "All values were the same!");
+            while (--maxTries >= 0)
+            {
+                T val = del();
+                if (!lookup.ContainsKey(val))
+                {
+                    lookup.Add(val, 1);
+                    if (lookup.Count >= targetCount)
+                        return;
+                }
+            }
 
-            // TODO: Change to an actual warning once we implement them
-            Assert.That(unique, Is.GreaterThanOrEqualTo(minExpected), "WARNING: The number of unique values less than expected.");
-        }
-
-        public static void Check<T>(ActualValueDelegate<T> del, int count)
-        {
-            Check(del, count, 0.8);
+            Assert.Fail("After {0} attempts, only {1} value(s) found", maxTries, lookup.Count);
         }
 
         #region Helper Methods


### PR DESCRIPTION
Instead of running a fixed number of times, the test now runs until it reaches the desired number of unique values, limited by a specified maximum.