### PR TITLE
Add ability for testcasedatasource to have parameters passed to methods

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -39,6 +39,7 @@ namespace NUnit.Framework
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class TestCaseSourceAttribute : NUnitAttribute, ITestBuilder, IImplyFixture
     {
+
         private NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
 
         #region Constructors
@@ -52,6 +53,19 @@ namespace NUnit.Framework
             this.SourceName = sourceName;
         }
 
+        /// <summary>
+        /// Construct with a Type and name
+        /// </summary>
+        /// <param name="sourceType">The Type that will provide data</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
+        /// <param name="methodParams">A set of parameters passed to the method, works only if the Source Name is a method. 
+        ///                     If the source name is a field or property has no effect.</param>
+        public TestCaseSourceAttribute(Type sourceType, string sourceName, object[] methodParams)
+        {
+            this.MethodParams = methodParams;
+            this.SourceType = sourceType;
+            this.SourceName = sourceName;
+        }
         /// <summary>
         /// Construct with a Type and name
         /// </summary>
@@ -75,7 +89,11 @@ namespace NUnit.Framework
         #endregion
 
         #region Properties
-
+        /// <summary>
+        /// A set of parameters passed to the method, works only if the Source Name is a method. 
+        /// If the source name is a field or property has no effect.
+        /// </summary>
+        public object[] MethodParams { get; private set; }
         /// <summary>
         /// The name of a the method, property or fiend to be used as a source
         /// </summary>
@@ -213,7 +231,7 @@ namespace NUnit.Framework
 
             // Handle Type implementing IEnumerable separately
             if (SourceName == null)
-                return Reflect.Construct(sourceType) as IEnumerable;
+                return Reflect.Construct(sourceType, null) as IEnumerable;
 
             MemberInfo[] members = sourceType.GetMember(SourceName,
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
@@ -237,7 +255,7 @@ namespace NUnit.Framework
                 var m = member as MethodInfo;
                 if (m != null)
                     return m.IsStatic
-                        ? (IEnumerable)m.Invoke(null, null)
+                        ? (IEnumerable)m.Invoke(null, MethodParams)
                         : SourceMustBeStaticError();
             }
 

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -139,7 +139,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
             private static object[] myObject;
             public static string MyField;
-            public static int MyProperty { get; }
+            public static int MyProperty { get; set; }
             public static IEnumerable HereIsTheDataWithParameters(int inject1, int inject2, int inject3)
             {
                 yield return new object[] { inject1, inject2, inject3 };

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -104,6 +104,21 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             }
         }
 
+        [Test, TestCaseSource(typeof(DivideDataProvider), "MyField", new object[] { 100, 4, 25 })]
+        public void SourceInAnotherClassPassingParamsToField(int n, int d, int q)
+        {
+        }
+
+        [Test, TestCaseSource(typeof(DivideDataProvider), "MyProperty", new object[] { 100, 4, 25 })]
+        public void SourceInAnotherClassPassingParamsToProperty(int n, int d, int q)
+        {
+        }
+
+        [Test, TestCaseSource(typeof(DivideDataProvider), "HereIsTheDataWithParameters", new object[] { 100, 4 })]
+        public void SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam(int n, int d, int q)
+        {
+        }
+
         [TestCaseSource("exception_source")]
         public void MethodWithSourceThrowingException(string lhs, string rhs)
         {
@@ -117,6 +132,25 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
                 yield return new TestCaseData("b", "b");
 
                 throw new System.Exception("my message");
+            }
+        }
+
+        private class DivideDataProvider
+        {
+            private static object[] myObject;
+            public static string MyField;
+            public static int MyProperty { get; }
+            public static IEnumerable HereIsTheDataWithParameters(int inject1, int inject2, int inject3)
+            {
+                yield return new object[] { inject1, inject2, inject3 };
+            }
+            public static IEnumerable HereIsTheData
+            {
+                get
+                {
+                    yield return new object[] { 100, 20, 5 };
+                    yield return new object[] { 100, 4, 25 };
+                }
             }
         }
     }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         [TestCaseSource("MyData")]
-        [TestCaseSource("MoreData", Category="Extra")]
+        [TestCaseSource("MoreData", Category = "Extra")]
         [TestCase(12, 2, 6)]
         public void TestMayUseMultipleSourceAttributes(int n, int d, int q)
         {
@@ -166,7 +166,11 @@ namespace NUnit.Framework.Attributes
         {
             Assert.AreEqual(q, n / d);
         }
-
+        [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), "HereIsTheDataWithParameters", new object[] { 100, 4, 25 })]
+        public void SourceInAnotherClassPassingSomeDataToConstructor(int n, int d, int q)
+        {
+            Assert.AreEqual(q, n / d);
+        }
         [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), "TestCases")]
         public int SourceMayBeInAnotherClassWithReturn(int n, int d)
         {
@@ -190,7 +194,7 @@ namespace NUnit.Framework.Attributes
 
             Test testCase = TestFinder.Find("MethodWithIgnoredTestCases(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
- 
+
             testCase = TestFinder.Find("MethodWithIgnoredTestCases(2)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Ignored));
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Don't Run Me!"));
@@ -204,10 +208,10 @@ namespace NUnit.Framework.Attributes
 
             Test testCase = TestFinder.Find("MethodWithExplicitTestCases(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
- 
+
             testCase = TestFinder.Find("MethodWithExplicitTestCases(2)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Explicit));
- 
+
             testCase = TestFinder.Find("MethodWithExplicitTestCases(3)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Explicit));
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Connection failing"));
@@ -272,6 +276,12 @@ namespace NUnit.Framework.Attributes
 
         private class DivideDataProvider
         {
+            private static object[] myObject;
+
+            public static IEnumerable HereIsTheDataWithParameters(int inject1, int inject2, int inject3)
+            {
+                yield return new object[] { inject1, inject2, inject3 };
+            }
             public static IEnumerable HereIsTheData
             {
                 get
@@ -284,6 +294,8 @@ namespace NUnit.Framework.Attributes
                     //    .Throws(typeof(System.DivideByZeroException));
                     yield return new object[] { 100, 20, 5 };
                     yield return new object[] { 100, 4, 25 };
+
+
                 }
             }
         }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -172,7 +172,46 @@ namespace NUnit.Framework.Attributes
         {
             Assert.AreEqual(q, n / d);
         }
-        
+
+        [Test]
+        public void SourceInAnotherClassPassingParamsToField()
+        {
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingParamsToField").Tests[0];
+            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            ITestResult result = TestBuilder.RunTest(testMethod, null);
+            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
+            Assert.AreEqual("You have specified a data source field but also given a set of parameters. Fields cannot take parameters, " +
+                            "please revise the 3rd parameter passed to the TestCaseSourceAttribute and either remove " +
+                            "it or specify a method.", result.Message);
+        }
+
+        [Test]
+        public void SourceInAnotherClassPassingParamsToProperty()
+        {
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingParamsToProperty").Tests[0];
+            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            ITestResult result = TestBuilder.RunTest(testMethod, null);
+            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
+            Assert.AreEqual("You have specified a data source property but also given a set of parameters. " +
+                            "Properties cannot take parameters, please revise the 3rd parameter passed to the " +
+                            "TestCaseSource attribute and either remove it or specify a method.", result.Message);
+        }
+
+        [Test]
+        public void SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam()
+        {
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam").Tests[0];
+            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            ITestResult result = TestBuilder.RunTest(testMethod, null);
+            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
+            Assert.AreEqual("You have given the wrong number of arguments to the method in the TestCaseSourceAttribute" +
+                            ", please check the number of parameters passed in the object is correct in the 3rd parameter for the " +
+                            "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.", result.Message);
+        }
+
         [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), "TestCases")]
         public int SourceMayBeInAnotherClassWithReturn(int n, int d)
         {
@@ -279,7 +318,7 @@ namespace NUnit.Framework.Attributes
         private class DivideDataProvider
         {
             private static object[] myObject;
-
+         
             public static IEnumerable HereIsTheDataWithParameters(int inject1, int inject2, int inject3)
             {
                 yield return new object[] { inject1, inject2, inject3 };
@@ -288,12 +327,6 @@ namespace NUnit.Framework.Attributes
             {
                 get
                 {
-                    //yield return new TestCaseData(0, 0, 0)
-                    //    .SetName("ThisOneShouldThrow")
-                    //    .SetDescription("Demonstrates use of ExpectedException")
-                    //    .SetCategory("Junk")
-                    //    .SetProperty("MyProp", "zip")
-                    //    .Throws(typeof(System.DivideByZeroException));
                     yield return new object[] { 100, 20, 5 };
                     yield return new object[] { 100, 4, 25 };
                 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -166,11 +166,13 @@ namespace NUnit.Framework.Attributes
         {
             Assert.AreEqual(q, n / d);
         }
+        
         [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), "HereIsTheDataWithParameters", new object[] { 100, 4, 25 })]
         public void SourceInAnotherClassPassingSomeDataToConstructor(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
         }
+        
         [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), "TestCases")]
         public int SourceMayBeInAnotherClassWithReturn(int n, int d)
         {
@@ -294,8 +296,6 @@ namespace NUnit.Framework.Attributes
                     //    .Throws(typeof(System.DivideByZeroException));
                     yield return new object[] { 100, 20, 5 };
                     yield return new object[] { 100, 4, 25 };
-
-
                 }
             }
         }


### PR DESCRIPTION
Comments on Issue #7 reflect changes in here. However @CharliePoole mentioned creating a new issue for this change as its actually unrelated to the original intention of issue number 7.

One thing i did consider changing is making the TestCaseDataSource "blow up", or not, if someone tries to use it with a property or field instead of a method. Personally I don't like things that silently fail, but would someone ever try to pass parameters to a field or property?