### PR TITLE
NUnitProject should parse .nunit project files containing Xml Declarations

### DIFF
--- a/NUnit.sln.DotSettings
+++ b/NUnit.sln.DotSettings
@@ -36,7 +36,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.&#xD;
 </s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/@KeyIndexDefined">True</s:Boolean>
 	
 	

--- a/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
@@ -86,10 +86,12 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [TestCase("NUnitProject.nunit")]
+        [TestCase("NUnitProject_XmlDecl.nunit")]
         [Test]
-        public void LoadNormalProject()
+        public void LoadNormalProject(string resourceName)
         {
-            using (TestResource file = new TestResource("NUnitProject.nunit"))
+            using (TestResource file = new TestResource(resourceName))
             {
                 IProject _project = _loader.LoadFrom(file.Path);
 

--- a/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
@@ -88,7 +88,6 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
 
         [TestCase("NUnitProject.nunit")]
         [TestCase("NUnitProject_XmlDecl.nunit")]
-        [Test]
         public void LoadNormalProject(string resourceName)
         {
             using (TestResource file = new TestResource(resourceName))

--- a/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
+++ b/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
@@ -150,6 +150,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\NUnitProject_XmlDecl.nunit" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NUnitEngine/Addins/addin-tests/resources/NUnitProject_XmlDecl.nunit
+++ b/src/NUnitEngine/Addins/addin-tests/resources/NUnitProject_XmlDecl.nunit
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0"?>
+<NUnitProject>
+  <Settings activeconfig="Debug" />
+  <Config name="Debug" appbase="bin\debug" binpathtype="Auto">
+    <assembly path="assembly1.dll" />
+    <assembly path="assembly2.dll" />
+  </Config>
+  <Config name="Release" appbase="bin\release" binpathtype="Auto">
+    <assembly path="assembly1.dll" />
+    <assembly path="assembly2.dll" />
+  </Config>
+</NUnitProject>

--- a/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
@@ -156,7 +156,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
         /// </summary>
         internal XmlNode RootNode
         {
-            get { return xmlDoc.FirstChild; }
+            get { return xmlDoc.DocumentElement ; }
         }
 
         /// <summary>


### PR DESCRIPTION
I was handcrafting an .nunit project and had included the `<?xml version="1.0"?>` header in the file, and nunit3-console was unable to parse it properly, as `firstChild` refers to the xml declaration node. A one line fix to use the `documentElement` instead was sufficient to fix the bug.

I've included a test case illustrating the issue.

