### PR TITLE
Issue 954

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -208,7 +208,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            InsertSettingsElement(result);
+            if (Settings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, Settings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif
@@ -241,7 +242,7 @@ namespace NUnit.Framework.Api
         }
 
 #if !PORTABLE && !SILVERLIGHT
-        private TNode InsertEnvironmentElement(TNode targetNode)
+        public static TNode InsertEnvironmentElement(TNode targetNode)
         {
             TNode env = new TNode("environment");
             targetNode.ChildNodes.Insert(0, env);
@@ -269,16 +270,16 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-        private TNode InsertSettingsElement(TNode targetNode)
+        public static TNode InsertSettingsElement(TNode targetNode, IDictionary settings)
         {
             TNode settingsNode = new TNode("settings");
             targetNode.ChildNodes.Insert(0, settingsNode);
 
-            foreach (string key in Settings.Keys)
-                AddSetting(settingsNode, key, Settings[key]);
+            foreach (string key in settings.Keys)
+                AddSetting(settingsNode, key, settings[key]);
 
             // Add default values for display
-            if (!Settings.Contains(PackageSettings.NumberOfTestWorkers))
+            if (!settings.Contains(PackageSettings.NumberOfTestWorkers))
 #if NETCF
                 AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, 2);
 #else
@@ -288,7 +289,7 @@ namespace NUnit.Framework.Api
                 return settingsNode;
         }
 
-        private void AddSetting(TNode settingsNode, string name, object value)
+        private static void AddSetting(TNode settingsNode, string name, object value)
         {
             TNode setting = new TNode("setting");
             setting.AddAttribute("name", name);

--- a/src/NUnitFramework/framework/Interfaces/ITestFilter.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestFilter.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Interfaces
     /// The filter applies when running the test, after it has been
     /// loaded, since this is the only time an ITest exists.
     /// </summary>
-    public interface ITestFilter
+    public interface ITestFilter : IXmlNodeBuilder
     {
         /// <summary>
         /// Determine if a particular test passes the filter criteria. Pass

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -72,5 +72,10 @@ namespace NUnit.Framework.Internal.Filters
 
             return true;
         }
+
+        protected override string ElementName
+        {
+            get { return "and"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -59,5 +59,10 @@ namespace NUnit.Framework.Internal.Filters
 
             return false;
         }
+
+        protected override string ElementName
+        {
+            get { return "cat"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -50,5 +50,10 @@ namespace NUnit.Framework.Internal.Filters
 
             return Match(test.ClassName);
         }
+
+        protected override string ElementName
+        {
+            get { return "class"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -62,5 +62,18 @@ namespace NUnit.Framework.Internal.Filters
         /// Return a list of the composing filters.
         /// </summary>
         public IList<ITestFilter> Filters { get; private set; }
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            TNode result = parentNode.AddElement(ElementName);
+
+            if (recursive)
+                foreach (ITestFilter filter in Filters)
+                    filter.AddToXml(result, true);
+
+            return result;
+        }
+
+        protected abstract string ElementName { get; }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -45,5 +45,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             return Match(test.FullName);
         }
+
+        protected override string ElementName
+        {
+            get { return "test"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -48,5 +48,10 @@ namespace NUnit.Framework.Internal.Filters
             // because regular expressions are not supported for ID.
             return test.Id == ExpectedValue;
         }
+
+        protected override string ElementName
+        {
+            get { return "id"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -45,5 +45,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             return Match(test.MethodName);
         }
+
+        protected override string ElementName
+        {
+            get { return "method"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -99,5 +99,13 @@ namespace NUnit.Framework.Internal.Filters
 
         //    return false;
         //}	
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            TNode result = parentNode.AddElement("not");
+            if (recursive)
+                BaseFilter.AddToXml(result, true);
+            return result;
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -27,50 +27,55 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
 {
-	/// <summary>
-	/// Combines multiple filters so that a test must pass one 
-	/// of them in order to pass this filter.
-	/// </summary>
-	[Serializable]
-	public class OrFilter : CompositeFilter
-	{
-		/// <summary>
-		/// Constructs an empty OrFilter
-		/// </summary>
-		public OrFilter() { }
+    /// <summary>
+    /// Combines multiple filters so that a test must pass one 
+    /// of them in order to pass this filter.
+    /// </summary>
+    [Serializable]
+    public class OrFilter : CompositeFilter
+    {
+        /// <summary>
+        /// Constructs an empty OrFilter
+        /// </summary>
+        public OrFilter() { }
 
-		/// <summary>
-		/// Constructs an AndFilter from an array of filters
-		/// </summary>
-		/// <param name="filters"></param>
-		public OrFilter( params ITestFilter[] filters ) : base(filters) { }
+        /// <summary>
+        /// Constructs an AndFilter from an array of filters
+        /// </summary>
+        /// <param name="filters"></param>
+        public OrFilter( params ITestFilter[] filters ) : base(filters) { }
 
-		/// <summary>
-		/// Checks whether the OrFilter is matched by a test
-		/// </summary>
-		/// <param name="test">The test to be matched</param>
-		/// <returns>True if any of the component filters pass, otherwise false</returns>
-		public override bool Pass( ITest test )
-		{
-			foreach( ITestFilter filter in Filters )
-				if ( filter.Pass( test ) )
-					return true;
+        /// <summary>
+        /// Checks whether the OrFilter is matched by a test
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        /// <returns>True if any of the component filters pass, otherwise false</returns>
+        public override bool Pass( ITest test )
+        {
+            foreach( ITestFilter filter in Filters )
+                if ( filter.Pass( test ) )
+                    return true;
 
-			return false;
-		}
+            return false;
+        }
 
-		/// <summary>
-		/// Checks whether the OrFilter is matched by a test
-		/// </summary>
-		/// <param name="test">The test to be matched</param>
-		/// <returns>True if any of the component filters match, otherwise false</returns>
-		public override bool Match( ITest test )
-		{
-			foreach( TestFilter filter in Filters )
-				if ( filter.Match( test ) )
-					return true;
+        /// <summary>
+        /// Checks whether the OrFilter is matched by a test
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        /// <returns>True if any of the component filters match, otherwise false</returns>
+        public override bool Match( ITest test )
+        {
+            foreach( TestFilter filter in Filters )
+                if ( filter.Match( test ) )
+                    return true;
 
-			return false;
-		}
-	}
+            return false;
+        }
+
+        protected override string ElementName
+        {
+            get { return "or"; }
+        }
+    }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -65,5 +65,17 @@ namespace NUnit.Framework.Internal.Filters
 
             return false;
         }
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            TNode result = base.AddToXml(parentNode, recursive);
+            result.AddAttribute("name", _propertyName);
+            return result;
+        }
+
+        protected override string ElementName
+        {
+            get { return "prop"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -45,5 +45,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             return Match(test.Name);
         }
+
+        protected override string ElementName
+        {
+            get { return "name"; }
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2013 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -66,5 +66,15 @@ namespace NUnit.Framework.Internal.Filters
             else
                 return ExpectedValue == input;
         }
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            TNode result = parentNode.AddElement(ElementName, ExpectedValue);
+            if (IsRegex)
+                result.AddAttribute("re", "1");
+            return result;
+        }
+
+        protected abstract string ElementName { get; }
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -217,6 +217,22 @@ namespace NUnit.Framework.Internal
             {
                 return false;
             }
+
+            public override TNode AddToXml(TNode parentNode, bool recursive)
+            {
+                return parentNode.AddElement("filter");
+            }
         }
+
+        #region IXmlNodeBuilder Implementation
+
+        public TNode ToXml(bool recursive)
+        {
+            return AddToXml(new TNode("dummy"), recursive);
+        }
+
+        public abstract TNode AddToXml(TNode parentNode, bool recursive);
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/nunitlite.runner/OutputManager.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputManager.cs
@@ -22,11 +22,13 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.IO;
 using System.Reflection;
 using System.Xml;
 using NUnit.Common;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 
 namespace NUnitLite
 {
@@ -52,7 +54,7 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The test result</param>
         /// <param name="spec">An output specification</param>
-        public void WriteResultFile(ITestResult result, OutputSpecification spec)
+        public void WriteResultFile(ITestResult result, OutputSpecification spec, IDictionary runSettings, TestFilter filter)
         {
             string outputPath = Path.Combine(_workDirectory, spec.OutputPath);
             OutputWriter outputWriter = null;
@@ -79,7 +81,7 @@ namespace NUnitLite
                         "spec");
             }
 
-            outputWriter.WriteResultFile(result, outputPath);
+            outputWriter.WriteResultFile(result, outputPath, runSettings, filter);
             Console.WriteLine("Results ({0}) saved as {1}", spec.Format, outputPath);
         }
 

--- a/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -56,7 +57,7 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The test result for the run</param>
         /// <param name="writer">The TextWriter to which the xml will be written</param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer)
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
         {
             // NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
             // but does implement Close(). Hence we cannot use a 'using' clause.

--- a/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -85,7 +85,7 @@ namespace NUnitLite
 
             TNode testRun = MakeTestRunElement(result);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETCF
             testRun.ChildNodes.Add(MakeCommandLineElement());
 #endif
             testRun.ChildNodes.Add(MakeTestFilterElement(filter));
@@ -127,7 +127,7 @@ namespace NUnitLite
             return testRun;
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETCF
         private static TNode MakeCommandLineElement()
         {
             return new TNode("command-line", Environment.CommandLine, true);

--- a/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -22,11 +22,13 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xml;
 using NUnit.Common;
+using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -38,8 +40,6 @@ namespace NUnitLite
     /// </summary>
     public class NUnit3XmlOutputWriter : OutputWriter
     {
-        private XmlWriter xmlWriter;
-
         /// <summary>
         /// Writes test info to the specified TextWriter
         /// </summary>
@@ -61,93 +61,85 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The result to be written to a file</param>
         /// <param name="writer">A TextWriter to which the result is written</param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer)
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
         {
-            XmlWriterSettings settings = new XmlWriterSettings();
-            settings.Indent = true;
+            XmlWriterSettings xmlSettings = new XmlWriterSettings();
+            xmlSettings.Indent = true;
 
-            using (XmlWriter xmlWriter = XmlWriter.Create(writer, settings))
+            using (XmlWriter xmlWriter = XmlWriter.Create(writer, xmlSettings))
             {
-                WriteXmlResultOutput(result, xmlWriter);
+                WriteXmlResultOutput(result, xmlWriter, runSettings, filter);
             }
         }
 
-        private void WriteXmlResultOutput(ITestResult result, XmlWriter xmlWriter)
+        private void WriteXmlResultOutput(ITestResult result, XmlWriter xmlWriter, IDictionary runSettings, TestFilter filter)
         {
-            this.xmlWriter = xmlWriter;
+            TNode resultNode = result.ToXml(true);
 
-            InitializeXmlFile(result);
-
-            result.ToXml(true).WriteTo(xmlWriter);
-
-            TerminateXmlFile();
-        }
-
-        private void InitializeXmlFile(ITestResult result)
-        {
-            xmlWriter.WriteStartDocument(false);
-
-            // In order to match the format used by NUnit 3.0, we
-            // wrap the entire result from the framework in a 
-            // <test-run> element.
-            xmlWriter.WriteStartElement("test-run");
-
-            xmlWriter.WriteAttributeString("id", "2"); // TODO: Should not be hard-coded
-            xmlWriter.WriteAttributeString("name", result.Name);
-            xmlWriter.WriteAttributeString("fullname", result.FullName);
-            xmlWriter.WriteAttributeString("testcasecount", result.Test.TestCaseCount.ToString());
-
-            xmlWriter.WriteAttributeString("result", result.ResultState.Status.ToString());
-            if (result.ResultState.Label != string.Empty) // && result.ResultState.Label != ResultState.Status.ToString())
-                xmlWriter.WriteAttributeString("label", result.ResultState.Label);
-
-            xmlWriter.WriteAttributeString("start-time", result.StartTime.ToString("u"));
-            xmlWriter.WriteAttributeString("end-time", result.EndTime.ToString("u"));
-            xmlWriter.WriteAttributeString("duration", result.Duration.ToString("0.000000", NumberFormatInfo.InvariantInfo));
-
-            xmlWriter.WriteAttributeString("total", (result.PassCount + result.FailCount + result.SkipCount + result.InconclusiveCount).ToString());
-            xmlWriter.WriteAttributeString("passed", result.PassCount.ToString());
-            xmlWriter.WriteAttributeString("failed", result.FailCount.ToString());
-            xmlWriter.WriteAttributeString("inconclusive", result.InconclusiveCount.ToString());
-            xmlWriter.WriteAttributeString("skipped", result.SkipCount.ToString());
-            xmlWriter.WriteAttributeString("asserts", result.AssertCount.ToString());
-
-            xmlWriter.WriteAttributeString("random-seed", Randomizer.InitialSeed.ToString());
-
-            WriteEnvironmentElement();
-        }
-
-        private void WriteEnvironmentElement()
-        {
-            xmlWriter.WriteStartElement("environment");
-
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            AssemblyName assemblyName = AssemblyHelper.GetAssemblyName(assembly);
-            xmlWriter.WriteAttributeString("nunit-version", assemblyName.Version.ToString());
-
-            xmlWriter.WriteAttributeString("clr-version", Environment.Version.ToString());
-            xmlWriter.WriteAttributeString("os-version", Environment.OSVersion.ToString());
-            xmlWriter.WriteAttributeString("platform", Environment.OSVersion.Platform.ToString());
-#if !NETCF
-            xmlWriter.WriteAttributeString("cwd", Environment.CurrentDirectory);
+            // Insert elements as first child in reverse order
+            if (runSettings != null) // Some platforms don't have settings
+                FrameworkController.InsertSettingsElement(resultNode, runSettings);
 #if !SILVERLIGHT
-            xmlWriter.WriteAttributeString("machine-name", Environment.MachineName);
-            xmlWriter.WriteAttributeString("user", Environment.UserName);
-            xmlWriter.WriteAttributeString("user-domain", Environment.UserDomainName);
+            FrameworkController.InsertEnvironmentElement(resultNode);
 #endif
-#endif
-            xmlWriter.WriteAttributeString("culture", System.Globalization.CultureInfo.CurrentCulture.ToString());
-            xmlWriter.WriteAttributeString("uiculture", System.Globalization.CultureInfo.CurrentUICulture.ToString());
 
-            xmlWriter.WriteEndElement();
+            TNode testRun = MakeTestRunElement(result);
+
+#if !SILVERLIGHT
+            testRun.ChildNodes.Add(MakeCommandLineElement());
+#endif
+            testRun.ChildNodes.Add(MakeTestFilterElement(filter));
+            testRun.ChildNodes.Add(resultNode);
+
+            testRun.WriteTo(xmlWriter);
         }
 
-        private void TerminateXmlFile()
+        private TNode MakeTestRunElement(ITestResult result)
         {
-            xmlWriter.WriteEndElement(); // test-run
-            xmlWriter.WriteEndDocument();
-            xmlWriter.Flush();
-            xmlWriter.Close();
+            TNode testRun = new TNode("test-run");
+
+            testRun.AddAttribute("id", "2");
+            testRun.AddAttribute("name", result.Name);
+            testRun.AddAttribute("fullname", result.FullName);
+            testRun.AddAttribute("testcasecount", result.Test.TestCaseCount.ToString());
+
+            testRun.AddAttribute("result", result.ResultState.Status.ToString());
+            if (result.ResultState.Label != string.Empty)
+                testRun.AddAttribute("label", result.ResultState.Label);
+
+            testRun.AddAttribute("start-time", result.StartTime.ToString("u"));
+            testRun.AddAttribute("end-time", result.EndTime.ToString("u"));
+            testRun.AddAttribute("duration", result.Duration.ToString("0.000000", NumberFormatInfo.InvariantInfo));
+
+            testRun.AddAttribute("total", (result.PassCount + result.FailCount + result.SkipCount + result.InconclusiveCount).ToString());
+            testRun.AddAttribute("passed", result.PassCount.ToString());
+            testRun.AddAttribute("failed", result.FailCount.ToString());
+            testRun.AddAttribute("inconclusive", result.InconclusiveCount.ToString());
+            testRun.AddAttribute("skipped", result.SkipCount.ToString());
+            testRun.AddAttribute("asserts", result.AssertCount.ToString());
+
+            testRun.AddAttribute("random-seed", Randomizer.InitialSeed.ToString());
+
+            // NOTE: The console runner adds attributes for engine-version and clr-version
+            // Neither of these is needed under nunitlite since there is no engine involved
+            // and we are running under the same runtime as the tests.
+
+            return testRun;
+        }
+
+#if !SILVERLIGHT
+        private static TNode MakeCommandLineElement()
+        {
+            return new TNode("command-line", Environment.CommandLine, true);
+        }
+#endif
+
+        private static TNode MakeTestFilterElement(TestFilter filter)
+        {
+            TNode result = new TNode("filter");
+            if (!filter.IsEmpty)
+                filter.AddToXml(result, true);
+            return result;
         }
     }
 }

--- a/src/NUnitFramework/nunitlite.runner/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputWriters/OutputWriter.cs
@@ -21,9 +21,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Collections;
 using System.IO;
 using System.Text;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 
 namespace NUnitLite
 {
@@ -39,11 +41,12 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The result to be written</param>
         /// <param name="outputPath">Path to the file to which the result is written</param>
-        public void WriteResultFile(ITestResult result, string outputPath)
+        /// <param name="runSettings">A dictionary of settings used for this test run</param>
+        public void WriteResultFile(ITestResult result, string outputPath, IDictionary runSettings, TestFilter filter)
         {
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
             {
-                WriteResultFile(result, writer);
+                WriteResultFile(result, writer, runSettings, filter);
             }
         }
 
@@ -65,7 +68,8 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The result to be written</param>
         /// <param name="writer">A TextWriter to which the result is written</param>
-        public abstract void WriteResultFile(ITestResult result, TextWriter writer);
+        /// <param name="runSettings">A dictionary of settings used for this test run</param>
+        public abstract void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter);
 
         /// <summary>
         /// Abstract method that writes test info to a TextWriter

--- a/src/NUnitFramework/nunitlite.runner/OutputWriters/TestCaseOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite.runner/OutputWriters/TestCaseOutputWriter.cs
@@ -21,9 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Collections;
 using System.IO;
-using System.Text;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 
 namespace NUnitLite
 {
@@ -51,7 +52,7 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result"></param>
         /// <param name="writer"></param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer)
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
         {
             WriteTestFile(result.Test, writer);
         }

--- a/src/NUnitFramework/nunitlite.runner/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite.runner/TextRunner.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -163,11 +164,11 @@ namespace NUnitLite
                 TestFilter filter = CreateTestFilter(_options);
 
                 if (_runner.Load(assembly, runSettings) != null)
-                    return _options.Explore ? ExploreTests() : RunTests(filter);
+                    return _options.Explore ? ExploreTests() : RunTests(filter, runSettings);
 #else
                 Assembly assembly = callingAssembly;
                 if (_runner.Load(assembly, new Dictionary<string, object>()) != null)
-                    return RunTests(TestFilter.Empty);
+                    return RunTests(TestFilter.Empty, null);
 #endif
 
                 var assemblyName = AssemblyHelper.GetAssemblyName(assembly);
@@ -190,7 +191,7 @@ namespace NUnitLite
 
         #region Helper Methods
 
-        private int RunTests(ITestFilter filter)
+        private int RunTests(TestFilter filter, IDictionary runSettings)
         {
             var startTime = DateTime.UtcNow;
 
@@ -210,7 +211,7 @@ namespace NUnitLite
                 var outputManager = new OutputManager(_options.WorkDirectory);
 
                 foreach (var spec in _options.ResultOutputSpecifications)
-                    outputManager.WriteResultFile(result, spec);
+                    outputManager.WriteResultFile(result, spec, runSettings, filter);
             }
 #endif
 

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2011 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -48,7 +48,7 @@ namespace NUnitLite.Tests
 
             StringBuilder sb = new StringBuilder();
             StringWriter writer = new StringWriter(sb);
-            new NUnit2XmlOutputWriter().WriteResultFile(result, writer);
+            new NUnit2XmlOutputWriter().WriteResultFile(result, writer, null, null);
             writer.Close();
 
 #if DEBUG

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -28,8 +28,10 @@ namespace NUnit.Framework.Internal.Filters
 {
     public class TestFilterXmlTests : TestFilterTests
     {
+        #region ClassNameFilter
+
         [Test]
-        public void BuildClassNameFilter()
+        public void ClassNameFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><class>" + TestFilterTests.DUMMY_CLASS + "</class></filter>");
@@ -40,7 +42,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildClassNameFilter_Regex()
+        public void ClassNameFilter_ToXml()
+        {
+            TestFilter filter = new ClassNameFilter("FULLNAME");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<class>FULLNAME</class>"));
+        }
+
+        [Test]
+        public void ClassNameFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><class re='1'>Dummy</class></filter>");
@@ -51,7 +60,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildMethodNameFilter()
+        public void ClassNameFilter_ToXml_Regex()
+        {
+            TestFilter filter = new ClassNameFilter("FULLNAME") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<class re=\"1\">FULLNAME</class>"));
+        }
+
+        #endregion
+
+        #region MethodNameFilter
+
+        [Test]
+        public void MethodNameFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><method>Test</method></filter>");
@@ -63,7 +83,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildMethodNameFilter_Regex()
+        public void MethodNameFilter_ToXml()
+        {
+            TestFilter filter = new MethodNameFilter("Test");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<method>Test</method>"));
+        }
+
+        [Test]
+        public void BuildMethodNameFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><method re='1'>T.st</method></filter>");
@@ -75,7 +102,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildTestNameFilter()
+        public void MethodNameFilter_ToXml_Regex()
+        {
+            TestFilter filter = new MethodNameFilter("Test") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<method re=\"1\">Test</method>"));
+        }
+
+        #endregion
+
+        #region TestNameFilter
+
+        [Test]
+        public void TestNameFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><name>TestFilterTests+DummyFixture</name></filter>");
@@ -86,7 +124,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildTestNameFilter_Regex()
+        public void TestNameFilter_ToXml()
+        {
+            TestFilter filter = new TestNameFilter("TestFilterTests+DummyFixture");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<name>TestFilterTests+DummyFixture</name>"));
+        }
+
+        [Test]
+        public void TestNameFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><name re='1'>Dummy</name></filter>");
@@ -97,7 +142,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildFullNameFilter()
+        public void TestNameFilter_ToXml_Regex()
+        {
+            TestFilter filter = new TestNameFilter("TestFilterTests+DummyFixture") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<name re=\"1\">TestFilterTests+DummyFixture</name>"));
+        }
+
+        #endregion
+
+        #region FullNameFilter
+
+        [Test]
+        public void FullNameFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><test>" + TestFilterTests.DUMMY_CLASS + "</test></filter>");
@@ -108,7 +164,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildFullNameFilter_Regex()
+        public void FullNameFilter_ToXml()
+        {
+            TestFilter filter = new FullNameFilter("FULLNAME");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<test>FULLNAME</test>"));
+        }
+
+        [Test]
+        public void FullNameFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><test re='1'>Dummy</test></filter>");
@@ -119,7 +182,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildCategoryFilter()
+        public void FullNameFilter_ToXml_Regex()
+        {
+            TestFilter filter = new FullNameFilter("FULLNAME") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<test re=\"1\">FULLNAME</test>"));
+        }
+
+        #endregion
+
+        #region CategoryFilter
+
+        [Test]
+        public void CategoryFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><cat>Dummy</cat></filter>");
@@ -130,7 +204,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildCategoryFilter_Regex()
+        public void CategoryFilter_ToXml()
+        {
+            TestFilter filter = new CategoryFilter("CATEGORY");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<cat>CATEGORY</cat>"));
+        }
+
+        [Test]
+        public void CategoryFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><cat re='1'>D.mmy</cat></filter>");
@@ -141,7 +222,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildPropertyFilter()
+        public void CategoryFilter_ToXml_Regex()
+        {
+            TestFilter filter = new CategoryFilter("CATEGORY") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<cat re=\"1\">CATEGORY</cat>"));
+        }
+
+        #endregion
+
+        #region PropertyFilter
+
+        [Test]
+        public void PropertyFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><prop name='Priority'>High</prop></filter>");
@@ -153,7 +245,14 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildPropertyFilter_Regex()
+        public void PropertyFilter_ToXml()
+        {
+            TestFilter filter = new PropertyFilter("Priority", "High");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<prop name=\"Priority\">High</prop>"));
+        }
+
+        [Test]
+        public void PropertyFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
                 "<filter><prop name='Author' re='1'>Charlie P</prop></filter>");
@@ -165,7 +264,18 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildIdFilter()
+        public void PropertyFilter_ToXml_Regex()
+        {
+            TestFilter filter = new PropertyFilter("Priority", "High") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<prop re=\"1\" name=\"Priority\">High</prop>"));
+        }
+
+        #endregion
+
+        #region IdFilter
+
+        [Test]
+        public void IdFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
                 string.Format("<filter><id>{0}</id></filter>", _dummyFixture.Id));
@@ -174,5 +284,14 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.False(filter.Match(_anotherFixture));
         }
+
+        [Test]
+        public void IdFilter_ToXml()
+        {
+            TestFilter filter = new IdFilter("ID-123");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<id>ID-123</id>"));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
This makes the NUnitLite XML output like that produced by the engine.

The test-run element has child elements command-line and filter, while the top-level test-suite has environment and settings. The environment element is skipped for Silverlight and the command-line is element is skipped on Silverlight and CF.

This should fixes #954 relating to XML output. There are other issues pending regarding text output from NUnitLite.