### PR TITLE
Console options refactor

### DIFF
--- a/src/NUnitConsole/nunit-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleOptions.cs
@@ -1,0 +1,131 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mono.Options;
+
+namespace NUnit.Common
+{
+    /// <summary>
+    /// ConsoleOptions encapsulates the option settings for
+    /// the nunit-console program.
+    /// </summary>
+    public class ConsoleOptions : CommandLineOptions
+    {
+        #region Constructors
+
+        internal ConsoleOptions(IDefaultOptionsProvider provider, params string[] args) : base(provider, args) { }
+
+        public ConsoleOptions(params string[] args) : base(args) { }
+
+        #endregion
+
+        #region Properties
+
+        public string ActiveConfig { get; private set; }
+        public bool ActiveConfigSpecified { get { return ActiveConfig != null; } }
+
+        // Where to Run Tests
+
+        public string ProcessModel { get; private set; }
+        public bool ProcessModelSpecified { get { return ProcessModel != null; } }
+
+        public string DomainUsage { get; private set; }
+        public bool DomainUsageSpecified { get { return DomainUsage != null; } }
+
+        // How to Run Tests
+
+        public string Framework { get; private set; }
+        public bool FrameworkSpecified { get { return Framework != null; } }
+
+        public bool RunAsX86 { get; private set; }
+
+        public bool DisposeRunners { get; private set; }
+
+        public bool ShadowCopyFiles { get; private set; }
+
+        private int maxAgents = -1;
+        public int MaxAgents { get { return maxAgents; } }
+        public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
+
+        public bool DebugTests { get; private set; }
+
+        public bool DebugAgent { get; private set; }
+
+        #endregion
+
+        #region Configure Additional Options for Console
+
+        protected override void ConfigureOptions()
+        {
+            base.ConfigureOptions();
+
+            this.Add("config=", "{NAME} of a project configuration to load (e.g.: Debug).",
+                v => ActiveConfig = RequiredValue(v, "--config"));
+
+            // Where to Run Tests
+            this.Add("process=", "{PROCESS} isolation for test assemblies.\nValues: InProcess, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",
+                v =>
+                {
+                    ProcessModel = RequiredValue(v, "--process", "Single", "InProcess", "Separate", "Multiple");
+                    // Change so it displays correctly even though it isn't absolutely needed
+                    if (ProcessModel.ToLower() == "single")
+                        ProcessModel = "InProcess";
+                });
+
+            this.Add("inprocess", "Synonym for --process:InProcess",
+                v => ProcessModel = "InProcess");
+
+            this.Add("domain=", "{DOMAIN} isolation for test assemblies.\nValues: None, Single, Multiple. If not specified, defaults to Single for a single assembly or Multiple for more than one.",
+                v => DomainUsage = RequiredValue(v, "--domain", "None", "Single", "Multiple"));
+
+            // How to Run Tests
+            this.Add("framework=", "{FRAMEWORK} type/version to use for tests.\nExamples: mono, net-3.5, v4.0, 2.0, mono-4.0. If not specified, tests will run under the framework they are compiled with.",
+                v => Framework = RequiredValue(v, "--framework"));
+
+            this.Add("x86", "Run tests in an x86 process on 64 bit systems",
+                v => RunAsX86 = v != null);
+
+            this.Add("dispose-runners", "Dispose each test runner after it has finished running its tests.",
+                v => DisposeRunners = v != null);
+
+            this.Add("shadowcopy", "Shadow copy test files",
+                v => ShadowCopyFiles = v != null);
+
+            this.Add("agents=", "Specify the maximum {NUMBER} of test assembly agents to run at one time. If not specified, there is no limit.",
+                v => maxAgents = RequiredInt(v, "--agents"));
+
+            this.Add("debug", "Launch debugger to debug tests.",
+                v => DebugTests = v != null);
+
+#if DEBUG
+            this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",
+                v => DebugAgent = v != null);
+#endif
+
+        #endregion
+        }
+    }
+}

--- a/src/NUnitConsole/nunit-console/nunit-console.csproj
+++ b/src/NUnitConsole/nunit-console/nunit-console.csproj
@@ -57,8 +57,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>DefaultOptionsProvider.cs</Link>
@@ -99,6 +99,7 @@
     <Compile Include="..\ConsoleVersion.cs">
       <Link>ConsoleVersion.cs</Link>
     </Compile>
+    <Compile Include="ConsoleOptions.cs" />
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ResultSummary.cs" />

--- a/src/NUnitFramework/nunitlite.runner/Runner/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/AutoRun.cs
@@ -51,7 +51,7 @@ namespace NUnitLite.Runner
         /// <param name="args">Execution options</param>
         public int Execute(string[] args)
         {
-            var options = new ConsoleOptions(args);
+            var options = new NUnitLiteOptions(args);
             var callingAssembly = Assembly.GetCallingAssembly();
 
             var level = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel ?? "Off", true);

--- a/src/NUnitFramework/nunitlite.runner/Runner/NUnitLiteOptions.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/NUnitLiteOptions.cs
@@ -1,0 +1,44 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Common;
+
+namespace NUnitLite.Runner
+{
+    /// <summary>
+    /// NUnitLiteOptions encapsulates the option settings for NUnitLite.
+    /// Currently, there are no additional options beyond those common
+    /// options that are shared with nunit-console. If NUnitLite should
+    /// acquire some unique options, they should be placed here.
+    /// </summary>
+    public class NUnitLiteOptions : CommandLineOptions
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public NUnitLiteOptions(params string[] args) : base(args) { }
+
+        // Currently used only by test
+        internal NUnitLiteOptions(IDefaultOptionsProvider provider, params string[] args) : base(provider, args) { }
+    }
+}

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextRunner.cs
@@ -70,7 +70,7 @@ namespace NUnitLite.Runner
         private ITestAssemblyRunner _runner;
 
 #if !SILVERLIGHT
-        private ConsoleOptions _options;
+        private NUnitLiteOptions _options;
 #if !NETCF
         private TeamCityEventListener _teamCity;
 #endif
@@ -102,7 +102,7 @@ namespace NUnitLite.Runner
         }
 #else
         /// <param name="options">The options to use when running the test</param>
-        public TextRunner(TextUI textUI, ConsoleOptions options)
+        public TextRunner(TextUI textUI, NUnitLiteOptions options)
         {
             _textUI = textUI;
             _options = options;
@@ -251,7 +251,7 @@ namespace NUnitLite.Runner
         /// <summary>
         /// Make the settings for this run - this is public for testing
         /// </summary>
-        public static Dictionary<string, object> MakeRunSettings(ConsoleOptions options)
+        public static Dictionary<string, object> MakeRunSettings(NUnitLiteOptions options)
         {
             // Transfer command line options to run settings
             var runSettings = new Dictionary<string, object>();
@@ -276,7 +276,7 @@ namespace NUnitLite.Runner
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static TestFilter CreateTestFilter(ConsoleOptions options)
+        public static TestFilter CreateTestFilter(NUnitLiteOptions options)
         {
             TestFilter namefilter = options.TestList.Count > 0
                 ? new SimpleNameFilter(options.TestList)

--- a/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Runner/TextUI.cs
@@ -36,7 +36,7 @@ namespace NUnitLite.Runner
     {
         private ExtendedTextWriter _outWriter;
 #if !SILVERLIGHT
-        private ConsoleOptions _options;
+        private NUnitLiteOptions _options;
 #endif
 
         #region Constructors
@@ -47,9 +47,9 @@ namespace NUnitLite.Runner
             _outWriter = writer;
         }
 #else
-        public TextUI(ConsoleOptions options) : this(null, options) { }
+        public TextUI(NUnitLiteOptions options) : this(null, options) { }
 
-        public TextUI(ExtendedTextWriter writer, ConsoleOptions options)
+        public TextUI(ExtendedTextWriter writer, NUnitLiteOptions options)
         {
             _options = options;
             _outWriter = writer ?? new ColorConsoleWriter(!options.NoColor);

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-2.0.csproj
@@ -54,8 +54,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>Runner\ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>Runner\ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>Runner\CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>Runner\DefaultOptionsProvider.cs</Link>
@@ -92,6 +92,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Runner\DebugWriter.cs" />
+    <Compile Include="Runner\NUnitLiteOptions.cs" />
     <Compile Include="Runner\OutputManager.cs" />
     <Compile Include="Runner\OutputWriters\NUnit2XmlOutputWriter.cs" />
     <Compile Include="Runner\OutputWriters\NUnit3XmlOutputWriter.cs" />

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.0.csproj
@@ -55,8 +55,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>Runner\ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>Runner\ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>Runner\CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>Runner\DefaultOptionsProvider.cs</Link>
@@ -91,6 +91,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runner\AutoRun.cs" />
     <Compile Include="Runner\DebugWriter.cs" />
+    <Compile Include="Runner\NUnitLiteOptions.cs" />
     <Compile Include="Runner\OutputManager.cs" />
     <Compile Include="Runner\OutputWriters\NUnit2XmlOutputWriter.cs" />
     <Compile Include="Runner\OutputWriters\NUnit3XmlOutputWriter.cs" />

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-4.5.csproj
@@ -57,8 +57,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>Runner\ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>Runner\ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>Runner\CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>Runner\DefaultOptionsProvider.cs</Link>
@@ -93,6 +93,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runner\AutoRun.cs" />
     <Compile Include="Runner\DebugWriter.cs" />
+    <Compile Include="Runner\NUnitLiteOptions.cs" />
     <Compile Include="Runner\OutputManager.cs" />
     <Compile Include="Runner\OutputWriters\NUnit2XmlOutputWriter.cs" />
     <Compile Include="Runner\OutputWriters\NUnit3XmlOutputWriter.cs" />

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
@@ -71,8 +71,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>Runner\ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>Runner\ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>Runner\CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>Runner\DefaultOptionsProvider.cs</Link>
@@ -107,6 +107,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runner\AutoRun.cs" />
     <Compile Include="Runner\DebugWriter.cs" />
+    <Compile Include="Runner\NUnitLiteOptions.cs" />
     <Compile Include="Runner\OutputManager.cs" />
     <Compile Include="Runner\OutputWriters\NUnit2XmlOutputWriter.cs" />
     <Compile Include="Runner\OutputWriters\NUnit3XmlOutputWriter.cs" />

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-portable.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-portable.csproj
@@ -59,8 +59,8 @@
     <Compile Include="..\..\Common\nunit\ColorStyle.cs">
       <Link>Runner\ColorStyle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\ConsoleOptions.cs">
-      <Link>Runner\ConsoleOptions.cs</Link>
+    <Compile Include="..\..\Common\nunit\CommandLineOptions.cs">
+      <Link>Runner\CommandLineOptions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\DefaultOptionsProvider.cs">
       <Link>Runner\DefaultOptionsProvider.cs</Link>
@@ -95,6 +95,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runner\AutoRun.cs" />
     <Compile Include="Runner\DebugWriter.cs" />
+    <Compile Include="Runner\NUnitLiteOptions.cs" />
     <Compile Include="Runner\OutputManager.cs" />
     <Compile Include="Runner\OutputWriters\NUnit2XmlOutputWriter.cs" />
     <Compile Include="Runner\OutputWriters\NUnit3XmlOutputWriter.cs" />

--- a/src/NUnitFramework/tests/Runner/CommandLineTests.cs
+++ b/src/NUnitFramework/tests/Runner/CommandLineTests.cs
@@ -41,7 +41,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void NoInputFiles()
         {
-            ConsoleOptions options = new ConsoleOptions();
+            var options = new NUnitLiteOptions();
             Assert.True(options.Validate());
             Assert.AreEqual(0, options.InputFiles.Count);
         }
@@ -71,19 +71,19 @@ namespace NUnitLite.Runner.Tests
 
             foreach (string option in prototypes)
             {
-                ConsoleOptions options = new ConsoleOptions("-" + option);
+                var options = new NUnitLiteOptions("-" + option);
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
 
-                options = new ConsoleOptions("-" + option + "+");
+                options = new NUnitLiteOptions("-" + option + "+");
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "+");
 
-                options = new ConsoleOptions("-" + option + "-");
+                options = new NUnitLiteOptions("-" + option + "-");
                 Assert.AreEqual(false, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "-");
 
-                options = new ConsoleOptions("--" + option);
+                options = new NUnitLiteOptions("--" + option);
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
 
-                options = new ConsoleOptions("/" + option);
+                options = new NUnitLiteOptions("/" + option);
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize /" + option);
             }
         }
@@ -107,7 +107,7 @@ namespace NUnitLite.Runner.Tests
                 foreach (string value in goodValues)
                 {
                     string optionPlusValue = string.Format("--{0}:{1}", option, value);
-                    ConsoleOptions options = new ConsoleOptions(optionPlusValue);
+                    var options = new NUnitLiteOptions(optionPlusValue);
                     Assert.True(options.Validate(), "Should be valid: " + optionPlusValue);
                     Assert.AreEqual(value, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
                 }
@@ -115,7 +115,7 @@ namespace NUnitLite.Runner.Tests
                 foreach (string value in badValues)
                 {
                     string optionPlusValue = string.Format("--{0}:{1}", option, value);
-                    ConsoleOptions options = new ConsoleOptions(optionPlusValue);
+                    var options = new NUnitLiteOptions(optionPlusValue);
                     Assert.False(options.Validate(), "Should not be valid: " + optionPlusValue);
                 }
             }
@@ -132,7 +132,7 @@ namespace NUnitLite.Runner.Tests
             {
                 string lowercaseValue = canonicalValue.ToLower(CultureInfo.InvariantCulture);
                 string optionPlusValue = string.Format("--{0}:{1}", optionName, lowercaseValue);
-                ConsoleOptions options = new ConsoleOptions(optionPlusValue);
+                var options = new NUnitLiteOptions(optionPlusValue);
                 Assert.True(options.Validate(), "Should be valid: " + optionPlusValue);
                 Assert.AreEqual(canonicalValue, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
             }
@@ -152,7 +152,7 @@ namespace NUnitLite.Runner.Tests
 
             foreach (string option in prototypes)
             {
-                ConsoleOptions options = new ConsoleOptions("--" + option + ":42");
+                var options = new NUnitLiteOptions("--" + option + ":42");
                 Assert.AreEqual(42, (int)property.GetValue(options, null), "Didn't recognize --" + option + ":text");
             }
         }
@@ -188,7 +188,7 @@ namespace NUnitLite.Runner.Tests
         [TestCase("--trace")]
         public void MissingValuesAreReported(string option)
         {
-            ConsoleOptions options = new ConsoleOptions(option + "=");
+            var options = new NUnitLiteOptions(option + "=");
             Assert.False(options.Validate(), "Missing value should not be valid");
             Assert.AreEqual("Missing required value for option '" + option + "'.", options.ErrorMessages[0]);
         }
@@ -196,7 +196,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void AssemblyName()
         {
-            ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
+            var options = new NUnitLiteOptions("nunit.tests.dll");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count);
             Assert.AreEqual("nunit.tests.dll", options.InputFiles[0]);
@@ -205,7 +205,7 @@ namespace NUnitLite.Runner.Tests
         // [Test]
         // public void FixtureNamePlusAssemblyIsValid()
         // {
-        //    ConsoleOptions options = new ConsoleOptions( "-fixture:NUnit.Tests.AllTests", "nunit.tests.dll" );
+        //    var options = new NUnitLiteOptions( "-fixture:NUnit.Tests.AllTests", "nunit.tests.dll" );
         //    Assert.AreEqual("nunit.tests.dll", options.Parameters[0]);
         //    Assert.AreEqual("NUnit.Tests.AllTests", options.fixture);
         //    Assert.IsTrue(options.Validate());
@@ -214,7 +214,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void AssemblyAloneIsValid()
         {
-            ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
+            var options = new NUnitLiteOptions("nunit.tests.dll");
             Assert.True(options.Validate());
             Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
         }
@@ -222,7 +222,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void InvalidOption()
         {
-            ConsoleOptions options = new ConsoleOptions("-asembly:nunit.tests.dll");
+            var options = new NUnitLiteOptions("-asembly:nunit.tests.dll");
             Assert.False(options.Validate());
             Assert.AreEqual(1, options.ErrorMessages.Count);
             Assert.AreEqual("Invalid argument: -asembly:nunit.tests.dll", options.ErrorMessages[0]);
@@ -238,7 +238,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void InvalidCommandLineParms()
         {
-            ConsoleOptions options = new ConsoleOptions("-garbage:TestFixture", "-assembly:Tests.dll");
+            var options = new NUnitLiteOptions("-garbage:TestFixture", "-assembly:Tests.dll");
             Assert.False(options.Validate());
             Assert.AreEqual(2, options.ErrorMessages.Count);
             Assert.AreEqual("Invalid argument: -garbage:TestFixture", options.ErrorMessages[0]);
@@ -252,7 +252,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void TimeoutIsMinusOneIfNoOptionIsProvided()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll");
+            var options = new NUnitLiteOptions("tests.dll");
             Assert.True(options.Validate());
             Assert.AreEqual(-1, options.DefaultTimeout);
         }
@@ -260,13 +260,13 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void TimeoutThrowsExceptionIfOptionHasNoValue()
         {
-            Assert.Throws<Mono.Options.OptionException>(() => new ConsoleOptions("tests.dll", "-timeout"));
+            Assert.Throws<Mono.Options.OptionException>(() => new NUnitLiteOptions("tests.dll", "-timeout"));
         }
 
         [Test]
         public void TimeoutParsesIntValueCorrectly()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:5000");
+            var options = new NUnitLiteOptions("tests.dll", "-timeout:5000");
             Assert.True(options.Validate());
             Assert.AreEqual(5000, options.DefaultTimeout);
         }
@@ -274,7 +274,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void TimeoutCausesErrorIfValueIsNotInteger()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:abc");
+            var options = new NUnitLiteOptions("tests.dll", "-timeout:abc");
             Assert.False(options.Validate());
             Assert.AreEqual(-1, options.DefaultTimeout);
         }
@@ -286,7 +286,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ResultOptionWithFilePath()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml");
+            var options = new NUnitLiteOptions("tests.dll", "-result:results.xml");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -300,7 +300,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ResultOptionWithFilePathAndFormat()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;format=nunit2");
+            var options = new NUnitLiteOptions("tests.dll", "-result:results.xml;format=nunit2");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -314,7 +314,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ResultOptionWithFilePathAndTransform()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;transform=transform.xslt");
+            var options = new NUnitLiteOptions("tests.dll", "-result:results.xml;transform=transform.xslt");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -328,7 +328,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void FileNameWithoutResultOptionLooksLikeParameter()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "results.xml");
+            var options = new NUnitLiteOptions("tests.dll", "results.xml");
             Assert.True(options.Validate());
             Assert.AreEqual(0, options.ErrorMessages.Count);
             Assert.AreEqual(2, options.InputFiles.Count);
@@ -337,7 +337,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ResultOptionWithoutFileNameIsInvalid()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:");
+            var options = new NUnitLiteOptions("tests.dll", "-result:");
             Assert.False(options.Validate(), "Should not be valid");
             Assert.AreEqual(1, options.ErrorMessages.Count, "An error was expected");
         }
@@ -345,7 +345,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ResultOptionMayBeRepeated()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml", "-result:nunit2results.xml;format=nunit2", "-result:myresult.xml;transform=mytransform.xslt");
+            var options = new NUnitLiteOptions("tests.dll", "-result:results.xml", "-result:nunit2results.xml;format=nunit2", "-result:myresult.xml;transform=mytransform.xslt");
             Assert.True(options.Validate(), "Should be valid");
 
             var specs = options.ResultOutputSpecifications;
@@ -370,7 +370,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void DefaultResultSpecification()
         {
-            var options = new ConsoleOptions("test.dll");
+            var options = new NUnitLiteOptions("test.dll");
             Assert.AreEqual(1, options.ResultOutputSpecifications.Count);
 
             var spec = options.ResultOutputSpecifications[0];
@@ -382,14 +382,14 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void NoResultSuppressesDefaultResultSpecification()
         {
-            var options = new ConsoleOptions("test.dll", "-noresult");
+            var options = new NUnitLiteOptions("test.dll", "-noresult");
             Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
         }
 
         [Test]
         public void NoResultSuppressesAllResultSpecifications()
         {
-            var options = new ConsoleOptions("test.dll", "-result:results.xml", "-noresult", "-result:nunit2results.xml;format=nunit2");
+            var options = new NUnitLiteOptions("test.dll", "-result:results.xml", "-noresult", "-result:nunit2results.xml;format=nunit2");
             Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
         }
 
@@ -400,7 +400,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ExploreOptionWithoutPath()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore");
+            var options = new NUnitLiteOptions("tests.dll", "-explore");
             Assert.True(options.Validate());
             Assert.True(options.Explore);
         }
@@ -408,7 +408,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ExploreOptionWithFilePath()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml");
+            var options = new NUnitLiteOptions("tests.dll", "-explore:results.xml");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -423,7 +423,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ExploreOptionWithFilePathAndFormat()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;format=cases");
+            var options = new NUnitLiteOptions("tests.dll", "-explore:results.xml;format=cases");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -438,7 +438,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ExploreOptionWithFilePathAndTransform()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;transform=myreport.xslt");
+            var options = new NUnitLiteOptions("tests.dll", "-explore:results.xml;transform=myreport.xslt");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -453,7 +453,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ExploreOptionWithFilePathUsingEqualSign()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore=C:/nunit/tests/bin/Debug/console-test.xml");
+            var options = new NUnitLiteOptions("tests.dll", "-explore=C:/nunit/tests/bin/Debug/console-test.xml");
             Assert.True(options.Validate());
             Assert.True(options.Explore);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
@@ -477,14 +477,14 @@ namespace NUnitLite.Runner.Tests
                 args.Add("--teamcity");
             }
 
-            ConsoleOptions options;
+            CommandLineOptions options;
             if (defaultTeamcity.HasValue)
             {
-                options = new ConsoleOptions(new DefaultOptionsProviderStub(defaultTeamcity.Value), args.ToArray());
+                options = new NUnitLiteOptions(new DefaultOptionsProviderStub(defaultTeamcity.Value), args.ToArray());
             }
             else
             {
-                options = new ConsoleOptions(args.ToArray());
+                options = new NUnitLiteOptions(args.ToArray());
             }
 
             // When
@@ -499,16 +499,16 @@ namespace NUnitLite.Runner.Tests
 
 #region Helper Methods
 
-        private static FieldInfo GetFieldInfo(string fieldName)
-        {
-            FieldInfo field = typeof(ConsoleOptions).GetField(fieldName);
-            Assert.IsNotNull(field, "The field '{0}' is not defined", fieldName);
-            return field;
-        }
+        //private static FieldInfo GetFieldInfo(string fieldName)
+        //{
+        //    FieldInfo field = typeof(NUnitLiteOptions).GetField(fieldName);
+        //    Assert.IsNotNull(field, "The field '{0}' is not defined", fieldName);
+        //    return field;
+        //}
 
         private static PropertyInfo GetPropertyInfo(string propertyName)
         {
-            PropertyInfo property = typeof(ConsoleOptions).GetProperty(propertyName);
+            PropertyInfo property = typeof(NUnitLiteOptions).GetProperty(propertyName);
             Assert.IsNotNull(property, "The property '{0}' is not defined", propertyName);
             return property;
         }

--- a/src/NUnitFramework/tests/Runner/CreateTestFilterTests.cs
+++ b/src/NUnitFramework/tests/Runner/CreateTestFilterTests.cs
@@ -161,7 +161,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void TestListFileMissing()
         {
-            var options = new ConsoleOptions("--testlist:\\badtestlistfile");
+            var options = new NUnitLiteOptions("--testlist:\\badtestlistfile");
             Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
             Assert.That(options.ErrorMessages, Does.Contain("Unable to locate file: \\badtestlistfile"));
             var filter = TextRunner.CreateTestFilter(options);
@@ -170,7 +170,7 @@ namespace NUnitLite.Runner.Tests
 
         private TestFilter GetFilter(params string[] args)
         {
-            return TextRunner.CreateTestFilter(new ConsoleOptions(args));
+            return TextRunner.CreateTestFilter(new NUnitLiteOptions(args));
         }
     }
 }

--- a/src/NUnitFramework/tests/Runner/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/tests/Runner/MakeRunSettingsTests.cs
@@ -33,7 +33,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void WhenTimeoutIsSpecified_RunSettingsIncludeIt()
         {
-            var options = new ConsoleOptions("test.dll", "--timeout=50");
+            var options = new NUnitLiteOptions("test.dll", "--timeout=50");
             var settings = TextRunner.MakeRunSettings(options);
 
             Assert.That(settings.ContainsKey("DefaultTimeout"));
@@ -43,7 +43,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void WhenWorkDirectoryIsSpecified_RunSettingsIncludeIt()
         {
-            var options = new ConsoleOptions("test.dll", "--work=results");
+            var options = new NUnitLiteOptions("test.dll", "--work=results");
             var settings = TextRunner.MakeRunSettings(options);
 
             Assert.That(settings.ContainsKey("WorkDirectory"));
@@ -53,7 +53,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void WhenSeedIsSpecified_RunSettingsIncludeIt()
         {
-            var options = new ConsoleOptions("test.dll", "--seed=1234");
+            var options = new NUnitLiteOptions("test.dll", "--seed=1234");
             var settings = TextRunner.MakeRunSettings(options);
 
             Assert.That(settings.ContainsKey("RandomSeed"));

--- a/src/NUnitFramework/tests/Runner/TextUITests.cs
+++ b/src/NUnitFramework/tests/Runner/TextUITests.cs
@@ -68,7 +68,7 @@ namespace NUnitLite.Runner.Tests
             _reportBuilder = new StringBuilder();
             var writer = new ExtendedTextWrapper(new StringWriter(_reportBuilder));
 #if !SILVERLIGHT
-            var options = new ConsoleOptions();
+            var options = new NUnitLiteOptions();
             _textUI = new TextUI(writer, options);
 #else
             _textUI = new TextUI(writer);
@@ -183,7 +183,7 @@ namespace NUnitLite.Runner.Tests
         [Test]
         public void ReportSequenceTest()
         {
-            var textRunner = new TextRunner(_textUI, new ConsoleOptions());
+            var textRunner = new TextRunner(_textUI, new NUnitLiteOptions());
             textRunner.ReportResults(_result);
 
             int last = -1;


### PR DESCRIPTION
Since we aren't making any big changes right now to NUnitLite, I decided to push up some work in progress so it's out of my way.

This PR creates separate options classes for NUnit-console and nunitlite, deriving them from a common base. I eliminated definitions of properties we don't actually use from the nunitlite version.

Currently, the nunitlite version simply inherits the base class. That's because there are nunitlite actually only has common features. If NUnitLite got a new option of some kind, then we would add the new stuff in the NUnitLiteOptions class. However, changes will now be localized to the options classes only, since the runners each reference the correct class.