### PR TITLE
1187 stoprun fix

### DIFF
--- a/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Api
         #region Methods
 
         /// <summary>
-        /// Loads the tests found in an Assembly, returning an 
+        /// Loads the tests found in an Assembly, returning an
         /// indication of whether or not the load succeeded.
         /// </summary>
         /// <param name="assemblyName">File name of the assembly to load</param>
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Api
         ITest Load(string assemblyName, System.Collections.IDictionary settings);
 
         /// <summary>
-        /// Loads the tests found in an Assembly, returning an 
+        /// Loads the tests found in an Assembly, returning an
         /// indication of whether or not the load succeeded.
         /// </summary>
         /// <param name="assembly">The assembly to load</param>

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,10 +24,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Reflection;
 using NUnit.Framework.Compatibility;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Interfaces;
-using System.Reflection;
 
 namespace NUnit.Framework.Internal.Execution
 {
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class CompositeWorkItem : WorkItem
     {
-//        static Logger log = InternalTrace.GetLogger("CompositeWorkItem");
+        //        static Logger log = InternalTrace.GetLogger("CompositeWorkItem");
 
         private TestSuite _suite;
         private ITestFilter _childFilter;
@@ -55,7 +55,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         /// <param name="suite">The TestSuite to be executed</param>
         /// <param name="childFilter">A filter used to select child tests</param>
-        public CompositeWorkItem(TestSuite suite, ITestFilter childFilter) : base(suite)
+        public CompositeWorkItem(TestSuite suite, ITestFilter childFilter)
+            : base(suite)
         {
             _suite = suite;
             _childFilter = childFilter;
@@ -69,7 +70,7 @@ namespace NUnit.Framework.Internal.Execution
         protected override void PerformWork()
         {
             // Inititialize actions, setup and teardown
-            // We can't do this in the constructor because 
+            // We can't do this in the constructor because
             // the context is not available at that point.
             InitializeSetUpAndTearDownCommands();
 
@@ -77,63 +78,63 @@ namespace NUnit.Framework.Internal.Execution
                 if (Test.RunState == RunState.Explicit && !_childFilter.IsExplicitMatch(Test))
                     SkipFixture(ResultState.Explicit, GetSkipReason(), null);
                 else
-                switch (Test.RunState)
-                {
-                    default:
-                    case RunState.Runnable:
-                    case RunState.Explicit:
-                        // Assume success, since the result will be inconclusive
-                        // if there is no setup method to run or if the
-                        // context initialization fails.
-                        Result.SetResult(ResultState.Success);
+                    switch (Test.RunState)
+                    {
+                        default:
+                        case RunState.Runnable:
+                        case RunState.Explicit:
+                            // Assume success, since the result will be inconclusive
+                            // if there is no setup method to run or if the
+                            // context initialization fails.
+                            Result.SetResult(ResultState.Success);
 
-                        CreateChildWorkItems();
+                            CreateChildWorkItems();
 
-                        if (_children.Count > 0)
-                        {
-                            PerformOneTimeSetUp();
+                            if (_children.Count > 0)
+                            {
+                                PerformOneTimeSetUp();
 
-                            if (!CheckForCancellation())
-                                switch (Result.ResultState.Status)
-                                {
-                                    case TestStatus.Passed:
-                                        RunChildren();
-                                        return;
-                                    // Just return: completion event will take care
-                                    // of TestFixtureTearDown when all tests are done.
+                                if (!CheckForCancellation())
+                                    switch (Result.ResultState.Status)
+                                    {
+                                        case TestStatus.Passed:
+                                            RunChildren();
+                                            return;
+                                        // Just return: completion event will take care
+                                        // of TestFixtureTearDown when all tests are done.
 
-                                    case TestStatus.Skipped:
-                                    case TestStatus.Inconclusive:
-                                    case TestStatus.Failed:
-                                        SkipChildren(_suite, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message);
-                                        break;
-                                }
+                                        case TestStatus.Skipped:
+                                        case TestStatus.Inconclusive:
+                                        case TestStatus.Failed:
+                                            SkipChildren(_suite, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message);
+                                            break;
+                                    }
 
-                            // Directly execute the OneTimeFixtureTearDown for tests that
-                            // were skipped, failed or set to inconclusive in one time setup
-                            // unless we are aborting.
-                            if (Context.ExecutionStatus != TestExecutionStatus.AbortRequested)
-                                PerformOneTimeTearDown();
-                        }
-                        break;
+                                // Directly execute the OneTimeFixtureTearDown for tests that
+                                // were skipped, failed or set to inconclusive in one time setup
+                                // unless we are aborting.
+                                if (Context.ExecutionStatus != TestExecutionStatus.AbortRequested)
+                                    PerformOneTimeTearDown();
+                            }
+                            break;
 
-                    case RunState.Skipped:
-                        SkipFixture(ResultState.Skipped, GetSkipReason(), null);
-                        break;
+                        case RunState.Skipped:
+                            SkipFixture(ResultState.Skipped, GetSkipReason(), null);
+                            break;
 
-                    case RunState.Ignored:
-                        SkipFixture(ResultState.Ignored, GetSkipReason(), null);
-                        break;
+                        case RunState.Ignored:
+                            SkipFixture(ResultState.Ignored, GetSkipReason(), null);
+                            break;
 
-                    case RunState.NotRunnable:
-                        SkipFixture(ResultState.NotRunnable, GetSkipReason(), GetProviderStackTrace());
-                        break;
-                }
+                        case RunState.NotRunnable:
+                            SkipFixture(ResultState.NotRunnable, GetSkipReason(), GetProviderStackTrace());
+                            break;
+                    }
 
             // Fall through in case nothing was run.
             // Otherwise, this is done in the completion event.
             WorkItemComplete();
-        
+
         }
 
         #region Helper Methods
@@ -161,15 +162,15 @@ namespace NUnit.Framework.Internal.Execution
                 // Special handling here for ParameterizedMethodSuite is a bit ugly. However,
                 // it is needed because Tests are not supposed to know anything about Action
                 // Attributes (or any attribute) and Attributes don't know where they were
-                // initially applied unless we tell them. 
+                // initially applied unless we tell them.
                 //
-                // ParameterizedMethodSuites and individual test cases both use the same 
+                // ParameterizedMethodSuites and individual test cases both use the same
                 // MethodInfo as a source of attributes. We handle the Test and Default targets
                 // in the test case, so we don't want to doubly handle it here.
-                bool applyToSuite = (action.Targets & ActionTargets.Suite) == ActionTargets.Suite 
+                bool applyToSuite = (action.Targets & ActionTargets.Suite) == ActionTargets.Suite
                     || action.Targets == ActionTargets.Default && !(Test is ParameterizedMethodSuite);
 
-                bool applyToTest = (action.Targets & ActionTargets.Test) == ActionTargets.Test 
+                bool applyToTest = (action.Targets & ActionTargets.Test) == ActionTargets.Test
                     && !(Test is ParameterizedMethodSuite);
 
                 if (applyToSuite)
@@ -194,7 +195,7 @@ namespace NUnit.Framework.Internal.Execution
             }
             catch (Exception ex)
             {
-                if (ex is NUnitException || ex is System.Reflection.TargetInvocationException)
+                if (ex is NUnitException || ex is TargetInvocationException)
                     ex = ex.InnerException;
 
                 Result.RecordException(ex, FailureSite.SetUp);
@@ -233,10 +234,8 @@ namespace NUnit.Framework.Internal.Execution
             _children = new List<WorkItem>();
 
             foreach (ITest test in _suite.Tests)
-            {
                 if (_childFilter.Pass(test))
                     _children.Add(WorkItem.CreateWorkItem(test, _childFilter));
-            }
         }
 
         private void SkipFixture(ResultState resultState, string message, string stackTrace)
@@ -329,6 +328,31 @@ namespace NUnit.Framework.Internal.Execution
         private static bool IsStaticClass(Type type)
         {
             return type.GetTypeInfo().IsAbstract && type.GetTypeInfo().IsSealed;
+        }
+
+        private object cancelLock = new object();
+
+        /// <summary>
+        /// Cancel (abort or stop) a CompositeWorkItem and all of its children
+        /// </summary>
+        /// <param name="force">true if the CompositeWorkItem and all of its children should be aborted, false if it should allow all currently running tests to complete</param>
+        public override void Cancel(bool force)
+        {
+            lock (cancelLock)
+            {
+                if (_children == null)
+                    return;
+
+                foreach (var child in _children)
+                {
+                    var ctx = child.Context;
+                    if (ctx != null)
+                        ctx.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
+
+                    if (child.State == WorkItemState.Running)
+                        child.Cancel(force);
+                }
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -40,6 +40,7 @@ namespace NUnit.Framework.Internal.Execution
         /// Cancel the ongoing run completely.
         /// If no run is in process, the call has no effect.
         /// </summary>
-        void CancelRun();
+        /// <param name="force">true if the IWorkItemDispatcher should abort all currently running WorkItems, false if it should allow all currently running WorkItems to complete</param>
+        void CancelRun(bool force);
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -141,10 +141,10 @@ namespace NUnit.Framework.Internal.Execution
         /// Cancel the ongoing run completely.
         /// If no run is in process, the call has no effect.
         /// </summary>
-        public void CancelRun()
+        public void CancelRun(bool force)
         {
             foreach (var shift in Shifts)
-                shift.Cancel();
+                shift.Cancel(force);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Internal.Execution
 
 #if !NETCF
                 if (work.TargetApartment == ApartmentState.STA)
-                    _runnerThread.SetApartment(ApartmentState.STA);
+                    _runnerThread.SetApartmentState(ApartmentState.STA);
 #endif
 
                 _runnerThread.Start();

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -65,6 +65,12 @@ namespace NUnit.Framework.Internal.Execution
             {
                 _topLevelWorkItem = work;
                 _runnerThread = new Thread(RunnerThreadProc);
+
+#if !NETCF
+                if (work.TargetApartment == ApartmentState.STA)
+                    _runnerThread.SetApartment(ApartmentState.STA);
+#endif
+
                 _runnerThread.Start();
             }
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -77,7 +77,9 @@ namespace NUnit.Framework.Internal.Execution
         }
 #endif
 
+#if !PORTABLE
         private object cancelLock = new object();
+#endif
 
         /// <summary>
         /// Cancel (abort or stop) the ongoing run.
@@ -86,6 +88,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="force">true if the run should be aborted, false if it should allow its currently running test to complete</param>
         public void CancelRun(bool force)
         {
+#if !PORTABLE
             lock (cancelLock)
             {
                 if (_topLevelWorkItem != null)
@@ -95,6 +98,7 @@ namespace NUnit.Framework.Internal.Execution
                         _topLevelWorkItem = null;
                 }
             }
+#endif
         }
         #endregion
     }

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Internal.Execution
                 _topLevelWorkItem = work;
                 _runnerThread = new Thread(RunnerThreadProc);
 
-#if !NETCF
+#if !NETCF && !SILVERLIGHT
                 if (work.TargetApartment == ApartmentState.STA)
                     _runnerThread.SetApartmentState(ApartmentState.STA);
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -96,6 +96,8 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Our ThreadProc, which pulls and runs tests in a loop
         /// </summary>
+        private WorkItem _currentWorkItem;
+
         private void TestWorkerThreadProc()
         {
             log.Info("{0} starting ", _workerThread.Name);
@@ -106,15 +108,15 @@ namespace NUnit.Framework.Internal.Execution
             {
                 while (_running)
                 {
-                    var workItem = _readyQueue.Dequeue();
-                    if (workItem == null)
+                    _currentWorkItem = _readyQueue.Dequeue();
+                    if (_currentWorkItem == null)
                         break;
 
-                    log.Info("{0} executing {1}", _workerThread.Name, workItem.Test.Name);
+                    log.Info("{0} executing {1}", _workerThread.Name, _currentWorkItem.Test.Name);
 
                     if (Busy != null)
                         Busy(this, EventArgs.Empty);
-                    workItem.Execute();
+                    _currentWorkItem.Execute();
                     if (Idle != null)
                         Idle(this, EventArgs.Empty);
 
@@ -135,19 +137,28 @@ namespace NUnit.Framework.Internal.Execution
             _workerThread.Start();
         }
 
+        private object cancelLock = new object();
+
         /// <summary>
         /// Stop the thread, either immediately or after finishing the current WorkItem
         /// </summary>
-        public void Cancel()
+        /// <param name="force">true if the thread should be aborted, false if it should allow the currently running test to complete</param>
+        public void Cancel(bool force)
         {
-            _running = false;
+            if (force)
+                _running = false;
 
-#if NETCF
-            if (_workerThread != null && !_workerThread.Join(0))
-#else
-            if (_workerThread != null && _workerThread.IsAlive)
-#endif
-                ThreadUtility.Kill(_workerThread);
+            lock (cancelLock)
+                if (_workerThread != null && _currentWorkItem != null)
+                {
+                    {
+                        _currentWorkItem.Context.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
+
+                        _currentWorkItem.Cancel(force);
+                        if (force)
+                            _currentWorkItem = null;
+                    }
+                }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -151,13 +151,9 @@ namespace NUnit.Framework.Internal.Execution
             lock (cancelLock)
                 if (_workerThread != null && _currentWorkItem != null)
                 {
-                    {
-                        _currentWorkItem.Context.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
-
-                        _currentWorkItem.Cancel(force);
-                        if (force)
-                            _currentWorkItem = null;
-                    }
+                    _currentWorkItem.Cancel(force);
+                    if (force)
+                        _currentWorkItem = null;
                 }
         }
     }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -261,6 +261,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
+        private Thread thread;
         private ApartmentState currentApartment;
 
         private void RunTestOnOwnThread(int timeout, ApartmentState apartment)
@@ -271,7 +272,7 @@ namespace NUnit.Framework.Internal.Execution
                 ? "has Timeout value set."
                 : currentApartment != apartment && apartment != ApartmentState.Unknown
                 ? "requires a different apartment."
-                :; "is TestMethod"
+                : "is TestMethod";
             log.Debug("Running test on own thread because it " + reason);
 
             Thread thread = new Thread(new ThreadStart(RunTest));

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -246,7 +246,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
         }
 
-#if (SILVERLIGHT || NETCF) && !PORTABLE
+#if SILVERLIGHT || NETCF
         private Thread thread;
 
         private void RunTestOnOwnThread(int timeout)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -275,9 +275,9 @@ namespace NUnit.Framework.Internal.Execution
                 : "is TestMethod";
             log.Debug("Running test on own thread because it " + reason);
 
-            Thread thread = new Thread(new ThreadStart(RunTest));
+            thread = new Thread(new ThreadStart(RunTest));
 
-            thread.SetApartmentState(apartment);
+            thread.SetApartmentState(apartment == ApartmentState.Unknown ? currentApartment : apartment);
 
             RunThread(timeout);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal.Execution
     /// from the abstract WorkItem class, which uses the template
     /// pattern to allow derived classes to perform work in
     /// whatever way is needed.
-    /// 
+    ///
     /// A WorkItem is created with a particular TestExecutionContext
     /// and is responsible for re-establishing that context in the
     /// current thread before it begins or resumes execution.
@@ -150,7 +150,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public List<ITestAction> Actions
         {
-            get { return _actions;  }
+            get { return _actions; }
         }
 
 #if PARALLEL
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public bool IsParallelizable
         {
-            get 
+            get
             {
                 ParallelScope scope = ParallelScope.None;
 
@@ -203,7 +203,7 @@ namespace NUnit.Framework.Internal.Execution
 #if !SILVERLIGHT && !NETCF && !PORTABLE
         internal ApartmentState TargetApartment
         {
-            get 
+            get
             {
                 return Test.Properties.ContainsKey(PropertyNames.ApartmentState)
                     ? (ApartmentState)_test.Properties.Get(PropertyNames.ApartmentState)
@@ -230,30 +230,61 @@ namespace NUnit.Framework.Internal.Execution
                 timeout = (int)Test.Properties.Get(PropertyNames.Timeout);
 
 #if SILVERLIGHT || NETCF
-            if (Test.RequiresThread || Test is TestMethod && timeout > 0)
+            if (Test is TestMethod)
                 RunTestOnOwnThread(timeout);
             else
                 RunTest();
 #elif PORTABLE
             RunTest();
 #else
-            ApartmentState currentApartment = Thread.CurrentThread.GetApartmentState();
+            currentApartment = Thread.CurrentThread.GetApartmentState();
 
-            if (Test.RequiresThread || Test is TestMethod && timeout > 0 || currentApartment != TargetApartment && TargetApartment != ApartmentState.Unknown)
+            if (Test is TestMethod)
                 RunTestOnOwnThread(timeout, TargetApartment);
             else
                 RunTest();
 #endif
         }
 
-#if SILVERLIGHT || NETCF
+#if (SILVERLIGHT || NETCF) && !PORTABLE
+        private Thread thread;
+
         private void RunTestOnOwnThread(int timeout)
         {
-            string reason = Test.RequiresThread ? "has RequiresThreadAttribute." : "has Timeout value set.";
+            string reason = Test.RequiresThread ? "has RequiresThreadAttribute." : timeout > 0 ? "has Timeout value set." : "is TestMethod";
             log.Debug("Running test on own thread because it " + reason);
 
-            Thread thread = new Thread(RunTest);
+            thread = new Thread(RunTest);
 
+            RunThread(timeout);
+        }
+#endif
+
+#if !SILVERLIGHT && !NETCF && !PORTABLE
+        private ApartmentState currentApartment;
+
+        private void RunTestOnOwnThread(int timeout, ApartmentState apartment)
+        {
+            string reason = Test.RequiresThread
+                ? "has RequiresThreadAttribute."
+                : timeout > 0
+                ? "has Timeout value set."
+                : currentApartment != apartment && apartment != ApartmentState.Unknown
+                ? "requires a different apartment."
+                :; "is TestMethod"
+            log.Debug("Running test on own thread because it " + reason);
+
+            Thread thread = new Thread(new ThreadStart(RunTest));
+
+            thread.SetApartmentState(apartment);
+
+            RunThread(timeout);
+        }
+#endif
+
+#if !PORTABLE
+        private void RunThread(int timeout)
+        {
 #if !NETCF
             thread.CurrentCulture = Context.CurrentCulture;
             thread.CurrentUICulture = Context.CurrentUICulture;
@@ -266,16 +297,23 @@ namespace NUnit.Framework.Internal.Execution
                 if (timeout <= 0)
                     timeout = Timeout.Infinite;
 
-                // Previous code:
-                // thread.Join(timeout);
-                //
-                // if (thread.IsAlive)
-                // Was this here for a reason?
-                // Is there some platform that needs it?
-
                 if (!thread.Join(timeout))
                 {
-                    ThreadUtility.Kill(thread);
+                    Thread tThread;
+                    lock (threadLock)
+                    {
+                        if (thread == null)
+                            return;
+
+                        tThread = thread;
+                        thread = null;
+                    }
+
+                    if (Context.ExecutionStatus == TestExecutionStatus.AbortRequested)
+                        return;
+
+                    log.Debug("Killing thread {0}, which exceeded timeout", tThread.ManagedThreadId);
+                    ThreadUtility.Kill(tThread);
 
                     // NOTE: Without the use of Join, there is a race condition here.
                     // The thread sets the result to Cancelled and our code below sets
@@ -284,56 +322,7 @@ namespace NUnit.Framework.Internal.Execution
                     // thread has terminated. There is a risk here: the test code might
                     // refuse to terminate. However, it's more important to deal with
                     // the normal rather than a pathological case.
-                    thread.Join();
-
-                    Result.SetResult(ResultState.Failure,
-                        string.Format("Test exceeded Timeout value of {0}ms", timeout));
-
-                    WorkItemComplete();
-                }
-            }
-        }
-#endif
-
-
-#if !SILVERLIGHT && !NETCF && !PORTABLE
-        private void RunTestOnOwnThread(int timeout, ApartmentState apartment)
-        {
-            string reason = Test.RequiresThread
-                ? "has RequiresThreadAttribute."
-                : timeout > 0
-                    ? "has Timeout value set."
-                    : "requires a different apartment.";
-            log.Debug("Running test on own thread because it " + reason);
-
-            Thread thread = new Thread(new ThreadStart(RunTest));
-
-            thread.SetApartmentState(apartment);
-            thread.CurrentCulture = Context.CurrentCulture;
-            thread.CurrentUICulture = Context.CurrentUICulture;
-
-            thread.Start();
-
-            if (!Test.IsAsynchronous || timeout > 0)
-            {
-                if (timeout <= 0)
-                    timeout = Timeout.Infinite;
-
-                thread.Join(timeout);
-
-                if (thread.IsAlive)
-                {
-                    log.Debug("Killing thread {0}, which exceeded timeout", thread.ManagedThreadId);
-                    ThreadUtility.Kill(thread);
-
-                    // NOTE: Without the use of Join, there is a race condition here.
-                    // The thread sets the result to Cancelled and our code below sets
-                    // it to Failure. In order for the result to be shown as a failure,
-                    // we need to ensure that the following code executes after the
-                    // thread has terminated. There is a risk here: the test code might
-                    // refuse to terminate. However, it's more important to deal with
-                    // the normal rather than a pathological case.
-                    thread.Join();
+                    tThread.Join();
 
                     log.Debug("Changing result from {0} to Timeout Failure", Result.ResultState);
 
@@ -343,6 +332,7 @@ namespace NUnit.Framework.Internal.Execution
                     WorkItemComplete();
                 }
             }
+
         }
 #endif
 
@@ -356,16 +346,49 @@ namespace NUnit.Framework.Internal.Execution
             _context.EstablishExecutionEnvironment();
 
             _state = WorkItemState.Running;
-#if PORTABLE
+
             PerformWork();
-#else
-            try
+
+        }
+
+        private object threadLock = new object();
+
+        /// <summary>
+        /// Cancel (abort or stop) a WorkItem
+        /// </summary>
+        /// <param name="force">true if the WorkItem should be aborted, false if it should run to completion</param>
+        public virtual void Cancel(bool force)
+        {
+            if (_context != null)
+                _context.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
+
+            if (!force)
+                return;
+
+#if !PORTABLE
+            Thread tThread;
+
+            lock (threadLock)
             {
-                PerformWork();
+                if (thread == null)
+                    return;
+
+                tThread = thread;
+                thread = null;
             }
-            catch (ThreadAbortException)
+
+            if (!tThread.Join(0))
             {
-                //Result.SetResult(ResultState.Cancelled);
+                log.Debug("Killing thread {0} for cancel", thread.ManagedThreadId);
+                ThreadUtility.Kill(tThread);
+
+                tThread.Join();
+
+                log.Debug("Changing result from {0} to Cancelled", Result.ResultState);
+
+                Result.SetResult(ResultState.Cancelled, "Cancelled by user");
+
+                WorkItemComplete();
             }
 #endif
         }
@@ -389,7 +412,7 @@ namespace NUnit.Framework.Internal.Execution
 
             Result.StartTime = Context.StartTime;
             Result.EndTime = DateTime.UtcNow;
-            
+
             long tickCount = Stopwatch.GetTimestamp() - Context.StartTicks;
             double seconds = (double)tickCount / Stopwatch.Frequency;
             Result.Duration = seconds;

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012-2014 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -29,23 +29,23 @@ using System.Threading;
 namespace NUnit.Framework.Internal.Execution
 {
     /// <summary>
-    /// The dispatcher needs to do different things at different, 
+    /// The dispatcher needs to do different things at different,
     /// non-overlapped times. For example, non-parallel tests may
     /// not be run at the same time as parallel tests. We model
     /// this using the metaphor of a working shift. The WorkShift
-    /// class associates one or more WorkItemQueues with one or 
-    /// more TestWorkers. 
-    /// 
-    /// Work in the queues is processed until all queues are empty 
-    /// and all workers are idle. Both tests are needed because a 
-    /// worker that is busy may end up adding more work to one of 
-    /// the queues. At that point, the shift is over and another 
-    /// shift may begin. This cycle continues until all the tests 
+    /// class associates one or more WorkItemQueues with one or
+    /// more TestWorkers.
+    ///
+    /// Work in the queues is processed until all queues are empty
+    /// and all workers are idle. Both tests are needed because a
+    /// worker that is busy may end up adding more work to one of
+    /// the queues. At that point, the shift is over and another
+    /// shift may begin. This cycle continues until all the tests
     /// have been run.
     /// </summary>
     public class WorkShift
     {
-        static Logger log = InternalTrace.GetLogger("WorkShift");
+        private static Logger log = InternalTrace.GetLogger("WorkShift");
 
         private object _syncRoot = new object();
         private int _busyCount = 0;
@@ -96,8 +96,10 @@ namespace NUnit.Framework.Internal.Execution
             get
             {
                 foreach (var q in Queues)
+                {
                     if (!q.IsEmpty)
                         return true;
+                }
 
                 return false;
             }
@@ -136,13 +138,15 @@ namespace NUnit.Framework.Internal.Execution
             {
                 // Quick check first using Interlocked.Decrement
                 if (Interlocked.Decrement(ref _busyCount) == 0)
+                {
                     lock (_syncRoot)
                     {
                         // Check busy count again under the lock
                         if (_busyCount == 0 && !HasWork)
                             this.EndShift();
                     }
-            };
+                }
+            }
 
             worker.Start();
         }
@@ -191,23 +195,20 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         /// <summary>
-        /// Cancel the shift without completing all work
+        /// Cancel (abort or stop) the shift without completing all work
         /// </summary>
-        public void Cancel()
+        /// <param name="force">true if the WorkShift should be aborted, false if it should allow its currently running tests to complete</param>
+        public void Cancel(bool force)
         {
-            this.IsActive = false;
+            if (force)
+                this.IsActive = false;
 
             foreach (var w in Workers)
-                w.Cancel();
-
-            foreach (var q in Queues)
-                q.Stop();
-
-            Workers.Clear();
-            Queues.Clear();
+                w.Cancel(force);
         }
 
         #endregion
     }
 }
+
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -142,7 +142,7 @@ namespace NUnit.Framework.Internal.Execution
                         if (_busyCount == 0 && !HasWork)
                             this.EndShift();
                     }
-            }
+            };
 
             worker.Start();
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -96,10 +96,8 @@ namespace NUnit.Framework.Internal.Execution
             get
             {
                 foreach (var q in Queues)
-                {
                     if (!q.IsEmpty)
                         return true;
-                }
 
                 return false;
             }
@@ -138,14 +136,12 @@ namespace NUnit.Framework.Internal.Execution
             {
                 // Quick check first using Interlocked.Decrement
                 if (Interlocked.Decrement(ref _busyCount) == 0)
-                {
                     lock (_syncRoot)
                     {
                         // Check busy count again under the lock
                         if (_busyCount == 0 && !HasWork)
                             this.EndShift();
                     }
-                }
             }
 
             worker.Start();

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -145,8 +145,8 @@ namespace NUnit.Framework.Internal
             this.TestCaseTimeout = other.TestCaseTimeout;
             this.UpstreamActions = new List<ITestAction>(other.UpstreamActions);
 
-            _currentCulture = CultureInfo.CurrentCulture;
-            _currentUICulture = CultureInfo.CurrentUICulture;
+            _currentCulture = other.CurrentCulture;
+            _currentUICulture = other.CurrentUICulture;
 
 #if !NETCF && !SILVERLIGHT && !PORTABLE
             _currentPrincipal = other.CurrentPrincipal;

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Tests
 {
     public class SlowTests
     {
-        const int DELAY = 100;
+        const int DELAY = 1000;
         
         public class AAA
         {

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -131,7 +131,7 @@ namespace NUnit.Framework.Api
         public void CountTestCases_WithoutLoad_ThrowsInvalidOperation()
         {
             var ex = Assert.Throws<InvalidOperationException>(
-                () => _runner.CountTestCases(TestFilter.Empty));
+                    () => _runner.CountTestCases(TestFilter.Empty));
             Assert.That(ex.Message, Is.EqualTo("The CountTestCases method was called but no test has been loaded"));
         }
 
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Api
         public void Run_WithoutLoad_ReturnsError()
         {
             var ex = Assert.Throws<InvalidOperationException>(
-                () => _runner.Run(TestListener.NULL, TestFilter.Empty));
+                    () => _runner.Run(TestListener.NULL, TestFilter.Empty));
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
@@ -268,7 +268,7 @@ namespace NUnit.Framework.Api
         public void RunAsync_WithoutLoad_ReturnsError()
         {
             var ex = Assert.Throws<InvalidOperationException>(
-                () => _runner.RunAsync(TestListener.NULL, TestFilter.Empty));
+                    () => _runner.RunAsync(TestListener.NULL, TestFilter.Empty));
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
@@ -348,7 +348,7 @@ namespace NUnit.Framework.Api
             _runner.StopRun(true);
         }
 
-        [Test, Explicit("Intermittent failure")]
+        [Test]
         public void CancelRun_WhenTestIsRunning_StopsTest()
         {
             var tests = _runner.Load(_slowTestsPath, _settings);
@@ -358,7 +358,7 @@ namespace NUnit.Framework.Api
 
             // When cancelling, the completion event may not be signalled,
             // so we only wait a short time before checking.
-            _runner.WaitForCompletion(10000);
+            _runner.WaitForCompletion(Timeout.Infinite);
 
             Assert.True(_runner.IsTestComplete, "Test is not complete");
 

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -72,8 +72,10 @@ namespace NUnit.Framework.Attributes
         public void TestWithRequiresMTARunsInMTA()
         {
             Assert.That(GetApartmentState(Thread.CurrentThread), Is.EqualTo(ApartmentState.MTA));
-            if (ParentThreadApartment == ApartmentState.MTA)
-                Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
+			//
+			// Currently this will not work since we are always running on a different thread then the ParentThread.
+            //if (ParentThreadApartment == ApartmentState.MTA)
+            //    Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
 
         [TestFixture, Apartment(ApartmentState.MTA)]


### PR DESCRIPTION
This PR implement/fixes the IAssemblyTestRunner.StopRun method to work in all cases.

It does this by always running a WorkItem on its own thread, where previously that was only done in cases of timeout, a separate thread or specific thread type required .
 
It then only aborts the actual thread the test is running on, and allows everything else to clean up itself normally.

This eliminates almost all special handling for both abort and stop operations.