### PR TITLE
Issue 920

### DIFF
--- a/nuget/nunit.console.nuspec
+++ b/nuget/nunit.console.nuspec
@@ -34,7 +34,6 @@
     <file src="bin/nunit.engine.addin.xml" target="tools" />
     <file src="bin/Mono.Cecil.dll" target="tools" />
     <file src="bin/addins/nunit.v2.driver.dll" target="tools/addins" />
-    <file src="bin/addins/nunit.engine.api.dll" target="tools/addins" />
     <file src="bin/addins/nunit.core.dll" target="tools/addins" />
     <file src="bin/addins/nunit.core.interfaces.dll" target="tools/addins" />
     <file src="bin/addins/nunit-v2-result-writer.dll" target="tools/addins" />

--- a/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
+++ b/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
       <Project>{775FAD50-3623-4922-97C4-DFB29A8BE4C7}</Project>
       <Name>nunit.engine.api</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
@@ -46,6 +46,7 @@
     <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
       <Project>{775FAD50-3623-4922-97C4-DFB29A8BE4C7}</Project>
       <Name>nunit.engine.api</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/Addins/nunit.v2.driver/nunit.v2.driver.csproj
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/nunit.v2.driver.csproj
@@ -50,6 +50,7 @@
     <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
       <Project>{775FAD50-3623-4922-97C4-DFB29A8BE4C7}</Project>
       <Name>nunit.engine.api</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/Addins/vs-project-loader/vs-project-loader.csproj
+++ b/src/NUnitEngine/Addins/vs-project-loader/vs-project-loader.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
       <Project>{775FAD50-3623-4922-97C4-DFB29A8BE4C7}</Project>
       <Name>nunit.engine.api</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes #920 by removing the unneeded copy of the api assembly from the addins directory.

Note that the assembly is still needed in addins\tests.