### PR TITLE
Create nuget feeds for CI builds on Appveyor

### DIFF
--- a/NUnit.proj
+++ b/NUnit.proj
@@ -7,9 +7,9 @@
   <PropertyGroup Label="Common Properties">
     <ProjectName>$(MSBuildProjectName)</ProjectName>
     
-    <PackageVersion Condition="'$(PackageVersion)' == ''">3.0.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">3.1.0</PackageVersion>
     <PackageModifier Condition="'$(PackageModifier)' == ''"></PackageModifier>
-    <DisplayVersion Condition="'$(DisplayVersion)' == ''">3.0</DisplayVersion>
+    <DisplayVersion Condition="'$(DisplayVersion)' == ''">3.1</DisplayVersion>
     
     <PackageName>$(ProjectName)-$(PackageVersion)$(PackageModifier)</PackageName>
     <PackageNameCF>$(ProjectName)CF-$(PackageVersion)$(PackageModifier)</PackageNameCF>

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,5 +1,5 @@
-# the version under development, update after a release
-$version = '3.0.0'
+# the default version under development, update after a release
+$version = '3.1.0'
 $modifier = '-ci'
 
 function isVersion($s){
@@ -9,7 +9,11 @@ function isVersion($s){
 
 # append the AppVeyor build number as the pre-release version
 if ($env:appveyor){
-    $modifier = $modifier + '-' + [int]::Parse($env:appveyor_build_number).ToString('000')
+	# force build number to four digits for correct ordering
+	$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
+    $modifier = "-" + $build_number + $modifier;
+
+	# if there is a tag, it provides both version and modifier
     if ($env:appveyor_repo_tag -eq 'true'){
         $tag = $env:appveyor_repo_tag_name
         $i = $tag.IndexOf('-')
@@ -22,6 +26,7 @@ if ($env:appveyor){
             $modifier = ''
         }
     }
+
     if(-not(isVersion($version)))
     {
         Write-Error "error parsing version '$version' in tag '$tag'"
@@ -32,4 +37,5 @@ if ($env:appveyor){
 
 ./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
 ./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
-./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:PackageNuget /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:PackageNugetNUnitSL /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -26,17 +26,9 @@ if ($env:appveyor){
 		$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
 		$modifier = $modifier + '-' + $build_number;
 
-		# add branch if not master
-		$branch = $env:appveyor_repo_branch;
-		if($branch -ne 'master')
+		if($env:appveyor_pull_request_number -ne '')
 		{
-			$modifier = $modifier + '-' + $branch;
-		}
-
-		$pr_number = $env:appveyor_pull_request_number;
-		if($pr_number -ne '')
-		{
-			$modifier = $modifier + '-pr' + $pr_number;
+			$modifier = $modifier + '-pr';
 		}
 	}
 

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -26,7 +26,7 @@ if ($env:appveyor){
 		$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
 		$modifier = $modifier + '-' + $build_number;
 
-		if($env:appveyor_pull_request_number -ne '')
+		if($env:appveyor_pull_request_number)
 		{
 			$modifier = $modifier + '-pr';
 		}

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -37,5 +37,4 @@ if ($env:appveyor){
 
 ./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
 ./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
-./build.cmd NUnit.proj /t:PackageNuget /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
-./build.cmd NUnit.proj /t:PackageNugetNUnitSL /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -9,10 +9,6 @@ function isVersion($s){
 
 # append the AppVeyor build number as the pre-release version
 if ($env:appveyor){
-	# force build number to four digits for correct ordering
-	$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
-    $modifier = $modifier + '-' + $build_number;
-
 	# if there is a tag, it provides both version and modifier
     if ($env:appveyor_repo_tag -eq 'true'){
         $tag = $env:appveyor_repo_tag_name
@@ -25,7 +21,24 @@ if ($env:appveyor){
             $version = $tag
             $modifier = ''
         }
-    }
+    } else {
+		# force build number to four digits for correct ordering
+		$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
+		$modifier = $modifier + '-' + $build_number;
+
+		# add branch if not master
+		$branch = $env:appveyor_repo_branch;
+		if($branch -ne 'master')
+		{
+			$modifier = $modifier + '-' + $branch;
+		}
+
+		$pr_number = $env:appveyor_pull_request_number;
+		if($pr_number -ne '')
+		{
+			$modifier = $modifier + '-pr' + $pr_number;
+		}
+	}
 
     if(-not(isVersion($version)))
     {

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -37,4 +37,4 @@ if ($env:appveyor){
 
 ./build.cmd NUnit.proj /t:BuildAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
 ./build.cmd NUnit.proj /t:TestAll /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
-./build.cmd NUnit.proj /t:Package /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m
+./build.cmd NUnit.proj /t:"Package;PackageSL" /p:Configuration=Release /p:PackageVersion="$version" /p:PackageModifier="$modifier" /v:m

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,6 +1,6 @@
 # the version under development, update after a release
 $version = '3.0.0'
-$modifier = '-beta-6'
+$modifier = '-ci'
 
 function isVersion($s){
     $v = New-Object Version

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -11,7 +11,7 @@ function isVersion($s){
 if ($env:appveyor){
 	# force build number to four digits for correct ordering
 	$build_number = [int]::Parse($env:appveyor_build_number).ToString('0000');
-    $modifier = "-" + $build_number + $modifier;
+    $modifier = $modifier + '-' + $build_number;
 
 	# if there is a tag, it provides both version and modifier
     if ($env:appveyor_repo_tag -eq 'true'){

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
   
 artifacts:
 - path: package\*.nupkg
-- path: package\*.msi
+#  - path: package\*.msi
 
 # AppVeyor defaults to just its build number
 version: '{build}'

--- a/nunit.sln
+++ b/nunit.sln
@@ -46,6 +46,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.travis.yml = .travis.yml
+		appveyor.ps1 = appveyor.ps1
+		appveyor.yml = appveyor.yml
 		BUILDING.txt = BUILDING.txt
 		CHANGES.txt = CHANGES.txt
 		CONTRIBUTORS.md = CONTRIBUTORS.md

--- a/src/NUnitConsole/ConsoleVersion.cs
+++ b/src/NUnitConsole/ConsoleVersion.cs
@@ -26,4 +26,4 @@ using System.Reflection;
 //
 // Current version for the NUnit Console
 //
-[assembly: AssemblyVersion("3.0.*")]
+[assembly: AssemblyVersion("3.1.*")]

--- a/src/NUnitEngine/EngineVersion.cs
+++ b/src/NUnitEngine/EngineVersion.cs
@@ -27,4 +27,4 @@ using System.Reflection;
 // Versioning for the NUnit Engine assemblies, with the exception
 // of nunit.engine.api, which uses a separate version file.
 //
-[assembly: AssemblyVersion("3.0.*")]
+[assembly: AssemblyVersion("3.1.*")]

--- a/src/NUnitFramework/FrameworkVersion.cs
+++ b/src/NUnitFramework/FrameworkVersion.cs
@@ -26,4 +26,4 @@ using System.Reflection;
 //
 // Current version for the NUnit Framework
 //
-[assembly: AssemblyVersion("3.0.*")]
+[assembly: AssemblyVersion("3.1.*")]


### PR DESCRIPTION
I have taken @ctaggart 's PR #932, rebased it on top of the current master and published it to this PR so I can make a few changes.

Even though we want to use something like Cake for our build script, this powershell script can provide an interim solution. The important thing is that we establish a solid naming convention for our builds, which we can continue to use, and that we make sure we are only publishing the artifacts for those builds where we really want them.
