### PR TITLE
Remove unnecessary using directives referencing System.Reflection

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 #if NETCF
 using System.Linq;
 #endif

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace NUnit.Framework
 {

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -25,7 +25,6 @@ namespace NUnit.Framework
 {
     using System;
     using System.Collections.Generic;
-    using System.Reflection;
     using NUnit.Framework.Interfaces;
     using NUnit.Framework.Internal;
     using NUnit.Framework.Internal.Builders;

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;

--- a/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
@@ -23,7 +23,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 

--- a/src/NUnitFramework/framework/ITestAction.cs
+++ b/src/NUnitFramework/framework/ITestAction.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 
 namespace NUnit.Framework
 {

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataProvider.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Collections;
-using System.Reflection;
 
 namespace NUnit.Framework.Interfaces
 {

--- a/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
+++ b/src/NUnitFramework/framework/Interfaces/IParameterDataSource.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Collections;
-using System.Reflection;
 
 namespace NUnit.Framework.Interfaces
 {

--- a/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISimpleTestBuilder.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Internal; // TODO: We shouldn't reference this in the interface
 
 namespace NUnit.Framework.Interfaces

--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 
 namespace NUnit.Framework.Interfaces
 {

--- a/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestBuilder.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Internal; // TODO: We shouldn't reference this in the interface
 
 namespace NUnit.Framework.Interfaces

--- a/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestCaseBuilder.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Reflection;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Interfaces

--- a/src/NUnitFramework/framework/Internal/Builders/CombinatorialStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/CombinatorialStrategy.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Builders

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 #if NETCF
 using System.Linq;
 #endif

--- a/src/NUnitFramework/framework/Internal/Builders/PairwiseStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/PairwiseStrategy.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 using NUnit.Framework.Interfaces;
 

--- a/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Interfaces;

--- a/src/NUnitFramework/framework/Internal/Builders/SequentialStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/SequentialStrategy.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Builders

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands

--- a/src/NUnitFramework/framework/Internal/CultureDetector.cs
+++ b/src/NUnitFramework/framework/Internal/CultureDetector.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Reflection;
 using System.Globalization;
 
 namespace NUnit.Framework.Internal

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Internal.Execution;


### PR DESCRIPTION
Closes #824
This affects only nunit-framework assembly.
Should I remove these from somewhere else?