### PR TITLE
#1121 : ValueSourceAttribute.GetDataSource should throw instead of return null

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -108,36 +108,47 @@ namespace NUnit.Framework
             MemberInfo[] members = sourceType.GetMember(SourceName,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
 
-            if (members.Length == 1)
+            var dataSource = GetDataSourceValue(members);
+
+            if (dataSource == null)
             {
-                MemberInfo member = members[0];
+                ThrowInvalidDataSourceException();
+            }
 
-                var field = member as FieldInfo;
-                if (field != null)
-                {
-                    if (field.IsStatic)
-                        return (IEnumerable)field.GetValue(null);
+            return dataSource;
+        }
 
-                    ThrowInvalidDataSourceException();
-                }
+        private static IEnumerable GetDataSourceValue(MemberInfo[] members)
+        {
+            if (members.Length != 1) return null;
 
-                var property = member as PropertyInfo;
-                if (property != null)
-                {
-                    if (property.GetGetMethod(true).IsStatic)
-                        return (IEnumerable)property.GetValue(null, null);
+            MemberInfo member = members[0];
 
-                    ThrowInvalidDataSourceException();
-                }
+            var field = member as FieldInfo;
+            if (field != null)
+            {
+                if (field.IsStatic)
+                    return (IEnumerable)field.GetValue(null);
 
-                var m = member as MethodInfo;
-                if (m != null)
-                {
-                    if (m.IsStatic)
-                        return (IEnumerable)m.Invoke(null, null);
+                ThrowInvalidDataSourceException();
+            }
 
-                    ThrowInvalidDataSourceException();
-                }
+            var property = member as PropertyInfo;
+            if (property != null)
+            {
+                if (property.GetGetMethod(true).IsStatic)
+                    return (IEnumerable)property.GetValue(null, null);
+
+                ThrowInvalidDataSourceException();
+            }
+
+            var m = member as MethodInfo;
+            if (m != null)
+            {
+                if (m.IsStatic)
+                    return (IEnumerable)m.Invoke(null, null);
+
+                ThrowInvalidDataSourceException();
             }
 
             return null;
@@ -145,7 +156,7 @@ namespace NUnit.Framework
 
         private static void ThrowInvalidDataSourceException()
         {
-            throw new InvalidDataSourceException("The sourceName specified on a ValueSourceAttribute must refer to a static field, property or method.");
+            throw new InvalidDataSourceException("The sourceName specified on a ValueSourceAttribute must refer to a non null static field, property or method.");
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -24,7 +24,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using NUnit.Framework.Compatibility;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
@@ -167,6 +171,51 @@ namespace NUnit.Framework.Attributes
                 dataList.Add(8);
 
                 return dataList;
+            }
+
+            public static IEnumerable<int> ForeignNullResultProvider()
+            {
+                return null;
+            }
+        }
+
+        public static string NullSource = null;
+
+        public static IEnumerable<int> NullDataSourceProvider()
+        {
+            return null;
+        }
+
+        public static IEnumerable<int> NullDataSourceProperty
+        {
+            get { return null; }
+        }
+
+        [Test, Explicit("Null or nonexisting data sources definitions should not prevent other tests from run #1121")]
+        public void ValueSourceMayNotBeNull(
+            [ValueSource("NullSource")] string nullSource,
+            [ValueSource("NullDataSourceProvider")] string nullDataSourceProvided,
+            [ValueSource(typeof(ValueProvider), "ForeignNullResultProvider")] string nullDataSourceProvider,
+            [ValueSource("NullDataSourceProperty")] int nullDataSourceProperty,
+            [ValueSource("SomeNonExistingMemberSource")] int nonExistingMember)
+        {
+            Assert.Fail();
+        }
+
+        [Test]
+        public void ValueSourceAttributeShouldThrowInsteadOfReturningNull()
+        {
+            var method = new MethodWrapper(GetType(), "ValueSourceMayNotBeNull");
+            var parameters = method.GetParameters();
+
+            foreach (var parameter in parameters)
+            {
+                var dataSource = parameter.GetCustomAttributes<IParameterDataSource>(false)[0];
+
+                Assert.Throws<InvalidDataSourceException>(() =>
+                {
+                    var data = dataSource.GetData(parameter);
+                }); 
             }
         }
     }


### PR DESCRIPTION
My attempt to fix bug #1121.
