### PR TITLE
Increase tolerance of StopwatchTests from 20% to 50%

### DIFF
--- a/src/NUnitFramework/tests/Compatibility/StopwatchTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/StopwatchTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Tests.Compatibility
     {
 #if SILVERLIGHT || PORTABLE
         private const int DELAY = 100;
-        private const int TOLERANCE = 20;
+        private const int TOLERANCE = 50;
 
         [Test]
         public void TestStartNewIsRunning()


### PR DESCRIPTION
It's not a very elegant solution, but it seems to be working for our CI builds. Fixes #865.