### PR TITLE
Do not expose System.Runtime.CompilerServices.ExtensionAttribute to public

### DIFF
--- a/src/Common/nunit/XmlHelper.cs
+++ b/src/Common/nunit/XmlHelper.cs
@@ -30,7 +30,7 @@ using System.Xml;
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-    public sealed class ExtensionAttribute : Attribute { }
+    sealed class ExtensionAttribute : Attribute { }
 }
 #endif
 

--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -31,7 +31,7 @@ using NUnit.Core;
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-    public sealed class ExtensionAttribute : Attribute { }
+    sealed class ExtensionAttribute : Attribute { }
 }
 
 namespace NUnit.Engine.Drivers

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.CompilerServices
     /// Enables compiling extension methods in .NET 2.0
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-    public sealed class ExtensionAttribute : Attribute { }
+    sealed class ExtensionAttribute : Attribute { }
 }
 #endif
 


### PR DESCRIPTION
Do not expose `System.Runtime.CompilerServices.ExtensionAttribute` to public.
It is only used internally for convenience of coding.
If the user already references `System.Core`, a compiler warning will be generated about duplicate attribute defined.