### PR TITLE
Give error message when a regex filter is used with NUnit V2

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/NUnit2FrameworkDriver.cs
@@ -187,9 +187,13 @@ namespace NUnit.Engine.Drivers
                     return new Core.Filters.NotFilter(FromXml(xmlNode.FirstChild));
 
                 case "test":
+                    if (xmlNode.Attributes["re"] != null)
+                        throw new NUnitEngineException("Filters with regular expressions are only supported when running NUnit 3 tests");
                     return new Core.Filters.SimpleNameFilter(xmlNode.InnerText);
 
                 case "cat":
+                    if (xmlNode.Attributes["re"] != null)
+                        throw new NUnitEngineException("Filters with regular expressions are only supported when running NUnit 3 tests");
                     var catFilter = new Core.Filters.CategoryFilter();
                     foreach (string cat in xmlNode.InnerText.Split(COMMA))
                         catFilter.AddCategory(cat);


### PR DESCRIPTION
This is something I just noticed when documenting the change made for #990.

When a regular expression is used, as in
   test =~ MyFixture
the driver was translating it to a V2 SimpleTestFixture, which only compares for equality.

So we now have another error message saying you can't use regular expressions to filter V2 tests.