### PR TITLE
Remove Assert.Multiple. Fixes #1017

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -262,15 +262,15 @@ namespace NUnit.Framework
 
         #region Multiple
 
-        /// <summary>
-        /// If an assert fails within this block, execution will continue and 
-        /// the errors will be reported at the end of the block.
-        /// </summary>
-        /// <param name="del">The test delegate</param>
-        public static void Multiple(TestDelegate del)
-        {
-            del();
-        }
+        ///// <summary>
+        ///// If an assert fails within this block, execution will continue and 
+        ///// the errors will be reported at the end of the block.
+        ///// </summary>
+        ///// <param name="del">The test delegate</param>
+        //public static void Multiple(TestDelegate del)
+        //{
+        //    del();
+        //}
 
         #endregion
     }


### PR DESCRIPTION
This is a stub method that does nothing but is showing up in Intellisense. We'll put it back when we do #391.