### PR TITLE
TestCase with Explicit=true should not crash console runner

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -320,6 +320,8 @@ namespace NUnit.Framework.Interfaces
 
         private static string EscapeInvalidXmlCharacters(string str)
         {
+            if (str == null) return null;
+
             // Based on the XML spec http://www.w3.org/TR/xml/#charsets
             // For detailed explanation of the regex see http://mnaoumov.wordpress.com/2014/06/15/escaping-invalid-xml-unicode-characters/
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -192,6 +192,12 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual("c", array[0]);
         }
 
+        [TestCase("a", "b", Explicit = true)]
+        public void ShouldNotRunAndShouldNotFailInConsoleRunner()
+        {
+            Assert.Fail();
+        }
+
         [Test]
         public void CanSpecifyDescription()
         {


### PR DESCRIPTION
There is a simple test that reproduce problem and a fix.

If TestCase attribute is marked with Explicit true with no Reason message, then whole console runner output is broken due to bug.