### PR TITLE
Fix tests for issue #859

### DIFF
--- a/src/NUnitConsole/nunit-console.tests/MockTestResult.xml
+++ b/src/NUnitConsole/nunit-console.tests/MockTestResult.xml
@@ -1,100 +1,117 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" name="mock-nunit-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\bin\Debug\net-2.0\mock-nunit-assembly.dll" testcasecount="31" result="Failed" total="28" passed="18" failed="5" inconclusive="1" skipped="4" asserts="2" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.192908">
-  <environment nunit-version="3.0.5448.33251" clr-version="4.0.30319.18444" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-3.0\bin\Debug" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" culture="en-US" uiculture="en-US" />
-  <test-suite type="Assembly" id="1046" name="mock-nunit-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\bin\Debug\net-2.0\mock-nunit-assembly.dll" runstate="Runnable" testcasecount="31" result="Failed" site="Child" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.128000" total="28" passed="18" failed="5" inconclusive="1" skipped="4" asserts="2">
+<test-run id="2" testcasecount="45" result="Failed" total="45" passed="30" failed="7" inconclusive="1" skipped="7" asserts="2" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.348616">
+  <environment nunit-version="3.0.5766.32177" clr-version="4.0.30319.34209" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-3.0\bin\Debug" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" culture="en-US" uiculture="en-US" os-architecture="x86" />
+  <command-line><![CDATA["D:\Dev\NUnit\nunit-3.0\bin\Debug\nunit-console.exe"  mock-nunit-assembly.exe ]]></command-line>
+  <settings>
+    <setting name="WorkDirectory" value="D:\Dev\NUnit\nunit-3.0\bin\Debug" />
+    <setting name="RuntimeFramework" value="net-2.0" />
+    <setting name="ProcessModel" value="Separate" />
+    <setting name="DomainUsage" value="Single" />
+    <setting name="NumberOfTestWorkers" value="4" />
+  </settings>
+  <test-suite type="Assembly" id="0-1064" name="mock-nunit-assembly.exe" fullname="D:\Dev\NUnit\nunit-3.0\bin\Debug\mock-nunit-assembly.exe" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.239888" total="45" passed="30" failed="7" inconclusive="1" skipped="7" asserts="2">
     <properties>
-      <property name="_PID" value="8832" />
-      <property name="_APPDOMAIN" value="test-domain-mock-nunit-assembly.dll" />
+      <property name="_PID" value="7472" />
+      <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
-      <message>One or more child tests had errors</message>
+      <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="TestSuite" id="1047" name="NUnit" fullname="NUnit" runstate="Runnable" testcasecount="31" result="Failed" site="Child" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.121000" total="28" passed="18" failed="5" inconclusive="1" skipped="4" asserts="2">
+    <test-suite type="TestSuite" id="0-1065" name="NUnit" fullname="NUnit" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.232343" total="45" passed="30" failed="7" inconclusive="1" skipped="7" asserts="2">
       <failure>
-        <message>One or more child tests had errors</message>
+        <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="TestSuite" id="1048" name="Tests" fullname="NUnit.Tests" runstate="Runnable" testcasecount="31" result="Failed" site="Child" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.121000" total="28" passed="18" failed="5" inconclusive="1" skipped="4" asserts="2">
+      <test-suite type="TestSuite" id="0-1066" name="Tests" fullname="NUnit.Tests" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.232173" total="45" passed="30" failed="7" inconclusive="1" skipped="7" asserts="2">
         <failure>
-          <message>One or more child tests had errors</message>
+          <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="TestSuite" id="1049" name="Assemblies" fullname="NUnit.Tests.Assemblies" runstate="Runnable" testcasecount="11" result="Failed" site="Child" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.102000" total="10" passed="4" failed="4" inconclusive="1" skipped="1" asserts="0">
+        <test-suite type="TestSuite" id="0-1067" name="Assemblies" fullname="NUnit.Tests.Assemblies" runstate="Runnable" testcasecount="11" result="Failed" site="Child" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.180716" total="11" passed="4" failed="4" inconclusive="1" skipped="2" asserts="0">
           <failure>
-            <message>One or more child tests had errors</message>
+            <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="1000" name="MockTestFixture" fullname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" testcasecount="11" result="Failed" site="Child" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.100000" total="10" passed="4" failed="4" inconclusive="1" skipped="1" asserts="0">
+          <test-suite type="TestFixture" id="0-1000" name="MockTestFixture" fullname="NUnit.Tests.Assemblies.MockTestFixture" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" testcasecount="11" result="Failed" site="Child" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.177568" total="11" passed="4" failed="4" inconclusive="1" skipped="2" asserts="0">
             <properties>
-              <property name="Category" value="FixtureCategory" />
               <property name="Description" value="Fake Test Fixture" />
+              <property name="Category" value="FixtureCategory" />
             </properties>
             <failure>
-              <message>One or more child tests had errors</message>
+              <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-case id="1005" name="FailingTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.FailingTest" runstate="Runnable" seed="277322916" result="Failed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.086000" asserts="0">
-              <failure>
-                <message>Intentional failure</message>
-                <stack-trace>at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 134
-</stack-trace>
-              </failure>
-            </test-case>
-            <test-case id="1010" name="InconclusiveTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest" runstate="Runnable" seed="1778333889" result="Inconclusive" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" asserts="0">
+            <test-case id="0-1008" name="ExplicitlyRunTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest" methodname="ExplicitlyRunTest" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Explicit" seed="1355097167" result="Skipped" label="Explicit" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.001314" asserts="0">
+              <properties>
+                <property name="Category" value="Special" />
+                <property name="_SKIPREASON" value="" />
+              </properties>
               <reason>
-                <message>No valid data</message>
+                <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="1001" name="MockTest1" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" runstate="Runnable" seed="1998102471" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0">
+            <test-case id="0-1005" name="FailingTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.FailingTest" methodname="FailingTest" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="277322916" result="Failed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.161650" asserts="0">
+              <failure>
+                <message><![CDATA[Intentional failure]]></message>
+                <stack-trace><![CDATA[at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 148
+]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="0-1010" name="InconclusiveTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest" methodname="InconclusiveTest" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="1347475421" result="Inconclusive" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.001153" asserts="0">
+              <reason>
+                <message><![CDATA[No valid data]]></message>
+              </reason>
+            </test-case>
+            <test-case id="0-1001" name="MockTest1" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" methodname="MockTest1" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="798259755" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000164" asserts="0">
               <properties>
                 <property name="Description" value="Mock Test #1" />
               </properties>
             </test-case>
-            <test-case id="1002" name="MockTest2" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" runstate="Runnable" seed="1630670862" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0">
+            <test-case id="0-1002" name="MockTest2" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" methodname="MockTest2" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="202129304" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000071" asserts="0">
               <properties>
                 <property name="Category" value="MockCategory" />
                 <property name="Severity" value="Critical" />
                 <property name="Description" value="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" />
               </properties>
             </test-case>
-            <test-case id="1003" name="MockTest3" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest3" runstate="Runnable" seed="1663476057" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" asserts="0">
+            <test-case id="0-1003" name="MockTest3" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest3" methodname="MockTest3" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="575529885" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.001019" asserts="0">
               <properties>
                 <property name="Category" value="AnotherCategory" />
                 <property name="Category" value="MockCategory" />
               </properties>
               <reason>
-                <message>Succeeded!</message>
+                <message><![CDATA[Succeeded!]]></message>
               </reason>
             </test-case>
-            <test-case id="1007" name="MockTest4" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest4" runstate="Ignored" seed="1460656856" result="Skipped" label="Ignored" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" asserts="0">
+            <test-case id="0-1007" name="MockTest4" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest4" methodname="MockTest4" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Ignored" seed="1460656856" result="Skipped" label="Ignored" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000013" asserts="0">
               <properties>
                 <property name="Category" value="Foo" />
                 <property name="_SKIPREASON" value="ignoring this test method for now" />
               </properties>
               <reason>
-                <message>ignoring this test method for now</message>
+                <message><![CDATA[ignoring this test method for now]]></message>
               </reason>
             </test-case>
-            <test-case id="1004" name="MockTest5" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest5" runstate="NotRunnable" seed="332551961" result="Failed" label="Invalid" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0">
+            <test-case id="0-1004" name="MockTest5" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest5" methodname="MockTest5" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="NotRunnable" seed="17143493" result="Failed" label="Invalid" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000128" asserts="0">
               <properties>
                 <property name="_SKIPREASON" value="Method is not public" />
               </properties>
               <failure>
-                <message>Method is not public</message>
+                <message><![CDATA[Method is not public]]></message>
               </failure>
             </test-case>
-            <test-case id="1009" name="NotRunnableTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest" runstate="NotRunnable" seed="421480137" result="Failed" label="Invalid" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0">
+            <test-case id="0-1009" name="NotRunnableTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest" methodname="NotRunnableTest" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="NotRunnable" seed="421480137" result="Failed" label="Invalid" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000003" asserts="0">
               <properties>
                 <property name="_SKIPREASON" value="No arguments were provided" />
               </properties>
               <failure>
-                <message>No arguments were provided</message>
+                <message><![CDATA[No arguments were provided]]></message>
               </failure>
             </test-case>
-            <test-case id="1011" name="TestWithException" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithException" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.002000" asserts="0">
+            <test-case id="0-1011" name="TestWithException" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithException" methodname="TestWithException" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="1272539657" result="Failed" label="Error" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.002230" asserts="0">
               <failure>
-                <message>System.Exception : Intentional Exception</message>
-                <stack-trace>   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 171
-   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 166</stack-trace>
+                <message><![CDATA[System.Exception : Intentional Exception]]></message>
+                <stack-trace><![CDATA[   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 185
+   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 180]]></stack-trace>
               </failure>
             </test-case>
-            <test-case id="1006" name="TestWithManyProperties" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithManyProperties" runstate="Runnable" seed="994105559" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0">
+            <test-case id="0-1006" name="TestWithManyProperties" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithManyProperties" methodname="TestWithManyProperties" classname="NUnit.Tests.Assemblies.MockTestFixture" runstate="Runnable" seed="994105559" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000086" asserts="0">
               <properties>
                 <property name="Size" value="5" />
                 <property name="TargetMethod" value="SomeClassName" />
@@ -102,80 +119,143 @@
             </test-case>
           </test-suite>
         </test-suite>
-        <test-suite type="TestFixture" id="1023" name="BadFixture" fullname="NUnit.Tests.BadFixture" runstate="NotRunnable" testcasecount="1" result="Failed" label="Invalid" site="SetUp" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
+        <test-suite type="TestFixture" id="0-1023" name="BadFixture" fullname="NUnit.Tests.BadFixture" classname="NUnit.Tests.BadFixture" runstate="NotRunnable" testcasecount="1" result="Failed" label="Invalid" site="SetUp" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000888" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
           <properties>
             <property name="_SKIPREASON" value="No suitable constructor was found" />
           </properties>
           <failure>
-            <message>No suitable constructor was found</message>
+            <message><![CDATA[No suitable constructor was found]]></message>
           </failure>
-          <test-case id="1024" name="SomeTest" fullname="NUnit.Tests.BadFixture.SomeTest" runstate="Runnable" seed="193735939" result="Failed" label="Invalid" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+          <test-case id="0-1024" name="SomeTest" fullname="NUnit.Tests.BadFixture.SomeTest" methodname="SomeTest" classname="NUnit.Tests.BadFixture" runstate="Runnable" seed="79304597" result="Failed" label="Invalid" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
             <failure>
-              <message>OneTimeSetUp: No suitable constructor was found</message>
+              <message><![CDATA[OneTimeSetUp: No suitable constructor was found]]></message>
             </failure>
           </test-case>
         </test-suite>
-        <test-suite type="TestFixture" id="1025" name="FixtureWithTestCases" fullname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" testcasecount="4" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.012000" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="2">
-          <test-suite type="GenericMethod" id="1031" name="GenericMethod" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1029" name="GenericMethod&lt;Int32&gt;(2,4)" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Int32&gt;(2,4)" runstate="Runnable" seed="52758991" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-            <test-case id="1030" name="GenericMethod&lt;Double&gt;(9.2d,11.7d)" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Double&gt;(9.2d,11.7d)" runstate="Runnable" seed="1262715352" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+        <test-suite type="TestFixture" id="0-1046" name="CDataTestFixure" fullname="NUnit.Tests.CDataTestFixure" classname="NUnit.Tests.CDataTestFixure" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.002892" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+          <failure>
+            <message><![CDATA[One or more child tests had errors]]></message>
+          </failure>
+          <test-case id="0-1050" name="DemonstrateIllegalSequenceAtEndOfFailureMessage" fullname="NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceAtEndOfFailureMessage" methodname="DemonstrateIllegalSequenceAtEndOfFailureMessage" classname="NUnit.Tests.CDataTestFixure" runstate="Runnable" seed="1567116626" result="Failed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000669" asserts="0">
+            <failure>
+              <message><![CDATA[The CDATA was: <![CDATA[ My <xml> ]]]]><![CDATA[>]]></message>
+              <stack-trace><![CDATA[at NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceAtEndOfFailureMessage() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 344
+]]></stack-trace>
+            </failure>
+          </test-case>
+          <test-case id="0-1048" name="DemonstrateIllegalSequenceAtEndOfSuccessMessage" fullname="NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceAtEndOfSuccessMessage" methodname="DemonstrateIllegalSequenceAtEndOfSuccessMessage" classname="NUnit.Tests.CDataTestFixure" runstate="Runnable" seed="591934172" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000531" asserts="0">
+            <reason>
+              <message><![CDATA[The CDATA was: <![CDATA[ My <xml> ]]]]><![CDATA[>]]></message>
+            </reason>
+          </test-case>
+          <test-case id="0-1049" name="DemonstrateIllegalSequenceInFailureMessage" fullname="NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceInFailureMessage" methodname="DemonstrateIllegalSequenceInFailureMessage" classname="NUnit.Tests.CDataTestFixure" runstate="Runnable" seed="125979337" result="Failed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000500" asserts="0">
+            <failure>
+              <message><![CDATA[Deliberate failure to illustrate ]]]]><![CDATA[> in message ]]></message>
+              <stack-trace><![CDATA[at NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceInFailureMessage() in d:\Dev\NUnit\nunit-3.0\src\NUnitFramework\mock-assembly\MockAssembly.cs:line 338
+]]></stack-trace>
+            </failure>
+          </test-case>
+          <test-case id="0-1047" name="DemonstrateIllegalSequenceInSuccessMessage" fullname="NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceInSuccessMessage" methodname="DemonstrateIllegalSequenceInSuccessMessage" classname="NUnit.Tests.CDataTestFixure" runstate="Runnable" seed="1958916467" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000426" asserts="0">
+            <reason>
+              <message><![CDATA[Deliberate failure to illustrate ]]]]><![CDATA[> in message ]]></message>
+            </reason>
+          </test-case>
+        </test-suite>
+        <test-suite type="TestFixture" id="0-1020" name="ExplicitFixture" fullname="NUnit.Tests.ExplicitFixture" classname="NUnit.Tests.ExplicitFixture" runstate="Explicit" testcasecount="2" result="Skipped" label="Explicit" site="SetUp" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000124" total="2" passed="0" failed="0" inconclusive="0" skipped="2" asserts="0">
+          <properties>
+            <property name="_SKIPREASON" value="" />
+          </properties>
+          <reason>
+            <message><![CDATA[]]></message>
+          </reason>
+          <test-case id="0-1021" name="Test1" fullname="NUnit.Tests.ExplicitFixture.Test1" methodname="Test1" classname="NUnit.Tests.ExplicitFixture" runstate="Runnable" seed="1931312539" result="Skipped" label="Explicit" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+            <reason>
+              <message><![CDATA[OneTimeSetUp: ]]></message>
+            </reason>
+          </test-case>
+          <test-case id="0-1022" name="Test2" fullname="NUnit.Tests.ExplicitFixture.Test2" methodname="Test2" classname="NUnit.Tests.ExplicitFixture" runstate="Runnable" seed="1002758134" result="Skipped" label="Explicit" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+            <reason>
+              <message><![CDATA[OneTimeSetUp: ]]></message>
+            </reason>
+          </test-case>
+        </test-suite>
+        <test-suite type="TestFixture" id="0-1025" name="FixtureWithTestCases" fullname="NUnit.Tests.FixtureWithTestCases" classname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" testcasecount="4" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.037301" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="2">
+          <test-suite type="GenericMethod" id="0-1031" name="GenericMethod" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.023702" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1029" name="GenericMethod&lt;Int32&gt;(2,4)" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Int32&gt;(2,4)" methodname="GenericMethod" classname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" seed="657609446" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000198" asserts="0" />
+            <test-case id="0-1030" name="GenericMethod&lt;Double&gt;(9.2d,11.7d)" fullname="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Double&gt;(9.2d,11.7d)" methodname="GenericMethod" classname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" seed="875415367" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000132" asserts="0" />
           </test-suite>
-          <test-suite type="ParameterizedMethod" id="1028" name="MethodWithParameters" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.011000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
-            <test-case id="1026" name="MethodWithParameters(9,11)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)" runstate="Runnable" seed="1899952087" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.011000" asserts="1" />
-            <test-case id="1027" name="MethodWithParameters(2,2)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(2,2)" runstate="Runnable" seed="1231727827" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="1" />
+          <test-suite type="ParameterizedMethod" id="0-1028" name="MethodWithParameters" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.013325" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
+            <test-case id="0-1026" name="MethodWithParameters(2,2)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(2,2)" methodname="MethodWithParameters" classname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" seed="193735939" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.013018" asserts="1" />
+            <test-case id="0-1027" name="MethodWithParameters(9,11)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)" methodname="MethodWithParameters" classname="NUnit.Tests.FixtureWithTestCases" runstate="Runnable" seed="304199382" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000048" asserts="1" />
           </test-suite>
         </test-suite>
-        <test-suite type="GenericFixture" id="1039" name="GenericFixture&lt;T&gt;" fullname="NUnit.Tests.GenericFixture&lt;T&gt;" runstate="Runnable" testcasecount="4" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.118000" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
-          <test-suite type="TestFixture" id="1043" name="GenericFixture&lt;Double&gt;(11.5d)" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d)" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1044" name="Test1" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test1" runstate="Runnable" seed="125979337" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-            <test-case id="1045" name="Test2" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test2" runstate="Runnable" seed="1567116626" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+        <test-suite type="GenericFixture" id="0-1045" name="GenericFixture&lt;T&gt;" fullname="NUnit.Tests.GenericFixture&lt;T&gt;" runstate="Runnable" testcasecount="4" result="Passed" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.226481" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1042" name="GenericFixture&lt;Double&gt;(11.5d)" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d)" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000725" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1043" name="Test1" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test1" methodname="Test1" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" seed="502868772" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000091" asserts="0" />
+            <test-case id="0-1044" name="Test2" fullname="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test2" methodname="Test2" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" seed="1072944492" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000088" asserts="0" />
           </test-suite>
-          <test-suite type="TestFixture" id="1040" name="GenericFixture&lt;Int32&gt;(5)" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5)" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.003000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1041" name="Test1" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test1" runstate="Runnable" seed="1548732413" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-            <test-case id="1042" name="Test2" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test2" runstate="Runnable" seed="105033491" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+          <test-suite type="TestFixture" id="0-1039" name="GenericFixture&lt;Int32&gt;(5)" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5)" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.005732" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1040" name="Test1" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test1" methodname="Test1" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" seed="392352118" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000098" asserts="0" />
+            <test-case id="0-1041" name="Test2" fullname="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test2" methodname="Test2" classname="NUnit.Tests.GenericFixture`1" runstate="Runnable" seed="826164525" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000080" asserts="0" />
           </test-suite>
         </test-suite>
-        <test-suite type="TestFixture" id="1016" name="IgnoredFixture" fullname="NUnit.Tests.IgnoredFixture" runstate="Ignored" testcasecount="3" result="Skipped" label="Ignored" site="SetUp" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" total="3" passed="0" failed="0" inconclusive="0" skipped="3" asserts="0">
+        <test-suite type="TestFixture" id="0-1016" name="IgnoredFixture" fullname="NUnit.Tests.IgnoredFixture" classname="NUnit.Tests.IgnoredFixture" runstate="Ignored" testcasecount="3" result="Skipped" label="Ignored" site="SetUp" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000074" total="3" passed="0" failed="0" inconclusive="0" skipped="3" asserts="0">
           <properties>
             <property name="_SKIPREASON" value="BECAUSE" />
           </properties>
           <reason>
-            <message>BECAUSE</message>
+            <message><![CDATA[BECAUSE]]></message>
           </reason>
-          <test-case id="1017" name="Test1" fullname="NUnit.Tests.IgnoredFixture.Test1" runstate="Runnable" seed="2083519019" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+          <test-case id="0-1017" name="Test1" fullname="NUnit.Tests.IgnoredFixture.Test1" methodname="Test1" classname="NUnit.Tests.IgnoredFixture" runstate="Runnable" seed="1328488278" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
             <reason>
-              <message>OneTimeSetUp: BECAUSE</message>
+              <message><![CDATA[OneTimeSetUp: BECAUSE]]></message>
             </reason>
           </test-case>
-          <test-case id="1018" name="Test2" fullname="NUnit.Tests.IgnoredFixture.Test2" runstate="Runnable" seed="1888940438" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+          <test-case id="0-1018" name="Test2" fullname="NUnit.Tests.IgnoredFixture.Test2" methodname="Test2" classname="NUnit.Tests.IgnoredFixture" runstate="Runnable" seed="1838194091" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
             <reason>
-              <message>OneTimeSetUp: BECAUSE</message>
+              <message><![CDATA[OneTimeSetUp: BECAUSE]]></message>
             </reason>
           </test-case>
-          <test-case id="1019" name="Test3" fullname="NUnit.Tests.IgnoredFixture.Test3" runstate="Runnable" seed="1079396103" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+          <test-case id="0-1019" name="Test3" fullname="NUnit.Tests.IgnoredFixture.Test3" methodname="Test3" classname="NUnit.Tests.IgnoredFixture" runstate="Runnable" seed="652308738" result="Skipped" label="Ignored" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
             <reason>
-              <message>OneTimeSetUp: BECAUSE</message>
+              <message><![CDATA[OneTimeSetUp: BECAUSE]]></message>
             </reason>
           </test-case>
         </test-suite>
-        <test-suite type="ParameterizedFixture" id="1032" name="ParameterizedFixture" fullname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" testcasecount="4" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.118000" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
-          <test-suite type="TestFixture" id="1033" name="ParameterizedFixture(42)" fullname="NUnit.Tests.ParameterizedFixture(42)" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.001000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1034" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(42).Test1" runstate="Runnable" seed="1835946489" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-            <test-case id="1035" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(42).Test2" runstate="Runnable" seed="1448988997" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+        <test-suite type="ParameterizedFixture" id="0-1038" name="ParameterizedFixture" fullname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" testcasecount="4" result="Passed" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.227233" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1035" name="ParameterizedFixture(42)" fullname="NUnit.Tests.ParameterizedFixture(42)" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000463" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1036" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(42).Test1" methodname="Test1" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" seed="1069402004" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000067" asserts="0" />
+            <test-case id="0-1037" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(42).Test2" methodname="Test2" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" seed="467836070" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000065" asserts="0" />
           </test-suite>
-          <test-suite type="TestFixture" id="1036" name="ParameterizedFixture(5)" fullname="NUnit.Tests.ParameterizedFixture(5)" runstate="Runnable" testcasecount="2" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1037" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(5).Test1" runstate="Runnable" seed="129833087" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-            <test-case id="1038" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(5).Test2" runstate="Runnable" seed="674926834" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
-          </test-suite>
-        </test-suite>
-        <test-suite type="TestSuite" id="1050" name="Singletons" fullname="NUnit.Tests.Singletons" runstate="Runnable" testcasecount="1" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.118000" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
-          <test-suite type="TestFixture" id="1012" name="OneTestCase" fullname="NUnit.Tests.Singletons.OneTestCase" runstate="Runnable" testcasecount="1" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1013" name="TestCase" fullname="NUnit.Tests.Singletons.OneTestCase.TestCase" runstate="Runnable" seed="118089422" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+          <test-suite type="TestFixture" id="0-1032" name="ParameterizedFixture(5)" fullname="NUnit.Tests.ParameterizedFixture(5)" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" testcasecount="2" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000414" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1033" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(5).Test1" methodname="Test1" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" seed="52758991" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000024" asserts="0" />
+            <test-case id="0-1034" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(5).Test2" methodname="Test2" classname="NUnit.Tests.ParameterizedFixture" runstate="Runnable" seed="1960734727" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000016" asserts="0" />
           </test-suite>
         </test-suite>
-        <test-suite type="TestSuite" id="1051" name="TestAssembly" fullname="NUnit.Tests.TestAssembly" runstate="Runnable" testcasecount="1" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.119000" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
-          <test-suite type="TestFixture" id="1014" name="MockTestFixture" fullname="NUnit.Tests.TestAssembly.MockTestFixture" runstate="Runnable" testcasecount="1" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
-            <test-case id="1015" name="MyTest" fullname="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" runstate="Runnable" seed="1096460943" result="Passed" start-time="2014-12-02 03:07:10Z" end-time="2014-12-02 03:07:10Z" duration="0.000000" asserts="0" />
+        <test-suite type="TestSuite" id="0-1068" name="Singletons" fullname="NUnit.Tests.Singletons" runstate="Runnable" testcasecount="1" result="Passed" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.227552" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1012" name="OneTestCase" fullname="NUnit.Tests.Singletons.OneTestCase" classname="NUnit.Tests.Singletons.OneTestCase" runstate="Runnable" testcasecount="1" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000365" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1013" name="TestCase" fullname="NUnit.Tests.Singletons.OneTestCase.TestCase" methodname="TestCase" classname="NUnit.Tests.Singletons.OneTestCase" runstate="Runnable" seed="118089422" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000069" asserts="0" />
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="0-1069" name="TestAssembly" fullname="NUnit.Tests.TestAssembly" runstate="Runnable" testcasecount="1" result="Passed" start-time="2015-10-19 02:12:28Z" end-time="2015-10-19 02:12:29Z" duration="0.227798" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1014" name="MockTestFixture" fullname="NUnit.Tests.TestAssembly.MockTestFixture" classname="NUnit.Tests.TestAssembly.MockTestFixture" runstate="Runnable" testcasecount="1" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000293" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1015" name="MyTest" fullname="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" methodname="MyTest" classname="NUnit.Tests.TestAssembly.MockTestFixture" runstate="Runnable" seed="1620750620" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000067" asserts="0" />
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestFixture" id="0-1051" name="TestNameEscaping" fullname="NUnit.Tests.TestNameEscaping" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" testcasecount="10" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.001998" total="10" passed="10" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="ParameterizedMethod" id="0-1057" name="MustBeEscaped" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped" runstate="Runnable" testcasecount="5" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000866" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1052" name="MustBeEscaped(&quot;\&quot;double quote\&quot;&quot;)" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped(&quot;\&quot;double quote\&quot;&quot;)" methodname="MustBeEscaped" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1687081151" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000077" asserts="0" />
+            <test-case id="0-1053" name="MustBeEscaped(&quot;&lt; left bracket&quot;)" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped(&quot;&lt; left bracket&quot;)" methodname="MustBeEscaped" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="320302720" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000022" asserts="0" />
+            <test-case id="0-1054" name="MustBeEscaped(&quot;\'single quote\'&quot;)" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped(&quot;\'single quote\'&quot;)" methodname="MustBeEscaped" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="609475020" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000032" asserts="0" />
+            <test-case id="0-1055" name="MustBeEscaped(&quot;&gt; right bracket&quot;)" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped(&quot;&gt; right bracket&quot;)" methodname="MustBeEscaped" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1171064073" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000018" asserts="0" />
+            <test-case id="0-1056" name="MustBeEscaped(&quot;&amp;amp&quot;)" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped(&quot;&amp;amp&quot;)" methodname="MustBeEscaped" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1693718546" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000017" asserts="0" />
+          </test-suite>
+          <test-suite type="ParameterizedMethod" id="0-1063" name="MustBeEscaped_CustomName" fullname="NUnit.Tests.TestNameEscaping.MustBeEscaped_CustomName" runstate="Runnable" testcasecount="5" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000774" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-case id="0-1058" name="&quot;" fullname="NUnit.Tests.TestNameEscaping.&quot;" methodname="MustBeEscaped_CustomName" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1487151050" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000077" asserts="0" />
+            <test-case id="0-1059" name="&lt;" fullname="NUnit.Tests.TestNameEscaping.&lt;" methodname="MustBeEscaped_CustomName" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1061146939" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000024" asserts="0" />
+            <test-case id="0-1060" name="&amp;" fullname="NUnit.Tests.TestNameEscaping.&amp;" methodname="MustBeEscaped_CustomName" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1471442810" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000061" asserts="0" />
+            <test-case id="0-1061" name="&gt;" fullname="NUnit.Tests.TestNameEscaping.&gt;" methodname="MustBeEscaped_CustomName" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="672876239" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000019" asserts="0" />
+            <test-case id="0-1062" name="'" fullname="NUnit.Tests.TestNameEscaping.'" methodname="MustBeEscaped_CustomName" classname="NUnit.Tests.TestNameEscaping" runstate="Runnable" seed="1608762882" result="Passed" start-time="2015-10-19 02:12:29Z" end-time="2015-10-19 02:12:29Z" duration="0.000017" asserts="0" />
           </test-suite>
         </test-suite>
       </test-suite>

--- a/src/NUnitConsole/nunit-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit-console.tests/ResultReporterTests.cs
@@ -38,9 +38,10 @@ namespace NUnit.ConsoleRunner.Tests
     {
         private const string MOCK_TEST_RESULT = "NUnit.ConsoleRunner.Tests.MockTestResult.xml";
         private static readonly string[] REPORT_SEQUENCE = new string[] {
-            "Test Run Summary",
+            "Tests Not Run",
             "Errors and Failures",
-            "Tests Not Run"
+            "Run Settings",
+            "Test Run Summary"
         };
 
         private XmlNode _result;
@@ -90,6 +91,7 @@ namespace NUnit.ConsoleRunner.Tests
                 var index = report.IndexOf(title);
                 Assert.That(index > 0, "Report not found: " + title);
                 Assert.That(index > last, "Report out of sequence: " + title);
+                last = index;
             }
         }
 
@@ -99,11 +101,11 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new string[] {
                 "Test Run Summary",
                 "    Overall result: Failed",
-                "   Tests run: 21, Passed: 18, Errors: 1, Failures: 1, Inconclusive: 1",
-                "     Not run: 7, Invalid: 3, Ignored: 4, Explicit: 0, Skipped: 0",
-                "  Start time: 2014-12-02 03:07:10Z",
-                "    End time: 2014-12-02 03:07:10Z",
-                "    Duration: 0.193 seconds",
+                "   Tests run: 35, Passed: 30, Errors: 1, Failures: 3, Inconclusive: 1",
+                "     Not run: 10, Invalid: 3, Ignored: 4, Explicit: 3, Skipped: 0",
+                "  Start time: 2015-10-19 02:12:28Z",
+                "    End time: 2015-10-19 02:12:29Z",
+                "    Duration: 0.349 seconds",
                 ""
             };
 
@@ -119,7 +121,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "",
                 "1) Failed : NUnit.Tests.Assemblies.MockTestFixture.FailingTest",
                 "Intentional failure",
-                "at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 134",
+                "at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 148",
                 "",
                 "2) Invalid : NUnit.Tests.Assemblies.MockTestFixture.MockTest5",
                 "Method is not public",
@@ -129,11 +131,19 @@ namespace NUnit.ConsoleRunner.Tests
                 "",
                 "4) Error : NUnit.Tests.Assemblies.MockTestFixture.TestWithException",
                 "System.Exception : Intentional Exception",
-                "   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 171",
-                "   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 166",
+                "   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 185",
+                "   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 180",
                 "",
                 "5) Invalid : NUnit.Tests.BadFixture",
                 "No suitable constructor was found",
+                "",
+                "6) Failed : NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceAtEndOfFailureMessage",
+                "The CDATA was: <![CDATA[ My <xml> ]]>",
+                "at NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceAtEndOfFailureMessage() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 344",
+                "",
+                "7) Failed : NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceInFailureMessage",
+                "Deliberate failure to illustrate ]]> in message ",
+                "at NUnit.Tests.CDataTestFixure.DemonstrateIllegalSequenceInFailureMessage() in d:\\Dev\\NUnit\\nunit-3.0\\src\\NUnitFramework\\mock-assembly\\MockAssembly.cs:line 338",
                 ""
             };
 
@@ -147,16 +157,25 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new string[] {
                 "Tests Not Run",
                 "",
-                "1) Ignored : NUnit.Tests.Assemblies.MockTestFixture.MockTest4",
+                "1) Explicit : NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest",
+                "",
+                "",
+                "2) Ignored : NUnit.Tests.Assemblies.MockTestFixture.MockTest4",
                 "ignoring this test method for now",
                 "",
-                "2) Ignored : NUnit.Tests.IgnoredFixture.Test1",
+                "3) Explicit : NUnit.Tests.ExplicitFixture.Test1",
+                "OneTimeSetUp: ",
+                "",
+                "4) Explicit : NUnit.Tests.ExplicitFixture.Test2",
+                "OneTimeSetUp: ",
+                "",
+                "5) Ignored : NUnit.Tests.IgnoredFixture.Test1",
                 "OneTimeSetUp: BECAUSE",
                 "",
-                "3) Ignored : NUnit.Tests.IgnoredFixture.Test2",
+                "6) Ignored : NUnit.Tests.IgnoredFixture.Test2",
                 "OneTimeSetUp: BECAUSE",
                 "",
-                "4) Ignored : NUnit.Tests.IgnoredFixture.Test3",
+                "7) Ignored : NUnit.Tests.IgnoredFixture.Test3",
                 "OneTimeSetUp: BECAUSE",
                 ""
             };


### PR DESCRIPTION
After #859 was merged and closed, I started wondering why changing the order of the reports did not affect the tests of the console runner. The test that was supposed to do that was not actualy working. In fixing it, I ended up updating the XML that we use to test the console runner, so that this push is actually more work than the original fix!

We need to make this a bit more robust than it is, since updating the xml is tedious and the tests are quite fragile with respect to changes in the XML output. I'm  creating another issue for that.