### PR TITLE
Add version option to console and nunitlite. Fixes #978

### DIFF
--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -76,6 +76,8 @@ namespace NUnit.Common
 
         public bool ShowHelp { get; private set; }
 
+        public bool ShowVersion { get; private set; }
+
         // Select tests
 
         private List<string> inputFiles = new List<string>();
@@ -350,6 +352,9 @@ namespace NUnit.Common
 
             this.Add("help|h", "Display this message and exit.",
                 v => ShowHelp = v != null);
+
+            this.Add("version|V", "Display the header and exit.",
+                v => ShowVersion = v != null);
 
             // Default
             this.Add("<>", v =>

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -47,6 +47,7 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [TestCase("ShowHelp", "help|h")]
+        [TestCase("ShowVersion", "version")]
         [TestCase("StopOnError", "stoponerror")]
         [TestCase("WaitBeforeExit", "wait")]
         [TestCase("NoHeader", "noheader|noh")]
@@ -67,17 +68,24 @@ namespace NUnit.ConsoleRunner.Tests
 
             foreach (string option in prototypes)
             {
-                ConsoleOptions options = new ConsoleOptions("-" + option);
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
+                ConsoleOptions options;
 
-                options = new ConsoleOptions("-" + option + "+");
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "+");
+                if (option.Length == 1)
+                {
+                    options = new ConsoleOptions("-" + option);
+                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
 
-                options = new ConsoleOptions("-" + option + "-");
-                Assert.AreEqual(false, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "-");
+                    options = new ConsoleOptions("-" + option + "+");
+                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "+");
 
-                options = new ConsoleOptions("--" + option);
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
+                    options = new ConsoleOptions("-" + option + "-");
+                    Assert.AreEqual(false, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "-");
+                }
+                else
+                {
+                    options = new ConsoleOptions("--" + option);
+                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
+                }
 
                 options = new ConsoleOptions("/" + option);
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize /" + option);

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [TestCase("ShowHelp", "help|h")]
-        [TestCase("ShowVersion", "version")]
+        [TestCase("ShowVersion", "version|V")]
         [TestCase("StopOnError", "stoponerror")]
         [TestCase("WaitBeforeExit", "wait")]
         [TestCase("NoHeader", "noheader|noh")]

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -77,7 +77,7 @@ namespace NUnit.ConsoleRunner
             //log.Info("NUnit3-console.exe starting");
             try
             {
-                if (!Options.NoHeader)
+                if (Options.ShowVersion || !Options.NoHeader)
                     WriteHeader();
 
                 if (Options.ShowHelp || args.Length == 0)

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -86,6 +86,10 @@ namespace NUnit.ConsoleRunner
                     return ConsoleRunner.OK;
                 }
 
+                // We already showed version as a part of the header
+                if (Options.ShowVersion)
+                    return ConsoleRunner.OK;
+
                 if (!Options.Validate())
                 {
                     using (new ColorConsole(ColorStyle.Error))

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>nunit3-console.tests.dll</Commandlineparameters>
+    <Commandlineparameters>nunit3-console.tests.dll -Vh --noheader</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>nunit3-console.tests.dll -V</Commandlineparameters>
+    <Commandlineparameters>nunit3-console.tests.dll</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>net-4.5/mock-nunit-assembly.exe --where test=~MockTestFixture</Commandlineparameters>
+    <Commandlineparameters>nunit3-console.tests.dll -V</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-2.0.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-2.0.csproj
@@ -37,6 +37,8 @@
     <WarningLevel>4</WarningLevel>
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
+    <Externalconsole>true</Externalconsole>
+    <Commandlineparameters>-V</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\..\bin\Release\net-2.0\</OutputPath>

--- a/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.5.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-nunit-assembly-4.5.csproj
@@ -40,7 +40,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>false</Prefer32Bit>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>--test:NUnit.Tests.Assemblies.MockTestFixture</Commandlineparameters>
+    <Commandlineparameters>--test:NUnit.Tests.Assemblies.MockTestFixture -V --noheader</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>

--- a/src/NUnitFramework/nunitlite.runner/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite.runner/AutoRun.cs
@@ -86,6 +86,10 @@ namespace NUnitLite
                 return TextRunner.OK;
             }
 
+            // We already showed version as a part of the header
+            if (options.ShowVersion)
+                return TextRunner.OK;
+
             if (options.ErrorMessages.Count > 0)
             {
                 _textUI.DisplayErrors(options.ErrorMessages);

--- a/src/NUnitFramework/nunitlite.runner/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite.runner/AutoRun.cs
@@ -77,7 +77,7 @@ namespace NUnitLite
 
             var _textUI = new TextUI(outWriter, options);
 
-            if (!options.NoHeader)
+            if (options.ShowVersion || !options.NoHeader)
                 _textUI.DisplayHeader();
 
             if (options.ShowHelp)

--- a/src/NUnitFramework/nunitlite.runner/Portable/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite.runner/Portable/AutoRun.cs
@@ -43,7 +43,7 @@ namespace NUnitLite
 
             var _textUI = new TextUI(writer, reader, options);
 
-            if (!options.NoHeader)
+            if ( options.ShowVersion || !options.NoHeader)
                 _textUI.DisplayHeader();
 
             if (options.ShowHelp)
@@ -51,6 +51,10 @@ namespace NUnitLite
                 _textUI.DisplayHelp();
                 return TextRunner.OK;
             }
+
+            // We already showed version as a part of the header
+            if (options.ShowVersion)
+                return TextRunner.OK;
 
             if (options.ErrorMessages.Count > 0)
             {

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -47,6 +47,7 @@ namespace NUnitLite.Tests
         }
 
         [TestCase("ShowHelp", "help|h")]
+        [TestCase("ShowVersion", "version|V")]
         [TestCase("StopOnError", "stoponerror")]
         [TestCase("WaitBeforeExit", "wait")]
 #if !PORTABLE
@@ -64,19 +65,19 @@ namespace NUnitLite.Tests
             PropertyInfo property = GetPropertyInfo(propertyName);
             Assert.AreEqual(typeof(bool), property.PropertyType, "Property '{0}' is wrong type", propertyName);
 
+            NUnitLiteOptions options;
             foreach (string option in prototypes)
             {
-                var options = new NUnitLiteOptions("-" + option);
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
-
-                options = new NUnitLiteOptions("-" + option + "+");
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "+");
-
-                options = new NUnitLiteOptions("-" + option + "-");
-                Assert.AreEqual(false, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "-");
-
-                options = new NUnitLiteOptions("--" + option);
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
+                if (option.Length == 1)
+                {
+                    options = new NUnitLiteOptions("-" + option);
+                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
+                }
+                else
+                {
+                    options = new NUnitLiteOptions("--" + option);
+                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
+                }
 
                 options = new NUnitLiteOptions("/" + option);
                 Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize /" + option);

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests-2.0.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests-2.0.csproj
@@ -40,9 +40,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
First shot at fixing #978. I'd like @NikolayPianikov to review in addition to at least one of the committers, since he's the one who asked for it. :-)

Particular questions... 

1. Should I further change the format to move the (Debug) in front of the version so the first line reads like...
    NUnit Console Runner (Debug) 3.0.1234

2. I did the same thing with NUnitLite. NUnitLite also shows some stuff in parentheses after the version, even in release. If I move the parenthesized stuff for console, I'll do the same for NUnitLite.

3. In addition to --version | -V I can add some special, long option just for use by CI programs if it's really needed... something like --version-number perhaps.
