### PR TITLE
add all AppVeyor builds to its NuGet feed

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -6,9 +6,9 @@
 
   <PropertyGroup Label="Common Properties">
     <ProjectName>$(MSBuildProjectName)</ProjectName>
-    <PackageVersion>3.0.0</PackageVersion>
-    <PackageModifier>-beta-5</PackageModifier>
-    <DisplayVersion>3.0 Beta 5</DisplayVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">3.0.0</PackageVersion>
+    <PackageModifier Condition="'$(PackageModifier)' == ''">-beta-5</PackageModifier>
+    <DisplayVersion Condition="'$(DisplayVersion)' == ''">3.0 Beta 5</DisplayVersion>
     <PackageName>$(ProjectName)-$(PackageVersion)$(PackageModifier)</PackageName>
     <PackageNameCF>$(ProjectName)CF-$(PackageVersion)$(PackageModifier)</PackageNameCF>
   </PropertyGroup>

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -30,4 +30,5 @@ if ($env:appveyor){
     Update-AppveyorBuild -Version "$version$modifier"
 }
 
+./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue /p:PackageVersion="$version" /p:PackageModifier="$modifier"
 ./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -30,5 +30,6 @@ if ($env:appveyor){
     Update-AppveyorBuild -Version "$version$modifier"
 }
 
+./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
 ./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
 ./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -30,6 +30,6 @@ if ($env:appveyor){
     Update-AppveyorBuild -Version "$version$modifier"
 }
 
-./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
-./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
-./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
+./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,0 +1,33 @@
+# the version under development, update after a release
+$version = '3.0.0'
+$modifier = '-beta-6'
+
+function isVersion($s){
+    $v = New-Object Version
+    [Version]::TryParse($s, [ref]$v)
+}
+
+# append the AppVeyor build number as the pre-release version
+if ($env:appveyor){
+    $modifier = $modifier + '-' + [int]::Parse($env:appveyor_build_number).ToString('000')
+    if ($env:appveyor_repo_tag -eq 'true'){
+        $tag = $env:appveyor_repo_tag_name
+        $i = $tag.IndexOf('-')
+        if($i -gt 0)
+        {
+            $version = $tag.Substring(0, $i)
+            $modifier = $tag.Substring($i)
+        } else {
+            $version = $tag
+            $modifier = ''
+        }
+    }
+    if(-not(isVersion($version)))
+    {
+        Write-Error "error parsing version '$version' in tag '$tag'"
+        exit
+    }
+    Update-AppveyorBuild -Version "$version$modifier"
+}
+
+./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -30,5 +30,5 @@ if ($env:appveyor){
     Update-AppveyorBuild -Version "$version$modifier"
 }
 
-./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue /p:PackageVersion="$version" /p:PackageModifier="$modifier"
+./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"
 ./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ before_build:
 build_script: 
   - ps: .\appveyor.ps1
   
-test_script:
-  - msbuild NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue
+#test_script:
+#  - msbuild NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue
 #  - ps: $wc = New-Object 'System.Net.WebClient'
 #  - ps: $dir = "bin\Release\Results"
 #  - ps: $uri = "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,7 @@ artifacts:
 - path: package\*.nupkg
 - path: package\*.msi
 
+# AppVeyor defaults to just its build number
 version: '{build}'
+# disable built-in tests.
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,9 @@ before_build:
   - nuget restore nunit.sln
 
 build_script: 
-  - ps: .\appveyor.ps1
+  - ps: |
+      .\appveyor.ps1
+      if ($lastexitcode -ne 0){ exit $lastexitcode }
   
 #test_script:
 #  - msbuild NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ before_build:
   - nuget restore nunit.sln
 
 build_script: 
-  - ps: appveyor.ps1
+  - ps: .\appveyor.ps1
   
 test_script:
   - msbuild NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue
@@ -18,3 +18,5 @@ test_script:
 artifacts:
 - path: package\*.nupkg
 - path: package\*.msi
+
+version: '{build}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ before_build:
   - nuget restore nunit.sln
 
 build_script: 
-  - msbuild nunit.sln /p:Configuration=Release /t:Rebuild
+  - ps: appveyor.ps1
   
 test_script:
   - msbuild NUnit.proj /t:TestAll /p:Configuration=Release /p:ResultFormat=nunit2 /p:ContinueOnFailure=ErrorAndContinue
@@ -15,3 +15,6 @@ test_script:
 #  - ps: $uri = "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)"
 #  - ps: foreach($item in (dir $dir "*.xml")) { $wc.UploadFile($uri, $item.FullName) }
   
+artifacts:
+- path: package\*.nupkg
+- path: package\*.msi


### PR DESCRIPTION
As I mentioned at https://github.com/nunit/nunit/pull/915#issuecomment-150994444, here is a PR that makes all builds available via the AppVeyor NuGet feed. See 
http://blog.ctaggart.com/2015/07/open-source-net-with-appveyor-nuget.html

@CharliePoole just needs to go to 
https://ci.appveyor.com/project/CharliePoole/nunit/settings/nuget

and change it to something like:
https://ci.appveyor.com/nuget/nunit

The script support creating a build from a tag. If you pushed a `3.0.0-beta-6` tag, it will correctly create the packages in the AppVeyor feed. Let me know what questions you have.