### PR TITLE
Remove statics to fix #960

### DIFF
--- a/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
@@ -29,39 +29,45 @@ namespace NUnit.Framework.Internal.Filters
 {
     public class IdFilterTests : TestFilterTests
     {
-        private readonly TestFilter filter = new IdFilter(_dummyFixture.Id);
+        private TestFilter _filter;
+
+        [SetUp]
+        public void CreateFilter()
+        {
+            _filter = new IdFilter(_dummyFixture.Id);
+        }
 
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(filter.IsEmpty);
+            Assert.False(_filter.IsEmpty);
         }
 
         [Test]
         public void MatchTest()
         {
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_dummyFixture));
+            Assert.False(_filter.Match(_anotherFixture));
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Pass(_dummyFixture));
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(_topLevelSuite));
+            Assert.That(_filter.Pass(_dummyFixture));
+            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(filter.Pass(_anotherFixture));
+            Assert.False(_filter.Pass(_anotherFixture));
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
+            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
 
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
@@ -61,13 +61,14 @@ namespace NUnit.Framework.Internal.Filters
     {
         public const string DUMMY_CLASS = "NUnit.Framework.Internal.Filters.TestFilterTests+DummyFixture";
 
-        protected static readonly TestSuite _dummyFixture = TestBuilder.MakeFixture(typeof(DummyFixture));
-        protected static readonly TestSuite _anotherFixture = TestBuilder.MakeFixture(typeof(AnotherFixture));
-        protected static readonly TestSuite _yetAnotherFixture = TestBuilder.MakeFixture(typeof(YetAnotherFixture));
-        protected static readonly TestSuite _fixtureWithMultipleTests = TestBuilder.MakeFixture (typeof (FixtureWithMultipleTests));
-        protected static readonly TestSuite _topLevelSuite = new TestSuite("MySuite");
+        protected readonly TestSuite _dummyFixture = TestBuilder.MakeFixture(typeof(DummyFixture));
+        protected readonly TestSuite _anotherFixture = TestBuilder.MakeFixture(typeof(AnotherFixture));
+        protected readonly TestSuite _yetAnotherFixture = TestBuilder.MakeFixture(typeof(YetAnotherFixture));
+        protected readonly TestSuite _fixtureWithMultipleTests = TestBuilder.MakeFixture (typeof (FixtureWithMultipleTests));
+        protected readonly TestSuite _topLevelSuite = new TestSuite("MySuite");
 
-        static TestFilterTests()
+        [OneTimeSetUp]
+        public void SetUpSuite()
         {
             _topLevelSuite.Add(_dummyFixture);
             _topLevelSuite.Add(_anotherFixture);


### PR DESCRIPTION
Multiple test fixtures were using the same static fields as test data, leading to problems when the fixtures are run in parallel. This fixes it.