### PR TITLE
Correctly report Unix variant in NUnit Console. Fixes #870

### DIFF
--- a/src/NUnitConsole/nunit-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit-console/ConsoleRunner.cs
@@ -195,7 +195,7 @@ namespace NUnit.ConsoleRunner
         {
             OperatingSystem os = Environment.OSVersion;
             string osString = os.ToString();
-            if (os.Platform == PlatformID.Unix && os.Platform != PlatformID.MacOSX)
+            if (os.Platform == PlatformID.Unix)
             {
                 IntPtr buf = Marshal.AllocHGlobal(8192);
                 if (uname(buf) == 0)


### PR DESCRIPTION
When run on any Unix variant, correctly reports the variant. For example, FreeBSD or Ubuntu will now report as such instead of just Unix and a Mac will report,

```
Runtime Environment
   OS Version: MacOSX 14.5.0.0 
  CLR Version: 4.0.30319.17020
```

Mac is the only Unix uname that I translated since I thought it was more readable than "Darwin"