### PR TITLE
Packaging SilverLight separately

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -407,7 +407,7 @@
   <!--   creates the package to first make sure that the build is up to date.  -->
   <!-- *********************************************************************** -->
   
-  <Target Name="Package" Label="Packages the source code and standard binaries. Excludes CF."
+  <Target Name="Package" Label="Packages the source code and standard binaries. Excludes CF and SilverLight."
     DependsOnTargets="@(AllPackages)">
   </Target>
 
@@ -467,7 +467,7 @@
 
   </Target>
 
-  <Target Name="PackageMasterMsi" Label="Creates the master MSI installer for NUnit"
+  <Target Name="PackageMsi" Label="Creates the master MSI installer for NUnit"
       DependsOnTargets="_CreateImageIfNotPresent">
     <MSBuild Targets="Rebuild" Projects="$(InstallDir)\master\nunit.wixproj"
       Properties="Configuration=$(Configuration); Platform=x86; PackageVersion=$(PackageVersion)$(PackageModifier)$(ConfigSuffix); DisplayVersion=$(DisplayVersion); OutDir=$(ProjectPackageDir)\; InstallImage=$(CurrentImageDir)" />
@@ -483,10 +483,6 @@
       DependsOnTargets="_CreateImageIfNotPresent">
     <MSBuild Targets="Rebuild" Projects="$(InstallDir)\runners\nunit-runners.wixproj"
       Properties="Configuration=$(Configuration); Platform=x86; PackageVersion=$(PackageVersion)$(PackageModifier)$(ConfigSuffix); DisplayVersion=$(DisplayVersion); OutDir=$(ProjectPackageDir)\; InstallImage=$(CurrentImageDir)" />
-  </Target>
-
-  <Target Name="PackageAllMsis" Label="Creates all of the MSI installers for NUnit"
-      DependsOnTargets="PackageMasterMsi;PackageFrameworkMsi;PackageConsoleMsi">
   </Target>
 
   <!-- Packaging for the Compact framework -->
@@ -595,9 +591,9 @@
                                        
   <ItemGroup Label ="Targets for Packaging">
     <AllPackages Include="PackageSource" />
-      <AllPackages Include="PackageBinaries" />
-      <AllPackages Include="PackageNuGet" Condition="$(IsWindows)" />
-      <AllPackages Include="PackageAllMsis" Condition="$(IsWindows)" />
+    <AllPackages Include="PackageBinaries" />
+    <AllPackages Include="PackageNuGet" Condition="$(IsWindows)" />
+    <AllPackages Include="PackageMsi" Condition="$(IsWindows)" />
   </ItemGroup>
 
   <ItemGroup Label="MSI Installer Files">

--- a/NUnit.proj
+++ b/NUnit.proj
@@ -11,6 +11,7 @@
     <DisplayVersion>3.0 Beta 5</DisplayVersion>
     <PackageName>$(ProjectName)-$(PackageVersion)$(PackageModifier)</PackageName>
     <PackageNameCF>$(ProjectName)CF-$(PackageVersion)$(PackageModifier)</PackageNameCF>
+		<PackageNameSL>$(ProjectName)SL-$(PackageVersion)$(PackageModifier)</PackageNameSL>
   </PropertyGroup>
 
   <PropertyGroup Label="Platform-specific properties">
@@ -84,10 +85,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Framework)'=='netcf-3.5'">
     <ProjectSuffix>netcf-3.5</ProjectSuffix>
-    <Runtime>netcf</Runtime>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Framework)'=='netcf-2.0'">
-    <ProjectSuffix>netcf-2.0</ProjectSuffix>
     <Runtime>netcf</Runtime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Framework)'=='sl-5.0'">
@@ -510,7 +507,7 @@
       DependsOnTargets="_CreateImageIfNotPresent">
 
     <Message Text="******************************************************************" />
-    <Message Text="* Creating the nunit Nuget $(Configuration) package" />
+    <Message Text="* Creating the nunit Nuget CF $(Configuration) package" />
     <Message Text="******************************************************************" />
 
     <Exec WorkingDirectory="$(ProjectBaseDir)"
@@ -522,13 +519,51 @@
       DependsOnTargets="_CreateImageIfNotPresent">
 
     <Message Text="******************************************************************" />
-    <Message Text="* Creating the nunitlite Nuget $(Configuration) package" />
+    <Message Text="* Creating the nunitlite Nuget CF $(Configuration) package" />
     <Message Text="******************************************************************" />
 
     <Exec WorkingDirectory="$(ProjectBaseDir)"
         Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitlitecf.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
 
   </Target>
+
+	<!-- Packaging for SilverLight -->
+	<Target Name="PackageSL" Label="Creates all packages for SilverLight"
+    DependsOnTargets="PackageBinariesSL;PackageNuGetNUnitSL;PackageNuGetNUnitLiteSL" />
+
+	<Target Name="PackageBinariesSL" Label="Packages the SilverLight binaries as a zip" DependsOnTargets="_CreateImageIfNotPresent">
+		<Message Text="******************************************************************" />
+		<Message Text="* Creating the binary $(Configuration) package as $(PackageNameSL)$(ConfigSuffix).zip" />
+		<Message Text="******************************************************************" />
+
+		<Zip Files="@(SLBinZipFiles)" WorkingDirectory="$(CurrentImageDir)"
+         ZipFileName="$(ProjectPackageDir)\$(PackageNameSL)$(ConfigSuffix).zip" />
+
+	</Target>
+
+	<Target Name="PackageNuGetNUnitSL" Label="Creates the NUnit Framework NuGet package for SilverLight"
+      DependsOnTargets="_CreateImageIfNotPresent">
+
+		<Message Text="******************************************************************" />
+		<Message Text="* Creating the nunit Nuget SilverLight $(Configuration) package" />
+		<Message Text="******************************************************************" />
+
+		<Exec WorkingDirectory="$(ProjectBaseDir)"
+        Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitSL.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
+
+	</Target>
+
+	<Target Name="PackageNuGetNUnitLiteSL" Label="Creates the NUnitlite NuGet package for SilverLight"
+      DependsOnTargets="_CreateImageIfNotPresent">
+
+		<Message Text="******************************************************************" />
+		<Message Text="* Creating the nunitlite Nuget SilverLight $(Configuration) package" />
+		<Message Text="******************************************************************" />
+
+		<Exec WorkingDirectory="$(ProjectBaseDir)"
+        Command="$(ManagedExeLauncher) &quot;$(NugetExecutable)&quot; pack $(NuspecDirectory)\nunitliteSL.nuspec -BasePath &quot;$(CurrentImageDir)&quot; -OutputDirectory &quot;$(ProjectPackageDir)&quot; -Properties version=$(NugetVersion)" />
+
+	</Target>
 
   <Target Name="CreateImage" DependsOnTargets="_CleanCurrentImageDir">
 
@@ -612,12 +647,15 @@
     <BinZipFiles Include="$(CurrentImageDir)\bin\net-4.0\*.*" />
     <BinZipFiles Include="$(CurrentImageDir)\bin\net-4.5\*.*" />
     <BinZipFiles Include="$(CurrentImageDir)\bin\portable\*.*" />
-    <BinZipFiles Include="$(CurrentImageDir)\bin\sl-5.0\*.*" Condition="$(IsWindows)" />
   </ItemGroup>
 
   <ItemGroup>
     <CFBinZipFiles Include="$(CurrentImageDir)\bin\netcf-3.5\*.*" />
   </ItemGroup>
+
+	<ItemGroup>
+		<SLBinZipFiles Include="$(CurrentImageDir)\bin\sl-5.0\*.*" />
+	</ItemGroup>
 
   <ItemGroup Label="Supported Frameworks">
     <SupportedFrameworks Include="net-4.5" />

--- a/install/framework/framework-directories.wxi
+++ b/install/framework/framework-directories.wxi
@@ -8,7 +8,6 @@
                     <Directory Id="NET40" Name="net-4.0" />
                     <Directory Id="NET45" Name="net-4.5" />
                     <Directory Id="PORTABLE" Name="portable" />
-                    <Directory Id="SL50" Name="sl-5.0" />
                 </Directory>
             </Directory>
         </DirectoryRef>

--- a/install/framework/framework-features.wxi
+++ b/install/framework/framework-features.wxi
@@ -23,9 +23,5 @@
                     Description="Installs the NUnit framework for Portable .NET" >
             <ComponentGroupRef Id="PORTABLE"/>
         </Feature>
-        <Feature Id="SL50" Level="1" Title="Silverlight 5.0"
-                    Description="Installs the NUnit framework for Silverlight 5.0" >
-            <ComponentGroupRef Id="SL50"/>
-        </Feature>
     </Feature>
 </Include>

--- a/install/framework/framework-files.wxi
+++ b/install/framework/framework-files.wxi
@@ -96,30 +96,5 @@
                 </RegistryKey>
             </Component>
         </ComponentGroup>
-
-        <!-- Silverlight 5.0 -->
-        <ComponentGroup Id="SL50" Directory="SL50">
-            <Component Id="SL50" Location="local" Guid="FE2ADBC4-DFEC-41A6-8D5A-6DCACC167059">
-                <File Id="nunit.framework.sl50.dll"
-                      Name="nunit.framework.dll"
-                      ProcessorArchitecture="msil"
-                      Source="$(var.Binaries)\sl-5.0\nunit.framework.dll" />
-                <File Id="nunit.framework.sl50.xml"
-                      Name="nunit.framework.xml"
-                      Source="$(var.Binaries)\sl-5.0\nunit.framework.xml"
-                      CompanionFile="nunit.framework.sl50.dll" />
-            </Component>
-            <Component Id="SL50_RUNNER" Location="local" Guid="4E09ED33-A575-4438-91F6-8130F416CDDC">
-                <File Id="nunitlite.sl50.dll"
-                      Name="nunitlite.dll"
-                      ProcessorArchitecture="msil"
-                      Source="$(var.Binaries)\sl-5.0\nunitlite.dll" />
-            </Component>
-            <Component Id="AssemblyReferenceFolderSL50" Guid="18C5D635-921C-4983-AD4C-65A7DAAA6476">
-                <RegistryKey Root="HKMU" Key="Software\Microsoft\Microsoft SDKs\Silverlight\v5.0\AssemblyFoldersEx\NUnit [ProductVersion]" >
-                    <RegistryValue Action="write" Type="string" Value="[SL50]" />
-                </RegistryKey>
-            </Component>
-        </ComponentGroup>
     </Fragment>
 </Include>

--- a/install/runners/console-files.wxi
+++ b/install/runners/console-files.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <Fragment>
-        <ComponentGroup Id="NUNIT.CONSOLE" Directory="CONSOLE-BIN">
+        <ComponentGroup Id="NUNIT.CONSOLE" Directory="CONSOLE_BIN">
             <Component Id="NUNIT_CONSOLE" Location="local" Guid="EEABEE65-D977-46B7-99B4-73814BF7BE63">
                 <File Id="nunit_console.exe"
                       ProcessorArchitecture="msil"

--- a/install/runners/console-files.wxi
+++ b/install/runners/console-files.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <Fragment>
-        <ComponentGroup Id="NUNIT.CONSOLE" Directory="BIN">
+        <ComponentGroup Id="NUNIT.CONSOLE" Directory="CONSOLE-BIN">
             <Component Id="NUNIT_CONSOLE" Location="local" Guid="EEABEE65-D977-46B7-99B4-73814BF7BE63">
                 <File Id="nunit_console.exe"
                       ProcessorArchitecture="msil"

--- a/install/runners/engine-files.wxi
+++ b/install/runners/engine-files.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <Fragment>
-        <ComponentGroup Id="NUNIT.ENGINE" Directory="BIN">
+        <ComponentGroup Id="NUNIT.ENGINE" Directory="CONSOLE-BIN">
             <Component Id="NUNIT.ENGINE" Location="local" Guid="033DE5BC-4AC4-4F98-9E5D-E5F3221FCD46">
                 <File Id="nunit.engine.dll"
                       ProcessorArchitecture="msil"
@@ -42,7 +42,7 @@
             </Component>
             <Component Id="NUNIT.ENGINE.REGISTRY">
                 <RegistryKey Root="HKMU" Key="Software\NUnit.org\Engine" >
-                    <RegistryValue Action="write" Type="string" Name="!(bind.FileVersion.nunit.engine.dll)" Value="[BIN]nunit.engine.dll" />
+                    <RegistryValue Action="write" Type="string" Name="!(bind.FileVersion.nunit.engine.dll)" Value="[CONSOLE-BIN]nunit.engine.dll" />
                 </RegistryKey>
             </Component>
         </ComponentGroup>

--- a/install/runners/engine-files.wxi
+++ b/install/runners/engine-files.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <Fragment>
-        <ComponentGroup Id="NUNIT.ENGINE" Directory="CONSOLE-BIN">
+        <ComponentGroup Id="NUNIT.ENGINE" Directory="CONSOLE_BIN">
             <Component Id="NUNIT.ENGINE" Location="local" Guid="033DE5BC-4AC4-4F98-9E5D-E5F3221FCD46">
                 <File Id="nunit.engine.dll"
                       ProcessorArchitecture="msil"
@@ -42,7 +42,7 @@
             </Component>
             <Component Id="NUNIT.ENGINE.REGISTRY">
                 <RegistryKey Root="HKMU" Key="Software\NUnit.org\Engine" >
-                    <RegistryValue Action="write" Type="string" Name="!(bind.FileVersion.nunit.engine.dll)" Value="[CONSOLE-BIN]nunit.engine.dll" />
+                    <RegistryValue Action="write" Type="string" Name="!(bind.FileVersion.nunit.engine.dll)" Value="[CONSOLE_BIN]nunit.engine.dll" />
                 </RegistryKey>
             </Component>
         </ComponentGroup>

--- a/install/runners/runner-directories.wxi
+++ b/install/runners/runner-directories.wxi
@@ -2,7 +2,7 @@
 <Include>
     <Fragment>
         <DirectoryRef Id="INSTALLDIR">
-            <Directory Id="BIN" Name="bin">
+            <Directory Id="CONSOLE-BIN" Name="nunit-console">
                 <Directory Id="ADDINS" Name="addins" />
             </Directory>
         </DirectoryRef>

--- a/install/runners/runner-directories.wxi
+++ b/install/runners/runner-directories.wxi
@@ -2,7 +2,7 @@
 <Include>
     <Fragment>
         <DirectoryRef Id="INSTALLDIR">
-            <Directory Id="CONSOLE-BIN" Name="nunit-console">
+            <Directory Id="CONSOLE_BIN" Name="nunit-console">
                 <Directory Id="ADDINS" Name="addins" />
             </Directory>
         </DirectoryRef>

--- a/nuget/nunit.nuspec
+++ b/nuget/nunit.nuspec
@@ -18,7 +18,6 @@ This package includes the NUnit 3.0 framework assembly, which is referenced by y
 Supported platforms:
   - .NET 2.0+
   - .NET Core (Universal Windows Apps 10+, DNX Core 5+)
-  - SilverLight 5.0
   - Windows 8
   - Windows Phone 8 (Silverlight)
   - Universal (Windows Phone 8.1+, Windows 8.1+)
@@ -39,8 +38,6 @@ Supported platforms:
     <file src="bin/net-4.0/nunit.framework.xml" target="lib/net40" />
     <file src="bin/net-4.5/nunit.framework.dll" target="lib/net45" />
     <file src="bin/net-4.5/nunit.framework.xml" target="lib/net45" />
-    <file src="bin/sl-5.0/nunit.framework.dll" target="lib\sl50" />
-    <file src="bin/sl-5.0/nunit.framework.xml" target="lib\sl50" />
     <file src="bin/portable/nunit.framework.dll" target="lib/dotnet" />
     <file src="bin/portable/nunit.framework.xml" target="lib/dotnet" />
     <file src="bin/portable/nunit.framework.dll" target="lib/portable-net45+win8+wp8+wpa81+Xamarin.Mac+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />

--- a/nuget/nunitCF.nuspec
+++ b/nuget/nunitCF.nuspec
@@ -12,7 +12,6 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
     <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.&#10;&#13;This package includes the NUnit 3.0 framework assembly for .NET Compact Framework 3.5, which is referenced by your tests. You will need to install the NUnitLiteCF package in order to run the tests. Two separate packages are used because future versions will be supported by additional runners.</description>
-    <releaseNotes>This is an beta release, but is ready for production use for people with prior NUnit experience.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory plugin addin cf compact framework</tags>
     <copyright>Copyright (c) 2015 Charlie Poole</copyright>

--- a/nuget/nunitSL.nuspec
+++ b/nuget/nunitSL.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>NUnit.SL50</id>
+    <title>NUnit Version 3 for SilverLight 5.0</title>
+    <version>$version$</version>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
+    <projectUrl>http://nunit.org</projectUrl>
+    <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>NUnit is a unit-testing framework for .Net languages with a strong TDD focus.</summary>
+    <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.&#10;&#13;This package includes the NUnit 3.0 framework assembly for SilverLight 5.0, which is referenced by your tests. You will need to install the NUnitLite.SL50 package in order to run the tests.</description>
+    <language>en-US</language>
+    <tags>nunit test testing tdd framework fluent assert theory</tags>
+    <copyright>Copyright (c) 2015 Charlie Poole</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin\sl-5.0\nunit.framework.dll" target="lib\sl50" />
+    <file src="bin\sl-5.0\nunit.framework.xml" target="lib\sl50" />
+  </files>
+</package>

--- a/nuget/nunitlite.nuspec
+++ b/nuget/nunitlite.nuspec
@@ -16,7 +16,6 @@
 Supported platforms:
 - .NET 2.0+
 - .NET Core (Universal Windows Apps 10+, DNX Core 5+)
-- SilverLight 5.0
 - Portable Libraries (supporting Profile259)
         
 How to use this package:
@@ -40,7 +39,6 @@ How to use this package:
     <file src="bin/net-2.0/nunitlite.dll" target="lib/net20" />
     <file src="bin/net-4.0/nunitlite.dll" target="lib/net40" />
     <file src="bin/net-4.5/nunitlite.dll" target="lib/net45" />
-    <file src="bin/sl-5.0/nunitlite.dll" target="lib/sl5" />
     <file src="bin/portable/nunitlite.dll" target="lib/dotnet" />
     <file src="bin/portable/nunitlite.dll" target="lib/portable-net45+win8+wp8+wpa81+Xamarin.Mac" />
     <file src="..\..\nuget\Program.cs" target="content" />

--- a/nuget/nunitliteSL.nuspec
+++ b/nuget/nunitliteSL.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>NUnitLiteCF</id>
-    <title>NUnitLite Version 3 for Compact Framework</title>
+    <id>NUnitLite.SL50</id>
+    <title>NUnitLite Version 3 for SilverLight 5.0</title>
     <version>$version$</version>
     <authors>Charlie Poole</authors>
     <owners>Charlie Poole</owners>
@@ -11,13 +11,13 @@
     <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>NUnitlite is a lightweight runner for tests that use the NUnit testing framework.</summary>
-    <description>NUnitLite provides a simple way to run NUnit tests, without the overhead of a full NUnit installation. This package contains a build of the NUnitLite runner for the .NET compact framework 3.5.</description>
+    <description>NUnitLite provides a simple way to run NUnit tests, without the overhead of a full NUnit installation. This package contains a build of the NUnitLite runner for SilverLight 5.0.</description>
     <language>en-US</language>
-    <tags>test unit testing tdd framework fluent assert device phone embedded cf compact</tags>
+    <tags>test unit testing tdd framework fluent assert</tags>
     <copyright>Copyright (c) 2015 Charlie Poole</copyright>
     <dependencies>
       <group>
-        <dependency id="NUnitCF" version="[$version$]" />
+        <dependency id="NUnit.SL50" version="[$version$]" />
       </group>
     </dependencies>
   </metadata>
@@ -25,9 +25,6 @@
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="bin\netcf-3.5\nunitlite.dll" target="lib\net35-cf" />
-    <file src="..\..\nuget\Program.cs" target="content" />
-    <file src="..\..\nuget\Program.vb" target="content" />
-    <file src="..\..\nuget\install.ps1" target="tools" />
+    <file src="bin\sl-5.0\nunitlite.dll" target="lib\sl50" />
   </files>
 </package>

--- a/nunit.sln
+++ b/nunit.sln
@@ -64,6 +64,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{A972031D
 		nuget\nunit.console.nuspec = nuget\nunit.console.nuspec
 		nuget\nunit.nuspec = nuget\nunit.nuspec
 		nuget\nunitlite.nuspec = nuget\nunitlite.nuspec
+		nuget\nunitliteSL.nuspec = nuget\nunitliteSL.nuspec
+		nuget\nunitSL.nuspec = nuget\nunitSL.nuspec
 		nuget\Program.cs = nuget\Program.cs
 		nuget\Program.vb = nuget\Program.vb
 	EndProjectSection


### PR DESCRIPTION
~~**Do not merge**~~

Fixes #783, packaging separately for Silverlight, but I am going to do #940 as part of this pull request. I wanted to start the PR so that I can document my changes.

From an offline discussion, we decided to do;

* new nuget packages and maybe a zip, just like CF. In fact you could
copy and edit CF's.
* remove it from the nunit and nunitlite general nuget packages.
* only remove it from the msi if you have time - I know msi updates
are pretty tedious.
* let's leave it in the zip for now
* we should keep it in the overall solution as well, since it let's us
make sure that changes compile

I have done all this except I removed it from the ZIP because it is in its own ZIP. I have also updated the Packaging NUnit 3.0 dev wiki with the new build steps.

--

- I have removed SilverLight from the installer
- I have switched the bin directory to nunit-console as discussed in #940 

--

I switched NUnit.proj to only package the master installer. I left the other installers in place for now in case we decide to re-instate them in the future. We can clean up later if nobody asks for them.

Fixes #940 