### PR TITLE
Fix error in Cecil resolving assemblies. Fixes #853.

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -292,7 +292,10 @@ namespace NUnit.Engine.Services
         /// </summary>
         private void FindExtensionsInAssembly(string assemblyName)
         {
-            var module = AssemblyDefinition.ReadAssembly(assemblyName).MainModule;
+            var resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyName));
+            var parameters = new ReaderParameters() { AssemblyResolver = resolver };
+            var module = AssemblyDefinition.ReadAssembly(assemblyName, parameters).MainModule;
             foreach (var type in module.GetTypes())
             {
                 CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");


### PR DESCRIPTION
Make sure cecil looks for assemblies in the directory where the assembly being resolved is located. It's weird that this isn't a default!