### PR TITLE
Fix Run Settings display in CF. Fixes #970

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -278,12 +278,10 @@ namespace NUnit.Framework.Api
             foreach (string key in settings.Keys)
                 AddSetting(settingsNode, key, settings[key]);
 
+#if PARALLEL
             // Add default values for display
             if (!settings.Contains(PackageSettings.NumberOfTestWorkers))
-#if NETCF
-                AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, 2);
-#else
-                AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, Math.Max(Environment.ProcessorCount, 2));
+                AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 #endif
 
                 return settingsNode;

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -69,6 +69,20 @@ namespace NUnit.Framework.Api
 
         #region Properties
 
+#if PARALLEL
+        /// <summary>
+        /// Gets the default level of parallel execution (worker threads)
+        /// </summary>
+        public static int DefaultLevelOfParallelism
+        {
+#if NETCF
+            get { return 2; }
+#else
+            get { return Math.Max(Environment.ProcessorCount, 2); }
+#endif
+        }
+#endif
+
         /// <summary>
         /// The tree of tests that was loaded by the builder
         /// </summary>
@@ -365,13 +379,10 @@ namespace NUnit.Framework.Api
                 ? (int)Settings[PackageSettings.NumberOfTestWorkers]
                 : (LoadedTest.Properties.ContainsKey(PropertyNames.LevelOfParallelism)
                    ? (int)LoadedTest.Properties.Get(PropertyNames.LevelOfParallelism)
-#if NETCF
-                   : 2);
-#else
-                   : Math.Max(Environment.ProcessorCount, 2));
-#endif
+                   : NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
         }
 #endif
+
 
         #endregion
     }

--- a/src/NUnitFramework/nunitlite.runner/Portable/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/Portable/TextUI.cs
@@ -157,15 +157,18 @@ namespace NUnitLite
 
         public void DisplayRunSettings()
         {
-            WriteLine("Run Settings");
+            if (_options.DefaultTimeout >= 0 || _options.TeamCity)
+            {
+                WriteLine("Run Settings");
 
-            if (_options.DefaultTimeout >= 0)
-                WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
+                if (_options.DefaultTimeout >= 0)
+                    WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
 
-            if (_options.TeamCity)
-                WriteLine("    Display TeamCity Service Messages");
+                if (_options.TeamCity)
+                    WriteLine("    Display TeamCity Service Messages");
 
-            _writer.WriteLine();
+                _writer.WriteLine();
+            }
         }
 
         public void TestFinished(ITestResult result)

--- a/src/NUnitFramework/nunitlite.runner/TextUI.cs
+++ b/src/NUnitFramework/nunitlite.runner/TextUI.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using NUnit.Common;
+using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -250,11 +251,10 @@ namespace NUnitLite
                 WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
 
 #if PARALLEL
-            WriteLabelLine(
-                "    Number of Test Workers: ", 
-                _options.NumberOfTestWorkers >= 0
-                    ? _options.NumberOfTestWorkers
-                    : Math.Max(Environment.ProcessorCount, 2));
+            WriteLabelLine("    Number of Test Workers: ", 
+                _options.NumberOfTestWorkers >= 0 
+                    ? _options.NumberOfTestWorkers 
+                    : NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 #endif
 
             WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? NUnit.Env.DefaultWorkDirectory);

--- a/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
+++ b/src/NUnitFramework/nunitlite.runner/nunitlite.runner-netcf-3.5.csproj
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;NUNITLITE;PARALLEL</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
This takes care of the ProcessorCount issue in CF and adds PARALLEL to the build of NUnitLite for CF so that the number of worker threads is displayed.