### PR TITLE
Allow Theories to combine Datapoints and attribute data. Fixes #1033.

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
@@ -39,6 +39,6 @@ namespace NUnit.Framework
         /// <summary>
         /// Default constructor
         /// </summary>
-        public CombinatorialAttribute() : base(new CombinatorialStrategy()) { }
+        public CombinatorialAttribute() : base(new CombinatorialStrategy(), new ParameterDataSourceProvider()) { }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -43,28 +43,31 @@ namespace NUnit.Framework
     public abstract class CombiningStrategyAttribute : NUnitAttribute, ITestBuilder, IApplyToTest
     {
         private NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
-        private IParameterDataProvider _dataProvider = new ParameterDataProvider();
 
         private ICombiningStrategy _strategy;
+        private IParameterDataProvider _dataProvider;
 
         /// <summary>
-        /// Construct a CombiningStrategyAttribute incorporating an object
-        /// that implements ICombiningStrategy.
+        /// Construct a CombiningStrategyAttribute incorporating an
+        /// ICombiningStrategy and an IParamterDataProvider.
         /// </summary>
-        /// <param name="strategy">Combining strategy to be used</param>
-        protected CombiningStrategyAttribute(ICombiningStrategy strategy)
+        /// <param name="strategy">Combining strategy to be used in combining data</param>
+        /// <param name="provider">An IParameterDataProvider to supply data</param>
+        protected CombiningStrategyAttribute(ICombiningStrategy strategy, IParameterDataProvider provider)
         {
             _strategy = strategy;
+            _dataProvider = provider;
         }
 
         /// <summary>
         /// Construct a CombiningStrategyAttribute incorporating an object
-        /// that implements ICombiningStrategy. This constructor is provided
-        /// for CLS compliance.
+        /// that implements ICombiningStrategy and an IParameterDataProvider.
+        /// This constructor is provided for CLS compliance.
         /// </summary>
-        /// <param name="strategy">Combining strategy to be used</param>
-        protected CombiningStrategyAttribute(object strategy)
-            : this((ICombiningStrategy)strategy)
+        /// <param name="strategy">Combining strategy to be used in combining data</param>
+        /// <param name="provider">An IParameterDataProvider to supply data</param>
+        protected CombiningStrategyAttribute(object strategy, IParameterDataProvider provider)
+            : this((ICombiningStrategy)strategy, provider)
         {
         }
 

--- a/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
@@ -39,6 +39,6 @@ namespace NUnit.Framework
         /// <summary>
         /// Default constructor
         /// </summary>
-        public PairwiseAttribute() : base(new PairwiseStrategy()) { }
+        public PairwiseAttribute() : base(new PairwiseStrategy(), new ParameterDataSourceProvider()) { }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
@@ -39,6 +39,6 @@ namespace NUnit.Framework
         /// <summary>
         /// Default constructor
         /// </summary>
-        public SequentialAttribute() : base(new SequentialStrategy()) { }
+        public SequentialAttribute() : base(new SequentialStrategy(), new ParameterDataSourceProvider()) { }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TheoryAttribute.cs
@@ -21,9 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
@@ -52,39 +49,15 @@ namespace NUnit.Framework
     /// </example>
     /// 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=true)]
-    public class TheoryAttribute : NUnitAttribute, ITestBuilder, IImplyFixture
+    public class TheoryAttribute : CombiningStrategyAttribute, ITestBuilder, IImplyFixture
     {
-        private NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
-        private IParameterDataProvider _dataProvider = new DatapointProvider();
-
-        #region ITestBuilder Members
-
         /// <summary>
-        /// Construct one or more TestMethods from a given MethodInfo,
-        /// using available parameter data.
+        /// Construct the attribute, specifying a combining strategy and source of parameter data.
         /// </summary>
-        /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
-        /// <param name="suite">The suite to which the tests will be added.</param>
-        /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Internal.Test suite)
+        public TheoryAttribute() : base(
+            new CombinatorialStrategy(),
+            new ParameterDataProvider(new DatapointProvider(), new ParameterDataSourceProvider()))
         {
-            IParameterInfo[] parameters = method.GetParameters();
-
-            List<TestMethod> tests = new List<TestMethod>();
-
-            if (parameters.Length > 0)
-            {
-                IEnumerable[] sources = new IEnumerable[parameters.Length];
-                for (int i = 0; i < parameters.Length; i++)
-                    sources[i] = _dataProvider.GetDataFor(parameters[i]);
-
-                foreach (var parms in new CombinatorialStrategy().GetTestCases(sources))
-                    tests.Add(_builder.BuildTestMethod(method, suite, (TestCaseParameters)parms));
-            }
-
-            return tests;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
+    <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
@@ -369,7 +370,7 @@
     <Compile Include="Internal\Builders\DefaultTestCaseBuilder.cs" />
     <Compile Include="Internal\Builders\NUnitTestFixtureBuilder.cs" />
     <Compile Include="Internal\Builders\PairwiseStrategy.cs" />
-    <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Builders\ParameterDataSourceProvider.cs" />
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\Commands\CommandStage.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Internal\Builders\DefaultSuiteBuilder.cs" />
     <Compile Include="Internal\Builders\PairwiseStrategy.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Builders\ParameterDataSourceProvider.cs" />
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\Commands\ApplyChangesToContextCommand.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -318,6 +318,7 @@
     <Compile Include="Internal\Builders\NUnitTestFixtureBuilder.cs" />
     <Compile Include="Internal\Builders\PairwiseStrategy.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Builders\ParameterDataSourceProvider.cs" />
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\AsyncInvocationRegion.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Internal\Builders\NUnitTestFixtureBuilder.cs" />
     <Compile Include="Internal\Builders\PairwiseStrategy.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Builders\ParameterDataSourceProvider.cs" />
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\Commands\ApplyChangesToContextCommand.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -334,6 +334,7 @@
     <Compile Include="Internal\Builders\NUnitTestFixtureBuilder.cs" />
     <Compile Include="Internal\Builders\PairwiseStrategy.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Builders\ParameterDataSourceProvider.cs" />
     <Compile Include="Internal\Builders\ProviderCache.cs" />
     <Compile Include="Internal\Builders\SequentialStrategy.cs" />
     <Compile Include="Internal\Commands\ApplyChangesToContextCommand.cs" />

--- a/src/NUnitFramework/testdata/TheoryFixture.cs
+++ b/src/NUnitFramework/testdata/TheoryFixture.cs
@@ -69,6 +69,20 @@ namespace NUnit.TestData.TheoryFixture
         }
 
         [Theory]
+        public void TestWithBothDatapointAndAttributeData(
+            int i,
+            [Values(0, 5)]decimal d)
+        {
+        }
+
+        [Theory]
+        public void TestWithAllDataSuppliedByAttributes(
+            [Values(1.0, 2.0)]double d1,
+            [Values(3.0, 4.0)]double d2)
+        {
+        }
+
+        [Theory]
         public void TestWithAllBadValues(
             [Values(-12.0, -4.0, -9.0)] double d)
         {

--- a/src/NUnitFramework/tests/Attributes/TheoryTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TheoryTests.cs
@@ -63,6 +63,14 @@ namespace NUnit.Framework.Attributes
             Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
 
+        [Test]
+        public void DatapointAndAttributeDataMayBeCombined()
+        {
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithBothDatapointAndAttributeData");
+            TestAssert.IsRunnable(test);
+            Assert.That(test.TestCaseCount, Is.EqualTo(6));
+        }
+
         [Datapoint]
         object nullObj = null;
 
@@ -80,6 +88,18 @@ namespace NUnit.Framework.Attributes
             Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithEnumAsArgument");
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(16));
+        }
+
+        [Test]
+        public void AllValuesMayBeSuppliedByAttributes()
+        {       
+            // NOTE: This test was failing with a count of 8 because both
+            // TheoryAttribute and CombinatorialAttribute were adding cases.
+            // Solution is to make TheoryAttribute a CombiningAttribute so
+            // that no extra attribute is added to the method.
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithAllDataSuppliedByAttributes");
+            TestAssert.IsRunnable(test);
+            Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
 
         [Theory]

--- a/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestBuilder.cs
@@ -55,7 +55,9 @@ namespace NUnit.TestUtilities
 
         public static TestSuite MakeParameterizedMethodSuite(Type type, string methodName)
         {
-            return (TestSuite)MakeTestFromMethod(type, methodName);
+            var suite = MakeTestFromMethod(type, methodName) as TestSuite;
+            Assert.NotNull(suite, "Unable to create parameterized suite - most likely there is no data provided");
+            return suite;
         }
 
         public static TestSuite MakeParameterizedMethodSuite(object fixture, string methodName)


### PR DESCRIPTION
This bug pointed to a design deficiency. TheoryAttribute was only looking at data from Datapoints, while CombinatorialAttribute was looking at attribute data.

* Renamed ParameterDataProvider to ParameterDataSourceProvider, since it gets data only from attributes implementing IParameterDataSource
* Created a new ParameterDataProvider to hold a list of IParameterDataProviders
* Modified CombiningStrategyAttribute so that the derived class provides the data source as well as the combining strategy.
* Changed TheoryAttribute to a CombiningStrategyAttribute

TheoryAttribute now draws on both data providers, while CombinatorialAttribute uses only one.

Future attributes can be defined, which supply both the CombiningStrategy and the data provider independently.

As a side-effect, another bug was discovered and removed: When a Theory gets data for all it's arguments from attributes like Values or Random, the test cases were generated twice, once for the theory and once for the invisible CombinatorialAttribute generated by NUnit. Now that TheoryAttribute is a CombiningStrategyAttribute, this no longer happens.