### PR TITLE
Fix misbehaviour of Throws.Exception with non-void returning functions

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -109,9 +109,9 @@ namespace NUnit.Framework.Constraints
 #if NET_4_0 || NET_4_5 || PORTABLE
             if (AsyncInvocationRegion.IsAsyncOperation(del))
                 using (var region = AsyncInvocationRegion.Create(del))
-                    return ApplyTo(region.WaitForPendingOperationsToComplete(del()));
+                    return ApplyTo(GetTestObject(() => region.WaitForPendingOperationsToComplete(del())));
 #endif
-            return ApplyTo(del());
+            return ApplyTo(GetTestObject(del));
         }
 
 #pragma warning disable 3006
@@ -127,6 +127,18 @@ namespace NUnit.Framework.Constraints
             return ApplyTo(actual);
         }
 #pragma warning restore 3006
+
+        /// <summary>
+        /// Retrieves the value to be tested from an ActualValueDelegate.
+        /// The default implementation simply evaluates the delegate but derived
+        /// classes may override it to provide for delayed processing.
+        /// </summary>
+        /// <param name="del">An ActualValueDelegate</param>
+        /// <returns>Delegate evaluation result</returns>
+        protected virtual object GetTestObject<TActual>(ActualValueDelegate<TActual> del)
+        {
+            return del();
+        }
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -66,6 +66,16 @@ namespace NUnit.Framework.Constraints
             return new ThrowsExceptionConstraintResult(this, caughtException);
         }
 
+        /// <summary>
+        /// Returns the ActualValueDelegate itself as the value to be tested.
+        /// </summary>
+        /// <param name="del">A delegate representing the code to be tested</param>
+        /// <returns>The delegate itself</returns>
+        protected override object GetTestObject<TActual>(ActualValueDelegate<TActual> del)
+        {
+            return new TestDelegate(() => del());
+        }
+
         #region Nested Result Class
 
         class ThrowsExceptionConstraintResult : ConstraintResult

--- a/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Internal;
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Constraints
@@ -35,6 +36,18 @@ namespace NUnit.Framework.Constraints
             theConstraint = new ThrowsExceptionConstraint();
             expectedDescription = "an exception to be thrown";
             stringRepresentation = "<throwsexception>";
+        }
+
+        [Test]
+        public void SucceedsWithNonVoidReturningFunction()
+        {
+            var constraintResult = theConstraint.ApplyTo(TestDelegates.ThrowsInsteadOfReturns);
+            if (!constraintResult.IsSuccess)
+            {
+                MessageWriter writer = new TextMessageWriter();
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
+            }
         }
 
         static object[] SuccessData = new object[]

--- a/src/NUnitFramework/tests/TestUtilities/TestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestDelegates.cs
@@ -61,6 +61,11 @@ namespace NUnit.TestUtilities
             throw new DerivedException();
         }
 
+        public static int ThrowsInsteadOfReturns()
+        {
+            throw new Exception("my message");
+        }
+
         public class BaseException : Exception
         {
         }


### PR DESCRIPTION
I ran into this issue with code like this

    class ThrowsTester
    {
        [Test]
        public void RunTest()
        {

            Assert.That(RetMethod, Throws.Exception);

        }

        private static sbyte RetMethod()
        {

            throw _err;

        }
    }
The test should pass with success since the function throws an exception as expected. This example worked fine with nUnit 2.6.4 but with nUnit 3(latest development sources) it fails with the exact exception I'm throwing(as if no Throws.Exception constraint were ever specified).

some remarks on this pull request:
1. I'm not sure if I should open an bug issue first; I've read the contribution guidelines but have found no hint for this.
2. I've written a test case to expose the problem. I didn't want to put it with the ThrowsExceptionConstraintTests.SuccessData since they return generic objects and would trigger the wrong function call(one different from the one I wanted to test).
3. I'm not sure if I should write a syntax test in ThrowsTests.cs. I thought it would be a little coarse-grained as the one I've added more tightly and closely exposes the problem. I'm ready however to add one if it's needed.
4. The comments above Constraint.ApplyTo suggest that derived classes could override its implementation. However I didn't want to override it in ThrowsExceptionConstraint since the one in the base class contains some logic for asynchronous delegates and I didn't want to lose(or duplicate) that logic in derived classes(here ThrowsExceptionConstraint). I thus created a new virtual method GetTestObject that provides the correct test object(immediate or lazy value).

Appreciating your feedback for the proposed changes. Thanks in advance.