### PR TITLE
Display Run Settings Report. Fixes #967.

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.ConsoleRunner.Tests
         private static readonly string[] REPORT_SEQUENCE = new string[] {
             "Tests Not Run",
             "Errors and Failures",
-            "Run Settings",
+            //"Run Settings",
             "Test Run Summary"
         };
 

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -77,21 +77,25 @@ namespace NUnit.ConsoleRunner
 
         private void WriteRunSettingsReport()
         {
-            var settings = _result.SelectNodes("settings/setting");
-
-            if (settings.Count > 0)
+            var firstSuite = _result.SelectSingleNode("test-suite");
+            if (firstSuite != null)
             {
-                _writer.WriteLine(ColorStyle.SectionHeader, "Run Settings");
+                var settings = firstSuite.SelectNodes("settings/setting");
 
-                foreach (XmlNode node in settings)
+                if (settings.Count > 0)
                 {
-                    string name = node.GetAttribute("name");
-                    string val = node.GetAttribute("value");
-                    string label = string.Format("    {0}: ", name);
-                    _writer.WriteLabelLine(label, val);
-                }
+                    _writer.WriteLine(ColorStyle.SectionHeader, "Run Settings");
 
-                _writer.WriteLine();
+                    foreach (XmlNode node in settings)
+                    {
+                        string name = node.GetAttribute("name");
+                        string val = node.GetAttribute("value");
+                        string label = string.Format("    {0}: ", name);
+                        _writer.WriteLabelLine(label, val);
+                    }
+
+                    _writer.WriteLine();
+                }
             }
         }
 

--- a/src/NUnitFramework/nunitlite.runner/Portable/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Portable/TextUI.cs
@@ -155,24 +155,17 @@ namespace NUnitLite
             _writer.WriteLine();
         }
 
-        public void DisplayRequestedOptions()
+        public void DisplayRunSettings()
         {
-            _writer.WriteLine("Options");
+            WriteLine("Run Settings");
 
             if (_options.DefaultTimeout >= 0)
                 WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
 
+            if (_options.TeamCity)
+                WriteLine("    Display TeamCity Service Messages");
+
             _writer.WriteLine();
-
-            if (_options.TestList.Count > 0)
-            {
-                _writer.WriteLine("Selected test(s) -");
-                foreach (string testName in _options.TestList)
-                    _writer.WriteLine("    " + testName);
-                _writer.WriteLine();
-            }
-
-            // TODO: Add where clause here
         }
 
         public void TestFinished(ITestResult result)

--- a/src/NUnitFramework/nunitlite.runner/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite.runner/TextRunner.cs
@@ -232,6 +232,10 @@ namespace NUnitLite
                 _textUI.PrintFullReport(_result);
 #endif
 
+#if !SILVERLIGHT
+            _textUI.DisplayRunSettings();
+#endif
+
             _textUI.DisplaySummaryReport(Summary);
         }
 

--- a/src/NUnitFramework/nunitlite.runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/TextUI.cs
@@ -196,8 +196,6 @@ namespace NUnitLite
                     _outWriter.WriteLine(ColorStyle.Value, "    " + testName);
                 SkipLine();
             }
-
-            // TODO: Add where clause here
         }
 #endif
 
@@ -236,6 +234,37 @@ namespace NUnitLite
 
                 _outWriter.WriteLine();
             }
+        }
+#endif
+
+        #endregion
+
+        #region DisplayRunSettings
+
+#if !SILVERLIGHT
+        public void DisplayRunSettings()
+        {
+            WriteSectionHeader("Run Settings");
+
+            if (_options.DefaultTimeout >= 0)
+                WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
+
+#if PARALLEL
+            WriteLabelLine(
+                "    Number of Test Workers: ", 
+                _options.NumberOfTestWorkers >= 0
+                    ? _options.NumberOfTestWorkers
+                    : Math.Max(Environment.ProcessorCount, 2));
+#endif
+
+            WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? NUnit.Env.DefaultWorkDirectory);
+
+            WriteLabelLine("    Internal Trace: ", _options.InternalTraceLevel ?? "Off");
+
+            if (_options.TeamCity)
+                _outWriter.WriteLine(ColorStyle.Value, "    Display TeamCity Service Messages");
+
+            SkipLine();
         }
 #endif
 


### PR DESCRIPTION
Run settings was not working in nunit-console because of a change in the XML format. It had never been ported to nunitlite. Both are done in this PR.