### PR TITLE
Reorder console runner reports. Fixes #859.

### DIFF
--- a/src/NUnitConsole/nunit-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit-console/ResultReporter.cs
@@ -62,15 +62,15 @@ namespace NUnit.ConsoleRunner
         {
             _writer.WriteLine();
 
-            WriteRunSettingsReport();
-
-            WriteSummaryReport();
+            if (Summary.SkipCount + Summary.IgnoreCount > 0)
+                WriteNotRunReport();
 
             if (_overallResult == "Failed")
                 WriteErrorsAndFailuresReport();
 
-            if (Summary.SkipCount + Summary.IgnoreCount > 0)
-                WriteNotRunReport();
+            WriteRunSettingsReport();
+
+            WriteSummaryReport();
         }
 
         #region


### PR DESCRIPTION
This moves the summary to the end. New order is test output, skipped tests, failed tests, run settings, summary report.

If folks complain about this, we could provide a command-line argument to control it.