### PR TITLE
Check null arguments

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -193,6 +193,10 @@ namespace NUnit.Engine.Drivers
         // Adds a property element and its contents
         private static void AddProperty(this XmlNode parent, string key, object val)
         {
+            if (parent == null)
+                throw new ArgumentNullException("parent");
+            if (val == null)
+                throw new ArgumentNullException("val");
             var node = parent.AddElement("property");
             node.AddAttribute("name", key);
             node.AddAttribute("value", val.ToString());


### PR DESCRIPTION
I'm getting a NullReferenceException in this AddProperty method while running tests with `nunit3-console`. Not sure where it's coming from (I'm using [NUnit.Specifications](https://github.com/derekgreer/nunit.specifications) so it might be related to that) but at least with explicit null checks we can have a better chance to figure out what exactly is wrong. 

The stack trace is:

```
Object reference not set to an instance of an object.

Server stack trace: 
   at NUnit.Engine.Drivers.XmlExtensions.AddProperty(XmlNode parent, String key, Object val)
   at NUnit.Engine.Drivers.XmlExtensions.AddProperties(XmlNode parent, ITest test)
   at NUnit.Engine.Drivers.XmlExtensions.AddTest(XmlNode parent, ITest test, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.AddResult(XmlNode parent, TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.XmlExtensions.ToXml(TestResult result, Boolean recursive)
   at NUnit.Engine.Drivers.NUnit2FrameworkDriver.Run(ITestEventListener listener, String filter)
   at NUnit.Engine.Runners.DirectTestRunner.RunTests(ITestEventListener listener, TestFilter filter)
   at System.Runtime.Remoting.Messaging.StackBuilderSink._PrivateProcessMessage(IntPtr md, Object[] args, Object server, Object[]& outArgs)
   at System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at NUnit.Engine.ITestEngineRunner.Run(ITestEventListener listener, TestFilter filter)
   at NUnit.Engine.Runners.ProcessRunner.RunTests(ITestEventListener listener, TestFilter filter)
```