### PR TITLE
Add command-line and settings elements to XML

### DIFF
--- a/src/Common/nunit/ConsoleOptions.cs
+++ b/src/Common/nunit/ConsoleOptions.cs
@@ -78,20 +78,26 @@ namespace NUnit.Common
         public IList<string> TestList { get { return testList; } }
 
         public string Include { get; private set; }
+        public bool IncludeSpecified { get { return Include != null; } }
 
         public string Exclude { get; private set; }
+        public bool ExcludeSpecified { get { return Exclude != null; } }
 
         public string ActiveConfig { get; private set; }
+        public bool ActiveConfigSpecified { get { return ActiveConfig != null; } }
 
         // Where to Run Tests
 
         public string ProcessModel { get; private set; }
+        public bool ProcessModelSpecified { get { return ProcessModel != null;  } }
 
         public string DomainUsage { get; private set; }
+        public bool DomainUsageSpecified { get { return DomainUsage != null; } }
 
         // How to Run Tests
 
         public string Framework { get; private set; }
+        public bool FrameworkSpecified { get { return Framework != null;  } }
 
         public bool RunAsX86 { get; private set; }
 
@@ -101,15 +107,19 @@ namespace NUnit.Common
 
         private int defaultTimeout = -1;
         public int DefaultTimeout { get { return defaultTimeout; } }
+        public bool DefaultTimeoutSpecified { get { return defaultTimeout >= 0; } }
 
         private int randomSeed = -1;
         public int RandomSeed { get { return randomSeed; } }
+        public bool RandomSeedSpecified { get { return randomSeed >= 0; } }
 
         private int numWorkers = -1;
-        public int NumWorkers { get { return numWorkers; } }
+        public int NumberOfTestWorkers { get { return numWorkers; } }
+        public bool NumberOfTestWorkersSpecified { get { return numWorkers >= 0; } }
 
         private int maxAgents = -1;
         public int MaxAgents { get { return maxAgents; } }
+        public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
 
         public bool StopOnError { get; private set; }
 
@@ -130,18 +140,22 @@ namespace NUnit.Common
         public bool TeamCity { get; private set; }
 
         public string OutFile { get; private set; }
+        public bool OutFileSpecified { get { return OutFile != null; } }
 
         public string ErrFile { get; private set; }
+        public bool ErrFileSpecified { get { return ErrFile != null; } }
 
         public string DisplayTestLabels { get; private set; }
 
-        private string workDirectory = NUnit.Env.DefaultWorkDirectory;
+        private string workDirectory = null;
         public string WorkDirectory 
         {
-            get { return workDirectory; }
+            get { return workDirectory ?? NUnit.Env.DefaultWorkDirectory; }
         }
+        public bool WorkDirectorySpecified { get { return workDirectory != null; } }
 
         public string InternalTraceLevel { get; private set; }
+        public bool InternalTraceLevelSpecified { get { return InternalTraceLevel != null; } }
 
         /// <summary>Indicates whether a full report should be displayed.</summary>
         public bool Full { get; private set; }

--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -25,61 +25,106 @@ namespace NUnit.Common
 {
     /// <summary>
     /// PackageSettings is a static class containing constant values that
-    /// are used as keys in setting up a TestPackage. These values duplicate
-    /// settings in the engine and framework.
+    /// are used as keys in setting up a TestPackage. These values are used in
+    /// the engine and framework. Setting values may be a string, int or bool.
     /// </summary>
     public static class PackageSettings
     {
-        #region Settings taken from RunnerSettings in the engine
+        #region Common Settings - Used by both the Engine and the 3.0 Framework
 
         /// <summary>
-        /// The config to use in loading a project
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        /// <summary>
+        /// Full path of the directory to be used for work and result files.
+        /// This path is provided to tests by the frameowrk TestContext.
+        /// </summary>
+        public const string WorkDirectory = "WorkDirectory";
+
+        #endregion
+
+        #region Engine Settings - Used by the Engine itself
+
+        /// <summary>
+        /// The name of the config to use in loading a project.
+        /// If not specified, the first config found is used.
         /// </summary>
         public const string ActiveConfig = "ActiveConfig";
 
         /// <summary>
-        /// If true, the engine should determine the private bin
-        /// path by examining the paths to all the tests.
+        /// Bool indicating whether the engine should determine the private
+        /// bin path by examining the paths to all the tests. Defaults to
+        /// true unless PrivateBinPath is specified.
         /// </summary>
         public const string AutoBinPath = "AutoBinPath";
 
         /// <summary>
-        /// The ApplicationBase to use in loading the tests.
+        /// The ApplicationBase to use in loading the tests. If not 
+        /// specified, and each assembly has its own process, then the
+        /// location of the assembly is used. For multiple  assemblies
+        /// in a single process, the closest common root directory is used.
         /// </summary>
         public const string BasePath = "BasePath";
 
         /// <summary>
-        /// The config file to use in running the tests 
+        /// Path to the config file to use in running the tests. 
         /// </summary>
         public const string ConfigurationFile = "ConfigurationFile";
 
         /// <summary>
-        /// Indicates whether a debugger should be launched at agent startup.
+        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// startup. Used only for debugging NUnit itself.
         /// </summary>
         public const string DebugAgent = "DebugAgent";
 
         /// <summary>
-        /// Indicates how to load tests across AppDomains
+        /// Indicates how to load tests across AppDomains. Values are:
+        /// "Default", "None", "Single", "Multiple". Default is "Multiple"
+        /// if more than one assembly is loaded in a process. Otherwise,
+        /// it is "Single".
         /// </summary>
         public const string DomainUsage = "DomainUsage";
 
         /// <summary>
-        /// The private binpath used to locate assemblies
+        /// The private binpath used to locate assemblies. Directory paths
+        /// is separated by a semicolon. It's an error to specify this and
+        /// also set AutoBinPath to true.
         /// </summary>
         public const string PrivateBinPath = "PrivateBinPath";
 
         /// <summary>
-        /// Indicates how to allocate assemblies to processes
+        /// The maximum number of test agents permitted to run simultneously. 
+        /// Ignored if the ProcessModel is not set or defaulted to Multiple.
+        /// </summary>
+        public const string MaxAgents = "MaxAgents";
+
+        /// <summary>
+        /// Indicates how to allocate assemblies to processes. Values are:
+        /// "Default", "Single", "Separate", "Multiple". Default is "Multiple"
+        /// for more than one assembly, "Separate" for a single assembly.
         /// </summary>
         public const string ProcessModel = "ProcessModel";
 
         /// <summary>
-        /// Indicates the desired runtime to use for the tests.
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
         /// </summary>
         public const string RuntimeFramework = "RuntimeFramework";
 
         /// <summary>
-        /// Indicates the test should be run in a 32-bit process on a 64-bit system
+        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
+        /// a 64-bit system. Ignored if set on a 32-bit system.
         /// </summary>
         public const string RunAsX86 = "RunAsX86";
 
@@ -89,29 +134,21 @@ namespace NUnit.Common
         public const string DisposeRunners = "DisposeRunners";
 
         /// <summary>
-        /// Indicates that the test assemblies should be shadow copied. Defaults to false.
+        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Defaults to false.
         /// </summary>
         public const string ShadowCopyFiles = "ShadowCopyFiles";
 
         #endregion
 
-        #region Settings taken from DriverSettings in the framework
-
-        /// <summary>
-        /// Indicates whether tests are being debugged.
-        /// </summary>
-        public const string DebugTests = "DebugTests";
+        #region Framework Settings - Passed through and used by the 3.0 Framework
 
         /// <summary>
         /// Integer value in milliseconds for the default timeout value
-        /// for test cases. If not specified, there is no timeout.
+        /// for test cases. If not specified, there is no timeout except
+        /// as specified by attributes on the tests themselves.
         /// </summary>
         public const string DefaultTimeout = "DefaultTimeout";
-
-        /// <summary>
-        /// An InternalTraceLevel enumeration value for this run. 
-        /// </summary>
-        public const string InternalTraceLevel = "InternalTraceLevel";
 
         /// <summary>
         /// A TextWriter to which the internal trace will be sent.
@@ -125,17 +162,18 @@ namespace NUnit.Common
         public const string LOAD = "LOAD";
 
         /// <summary>
-        /// The maximum number of test agents to run simultneously
-        /// </summary>
-        public const string MaxAgents = "MaxAgents";
-
-        /// <summary>
-        /// The number of test threads to run for the assembly.
+        /// The number of test threads to run for the assembly. If set to
+        /// 1, a single queue is used. If set to 0, tests are executed
+        /// directly, without queuing.
         /// </summary>
         public const string NumberOfTestWorkers = "NumberOfTestWorkers";
 
         /// <summary>
-        /// The random seed to be used for this assembly.
+        /// The random seed to be used for this assembly. If specified
+        /// as the value reported from a prior run, the framework should
+        /// generate identical random values for tests as were used for
+        /// that run, provided that no change has been made to the test
+        /// assembly. Default is a random value itself.
         /// </summary>
         public const string RandomSeed = "RandomSeed";
 
@@ -143,11 +181,6 @@ namespace NUnit.Common
         /// If true, execution stops after the first error or failure.
         /// </summary>
         public const string StopOnError = "StopOnError";
-
-        /// <summary>
-        /// Full path of the directory to be used for work and result files.
-        /// </summary>
-        public const string WorkDirectory = "WorkDirectory";
 
         #endregion
     }

--- a/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/CommandLineTests.cs
@@ -149,7 +149,7 @@ namespace NUnit.ConsoleRunner.Tests
 
         [TestCase("DefaultTimeout", "timeout")]
         [TestCase("RandomSeed", "seed")]
-        [TestCase("NumWorkers", "workers")]
+        [TestCase("NumberOfTestWorkers", "workers")]
         [TestCase("MaxAgents", "agents")]
         public void CanRecognizeIntOptions(string propertyName, string pattern)
         {

--- a/src/NUnitConsole/nunit-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit-console/ResultReporter.cs
@@ -62,6 +62,8 @@ namespace NUnit.ConsoleRunner
         {
             _writer.WriteLine();
 
+            WriteRunSettingsReport();
+
             WriteSummaryReport();
 
             if (_overallResult == "Failed")
@@ -70,6 +72,30 @@ namespace NUnit.ConsoleRunner
             if (Summary.SkipCount + Summary.IgnoreCount > 0)
                 WriteNotRunReport();
         }
+
+        #region
+
+        private void WriteRunSettingsReport()
+        {
+            var settings = _result.SelectNodes("settings/setting");
+
+            if (settings.Count > 0)
+            {
+                _writer.WriteLine(ColorStyle.SectionHeader, "Run Settings");
+
+                foreach (XmlNode node in settings)
+                {
+                    string name = node.GetAttribute("name");
+                    string val = node.GetAttribute("value");
+                    string label = string.Format("    {0}: ", name);
+                    _writer.WriteLabelLine(label, val);
+                }
+
+                _writer.WriteLine();
+            }
+        }
+
+        #endregion
 
         #region Summary Report
 

--- a/src/NUnitEngine/Addins/nunit-project-loader/RunnerSettings.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/RunnerSettings.cs
@@ -25,15 +25,16 @@ namespace NUnit.Engine
 {
     /// <summary>
     /// RunnerSettings is a static class containing constant values that
-    /// are used as keys in a TestPackage and are acted on by the engine.
+    /// are used as keys in the TestPackage created by the project loader.
     /// </summary>
+    /// <remarks>
+    /// This class is used only in the NUnitProjectLoader extension and
+    /// represents knowledge the extension has of the internals of the
+    /// engine - that is, the meaning of various settings. Only setting
+    /// keys actually used by the loader are included.
+    /// </remarks>
     public static class RunnerSettings
     {
-        /// <summary>
-        /// The config to use in loading a project
-        /// </summary>
-        public const string ActiveConfig = "ActiveConfig";
-
         /// <summary>
         /// If true, the engine should determine the private bin
         /// path by examining the paths to all the tests.
@@ -69,20 +70,5 @@ namespace NUnit.Engine
         /// Indicates the desired runtime to use for the tests.
         /// </summary>
         public const string RuntimeFramework = "RuntimeFramework";
-
-        /// <summary>
-        /// Indicates that the tests should be run in a 32-bit process on a 64-bit system
-        /// </summary>
-        public const string RunAsX86 = "RunAsX86";
-
-        /// <summary>
-        /// Indicates that test runners should be disposed after the tests are executed
-        /// </summary>
-        public const string DisposeRunners = "DisposeRunners";
-
-        /// <summary>
-        /// Indicates that the test assemblies should be shadow copied. Defaults to false.
-        /// </summary>
-        public const string ShadowCopyFiles = "ShadowCopyFiles";
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Xml;
 
 namespace NUnit.Engine
@@ -35,6 +36,11 @@ namespace NUnit.Engine
         /// Get a flag indicating whether a test is running
         /// </summary>
         bool IsTestRunning { get; }
+
+        /// <summary>
+        /// Gets a dictionary of the package settings with defaults resolved by the engine.
+        /// </summary>
+        IDictionary<string,object> EffectiveSettings { get; }
 
         /// <summary>
         /// Load a TestPackage for possible execution

--- a/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
@@ -38,11 +38,6 @@ namespace NUnit.Engine
         bool IsTestRunning { get; }
 
         /// <summary>
-        /// Gets a dictionary of the package settings with defaults resolved by the engine.
-        /// </summary>
-        IDictionary<string,object> EffectiveSettings { get; }
-
-        /// <summary>
         /// Load a TestPackage for possible execution
         /// </summary>
         /// <returns>An XmlNode representing the loaded package.</returns>

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine
             if (filePath != null)
             {
                 FullName = Path.GetFullPath(filePath);
-                Settings = new Dictionary<string, object>();
+                Settings = new Dictionary<string,object>();
                 SubPackages = new List<TestPackage>();
             }
         }
@@ -63,7 +63,7 @@ namespace NUnit.Engine
         {
             ID = GetNextID();
             SubPackages = new List<TestPackage>();
-            Settings = new Dictionary<string, object>();
+            Settings = new Dictionary<string,object>();
 
             foreach (string testFile in testFiles)
                 SubPackages.Add(new TestPackage(testFile));

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -131,6 +131,34 @@ namespace NUnit.Engine.Internal
             return IntPtr.Size == 8 ? "x64" : "x86";
         }
 
+        public static void InsertCommandLineElement(this XmlNode resultNode)
+        {
+            var doc = resultNode.OwnerDocument;
+
+            XmlNode cmd = doc.CreateElement("command-line");
+            resultNode.InsertAfter(cmd, null);
+
+            var cdata = doc.CreateCDataSection(Environment.CommandLine);
+            cmd.AppendChild(cdata);
+        }
+
+        public static void InsertSettingsElement(this XmlNode resultNode, TestPackage package)
+        {
+            var doc = resultNode.OwnerDocument;
+
+            XmlNode settings = doc.CreateElement("settings");
+            resultNode.InsertAfter(settings, null);
+
+            foreach (string name in package.Settings.Keys)
+            {
+                string value = package.Settings[name].ToString();
+                XmlNode setting = doc.CreateElement("setting");
+                setting.AddAttribute("name", name);
+                setting.AddAttribute("value", value);
+                settings.AppendChild(setting);
+            }
+        }
+
         #endregion
 
         #region Methods that operate on a list of XmlNodes

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -142,20 +142,20 @@ namespace NUnit.Engine.Internal
             cmd.AppendChild(cdata);
         }
 
-        public static void InsertSettingsElement(this XmlNode resultNode, TestPackage package)
+        public static void InsertSettingsElement(this XmlNode resultNode, IDictionary<string,object> settings)
         {
             var doc = resultNode.OwnerDocument;
 
-            XmlNode settings = doc.CreateElement("settings");
-            resultNode.InsertAfter(settings, null);
+            XmlNode settingsNode = doc.CreateElement("settings");
+            resultNode.InsertAfter(settingsNode, null);
 
-            foreach (string name in package.Settings.Keys)
+            foreach (string name in settings.Keys)
             {
-                string value = package.Settings[name].ToString();
-                XmlNode setting = doc.CreateElement("setting");
-                setting.AddAttribute("name", name);
-                setting.AddAttribute("value", value);
-                settings.AppendChild(setting);
+                string value = settings[name].ToString();
+                XmlNode settingNode = doc.CreateElement("setting");
+                settingNode.AddAttribute("name", name);
+                settingNode.AddAttribute("value", value);
+                settingsNode.AppendChild(settingNode);
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -105,6 +105,9 @@ namespace NUnit.Engine.Runners
 
             TestEngineResult result = _realRunner.Run(listener, filter).Aggregate("test-run", TestPackage.Name, TestPackage.FullName);
 
+            // These are inserted in reverse order, since each is added as the first child.
+            result.Xml.InsertSettingsElement(TestPackage);
+            result.Xml.InsertCommandLineElement();
             result.Xml.InsertEnvironmentElement();
 
             double duration = (double)(Stopwatch.GetTimestamp() - startTicks) / Stopwatch.Frequency;

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -98,7 +98,6 @@ namespace NUnit.Engine.Services
             // TODO: What about bad extensions?
 
             ProcessModel processModel = GetTargetProcessModel(package);
-            package.Settings.Remove(PackageSettings.ProcessModel);
 
             switch (processModel)
             {

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -61,7 +61,6 @@ namespace NUnit.Engine.Services
                         return new TestDomainRunner(this.ServiceContext, package);
 
                 case DomainUsage.Multiple:
-                    package.Settings.Remove("DomainUsage");
                     return new MultipleTestDomainRunner(ServiceContext, package);
 
                 case DomainUsage.None:

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -38,14 +38,14 @@ namespace NUnit.Engine.Services
     public class NUnit3XmlResultWriter : IResultWriter
     {
         /// <summary>
-        /// Checks if the output is writable. If the output is not
+        /// Checks if the output is writable by creating a stub result file. If the output is not
         /// writable, this method should throw an exception.
         /// </summary>
         /// <param name="outputPath"></param>
         public void CheckWritability(string outputPath)
         {
-            XmlNode commandLine = GetCommandLine();
-            WriteResultFile(commandLine, outputPath);
+            XmlNode stub = GetStubResult();
+            WriteResultFile(stub, outputPath);
         }
 
         public void WriteResultFile(XmlNode resultNode, string outputPath)
@@ -68,7 +68,7 @@ namespace NUnit.Engine.Services
             }
         }
 
-        private XmlNode GetCommandLine()
+        private XmlNode GetStubResult()
         {
             var doc = new XmlDocument();
             var test = doc.CreateElement("test-run");

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -155,7 +155,7 @@ namespace NUnit.Common.Tests
         [TestCase("DefaultTimeout", "timeout")]
         [TestCase("RandomSeed", "seed")]
 #if PARALLEL
-        [TestCase("NumWorkers", "workers")]
+        [TestCase("NumberOfTestWorkers", "workers")]
 #endif
         public void CanRecognizeIntOptions(string propertyName, string pattern)
         {


### PR DESCRIPTION
This adds both a command-line element and a settings element to the XML. The command-line element shows what was entered and the settings element shows the settings pulled from that command line.

However, at this point, the engine defaults have not yet been added to the settings as discussed in issue #713. Only those settings specified on the command-line are included.