### PR TITLE
Don't allow V2 framework to update in V2 driver tests

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver.tests/packages.config
+++ b/src/NUnitEngine/Addins/nunit.v2.driver.tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net20" />
+  <package id="NUnit" version="2.6.4" allowedVersions="[2,3)" targetFramework="net20" />
 </packages>


### PR DESCRIPTION
MonoDevelop was offering to update this package to 3.0.1, which would defeat the purpose of the v2 driver tests.