### PR TITLE
Issues 990 991

### DIFF
--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Mono.Options;
+using NUnit.Options;
 
 namespace NUnit.Common
 {

--- a/src/Common/nunit/Options.cs
+++ b/src/Common/nunit/Options.cs
@@ -124,7 +124,10 @@
 //
 // The NUnit version of this file introduces conditional compilation for 
 // building under the Compact Framework (NETCF) and Silverlight (SILVERLIGHT) 
-// as well as for use with a portable class library  (PORTABLE). 
+// as well as for use with a portable class library  (PORTABLE).
+//
+// 11/5/2015 -
+// Change namespace to avoid conflict with user code use of mono.options 
 
 using System;
 using System.Collections;
@@ -152,7 +155,9 @@ using System.Linq;
 using NDesk.Options;
 #endif
 
-#if NDESK_OPTIONS
+#if NUNIT_CONSOLE || NUNITLITE
+namespace NUnit.Options
+#elif NDESK_OPTIONS
 namespace NDesk.Options
 #else
 namespace Mono.Options

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -21,16 +21,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.IO;
 using System.Reflection;
-using System.Text;
 using NUnit.Common;
+using NUnit.Options;
 
 namespace NUnit.ConsoleRunner.Tests
 {
     using System.Collections.Generic;
-    using Engine;
     using Framework;
 
     [TestFixture]
@@ -272,7 +269,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void TimeoutThrowsExceptionIfOptionHasNoValue()
         {
-            Assert.Throws<Mono.Options.OptionException>(() => new ConsoleOptions("tests.dll", "-timeout"));
+            Assert.Throws<OptionException>(() => new ConsoleOptions("tests.dll", "-timeout"));
         }
 
         [Test]

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Mono.Options;
 
 namespace NUnit.Common
 {

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -24,8 +24,8 @@
 using System;
 using System.IO;
 using System.Reflection;
-using Mono.Options;
 using NUnit.Common;
+using NUnit.Options;
 using NUnit.Engine;
 
 namespace NUnit.ConsoleRunner

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -24,9 +24,9 @@
 #if !SILVERLIGHT
 using System;
 using System.Reflection;
-using System.Text;
 using System.Globalization;
 using NUnit.Common;
+using NUnit.Options;
 using NUnit.Framework;
 
 namespace NUnitLite.Tests
@@ -259,7 +259,7 @@ namespace NUnitLite.Tests
         [Test]
         public void TimeoutThrowsExceptionIfOptionHasNoValue()
         {
-            Assert.Throws<Mono.Options.OptionException>(() => new NUnitLiteOptions("tests.dll", "-timeout"));
+            Assert.Throws<OptionException>(() => new NUnitLiteOptions("tests.dll", "-timeout"));
         }
 
         [Test]


### PR DESCRIPTION
I did two in one PR here, since they are both small and critical to RC2. Not something we want to do generally, of course.

This fixes #990 by having the v2 driver identify known V3 filter elements that are not supported by V2 and give a special message for them using NUnitEngineException, which eliminates the stack trace display. I also discovered and fixed a problem with the test filter, which was expecting an older format.

It also fixes #991, by changing the Mono.Options namespace to NUnit.Options.