### PR TITLE
Display output from OneTimeSetUp and OneTimeTearDown. Fixes #1062

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ConsoleOutputTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleOutputTests.cs
@@ -1,0 +1,75 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.ConsoleRunner.Tests
+{
+    [TestFixture, Explicit]
+    public class ConsoleOutputTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Console.WriteLine("OneTimeSetUp: Console.WriteLine()");
+            Console.Error.WriteLine("OneTimeSetUp: Console.Error.WriteLine()");
+            TestContext.WriteLine("OneTimeSetUp: TestContext.WriteLine()");
+
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Console.WriteLine("SetUp: Console.WriteLine()");
+            Console.Error.WriteLine("SetUp: Console.Error.WriteLine()");
+            TestContext.WriteLine("SetUp: TestContext.WriteLine()");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Console.WriteLine("TearDown: Console.WriteLine()");
+            Console.Error.WriteLine("TearDown: Console.Error.WriteLine()");
+            TestContext.WriteLine("TearDown: TestContext.WriteLine()");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Console.WriteLine("OneTimeTearDown: Console.WriteLine()");
+            Console.Error.WriteLine("OneTimeTearDown: Console.Error.WriteLine()");
+            TestContext.WriteLine("OneTimeTearDown: TestContext.WriteLine()");
+        }
+
+        [Test]
+        public void Test()
+        {
+            Console.WriteLine("Test: Console.WriteLine()");
+            Console.Error.WriteLine("Test: Console.Error.WriteLine()");
+            TestContext.WriteLine("Test: TestContext.WriteLine()");
+        }
+    }
+}

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ColorConsoleTests.cs" />
     <Compile Include="ColorStyleTests.cs" />
     <Compile Include="CommandLineTests.cs" />
+    <Compile Include="ConsoleOutputTests.cs" />
     <Compile Include="MakeTestPackageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultReporterTests.cs" />

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -63,6 +63,10 @@ namespace NUnit.ConsoleRunner
                 case "test-case":
                     TestFinished(testEvent);
                     break;
+
+                case "test-suite":
+                    SuiteFinished(testEvent);
+                    break;
             }
 
             if (_teamCity != null)
@@ -89,7 +93,21 @@ namespace NUnit.ConsoleRunner
                     WriteTestLabel(testName);
 
                 WriteTestOutput(outputNode);
-            }            
+            }
+        }
+
+        private void SuiteFinished(XmlNode testResult)
+        {
+            var suiteName = testResult.Attributes["fullname"].Value;
+            var outputNode = testResult.SelectSingleNode("output");
+
+            if (outputNode != null)
+            {
+                if (_displayLabels == "ON" || _displayLabels == "ALL")
+                    WriteTestLabel(suiteName);
+
+                WriteTestOutput(outputNode);
+            }
         }
 
         private void WriteTestLabel(string name)


### PR DESCRIPTION
This fix displays the output from OneTimeSetUp and OneTimeTearDown. The order of display is a bit messy, since it doesn't come until the suite is finished. We may want to change this in a future version, but it will require handling OneTimeSetUp and OneTimeTearDown as separate commands, which is a fairly significant change.