### PR TITLE
#1196 pluggable value formatter

### DIFF
--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -32,6 +32,15 @@ namespace NUnit.Framework.Constraints
     public static class MsgUtilTests
     {
         #region FormatValue
+        class CustomFormattableType { }
+
+        [Test]
+        public static void FormatValue_CustomFormatterInvoked()
+        {
+            MsgUtils.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
+        }
 
         [Test]
         public static void FormatValue_IntegerIsWrittenAsIs()


### PR DESCRIPTION
+ Converted existing formatters

The order of registration maintains backwards compatibility with existing behavior: the last registered takes precedence.