### PR TITLE
Add setting to allow events to be synchronous. Fixes #830.

### DIFF
--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -182,6 +182,11 @@ namespace NUnit.Common
         /// </summary>
         public const string StopOnError = "StopOnError";
 
+        /// <summary>
+        /// If true, use of the event queue is suppressed and test events are synchronous.
+        /// </summary>
+        public const string SynchronousEvents = "SynchronousEvents";
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -235,13 +235,15 @@ namespace NUnit.Framework.Api
 #endif
 
 #if PARALLEL
-            QueuingEventListener queue = new QueuingEventListener();
-            Context.Listener = queue;
+            // Queue and pump events, unless settings have SynchronousEvents == false
+            if (!Settings.Contains(PackageSettings.SynchronousEvents) || !(bool)Settings[PackageSettings.SynchronousEvents])
+            {
+                QueuingEventListener queue = new QueuingEventListener();
+                Context.Listener = queue;
 
-            _pump = new EventPump(listener, queue.Events);
-            _pump.Start();
-#else
-            Context.Dispatcher = new SimpleWorkItemDispatcher();
+                _pump = new EventPump(listener, queue.Events);
+                _pump.Start();
+            }
 #endif
 
             if (!System.Diagnostics.Debugger.IsAttached &&
@@ -311,6 +313,8 @@ namespace NUnit.Framework.Api
             }
             else
                 Context.Dispatcher = new SimpleWorkItemDispatcher();
+#else
+                Context.Dispatcher = new SimpleWorkItemDispatcher();
 #endif
         }
 
@@ -320,7 +324,8 @@ namespace NUnit.Framework.Api
         private void OnRunCompleted(object sender, EventArgs e)
         {
 #if PARALLEL
-            _pump.Dispose();
+            if (_pump != null)
+                _pump.Dispose();
 #endif
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Internal.Execution
                 _topLevelWorkItem = work;
                 _runnerThread = new Thread(RunnerThreadProc);
                 _runnerThread.Start();
-			}	
+            }	
 #endif
         }
 
@@ -77,21 +77,21 @@ namespace NUnit.Framework.Internal.Execution
     }
 #endif
 
-		/// <summary>
-		/// Cancel the ongoing run completely.
-		/// If no run is in process, the call has no effect.
-		/// </summary>
-		public void CancelRun()
-		{
-	#if !PORTABLE
-	#if NETCF
-			if (_runnerThread != null && !_runnerThread.Join(0))
-	#else
-			if (_runnerThread != null && _runnerThread.IsAlive)
-	#endif
-				ThreadUtility.Kill(_runnerThread);
-	#endif
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Cancel the ongoing run completely.
+        /// If no run is in process, the call has no effect.
+        /// </summary>
+        public void CancelRun()
+        {
+    #if !PORTABLE
+    #if NETCF
+            if (_runnerThread != null && !_runnerThread.Join(0))
+    #else
+            if (_runnerThread != null && _runnerThread.IsAlive)
+    #endif
+                ThreadUtility.Kill(_runnerThread);
+    #endif
+        }
+        #endregion
+    }
 }


### PR DESCRIPTION
By setting "SynchronousEvents" to true in the settings dictionary passed to the framework Load method, the framework will not use an event queue and a separate thread for signaling test start and finish.

This setting is not exposed in any way to the user of the console runner but is available for alternative runners, like NCrunch, that need this level of control. Additionally, the runner may choose to set NumberOfTestWorkers to 0 in order to suppress parallel execution. The latter is necessary only if the runner relies on test start and end events always being nested. In general, NUnit runners get all their information from the end events.

This has been tested by observation and by debugging through the code. Naturally, we can't debug it with any third-party runner that is under development. However, since it does no harm to the NUnit tests, I'm merging this immediately.