### PR TITLE
Updated the framework nuspec portable frameworks

### DIFF
--- a/nuget/nunit.nuspec
+++ b/nuget/nunit.nuspec
@@ -29,7 +29,7 @@
     <file src="bin/net-4.5/nunit.framework.xml" target="lib/net45" />
     <file src="bin/sl-5.0/nunit.framework.dll" target="lib\sl50" />
     <file src="bin/sl-5.0/nunit.framework.xml" target="lib\sl50" />
-    <file src="bin/portable/nunit.framework.dll" target="lib/portable-net45+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1" />
-    <file src="bin/portable/nunit.framework.xml" target="lib/portable-net45+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1" />
+    <file src="bin/portable/nunit.framework.dll" target="lib/portable-net45+sl50+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="bin/portable/nunit.framework.xml" target="lib/portable-net45+sl50+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
   </files>
 </package>


### PR DESCRIPTION
Minor change. When I was looking at #876, I checked several other open source libraries for how they reference the various frameworks in their NuSpec for their portable libraries and noticed we had a few minor differences. I have updated the nuspec to use the same values as other libraries are using.