### PR TITLE
Do not merge yet. Initial attempt at a fix for issue 681.

### DIFF
--- a/src/NUnitEngine/nunit.engine/Internal/ProvidedPathsAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ProvidedPathsAssemblyResolver.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+using System.Diagnostics;
+
+namespace NUnit.Engine.Internal
+{
+    public class ProvidedPathsAssemblyResolver
+    {
+        public ProvidedPathsAssemblyResolver()
+        {
+            _resolutionPaths = new List<string>();
+        }
+
+        public void Install()
+        {
+            Debug.Assert(AppDomain.CurrentDomain.IsDefaultAppDomain());
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
+        }
+
+        public void AddPath(string dirPath)
+        {
+            if (!_resolutionPaths.Contains(dirPath))
+            {
+                _resolutionPaths.Add(dirPath);
+            }
+        }
+
+        public void AddPathFromFile(string filePath)
+        {
+            string dirPath = Path.GetDirectoryName(filePath);
+            AddPath(dirPath);
+        }
+
+        public void RemovePath(string dirPath)
+        {
+            _resolutionPaths.Remove(dirPath);
+        }
+
+        public void RemovePathFromFile(string filePath)
+        {
+            string dirPath = Path.GetDirectoryName(filePath);
+            RemovePath(dirPath);
+        }
+
+        Assembly AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            foreach (string path in _resolutionPaths)
+            {
+                string filename = new AssemblyName(args.Name).Name + ".dll";
+                string fullPath = Path.Combine(path, filename);
+                try
+                {
+                    if (File.Exists(fullPath))
+                    {
+                        return Assembly.LoadFrom(fullPath);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Resolution at this path failed. Do not interrupt the process; try the next path.
+                }
+            }
+
+            return null;
+        }
+
+        List<string> _resolutionPaths;
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/TestAssemblyDirectoryResolveHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TestAssemblyDirectoryResolveHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace NUnit.Engine.Internal
+{
+    public class TestAssemblyDirectoryResolveHelper
+    {
+        public static bool AssemblyHasAttribute(string assemblyPath)
+        {
+            var domain = AppDomain.CreateDomain("TestAssemblyDirectoryResolveHelperCheckDomain");
+            try
+            {
+                var agentType = typeof(AttributeCheckAgent);
+                var agent = domain.CreateInstanceFromAndUnwrap(agentType.Assembly.CodeBase, agentType.FullName) as AttributeCheckAgent;
+                bool helperRequested = agent.HelperRequested(assemblyPath);
+                return helperRequested;
+                
+            }
+            finally
+            {
+                AppDomain.Unload(domain);
+            }
+        }
+
+        private class AttributeCheckAgent : MarshalByRefObject
+        {
+            private const string ATTRIBUTE = "NUnit.Framework.TestAssemblyDirectoryResolveAttribute";
+
+            public bool HelperRequested(string assemblyPath)
+            {
+                // You can't get custom attributes when the assembly is loaded reflection only
+                var testAssembly = Assembly.LoadFrom(assemblyPath);
+                var allAttrs = testAssembly.GetCustomAttributes(false);
+                bool hasAttr = Array.Exists(allAttrs, attr => attr.GetType().FullName == ATTRIBUTE);
+                return hasAttr;
+            }
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -35,8 +35,19 @@ namespace NUnit.Engine.Runners
     public abstract class DirectTestRunner : AbstractTestRunner
     {
         private readonly List<IFrameworkDriver> _drivers = new List<IFrameworkDriver>();
+        private Dictionary<IFrameworkDriver, TestPackage> _packageIndex = new Dictionary<IFrameworkDriver, TestPackage>();
+        private ProvidedPathsAssemblyResolver _assemblyResolver;
 
-        public DirectTestRunner(IServiceLocator services, TestPackage package) : base(services, package) { }
+        public DirectTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        {
+            // Bypass the resolver if not in the default AppDomain. This prevents trying to use the resolver within
+            // NUnit's own automated tests (in a test AppDomain) which does not make sense anyway.
+            if (AppDomain.CurrentDomain.IsDefaultAppDomain())
+            {
+                _assemblyResolver = new ProvidedPathsAssemblyResolver();
+                _assemblyResolver.Install();
+            }
+        }
 
         #region Properties
 
@@ -86,10 +97,18 @@ namespace NUnit.Engine.Runners
             foreach (var subPackage in packages)
             {
                 var testFile = subPackage.FullName;
+
+                if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain() && TestAssemblyDirectoryResolveHelper.AssemblyHasAttribute(testFile))
+                {
+                    _assemblyResolver.AddPathFromFile(testFile);
+                }
+
                 IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile);
                 driver.ID = TestPackage.ID;
                 result.Add(driver.Load(testFile, subPackage.Settings));
                 _drivers.Add(driver);
+
+                _packageIndex.Add(driver, subPackage);
             }
 
             if (IsProjectPackage(TestPackage))
@@ -128,7 +147,15 @@ namespace NUnit.Engine.Runners
             var result = new TestEngineResult();
 
             foreach (IFrameworkDriver driver in _drivers)
+            {
                 result.Add(driver.Run(listener, filter.Text));
+
+                if (_assemblyResolver != null)
+                {
+                    TestPackage package = _packageIndex[driver];
+                    _assemblyResolver.RemovePathFromFile(package.FullName);
+                }
+            }
 
             if (IsProjectPackage(TestPackage))
                 result = result.MakePackageResult(TestPackage.Name, TestPackage.FullName);

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -109,9 +109,11 @@
     <Compile Include="Internal\NUnitConfiguration.cs" />
     <Compile Include="Internal\PathUtils.cs" />
     <Compile Include="Internal\ProcessModel.cs" />
+    <Compile Include="Internal\ProvidedPathsAssemblyResolver.cs" />
     <Compile Include="Internal\ResultHelper.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Internal\TestAssemblyDirectoryResolveHelper.cs" />
     <Compile Include="Internal\ServerBase.cs" />
     <Compile Include="Internal\ServerUtilities.cs" />
     <Compile Include="Internal\SettingsGroup.cs" />

--- a/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// TestAssemblyDirectoryResolveAttribute is used to mark a test assembly as needing a
+    /// special assembly resolution hook that will explicitly search the test assembly's
+    /// directory for dependent assemblies. This works around a conflict between mixed-mode
+    /// assembly initialization and tests running in their own AppDomain in some cases.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
+    public class TestAssemblyDirectoryResolveAttribute : NUnitAttribute
+    {
+    }
+
+}

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\RetryAttribute.cs" />
     <Compile Include="Attributes\OneTimeTearDownAttribute.cs" />
     <Compile Include="Attributes\OneTimeSetUpAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Attributes\CategoryAttribute.cs" />
     <Compile Include="Attributes\CombinatorialAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\OneTimeSetUpAttribute.cs" />
     <Compile Include="Attributes\OneTimeTearDownAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Attributes\ExplicitAttribute.cs" />
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\MaxTimeAttribute.cs" />
     <Compile Include="Attributes\NUnitAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Attributes\ExplicitAttribute.cs" />
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\MaxTimeAttribute.cs" />
     <Compile Include="Attributes\NUnitAttribute.cs" />


### PR DESCRIPTION
Notes:
- DirectTestRunner has to avoid installing the hook if it's run from a non-default AppDomain, in order to avoid installing a nonfunctional hook when running NUnit's own automated tests. The hook only makes sense to install in the default AppDomain given the issue at hand.
- Paths are removed from the resolver after running tests. This seems to work but I'm not 100% clear that it's impossible to re-run the tests without loading a new DirectTestRunner.
- The resolver hook is never actually uninstalled. This shouldn't be a functional problem but it would be cleaner to uninstall it.