### PR TITLE
[WIP] Fix #464: add support for Assert.ThrowsAsync

### DIFF
--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
 
 
 namespace NUnit.Framework
@@ -50,7 +51,7 @@ namespace NUnit.Framework
                     // Case where code() either
                     // - succeeded (synchronously or asynchronously)
                     // - failed asynchronously
-                    var ex = t.Exception?.InnerException;
+                    var ex = t.IsFaulted ? t.Exception.InnerException : null;
                     Assert.That(ex, expression, message, args);
                     return ex;
                 });
@@ -221,7 +222,7 @@ namespace NUnit.Framework
                     // Case where code() either
                     // - succeeded (synchronously or asynchronously)
                     // - failed asynchronously
-                    var ex = t.Exception?.InnerException;
+                    var ex = t.IsFaulted ? t.Exception.InnerException : null;
                     Assert.That(ex, new ThrowsNothingConstraint(), message, args);
                     return ex;
                 });
@@ -270,7 +271,7 @@ namespace NUnit.Framework
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)
-                        throw t.Exception.InnerException;
+                        ExceptionHelper.Rethrow(t.Exception.InnerException);
                     return (TActual)t.Result;
                 });
         }

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -1,0 +1,280 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework.Constraints;
+
+
+namespace NUnit.Framework
+{
+    public partial class Assert
+    {
+        #region ThrowsAsync
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <param name="expression">A constraint to be satisfied by the exception</param>
+        /// <param name="code">A TestSnippet delegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<Exception> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string message, params object[] args)
+        {
+            Exception caughtException;
+            try
+            {
+                var task = code();
+                return task.ContinueWith(t =>
+                {
+                    // Case where code() either
+                    // - succeeded (synchronously or asynchronously)
+                    // - failed asynchronously
+                    var ex = t.Exception?.InnerException;
+                    Assert.That(ex, expression, message, args);
+                    return ex;
+                });
+            }
+            // Case where code() failed synchronously
+            catch (Exception ex)
+            {
+                caughtException = ex;
+            }
+
+            Assert.That(caughtException, expression, message, args);
+
+            return TaskFromResult(caughtException);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <param name="expression">A constraint to be satisfied by the exception</param>
+        /// <param name="code">A TestSnippet delegate</param>
+        public static Task<Exception> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
+        {
+            return ThrowsAsync(expression, code, string.Empty, null);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <param name="expectedExceptionType">The exception Type expected</param>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<Exception> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object[] args)
+        {
+            return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <param name="expectedExceptionType">The exception Type expected</param>
+        /// <param name="code">A TestDelegate</param>
+        public static Task<Exception> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        {
+            return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, string.Empty, null);
+        }
+
+        #endregion
+
+        #region ThrowsAsync<TActual>
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <typeparam name="TActual">Type of the expected exception</typeparam>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<TActual> ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object[] args) where TActual : Exception
+        {
+            return Cast<TActual>(ThrowsAsync(typeof (TActual), code, message, args));
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws a particular exception when called.
+        /// </summary>
+        /// <typeparam name="TActual">Type of the expected exception</typeparam>
+        /// <param name="code">A TestDelegate</param>
+        public static Task<TActual> ThrowsAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
+        {
+            return ThrowsAsync<TActual>(code, string.Empty, null);
+        }
+
+        #endregion
+
+        #region CatchAsync
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception when called
+        /// and returns it.
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<Exception> CatchAsync(AsyncTestDelegate code, string message, params object[] args)
+        {
+            return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception when called
+        /// and returns it.
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        public static Task<Exception> CatchAsync(AsyncTestDelegate code)
+        {
+            return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception of a certain Type
+        /// or one derived from it when called and returns it.
+        /// </summary>
+        /// <param name="expectedExceptionType">The expected Exception Type</param>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<Exception> CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object[] args)
+        {
+            return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception of a certain Type
+        /// or one derived from it when called and returns it.
+        /// </summary>
+        /// <param name="expectedExceptionType">The expected Exception Type</param>
+        /// <param name="code">A TestDelegate</param>
+        public static Task<Exception> CatchAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        {
+            return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code);
+        }
+
+        #endregion
+
+        #region CatchAsync<TActual>
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception of a certain Type
+        /// or one derived from it when called and returns it.
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task<TActual> CatchAsync<TActual>(AsyncTestDelegate code, string message, params object[] args) where TActual : System.Exception
+        {
+            return Cast<TActual>(ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code, message, args));
+        }
+
+        /// <summary>
+        /// Verifies that an async delegate throws an exception of a certain Type
+        /// or one derived from it when called and returns it.
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        public static Task<TActual> CatchAsync<TActual>(AsyncTestDelegate code) where TActual : System.Exception
+        {
+            return Cast<TActual>(ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code));
+        }
+
+        #endregion
+
+        #region DoesNotThrowAsync
+
+        /// <summary>
+        /// Verifies that an async delegate does not throw an exception
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static Task DoesNotThrowAsync(AsyncTestDelegate code, string message, params object[] args)
+        {
+            Exception caughtException;
+            try
+            {
+                var task = code();
+                return task.ContinueWith(t =>
+                {
+                    // Case where code() either
+                    // - succeeded (synchronously or asynchronously)
+                    // - failed asynchronously
+                    var ex = t.Exception?.InnerException;
+                    Assert.That(ex, new ThrowsNothingConstraint(), message, args);
+                    return ex;
+                });
+            }
+            // Case where code() failed synchronously
+            catch (Exception ex)
+            {
+                caughtException = ex;
+            }
+
+            Assert.That(caughtException, new ThrowsNothingConstraint(), message, args);
+
+            return TaskFromResult(caughtException);
+        }
+        /// <summary>
+        /// Verifies that an async delegate does not throw an exception.
+        /// </summary>
+        /// <param name="code">A TestDelegate</param>
+        public static Task DoesNotThrowAsync(AsyncTestDelegate code)
+        {
+            return DoesNotThrowAsync(code, string.Empty, null);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static Task<T> TaskFromResult<T>(T value)
+        {
+            #if NET_4_5 || PORTABLE
+
+            return Task.FromResult(value);
+
+            #else
+
+            var tcs = new TaskCompletionSource<T>();
+            tcs.SetResult(value);
+            return tcs.Task;
+
+            #endif
+        }
+
+        private static Task<TActual> Cast<TActual>(Task<Exception> task) where TActual : Exception
+        {
+            return task
+                .ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                        throw t.Exception.InnerException;
+                    return (TActual)t.Result;
+                });
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -34,6 +34,14 @@ namespace NUnit.Framework
     /// </summary>
     public delegate void TestDelegate();
 
+#if NET_4_0 || NET_4_5 || PORTABLE
+    /// <summary>
+    /// Delegate used by tests that execute async code and
+    /// capture any thrown exception.
+    /// </summary>
+    public delegate System.Threading.Tasks.Task AsyncTestDelegate();
+#endif
+
     /// <summary>
     /// The Assert class contains a collection of static methods that
     /// implement the most common assertions used in NUnit.

--- a/src/NUnitFramework/framework/Constraints/ExceptionNotThrownConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionNotThrownConstraint.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    internal class ExceptionNotThrownConstraint : Constraint
+    {
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get { return "No Exception to be thrown"; }
+        }
+
+        /// <summary>
+        /// Applies the constraint to an actual value, returning a ConstraintResult.
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>A ConstraintResult</returns>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            var exception = actual as Exception;
+            return new ConstraintResult(this, exception, exception == null);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -161,10 +161,9 @@ namespace NUnit.Framework.Constraints
                 {
                     using (var region = AsyncInvocationRegion.Create(invocationDescriptor.Delegate))
                     {
-                        object result = invocationDescriptor.Invoke();
-
                         try
                         {
+                            object result = invocationDescriptor.Invoke();
                             region.WaitForPendingOperationsToComplete(result);
                             return null;
                         }
@@ -197,22 +196,36 @@ namespace NUnit.Framework.Constraints
                 {
                     var testDelegate = actual as TestDelegate;
 
-                    if (testDelegate == null)
-                        throw new ArgumentException(
-                            String.Format("The actual value must be a TestDelegate or ActualValueDelegate but was {0}",
-                                actual.GetType().Name),
-                            "actual");
+                    if (testDelegate != null)
+                    {
+                        invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
+                    }
 
-                    invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
+#if NET_4_0 || NET_4_5 || PORTABLE
+                    else
+                    {
+                        var asyncTestDelegate = actual as AsyncTestDelegate;
+                        if (asyncTestDelegate != null)
+                        {
+                            invocationDescriptor = new GenericInvocationDescriptor<System.Threading.Tasks.Task>(() => asyncTestDelegate());
+                        }
+                    }
+#endif
                 }
+                if (invocationDescriptor == null)
+                    throw new ArgumentException(
+                        String.Format(
+                            "The actual value must be a TestDelegate or AsyncTestDelegate but was {0}",
+                            actual.GetType().Name),
+                        "actual");
 
                 return invocationDescriptor;
             }
         }
 
-        #endregion
+#endregion
 
-        #region InvocationDescriptor
+#region InvocationDescriptor
 
         internal class GenericInvocationDescriptor<T> : IInvocationDescriptor
         {
@@ -261,6 +274,6 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -50,9 +49,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if no exception is thrown, otherwise false</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            caughtException = actual as Exception;
-            if (caughtException == null && actual != null)
-                caughtException = ThrowsConstraint.ExceptionInterceptor.Intercept(actual);
+            caughtException = ThrowsConstraint.ExceptionInterceptor.Intercept(actual);
             return new ConstraintResult(this, caughtException, caughtException == null);
         }
 

--- a/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
@@ -50,23 +50,9 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if no exception is thrown, otherwise false</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            //TestDelegate code = actual as TestDelegate;
-            //if (code == null)
-            //    throw new ArgumentException("The actual value must be a TestDelegate", "actual");
-
-            //caughtException = null;
-
-            //try
-            //{
-            //    code();
-            //}
-            //catch (Exception ex)
-            //{
-            //    caughtException = ex;
-            //}
-
-            caughtException = ThrowsConstraint.ExceptionInterceptor.Intercept(actual);
-
+            caughtException = actual as Exception;
+            if (caughtException == null && actual != null)
+                caughtException = ThrowsConstraint.ExceptionInterceptor.Intercept(actual);
             return new ConstraintResult(this, caughtException, caughtException == null);
         }
 

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraint.cs" />
     <Compile Include="Constraints\EqualConstraintResult.cs" />
+    <Compile Include="Constraints\ExceptionNotThrownConstraint.cs" />
     <Compile Include="Constraints\FileExistsConstraint.cs" />
     <Compile Include="Constraints\FileOrDirectoryExistsConstraint.cs" />
     <Compile Include="Constraints\IConstraint.cs" />
@@ -118,6 +119,9 @@
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Equality.cs">
+      <DependentUpon>Assert.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Assert.Exceptions.Async.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Types.cs">

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -95,6 +95,9 @@
     <Compile Include="Assert.Equality.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Assert.Exceptions.Async.cs">
+        <DependentUpon>Assert.cs</DependentUpon>
+    </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -96,7 +96,7 @@
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Exceptions.Async.cs">
-        <DependentUpon>Assert.cs</DependentUpon>
+      <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
@@ -203,6 +203,7 @@
     <Compile Include="Constraints\EqualConstraint.cs" />
     <Compile Include="Constraints\EqualityAdapter.cs" />
     <Compile Include="Constraints\ExactTypeConstraint.cs" />
+    <Compile Include="Constraints\ExceptionNotThrownConstraint.cs" />
     <Compile Include="Constraints\FalseConstraint.cs" />
     <Compile Include="Constraints\FileExistsConstraint.cs" />
     <Compile Include="Constraints\FileOrDirectoryExistsConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -100,7 +100,7 @@
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Exceptions.Async.cs">
-        <DependentUpon>Assert.cs</DependentUpon>
+      <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
@@ -207,6 +207,7 @@
     <Compile Include="Constraints\EqualConstraint.cs" />
     <Compile Include="Constraints\EqualityAdapter.cs" />
     <Compile Include="Constraints\ExactTypeConstraint.cs" />
+    <Compile Include="Constraints\ExceptionNotThrownConstraint.cs" />
     <Compile Include="Constraints\FalseConstraint.cs" />
     <Compile Include="Constraints\FileExistsConstraint.cs" />
     <Compile Include="Constraints\FileOrDirectoryExistsConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -99,6 +99,9 @@
     <Compile Include="Assert.Equality.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Assert.Exceptions.Async.cs">
+        <DependentUpon>Assert.cs</DependentUpon>
+    </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -95,6 +95,9 @@
     <Compile Include="Assert.Equality.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Assert.Exceptions.Async.cs">
+      <DependentUpon>Assert.cs</DependentUpon>
+    </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -201,6 +204,7 @@
     <Compile Include="Constraints\EqualityAdapter.cs" />
     <Compile Include="Constraints\ExactCountConstraint.cs" />
     <Compile Include="Constraints\ExactTypeConstraint.cs" />
+    <Compile Include="Constraints\ExceptionNotThrownConstraint.cs" />
     <Compile Include="Constraints\ExceptionTypeConstraint.cs" />
     <Compile Include="Constraints\FalseConstraint.cs" />
     <Compile Include="Constraints\FileExistsConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -112,6 +112,9 @@
     <Compile Include="Assert.Equality.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
+    <Compile Include="Assert.Exceptions.Async.cs">
+      <DependentUpon>Assert.cs</DependentUpon>
+    </Compile>
     <Compile Include="Assert.Exceptions.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -218,6 +221,7 @@
     <Compile Include="Constraints\EqualityAdapter.cs" />
     <Compile Include="Constraints\ExactCountConstraint.cs" />
     <Compile Include="Constraints\ExactTypeConstraint.cs" />
+    <Compile Include="Constraints\ExceptionNotThrownConstraint.cs" />
     <Compile Include="Constraints\ExceptionTypeConstraint.cs" />
     <Compile Include="Constraints\FalseConstraint.cs" />
     <Compile Include="Constraints\FileExistsConstraint.cs" />

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Tests.Assertions
+{
+    [TestFixture]
+    public class AssertThrowsAsyncTests
+    {
+        [Test]
+        public async Task CorrectExceptionThrownSync()
+        {
+            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionSync);
+            await Assert.ThrowsAsync(typeof(ArgumentException), delegate { throw new ArgumentException(); });
+
+            await Assert.ThrowsAsync<ArgumentException>(delegate { throw new ArgumentException(); });
+            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionSync);
+        }
+
+        [Test]
+        public async Task CorrectExceptionThrownAsync()
+        {
+            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            await Assert.ThrowsAsync(typeof(ArgumentException), async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException();
+            });
+
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException();
+            });
+            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+        }
+
+        [Test]
+        public async Task CorrectExceptionIsReturnedToMethodSync()
+        {
+            ArgumentException ex = await Assert.ThrowsAsync(typeof (ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionSync) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync<ArgumentException>(delegate { throw new ArgumentException("myMessage", "myParam"); });
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync(typeof(ArgumentException), delegate { throw new ArgumentException("myMessage", "myParam"); }) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionSync);
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+        }
+
+        [Test]
+        public async Task CorrectExceptionIsReturnedToMethodAsync()
+        {
+            ArgumentException ex = await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException("myMessage", "myParam");
+            });
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync(typeof(ArgumentException), async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException("myMessage", "myParam");
+            }) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+        }
+
+        [Test]
+        public async Task NoExceptionThrown()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
+            Assert.That(ex.Message, Is.EqualTo(
+                "  Expected: <System.ArgumentException>" + Env.NewLine +
+                "  But was:  null" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task UnrelatedExceptionThrownSync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionSync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.ArgumentException>" + Env.NewLine +
+                "  But was:  <System.NullReferenceException: my message" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task UnrelatedExceptionThrownAsync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.ArgumentException>" + Env.NewLine +
+                "  But was:  <System.NullReferenceException: my message" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task BaseExceptionThrownSync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionSync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.ArgumentException>" + Env.NewLine +
+                "  But was:  <System.Exception: my message" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task BaseExceptionThrownAsync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.ArgumentException>" + Env.NewLine +
+                "  But was:  <System.Exception: my message" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task DerivedExceptionThrownSync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionSync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.Exception>" + Env.NewLine +
+                "  But was:  <System.ArgumentException: myMessage" + Env.NewLine + "Parameter name: myParam" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task DerivedExceptionThrownAsync()
+        {
+            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.Exception>" + Env.NewLine +
+                "  But was:  <System.ArgumentException: myMessage" + Env.NewLine + "Parameter name: myParam" + Env.NewLine));
+        }
+
+        [Test]
+        public async Task DoesNotThrowSuceeds()
+        {
+            await Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsNothing);
+        }
+
+        [Test]
+        public async Task DoesNotThrowFailsSync()
+        {
+            var ex = await CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentExceptionSync));
+            Assert.That(ex, Is.Not.Null.With.TypeOf<AssertionException>());
+        }
+
+        [Test]
+        public async Task DoesNotThrowFailsAsync()
+        {
+            var ex = await CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
+            Assert.That(ex, Is.Not.Null.With.TypeOf<AssertionException>());
+        }
+
+        private async Task<Exception> CatchException(AsyncTestDelegate del)
+        {
+            try
+            {
+                await del();
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET_4_5 || PORTABLE
+using System;
 using System.Threading.Tasks;
 using NUnit.TestUtilities;
 
@@ -212,3 +213,4 @@ namespace NUnit.Framework.Tests.Assertions
         }
     }
 }
+#endif

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -1,45 +1,50 @@
-﻿#if NET_4_5 || PORTABLE
+﻿#if NET_4_0 || NET_4_5 || PORTABLE
 using System;
-using System.Threading.Tasks;
 using NUnit.TestUtilities;
 
-namespace NUnit.Framework.Tests.Assertions
+namespace NUnit.Framework.Assertions
 {
     [TestFixture]
     public class AssertThrowsAsyncTests
     {
         [Test]
-        public async Task CorrectExceptionThrownSync()
+        public void CorrectExceptionThrown()
         {
-            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionSync);
-            await Assert.ThrowsAsync(typeof(ArgumentException), delegate { throw new ArgumentException(); });
+            Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentException);
+            Assert.ThrowsAsync(typeof(ArgumentException),
+                delegate { throw new ArgumentException(); });
 
-            await Assert.ThrowsAsync<ArgumentException>(delegate { throw new ArgumentException(); });
-            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionSync);
+            Assert.ThrowsAsync<ArgumentException>(
+                delegate { throw new ArgumentException(); });
+            Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
+
+            // Without cast, delegate is ambiguous before C# 3.0.
+            Assert.That((AsyncTestDelegate)delegate { throw new ArgumentException(); },
+                    Throws.Exception.TypeOf<ArgumentException>());
         }
 
         [Test]
-        public async Task CorrectExceptionThrownAsync()
+        public void CorrectExceptionThrownAsync()
         {
-            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
-            await Assert.ThrowsAsync(typeof(ArgumentException), async () =>
-            {
-                await Task.Yield();
-                throw new ArgumentException();
-            });
+            Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            Assert.ThrowsAsync(typeof(ArgumentException),
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); });
 
-            await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await Task.Yield();
-                throw new ArgumentException();
-            });
-            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            Assert.ThrowsAsync<ArgumentException>(
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); });
+            Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+
+            // Without cast, delegate is ambiguous before C# 3.0.
+            Assert.That(
+                (AsyncTestDelegate)delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); },
+                    Throws.Exception.TypeOf<ArgumentException>());
         }
 
         [Test]
-        public async Task CorrectExceptionIsReturnedToMethodSync()
+        public void CorrectExceptionIsReturnedToMethod()
         {
-            ArgumentException ex = await Assert.ThrowsAsync(typeof (ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionSync) as ArgumentException;
+            ArgumentException ex = Assert.ThrowsAsync(typeof(ArgumentException),
+                new AsyncTestDelegate(AsyncTestDelegates.ThrowsArgumentException)) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -47,7 +52,8 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 #endif
 
-            ex = await Assert.ThrowsAsync<ArgumentException>(delegate { throw new ArgumentException("myMessage", "myParam"); });
+            ex = Assert.ThrowsAsync<ArgumentException>(
+                delegate { throw new ArgumentException("myMessage", "myParam"); });
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -55,7 +61,8 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 #endif
 
-            ex = await Assert.ThrowsAsync(typeof(ArgumentException), delegate { throw new ArgumentException("myMessage", "myParam"); }) as ArgumentException;
+            ex = Assert.ThrowsAsync(typeof(ArgumentException),
+                delegate { throw new ArgumentException("myMessage", "myParam"); }) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -63,51 +70,7 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 #endif
 
-            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionSync);
-
-            Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-#if !NETCF && !SILVERLIGHT && !PORTABLE
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-#endif
-        }
-
-        [Test]
-        public async Task CorrectExceptionIsReturnedToMethodAsync()
-        {
-            ArgumentException ex = await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync) as ArgumentException;
-
-            Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-#if !NETCF && !SILVERLIGHT && !PORTABLE
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-#endif
-
-            ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await Task.Yield();
-                throw new ArgumentException("myMessage", "myParam");
-            });
-
-            Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-#if !NETCF && !SILVERLIGHT && !PORTABLE
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-#endif
-
-            ex = await Assert.ThrowsAsync(typeof(ArgumentException), async () =>
-            {
-                await Task.Yield();
-                throw new ArgumentException("myMessage", "myParam");
-            }) as ArgumentException;
-
-            Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-#if !NETCF && !SILVERLIGHT && !PORTABLE
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-#endif
-
-            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            ex = Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -117,93 +80,133 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
-        public async Task NoExceptionThrown()
+        public void CorrectExceptionIsReturnedToMethodAsync()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
+            ArgumentException ex = Assert.ThrowsAsync(typeof(ArgumentException),
+                new AsyncTestDelegate(AsyncTestDelegates.ThrowsArgumentExceptionAsync)) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = Assert.ThrowsAsync<ArgumentException>(
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }); });
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = Assert.ThrowsAsync(typeof(ArgumentException),
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }); }) as ArgumentException;
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+
+            ex = Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+
+            Assert.IsNotNull(ex, "No ArgumentException thrown");
+            Assert.That(ex.Message, Does.StartWith("myMessage"));
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+#endif
+        }
+
+
+        [Test]
+        public void NoExceptionThrown()
+        {
+            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
             Assert.That(ex.Message, Is.EqualTo(
                 "  Expected: <System.ArgumentException>" + Env.NewLine +
                 "  But was:  null" + Env.NewLine));
         }
 
         [Test]
-        public async Task UnrelatedExceptionThrownSync()
+        public void UnrelatedExceptionThrown()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionSync));
+            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Env.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Env.NewLine));
         }
 
         [Test]
-        public async Task UnrelatedExceptionThrownAsync()
+        public void UnrelatedExceptionThrownAsync()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
+            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Env.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Env.NewLine));
         }
 
         [Test]
-        public async Task BaseExceptionThrownSync()
+        public void BaseExceptionThrown()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionSync));
+            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Env.NewLine +
                 "  But was:  <System.Exception: my message" + Env.NewLine));
         }
 
         [Test]
-        public async Task BaseExceptionThrownAsync()
+        public void BaseExceptionThrownAsync()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
+            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Env.NewLine +
                 "  But was:  <System.Exception: my message" + Env.NewLine));
         }
 
         [Test]
-        public async Task DerivedExceptionThrownSync()
+        public void DerivedExceptionThrown()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionSync));
+            var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.Exception>" + Env.NewLine +
                 "  But was:  <System.ArgumentException: myMessage" + Env.NewLine + "Parameter name: myParam" + Env.NewLine));
         }
 
         [Test]
-        public async Task DerivedExceptionThrownAsync()
+        public void DerivedExceptionThrownAsync()
         {
-            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
+            var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.Exception>" + Env.NewLine +
                 "  But was:  <System.ArgumentException: myMessage" + Env.NewLine + "Parameter name: myParam" + Env.NewLine));
         }
 
         [Test]
-        public async Task DoesNotThrowSuceeds()
+        public void DoesNotThrowSuceeds()
         {
-            await Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsNothing);
+            Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsNothing);
         }
 
         [Test]
-        public async Task DoesNotThrowFailsSync()
+        public void DoesNotThrowFails()
         {
-            var ex = await CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentExceptionSync));
+            var ex = CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentException));
             Assert.That(ex, Is.Not.Null.With.TypeOf<AssertionException>());
         }
 
         [Test]
-        public async Task DoesNotThrowFailsAsync()
+        public void DoesNotThrowFailsAsync()
         {
-            var ex = await CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
+            var ex = CatchException(() => Assert.DoesNotThrowAsync(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
             Assert.That(ex, Is.Not.Null.With.TypeOf<AssertionException>());
         }
 
-        private async Task<Exception> CatchException(AsyncTestDelegate del)
+        private Exception CatchException(TestDelegate del)
         {
             try
             {
-                await del();
+                del();
                 return null;
             }
             catch (Exception ex)

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET_4_0 || NET_4_5 || PORTABLE
 using System;
+using System.Threading.Tasks;
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Assertions
@@ -28,15 +29,15 @@ namespace NUnit.Framework.Assertions
         {
             Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
             Assert.ThrowsAsync(typeof(ArgumentException),
-                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); });
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }, TaskScheduler.Default); });
 
             Assert.ThrowsAsync<ArgumentException>(
-                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); });
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }, TaskScheduler.Default); });
             Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
 
             // Without cast, delegate is ambiguous before C# 3.0.
             Assert.That(
-                (AsyncTestDelegate)delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }); },
+                (AsyncTestDelegate)delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }, TaskScheduler.Default); },
                     Throws.Exception.TypeOf<ArgumentException>());
         }
 
@@ -92,7 +93,7 @@ namespace NUnit.Framework.Assertions
 #endif
 
             ex = Assert.ThrowsAsync<ArgumentException>(
-                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }); });
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }, TaskScheduler.Default); });
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -101,7 +102,7 @@ namespace NUnit.Framework.Assertions
 #endif
 
             ex = Assert.ThrowsAsync(typeof(ArgumentException),
-                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }); }) as ArgumentException;
+                delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }, TaskScheduler.Default); }) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NUnit.TestUtilities
+{
+    public class AsyncTestDelegates
+    {
+        public static Task ThrowsArgumentExceptionSync()
+        {
+            throw new ArgumentException("myMessage", "myParam");
+        }
+
+        public static async Task ThrowsArgumentExceptionAsync()
+        {
+            await Task.Yield();
+            throw new ArgumentException("myMessage", "myParam");
+        }
+
+        public static Task ThrowsNothing()
+        {
+            return Task.FromResult(0);
+        }
+
+        public static Task ThrowsNullReferenceExceptionSync()
+        {
+            throw new NullReferenceException("my message");
+        }
+
+        public static async Task ThrowsNullReferenceExceptionAsync()
+        {
+            await Task.Yield();
+            throw new NullReferenceException("my message");
+        }
+
+        public static Task ThrowsSystemExceptionSync()
+        {
+            throw new Exception("my message");
+        }
+
+        public static async Task ThrowsSystemExceptionAsync()
+        {
+            await Task.Yield();
+            throw new Exception("my message");
+        }
+    }
+}

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -1,4 +1,4 @@
-﻿#if NET_4_5 || PORTABLE
+﻿#if NET_4_0 || NET_4_5 || PORTABLE
 
 using System;
 using System.Threading.Tasks;
@@ -7,42 +7,56 @@ namespace NUnit.TestUtilities
 {
     public class AsyncTestDelegates
     {
-        public static Task ThrowsArgumentExceptionSync()
+        public static Task ThrowsArgumentException()
         {
             throw new ArgumentException("myMessage", "myParam");
         }
 
-        public static async Task ThrowsArgumentExceptionAsync()
+        public static Task ThrowsArgumentExceptionAsync()
         {
-            await Task.Yield();
-            throw new ArgumentException("myMessage", "myParam");
+            return Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); });
         }
 
         public static Task ThrowsNothing()
         {
+#if NET_4_0
+            var tcs = new TaskCompletionSource<int>();
+            tcs.SetResult(0);
+            return tcs.Task;
+#else
             return Task.FromResult(0);
+#endif
         }
 
-        public static Task ThrowsNullReferenceExceptionSync()
+        public static Task ThrowsNullReferenceException()
         {
             throw new NullReferenceException("my message");
         }
 
-        public static async Task ThrowsNullReferenceExceptionAsync()
+        public static Task ThrowsNullReferenceExceptionAsync()
         {
-            await Task.Yield();
-            throw new NullReferenceException("my message");
+            return Delay(5).ContinueWith(t => { throw new NullReferenceException("my message"); });
         }
 
-        public static Task ThrowsSystemExceptionSync()
+        public static Task ThrowsSystemException()
         {
             throw new Exception("my message");
         }
 
-        public static async Task ThrowsSystemExceptionAsync()
+        public static Task ThrowsSystemExceptionAsync()
         {
-            await Task.Yield();
-            throw new Exception("my message");
+            return Delay(5).ContinueWith(t => { throw new Exception("my message"); });
+        }
+
+        public static Task Delay(int milliseconds)
+        {
+#if NET_4_0
+            var tcs = new TaskCompletionSource<int>();
+            new System.Threading.Timer(_ => tcs.SetResult(0), null, milliseconds, System.Threading.Timeout.Infinite);
+            return tcs.Task;
+#else
+            return Task.Delay(milliseconds);
+#endif
         }
     }
 }

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET_4_5 || PORTABLE
+
+using System;
 using System.Threading.Tasks;
 
 namespace NUnit.TestUtilities
@@ -44,3 +46,5 @@ namespace NUnit.TestUtilities
         }
     }
 }
+
+#endif

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -14,7 +14,7 @@ namespace NUnit.TestUtilities
 
         public static Task ThrowsArgumentExceptionAsync()
         {
-            return Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); });
+            return Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }, TaskScheduler.Default);
         }
 
         public static Task ThrowsNothing()
@@ -35,7 +35,7 @@ namespace NUnit.TestUtilities
 
         public static Task ThrowsNullReferenceExceptionAsync()
         {
-            return Delay(5).ContinueWith(t => { throw new NullReferenceException("my message"); });
+            return Delay(5).ContinueWith(t => { throw new NullReferenceException("my message"); }, TaskScheduler.Default);
         }
 
         public static Task ThrowsSystemException()
@@ -45,15 +45,15 @@ namespace NUnit.TestUtilities
 
         public static Task ThrowsSystemExceptionAsync()
         {
-            return Delay(5).ContinueWith(t => { throw new Exception("my message"); });
+            return Delay(5).ContinueWith(t => { throw new Exception("my message"); }, TaskScheduler.Default);
         }
 
         public static Task Delay(int milliseconds)
         {
 #if NET_4_0
             var tcs = new TaskCompletionSource<int>();
-            new System.Threading.Timer(_ => tcs.SetResult(0), null, milliseconds, System.Threading.Timeout.Infinite);
-            return tcs.Task;
+            var timer = new System.Threading.Timer(_ => tcs.SetResult(0), null, milliseconds, System.Threading.Timeout.Infinite);
+            return tcs.Task.ContinueWith(t => timer.Dispose(), TaskScheduler.Default);
 #else
             return Task.Delay(milliseconds);
 #endif

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
+    <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\CollectionAssertTest.cs" />
@@ -143,6 +144,7 @@
     <Compile Include="Attributes\TestCaseSourceTests.cs" />
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestOfTests.cs" />
     <Compile Include="Attributes\TheoryTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
+    <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
@@ -116,6 +117,7 @@
     <Compile Include="Attributes\TestCaseSourceTests.cs" />
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestFixtureSourceTests.cs" />
     <Compile Include="Attributes\TestMethodBuilderTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
+    <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
@@ -250,6 +251,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
+    <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
@@ -240,6 +241,7 @@
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
+    <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />
     <Compile Include="Assertions\AssumeThatTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
@@ -144,6 +145,7 @@
     <Compile Include="Attributes\TestCaseSourceTests.cs" />
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestFixtureSourceTests.cs" />
     <Compile Include="Attributes\TestMethodBuilderTests.cs" />


### PR DESCRIPTION
Equivalent of `Assert.Throws` for non-void async methods.