### PR TITLE
Don't run portable tests from NUnit Console

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -33,8 +33,6 @@ using System.Reflection;
 
 #if PORTABLE
 [assembly: AssemblyMetadata("PCL", "True")]
-#else
-[assembly: AssemblyMetadata("PCL", "False")]
 #endif
 
 #if DEBUG

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -31,6 +31,12 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright (C) 2015 Charlie Poole")]
 [assembly: AssemblyTrademark("NUnit is a trademark of NUnit Software")]
 
+#if PORTABLE
+[assembly: AssemblyMetadata("PCL", "True")]
+#else
+[assembly: AssemblyMetadata("PCL", "False")]
+#endif
+
 #if DEBUG
 #if NET_4_5
 [assembly: AssemblyConfiguration(".NET 4.5 Debug")]

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Collections.Generic;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Extensibility;
+using System.Runtime.Serialization;
 
 namespace NUnit.Engine.Drivers
 {
@@ -73,7 +74,14 @@ namespace NUnit.Engine.Drivers
 
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
             _testAssemblyPath = testAssemblyPath;
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, (System.Collections.IDictionary)settings);
+            try
+            {
+                _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, (System.Collections.IDictionary)settings);
+            }
+            catch (SerializationException ex)
+            {
+                throw new NUnitEngineException("The NUnit 3.0 driver does not support the portable version of NUnit. Use a platform specific runner.", ex);
+            }
 
             CallbackHandler handler = new CallbackHandler();
 

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>CommonAssemblyInfo.cs</Link>
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
@@ -77,7 +77,7 @@
       <Link>Api\PackageSettings.cs</Link>
     </Compile>
     <Compile Include="..\FrameworkVersion.cs">
-      <Link>FrameworkVersion.cs</Link>
+      <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />


### PR DESCRIPTION
Fixes #988

I went with your suggestion @CharliePoole and catch the serialization error. If we add a driver that supports portable, we can remove it then. It is a bit hacky, but it does give a very clear error message that should prevent bugs being erroneously reported.

I also put in the AssemblyMetaData attribute on portable. It isn't used now, but my thinking is that it is how we will mark the assembly as portable so when/if we do add the ability to run portable to the engine or any of our other runners, they will be able to find this right back to the initial 3.0 release.

Feel free to merge this into master. I will merge into the release branch.