### PR TITLE
Issue 1015

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
@@ -100,6 +100,22 @@ namespace NUnit.Engine
             // Check the Application BaseDirectory
             string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, DefaultAssemblyName);
             Assembly newestAssemblyFound = CheckPathForEngine(path, minVersion, ref newestVersionFound, null);
+
+            // Check Probing Path is not found in Base Directory. This
+            // allows the console or other runner to be executed with
+            // a different application base and still function. In
+            // particular, we do this in some tests of NUnit.
+            if (newestAssemblyFound == null)
+            {
+                foreach (string relpath in AppDomain.CurrentDomain.RelativeSearchPath.Split(new char[] { ';' }))
+                {
+                    path = Path.Combine(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, relpath), DefaultAssemblyName);
+                    newestAssemblyFound = CheckPathForEngine(path, minVersion, ref newestVersionFound, null);
+                    if (newestAssemblyFound != null)
+                        break;
+                }
+            }
+
             if (!privateCopy)
             {
                 // Check the install for the current user, 32 bit process

--- a/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
@@ -105,7 +105,7 @@ namespace NUnit.Engine
             // allows the console or other runner to be executed with
             // a different application base and still function. In
             // particular, we do this in some tests of NUnit.
-            if (newestAssemblyFound == null)
+            if (newestAssemblyFound == null && AppDomain.CurrentDomain.RelativeSearchPath != null)
             {
                 foreach (string relpath in AppDomain.CurrentDomain.RelativeSearchPath.Split(new char[] { ';' }))
                 {

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -83,7 +83,11 @@ namespace NUnit.Engine.Services.Tests
                 Path.GetFileName(setup.ConfigurationFile),
                 Is.EqualTo("mock-nunit-assembly.exe.config").IgnoreCase,
                 "ConfigurationFile");
+#if DEBUG
             Assert.That(setup.PrivateBinPath, Is.SamePath(@"bin\Debug"), "PrivateBinPath");
+#else
+            Assert.That(setup.PrivateBinPath, Is.SamePath(@"bin\Release"), "PrivateBinPath");
+#endif
             Assert.That(setup.ShadowCopyFiles, Is.Null.Or.EqualTo("false"));
         }
 

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -141,6 +141,7 @@ namespace NUnit.Engine.Internal
 
             string aggregateResult = "Inconclusive";
             string aggregateLabel = null;
+            string aggregateSite = null;
 
             //double totalDuration = 0.0d;
             int testcasecount = 0;
@@ -180,6 +181,8 @@ namespace NUnit.Engine.Internal
                         case "Failed":
                             aggregateResult = "Failed";
                             aggregateLabel = label;
+                            if (elementName == "test-suite")
+                                aggregateSite = "Child";
                             break;
                     }
 
@@ -202,6 +205,8 @@ namespace NUnit.Engine.Internal
                 combinedNode.AddAttribute("result", aggregateResult);
                 if (aggregateLabel != null)
                     combinedNode.AddAttribute("label", aggregateLabel);
+                if (aggregateSite != null)
+                    combinedNode.AddAttribute("site", aggregateSite);
 
                 //combinedNode.AddAttribute("duration", totalDuration.ToString("0.000000", NumberFormatInfo.InvariantInfo));
                 combinedNode.AddAttribute("total", total.ToString());

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -78,6 +78,16 @@ namespace NUnit.Engine.Services
 
             foreach (var subPackage in tempPackage.SubPackages)
                 package.AddSubPackage(subPackage);
+
+            // If no config is specified (by user or by the proejct loader) check
+            // to see if one exists in same directory as the package. If so, we
+            // use it. If not, each assembly will use it's own config, if present.
+            if (!package.Settings.ContainsKey(PackageSettings.ConfigurationFile))
+            {
+                var packageConfig = Path.ChangeExtension(path, ".config");
+                if (File.Exists(packageConfig))
+                    package.Settings[PackageSettings.ConfigurationFile] = packageConfig;
+            }
         }
 
         #endregion


### PR DESCRIPTION
This fixes #1015. It's a bigger change than I really like to do between two RCs but it's an important issue.

I reworked the order of setting up the domain to make it easier to test and added some tests.

I also implemented a basic policy change as compared to NUnit V2: when running a project file named project.nunit (or any other project type) the config file project.nunit is only set up for the AppDomain if it exists, otherwise, we use the individual assembly configs.

This is not exactly a "breaking change" - it actually fixes something that was broken before - but it is a change in behavior.

Note that when multiple assemblies are made to run in the same AppDomain, there is no way for NUnit to give them separate config files.