### PR TITLE
Fixed test runner returning early when executing more than one test run.

### DIFF
--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Api
         private static Logger log = InternalTrace.GetLogger("DefaultTestAssemblyRunner");
 
         private ITestAssemblyBuilder _builder;
-        private ManualResetEvent _runComplete = new ManualResetEvent(false);
+        private AutoResetEvent _runComplete = new AutoResetEvent(false);
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
         // Saved Console.Out and Console.Error


### PR DESCRIPTION
Previous behaviour:  When the NUnit test runner is invoked via API to run tests more than once, it will immediately return without waiting for the execution run to complete.

New behaviour:  The NUnit test runner will always wait until the test run is complete before returning to the caller.

The cause of this problem was a ManualResetEvent that was never reset after the initial run.  The solution was to replace it with an AutoResetEvent.