### PR TITLE
Fix XML issues. Fixes #850. Fixes #860.

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -244,7 +244,7 @@ namespace NUnit.Framework.Interfaces
 
             if (Value != null)
                 if (ValueIsCDATA)
-                    writer.WriteCData(Value);
+                    WriteCDataTo(writer);
                 else
                     writer.WriteString(Value);
 
@@ -330,6 +330,28 @@ namespace NUnit.Framework.Interfaces
         private static string CharToUnicodeSequence(char symbol)
         {
             return string.Format("\\u{0}", ((int)symbol).ToString("x4"));
+        }
+
+        private void WriteCDataTo(XmlWriter writer)
+        {
+            int start = 0;
+            string text = Value;
+
+            while (true)
+            {
+                int illegal = text.IndexOf("]]>", start);
+                if (illegal < 0)
+                    break;
+                writer.WriteCData(text.Substring(start, illegal - start + 2));
+                start = illegal + 2;
+                if (start >= text.Length)
+                    return;
+            }
+
+            if (start > 0)
+                writer.WriteCData(text.Substring(start));
+            else
+                writer.WriteCData(text);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -132,18 +132,6 @@ namespace NUnit.Framework.Internal
         public string Message { get; private set; }
 
         /// <summary>
-        /// Gets the escaped message associated with a test
-        /// failure or with not running the test
-        /// </summary>
-        public string EscapedMessage
-        {
-            get
-            {
-                return EscapeInvalidXmlCharacters(Message);
-            }
-        }
-
-        /// <summary>
         /// Gets any stacktrace associated with an
         /// error or failure.
         /// </summary>
@@ -501,7 +489,7 @@ namespace NUnit.Framework.Internal
         private TNode AddReasonElement(TNode targetNode)
         {
             TNode reasonNode = targetNode.AddElement("reason");
-            return reasonNode.AddElement("message", EscapedMessage);
+            return reasonNode.AddElementWithCDATA("message", Message);
         }
 
         /// <summary>
@@ -514,31 +502,17 @@ namespace NUnit.Framework.Internal
             TNode failureNode = targetNode.AddElement("failure");
 
             if (Message != null)
-                failureNode.AddElement("message", EscapedMessage);
+                failureNode.AddElementWithCDATA("message", Message);
 
             if (StackTrace != null)
-                failureNode.AddElement("stack-trace", StackTrace);
+                failureNode.AddElementWithCDATA("stack-trace", StackTrace);
 
             return failureNode;
         }
 
         private TNode AddOutputElement(TNode targetNode)
         {
-            return targetNode.AddElement("output", Output);
-        }
-
-        static string EscapeInvalidXmlCharacters(string str)
-        {
-            // Based on the XML spec http://www.w3.org/TR/xml/#charsets
-            // For detailed explanation of the regex see http://mnaoumov.wordpress.com/2014/06/15/escaping-invalid-xml-unicode-characters/
-
-            var invalidXmlCharactersRegex = new Regex("[^\u0009\u000a\u000d\u0020-\ufffd]|([\ud800-\udbff](?![\udc00-\udfff]))|((?<![\ud800-\udbff])[\udc00-\udfff])");
-            return invalidXmlCharactersRegex.Replace(str, match => CharToUnicodeSequence(match.Value[0]));
-        }
-
-        static string CharToUnicodeSequence(char symbol)
-        {
-            return string.Format("\\u{0}", ((int) symbol).ToString("x4"));
+            return targetNode.AddElementWithCDATA("output", Output);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -105,6 +105,14 @@ namespace NUnit.Framework.Internal
             CheckXmlForTest(testSuite, true);
         }
 
+        [Test]
+        public void TestNameWithInvalidCharacter()
+        {
+            testMethod.Name = "\u0001HappyFace";
+            // This throws if the name is not properly escaped
+            Assert.That(testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"\\u0001HappyFace\""));
+        }
+
         #region Helper Methods For Checking XML
 
         private void CheckXmlForTest(Test test, bool recursive)


### PR DESCRIPTION
I moved the code to escape invalid XML chars to TNode, where it is done on all text data and attribute values at the point it is added to the node.

The output, message and stack-trace elements are now encoded as CDATA sections.