### PR TITLE
Issue 1196

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -44,9 +44,43 @@ namespace NUnit.Framework.Constraints
     public delegate ValueFormatter ValueFormatterFactory(ValueFormatter next);
 
     /// <summary>
+    /// Small class to allow adding ValueFormatter instances to MsgUtils
+    /// without exposing MsgUtils publicly.
+    /// </summary>
+    public static class ValueFormatters
+    {
+        /// <summary>
+        /// This method adds the a new ValueFormatterFactory to the
+        /// chain of responsibility.
+        /// </summary>
+        /// <param name="formatterFactory">The factory delegate</param>
+        public static void Add(ValueFormatterFactory formatterFactory)
+        {
+            if (Internal.TestExecutionContext.CurrentContext != null)
+                throw new InvalidOperationException("Cannot add global foratters once execution has started");
+
+            MsgUtils.AddFormatter(formatterFactory);
+        }
+
+        /// <summary>
+        /// This method provides a simplified way to add a ValueFormatter
+        /// delegate to the chain of responsibility, creating the factory
+        /// delegate internally. It is useful when the Type of the object
+        /// is the only criterion for selection of the formatter, since
+        /// it can be used without getting involved with a compould function.
+        /// </summary>
+        /// <typeparam name="TSUPPORTED">The type supported by this formatter</typeparam>
+        /// <param name="formatter">The ValueFormatter delegate</param>
+        public static void Add<TSUPPORTED>(ValueFormatter formatter)
+        {
+            Add(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
+        }
+    }
+
+    /// <summary>
     /// Static methods used in creating messages
     /// </summary>
-    public static class MsgUtils
+    internal static class MsgUtils
     {
         /// <summary>
         /// Static string used when strings are clipped

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -56,9 +56,6 @@ namespace NUnit.Framework.Constraints
         /// <param name="formatterFactory">The factory delegate</param>
         public static void Add(ValueFormatterFactory formatterFactory)
         {
-            if (Internal.TestExecutionContext.CurrentContext != null)
-                throw new InvalidOperationException("Cannot add global foratters once execution has started");
-
             MsgUtils.AddFormatter(formatterFactory);
         }
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -91,8 +91,6 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val.GetType().IsArray ? FormatArray((Array)val) : next(val));
 
-            AddFormatter(next => val => val == null ? Fmt_Null : next(val));
-
 #if NETCF
             AddFormatter(next => val =>
             {
@@ -113,7 +111,6 @@ namespace NUnit.Framework.Constraints
             ValueFormatter = formatterFactory(ValueFormatter);
         }
 
-
         /// <summary>
         /// Formats text to represent a generalized value.
         /// </summary>
@@ -121,7 +118,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>The formatted text</returns>
         public static string FormatValue(object val)
         {
-            return ValueFormatter(val);
+            return val == null ? Fmt_Null : ValueFormatter(val);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/GlobalSettings.cs
+++ b/src/NUnitFramework/framework/GlobalSettings.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2008 Charlie Poole
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,18 +22,45 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework
 {
 	/// <summary>
-	/// GlobalSettings is a place for setting default _values used
-	/// by the framework in performing asserts.
+	/// GlobalSettings is a place for setting default values used
+	/// by the framework in performing asserts. Anything set through
+    /// this class applies to the entire test run. It should not normally
+    /// be used from within a test, since it is not thread-safe.
 	/// </summary>
-	public class GlobalSettings
+	public static class GlobalSettings
 	{
 		/// <summary>
 		/// Default tolerance for floating point equality
 		/// </summary>
 		public static double DefaultFloatingPointTolerance = 0.0d;
-	}
+
+        /// <summary>
+        /// This method adds the a new ValueFormatterFactory to the
+        /// global chain of responsibility maintained by MsgUtils.
+        /// </summary>
+        /// <param name="formatterFactory">The factory delegate</param>
+        public static void AddFormatter(ValueFormatterFactory formatterFactory)
+        {
+            MsgUtils.AddFormatter(formatterFactory);
+        }
+
+        /// <summary>
+        /// This method provides a simplified way to add a ValueFormatter
+        /// delegate to the chain of responsibility, creating the factory
+        /// delegate internally. It is useful when the Type of the object
+        /// is the only criterion for selection of the formatter, since
+        /// it can be used without getting involved with a compould function.
+        /// </summary>
+        /// <typeparam name="TSUPPORTED">The type supported by this formatter</typeparam>
+        /// <param name="formatter">The ValueFormatter delegate</param>
+        public static void AddFormatter<TSUPPORTED>(ValueFormatter formatter)
+        {
+            AddFormatter(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
+        }
+    }
 }

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class ExceptionHelper
     {
-#if !NET_4_5 && !PORTABLE
+#if !NET_4_5 && !PORTABLE && !NETCF
         private static readonly Action<Exception> PreserveStackTrace;
 
         static ExceptionHelper()
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
+#if !NETCF
         /// <summary>
         /// Rethrows an exception, preserving its stack trace
         /// </summary>
@@ -67,6 +68,7 @@ namespace NUnit.Framework.Internal
             throw exception;
 #endif
         }
+#endif
 
 
         // TODO: Move to a utility class

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -225,6 +226,31 @@ namespace NUnit.Framework
 
         /// <summary>Write a formatted string to the current result followed by a line terminator</summary>
         public static void WriteLine(string format, params object[] args) { Out.WriteLine(format, args); }
+
+        /// <summary>
+        /// This method adds the a new ValueFormatterFactory to the
+        /// chain of responsibility used for fomatting values in messages.
+        /// The scope of the change is the current TestContext.
+        /// </summary>
+        /// <param name="formatterFactory">The factory delegate</param>
+        public static void AddFormatter(ValueFormatterFactory formatterFactory)
+        {
+            TestExecutionContext.CurrentContext.AddFormatter(formatterFactory);
+        }
+
+        /// <summary>
+        /// This method provides a simplified way to add a ValueFormatter
+        /// delegate to the chain of responsibility, creating the factory
+        /// delegate internally. It is useful when the Type of the object
+        /// is the only criterion for selection of the formatter, since
+        /// it can be used without getting involved with a compould function.
+        /// </summary>
+        /// <typeparam name="TSUPPORTED">The type supported by this formatter</typeparam>
+        /// <param name="formatter">The ValueFormatter delegate</param>
+        public static void AddFormatter<TSUPPORTED>(ValueFormatter formatter)
+        {
+            AddFormatter(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
+        }
 
         #endregion
 

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -35,26 +35,75 @@ namespace NUnit.Framework.Constraints
         class CustomFormattableType { }
 
         [Test]
-        public static void FormatValue_CustomFormatterInvoked_FactoryArg()
+        public static void FormatValue_GlobalCustomFormatterInvoked_FactoryArg()
         {
-            ValueFormatters.Add(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+            var originalFormatter = MsgUtils.DefaultValueFormatter;
+
+            try
+            {
+                GlobalSettings.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+                Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
+            }
+            finally
+            {
+                MsgUtils.DefaultValueFormatter = originalFormatter;
+            }
+        }
+
+        [Test]
+        public static void FormatValue_GlobalCustomFormatterNotInvokedForNull()
+        {
+            var originalFormatter = MsgUtils.DefaultValueFormatter;
+
+            try
+            {
+                // If this factory is actually called with null, it will throw
+                GlobalSettings.AddFormatter(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
+                Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
+            }
+            finally
+            {
+                MsgUtils.DefaultValueFormatter = originalFormatter;
+            }
+        }
+
+        [Test]
+        public static void FormatValue_GlobalCustomFormatterInvoked_FormatterArg()
+        {
+            var originalFormatter = MsgUtils.DefaultValueFormatter;
+
+            try
+            {
+                GlobalSettings.AddFormatter<CustomFormattableType>(val => "custom_formatted_using_type");
+                Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
+            }
+            finally
+            {
+                MsgUtils.DefaultValueFormatter = originalFormatter;
+            }
+        }
+
+        [Test]
+        public static void FormatValue_ContextualCustomFormatterInvoked_FactoryArg()
+        {
+            TestContext.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
 
             Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
         }
 
         [Test]
-        public static void FormatValue_CustomFormatterNotInvokedForNull()
+        public static void FormatValue_ContextualCustomFormatterNotInvokedForNull()
         {
             // If this factory is actually called with null, it will throw
-            ValueFormatters.Add(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
+            TestContext.AddFormatter(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
 
             Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
         }
 
         [Test]
-        public static void FormatValue_CustomFormatterInvoked_FormatterArg()
+        public static void FormatValue_ContextualCustomFormatterInvoked_FormatterArg()
         {
-            ValueFormatters.Add<CustomFormattableType>(val => "custom_formatted_using_type");
+            TestContext.AddFormatter<CustomFormattableType>(val => "custom_formatted_using_type");
 
             Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
         }

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -43,6 +43,15 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public static void FormatValue_CustomFormatterNotInvokedForNull()
+        {
+            // If this factory is actually called with null, it will throw
+            MsgUtils.AddFormatter(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
+
+            Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
+        }
+
+        [Test]
         public static void FormatValue_IntegerIsWrittenAsIs()
         {
             Assert.That(MsgUtils.FormatValue(42), Is.EqualTo("42"));

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -35,9 +35,9 @@ namespace NUnit.Framework.Constraints
         class CustomFormattableType { }
 
         [Test]
-        public static void FormatValue_CustomFormatterInvoked()
+        public static void FormatValue_CustomFormatterInvoked_FactoryArg()
         {
-            MsgUtils.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+            ValueFormatters.Add(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
 
             Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
         }
@@ -46,9 +46,17 @@ namespace NUnit.Framework.Constraints
         public static void FormatValue_CustomFormatterNotInvokedForNull()
         {
             // If this factory is actually called with null, it will throw
-            MsgUtils.AddFormatter(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
+            ValueFormatters.Add(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
 
             Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
+        }
+
+        [Test]
+        public static void FormatValue_CustomFormatterInvoked_FormatterArg()
+        {
+            ValueFormatters.Add<CustomFormattableType>(val => "custom_formatted_using_type");
+
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -32,6 +32,15 @@ namespace NUnit.Framework.Constraints
     public static class MsgUtilTests
     {
         #region FormatValue
+        class CustomFormattableType { }
+
+        [Test]
+        public static void FormatValue_CustomFormatterInvoked()
+        {
+            MsgUtils.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
+        }
 
         [Test]
         public static void FormatValue_IntegerIsWrittenAsIs()

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -27,11 +27,13 @@ using System.Threading;
 using System.Globalization;
 using NUnit.Common;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using NUnit.TestData.TestContextData;
+using NUnit.TestUtilities;
+
 #if !NETCF
 using System.Security.Principal;
 #endif
-using NUnit.TestData.TestContextData;
-using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Internal
 {
@@ -195,7 +197,7 @@ namespace NUnit.Framework.Internal
         CultureInfo originalUICulture;
 
         [Test]
-        public void FixtureSetUpontextReflectsCurrentCulture()
+        public void FixtureSetUpContextReflectsCurrentCulture()
         {
             Assert.That(fixtureContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
         }
@@ -323,6 +325,34 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(setupContext.CurrentPrincipal, originalPrincipal, "Principal not in final context");
         }
 #endif
+
+        #endregion
+
+        #region ValueFormatter
+
+        [Test]
+        public void SetAndRestoreValueFormatter()
+        {
+            var context = new TestExecutionContext(setupContext);
+            var originalFormatter = context.CurrentValueFormatter;
+
+            try
+            {
+                ValueFormatter f = val => "dummy";
+                context.AddFormatter(next => f);
+                Assert.That(context.CurrentValueFormatter, Is.EqualTo(f));
+
+                context.EstablishExecutionEnvironment();
+                Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("dummy"));
+            }
+            finally
+            {
+                setupContext.EstablishExecutionEnvironment();
+            }
+
+            Assert.That(TestExecutionContext.CurrentContext.CurrentValueFormatter, Is.EqualTo(originalFormatter));
+            Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("123"));
+        }
 
         #endregion
 


### PR DESCRIPTION
This PR fixes #1196 and replaces PR #1198, which was withdrawn by its creator @et1975.

The initial commit includes the original code from that PR plus a fix to ensure that a check for a null value is done before any custom formatters are called. This means that it is not possible to add a special display format for `null` but in compensation avoids any issues with formatters that make use of the value without checking.

Further commits will make this available through the TestContext. I'm not yet sure whether we need to keep the static method for use by F#. From some of @et1975 's comments, that seems to be the case, but he never explained how the feature would be used from F#, only that he didn't want to use it from a OneTimeSetUp method.

F# folks: you can help us here. The OP has left the scene, so there's a good chance we will end up creating something that is not useful to you unless somebody else is willing to communicate. :-)

