### PR TITLE
Wrap using InternalPreserveStackTrace in a try/catch

### DIFF
--- a/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
@@ -48,12 +48,14 @@ namespace NUnit.Framework.Internal
 
             if (method != null)
             {
-                PreserveStackTrace = (Action<Exception>)Delegate.CreateDelegate(typeof (Action<Exception>), method);
+                try
+                {
+                    PreserveStackTrace = (Action<Exception>)Delegate.CreateDelegate(typeof(Action<Exception>), method);
+                    return;
+                }
+                catch (InvalidOperationException) { }
             }
-            else 
-            {
-                PreserveStackTrace = _ => { };
-            }
+            PreserveStackTrace = _ => { };
         }
 #endif
 


### PR DESCRIPTION
Fixes #904 

I tested on Windows Phone. Stack traces won't be preserved across async calls on platforms that don't support it, but tests will run.

Unblocks nunit/nunit.xamarin#4 once we do the next release.