### PR TITLE
NUnitProject.GetTestPackage(config) should fail on missing configuration

### DIFF
--- a/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
@@ -128,6 +128,11 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 Assert.AreEqual(2, package2.Settings.Count);
                 Assert.AreEqual(releaseDir, package2.Settings["BasePath"]);
                 Assert.AreEqual(true, package2.Settings["AutoBinPath"]);
+
+                Assert.Throws<NUnitEngineException>(() =>
+                {
+                    var package3 = _project.GetTestPackage("MissingConfiguration");
+                }, "Project loader should throw exception when attempting to use missing configuration");
             }
         }
 

--- a/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/NUnitProject.cs
@@ -88,30 +88,26 @@ namespace NUnit.Engine.Services.ProjectLoaders
         public TestPackage GetTestPackage(string configName)
         {
             var package = new TestPackage(ProjectPath);
-
             if (configName == null)
                 configName = ActiveConfigName;
 
             if (configName != null)
             {
                 XmlNode configNode = GetConfigNode(configName);
+                
+                string basePath = GetBasePathForConfig(configNode);
 
-                if (configNode != null)
+                foreach (XmlNode node in configNode.SelectNodes("assembly"))
                 {
-                    string basePath = GetBasePathForConfig(configNode);
-
-                    foreach (XmlNode node in configNode.SelectNodes("assembly"))
-                    {
-                        string assembly = node.GetAttribute("path");
-                        if (basePath != null)
-                            assembly = Path.Combine(basePath, assembly);
-                        package.AddSubPackage(new TestPackage(assembly));
-                    }
-
-                    var settings = GetSettingsForConfig(configNode);
-                    foreach (var key in settings.Keys)
-                        package.Settings.Add(key, settings[key]);
+                    string assembly = node.GetAttribute("path");
+                    if (basePath != null)
+                        assembly = Path.Combine(basePath, assembly);
+                    package.AddSubPackage(new TestPackage(assembly));
                 }
+
+                var settings = GetSettingsForConfig(configNode);
+                foreach (var key in settings.Keys)
+                    package.Settings.Add(key, settings[key]);
             }
 
             return package;
@@ -179,13 +175,27 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
         #region Helper Methods
 
+        private IEnumerable<string> GetConfigNodeNames()
+        {
+            foreach (XmlNode node in ConfigNodes)
+            {
+                yield return node.GetAttribute("name");            
+            }
+        }
+
         private XmlNode GetConfigNode(string name)
         {
             foreach (XmlNode node in ConfigNodes)
                 if (node.GetAttribute("name") == name)
                     return node;
 
-            return null;
+            var configNodeNames = new List<string>(GetConfigNodeNames()).ToArray();
+            var errorMessage = "Unable to find a configuration named " + name.Enquote() + ".";
+            var tip =
+                configNodeNames.Length == 0 ? " There are no configuration nodes defined in " + ProjectPath + "." :
+                configNodeNames.Length == 1 ? " The only configuration defined is " + name.Enquote() :
+                                              " Available configuration names are " + configNodeNames.Enquote().Join(", ") + ".";
+            throw new NUnitEngineException(errorMessage + tip);
         }
 
         /// <summary>

--- a/src/NUnitEngine/Addins/nunit-project-loader/StringHelper.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/StringHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NUnit.Common
+{
+    static class StringHelper
+    {
+        public static string Enquote(this string source)
+        {
+            return "'" + source + "'";
+        }
+
+        public static IEnumerable<string> Enquote(this IEnumerable<string> source)
+        {
+            foreach (var item in source)
+            {
+                yield return item.Enquote();
+            }            
+        }
+
+        public static string Join(this IEnumerable<string> source, string delimiter)
+        {
+            return string.Join(delimiter, new List<string>(source).ToArray());
+        }
+    }
+}

--- a/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
+++ b/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\..\..\Common\nunit\XmlHelper.cs">
       <Link>XmlHelper.cs</Link>
     </Compile>
+    <Compile Include="StringHelper.cs" />
     <Compile Include="NUnitProject.cs" />
     <Compile Include="NUnitProjectLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
I was caught by a rookie mistake. Running nunit3-console against a missing configuration results in BadImageFormatException. This is because the project loader tries to load the .nunit project as a .NET assembly when it couldn't find a configuration with the given name.

This patch gives the correct error message on the console, and also provides some helpful suggestions.
