### PR TITLE
Return -100 if any test assemblies crash unexpectedly

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -190,6 +190,9 @@ namespace NUnit.ConsoleRunner
                 _outWriter.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
             }
 
+            if (reporter.Summary.UnexpectedError)
+                return ConsoleRunner.UNEXPECTED_ERROR;
+
             return reporter.Summary.InvalidAssemblies > 0
                     ? ConsoleRunner.INVALID_ASSEMBLY
                     : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -120,6 +120,11 @@ namespace NUnit.ConsoleRunner
         /// </summary>
         public int InvalidAssemblies { get; private set; }
 
+        /// <summary>
+        /// An Unexpected error occurred
+        /// </summary>
+        public bool UnexpectedError { get; private set; }
+
         #endregion
 
         #region Helper Methods
@@ -182,6 +187,11 @@ namespace NUnit.ConsoleRunner
                 case "test-suite":
                     if (type == "Assembly" && status == "Failed" && label == "Invalid")
                         InvalidAssemblies++;
+                    else if (type == "Assembly" && status == "UnexpectedError")
+                    {
+                        InvalidAssemblies++;
+                        UnexpectedError = true;
+                    }
 
                     Summarize(node.ChildNodes);
                     break;

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -187,7 +187,7 @@ namespace NUnit.ConsoleRunner
                 case "test-suite":
                     if (type == "Assembly" && status == "Failed" && label == "Invalid")
                         InvalidAssemblies++;
-                    else if (type == "Assembly" && status == "UnexpectedError")
+                    if (type == "Assembly" && status == "Failed" && label == "Error")
                     {
                         InvalidAssemblies++;
                         UnexpectedError = true;

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -232,7 +232,7 @@ namespace NUnit.Engine.Runners
             XmlHelper.AddAttribute(suite, "fullname", TestPackage.FullName);
             XmlHelper.AddAttribute(suite, "runstate", "NotRunnable");
             XmlHelper.AddAttribute(suite, "testcasecount", "1");
-            XmlHelper.AddAttribute(suite, "result", "Failed");
+            XmlHelper.AddAttribute(suite, "result", "UnexpectedError");
             XmlHelper.AddAttribute(suite, "label", "Error");
             XmlHelper.AddAttribute(suite, "start-time", DateTime.UtcNow.ToString("u"));
             XmlHelper.AddAttribute(suite, "end-time", DateTime.UtcNow.ToString("u"));

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -232,7 +232,7 @@ namespace NUnit.Engine.Runners
             XmlHelper.AddAttribute(suite, "fullname", TestPackage.FullName);
             XmlHelper.AddAttribute(suite, "runstate", "NotRunnable");
             XmlHelper.AddAttribute(suite, "testcasecount", "1");
-            XmlHelper.AddAttribute(suite, "result", "UnexpectedError");
+            XmlHelper.AddAttribute(suite, "result", "Failed");
             XmlHelper.AddAttribute(suite, "label", "Error");
             XmlHelper.AddAttribute(suite, "start-time", DateTime.UtcNow.ToString("u"));
             XmlHelper.AddAttribute(suite, "end-time", DateTime.UtcNow.ToString("u"));


### PR DESCRIPTION
Fixes #983

If any test run crashes unexpectedly in an external runner, returns -100