### PR TITLE
Add TestAssemblyRunner tests to both portable and silverlight builds

### DIFF
--- a/nunit.sln
+++ b/nunit.sln
@@ -161,6 +161,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunitlite-runner-4.0", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunitlite-runner-sl-5.0", "src\NUnitFramework\nunitlite-runner\nunitlite-runner-sl-5.0.csproj", "{901DA110-F30A-4515-880D-E9D59B6ECB4E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "slow-nunit-tests-portable", "src\NUnitFramework\slow-tests\slow-nunit-tests-portable.csproj", "{74CB429E-69D7-4525-BBDF-BBC47DBC7070}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "slow-nunit-tests-sl-5.0", "src\NUnitFramework\slow-tests\slow-nunit-tests-sl-5.0.csproj", "{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -371,6 +375,14 @@ Global
 		{901DA110-F30A-4515-880D-E9D59B6ECB4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{901DA110-F30A-4515-880D-E9D59B6ECB4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{901DA110-F30A-4515-880D-E9D59B6ECB4E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74CB429E-69D7-4525-BBDF-BBC47DBC7070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74CB429E-69D7-4525-BBDF-BBC47DBC7070}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74CB429E-69D7-4525-BBDF-BBC47DBC7070}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74CB429E-69D7-4525-BBDF-BBC47DBC7070}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -435,6 +447,8 @@ Global
 		{3FA7B726-8AF9-4554-B41A-0BD915E4EAB5} = {64FE69B2-CE0B-4A47-83A3-9DE803851447}
 		{C861E6BA-852B-4BC1-ACE7-77C8D6E7898B} = {83154E24-B0DD-48E7-8BB5-55CF3D7B0FE3}
 		{901DA110-F30A-4515-880D-E9D59B6ECB4E} = {A21BFC37-44FC-41A0-B6E7-6F949F45A635}
+		{74CB429E-69D7-4525-BBDF-BBC47DBC7070} = {A6EBC77C-9A34-4796-B4D0-E7A1E21A65A7}
+		{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39} = {A21BFC37-44FC-41A0-B6E7-6F949F45A635}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\NUnitFramework\tests\nunitlite.tests-2.0.csproj

--- a/src/Common/nunit/AssemblyHelper.cs
+++ b/src/Common/nunit/AssemblyHelper.cs
@@ -112,9 +112,10 @@ namespace NUnit.Common
 #endif
         }
 
-#endregion
+        #endregion
 
-#region Load
+        #region Load
+
 #if PORTABLE
         /// <summary>
         /// Loads an assembly given a string, which is the AssemblyName
@@ -123,8 +124,11 @@ namespace NUnit.Common
         /// <returns></returns>
         public static Assembly Load(string name)
         {
-            var asmName = new AssemblyName { Name = Path.GetFileNameWithoutExtension(name) };
-            return Assembly.Load(asmName);
+            var ext = Path.GetExtension(name);
+            if (ext == ".dll" || ext == ".exe")
+                name = Path.GetFileNameWithoutExtension(name);
+
+            return Assembly.Load(new AssemblyName { Name = name });
         }
 #else
 
@@ -154,7 +158,8 @@ namespace NUnit.Common
             return Assembly.Load(nameOrPath);
         }
 #endif
-#endregion
+
+        #endregion
 
 #region Helper Methods
 

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class ExceptionHelper
     {
-#if !NET_4_5 && !PORTABLE
+#if !NET_4_5 && !PORTABLE && !SILVERLIGHT
         private static readonly Action<Exception> PreserveStackTrace;
 
         static ExceptionHelper()
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
+#if NET_4_0 || NET_4_5 || PORTABLE
         /// <summary>
         /// Rethrows an exception, preserving its stack trace
         /// </summary>
@@ -67,7 +68,7 @@ namespace NUnit.Framework.Internal
             throw exception;
 #endif
         }
-
+#endif
 
         // TODO: Move to a utility class
         /// <summary>

--- a/src/NUnitFramework/slow-tests/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/slow-tests/Properties/AssemblyInfo.cs
@@ -13,6 +13,3 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("e06f3f6c-5e21-4615-a376-8d1538b4ac90")]

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Threading;
 using NUnit.Framework;
 
 namespace NUnit.Tests
@@ -33,31 +32,40 @@ namespace NUnit.Tests
         public class AAA
         {
             [Test]
-            public void Test1() { Thread.Sleep(DELAY); }
+            public void Test1() { SlowTests.Delay(); }
             [Test]
-            public void Test2() { Thread.Sleep(DELAY); }
+            public void Test2() { SlowTests.Delay(); }
             [Test]
-            public void Test3() { Thread.Sleep(DELAY); }
+            public void Test3() { SlowTests.Delay(); }
         }
 
         public class BBB
         {
             [Test]
-            public void Test1() { Thread.Sleep(DELAY); }
+            public void Test1() { SlowTests.Delay(); }
             [Test]
-            public void Test2() { Thread.Sleep(DELAY); }
+            public void Test2() { SlowTests.Delay(); }
             [Test]
-            public void Test3() { Thread.Sleep(DELAY); }
+            public void Test3() { SlowTests.Delay(); }
         }
 
         public class CCC
         {
             [Test]
-            public void Test1() { Thread.Sleep(DELAY); }
+            public void Test1() { SlowTests.Delay(); }
             [Test]
-            public void Test2() { Thread.Sleep(DELAY); }
+            public void Test2() { SlowTests.Delay(); }
             [Test]
-            public void Test3() { Thread.Sleep(DELAY); }
+            public void Test3() { SlowTests.Delay(); }
+        }
+
+        private static void Delay()
+        {
+#if PORTABLE
+            System.Threading.Tasks.Task.Delay(DELAY);
+#else
+            System.Threading.Thread.Sleep(DELAY);
+#endif
         }
     }
 }

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-portable.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-portable.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{74CB429E-69D7-4525-BBDF-BBC47DBC7070}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+    <AssemblyName>slow-nunit-tests</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <IntermediateOutputPath>obj\$(Configuration)\portable\</IntermediateOutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\Debug\portable\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\FrameworkVersion.cs">
+      <Link>Properties\FrameworkVersion.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SlowTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\framework\nunit.framework-portable.csproj">
+      <Project>{D6FBBB3A-F6B8-45BB-B657-A7226AB96624}</Project>
+      <Name>nunit.framework-portable</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-sl-5.0.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-sl-5.0.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A2B973C4-EA96-4B00-B2BE-04BFD9D5AA39}</ProjectGuid>
+    <ProjectTypeGuids>{A1591282-1198-4647-A2B1-27E5FF5F6F3B};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+    <AssemblyName>slow.nunit.tests</AssemblyName>
+    <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
+    <SilverlightApplication>false</SilverlightApplication>
+    <ValidateXaml>true</ValidateXaml>
+    <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
+    <IntermediateOutputPath>obj\$(Configuration)\sl-5.0\</IntermediateOutputPath>
+  </PropertyGroup>
+  <!-- This property group is only here to support building this project using the 
+       MSBuild 3.5 toolset. In order to work correctly with this older toolset, it needs 
+       to set the TargetFrameworkVersion to v3.5 -->
+  <PropertyGroup Condition="'$(MSBuildToolsVersion)' == '3.5'">
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\Debug\sl-5.0\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release\sl-5.0\</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="system" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\framework\nunit.framework-sl-5.0.csproj">
+      <Project>{3deb15f9-e7da-403f-b6d3-a8499310397f}</Project>
+      <Name>nunit.framework-sl-5.0</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\FrameworkVersion.cs">
+      <Link>Properties\FrameworkVersion.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SlowTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.CSharp.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{A1591282-1198-4647-A2B1-27E5FF5F6F3B}">
+        <SilverlightProjectProperties />
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -21,13 +21,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-// TODO: Get to work in Portable and Silverlight - will require building mock-assembly
-#if !SILVERLIGHT && !PORTABLE
-
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
+using NUnit.Framework.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
@@ -39,15 +39,18 @@ namespace NUnit.Framework.Api
     // Functional tests of the TestAssemblyRunner and all subordinate classes
     public class TestAssemblyRunnerTests : ITestListener
     {
-        private const string MOCK_ASSEMBLY = "mock-assembly.exe";
+        private const string MOCK_ASSEMBLY_FILE = "mock-assembly.exe";
         private const string BAD_FILE = "mock-assembly.pdb";
-        private const string SLOW_TESTS = "slow-nunit-tests.dll";
+        private const string SLOW_TESTS_FILE = "slow-nunit-tests.dll";
         private const string MISSING_FILE = "junk.dll";
 
-        private IDictionary _settings = new Hashtable();
+#if SILVERLIGHT || PORTABLE
+        private static readonly string MOCK_ASSEMBLY_NAME = typeof(MockAssembly).GetTypeInfo().Assembly.FullName;
+#endif
+
+        private static readonly IDictionary EMPTY_SETTINGS = new Dictionary<string, object>();
+
         private ITestAssemblyRunner _runner;
-        private string _mockAssemblyPath;
-        private string _slowTestsPath;
 
         private int _testStartedCount;
         private int _testFinishedCount;
@@ -59,8 +62,6 @@ namespace NUnit.Framework.Api
         [SetUp]
         public void CreateRunner()
         {
-            _mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-            _slowTestsPath = Path.Combine(TestContext.CurrentContext.TestDirectory, SLOW_TESTS);
             _runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
 
             _testStartedCount = 0;
@@ -72,14 +73,19 @@ namespace NUnit.Framework.Api
         }
 
         #region Load
+
         [Test]
         public void Load_GoodFile_ReturnsRunnableSuite()
         {
-            var result = _runner.Load(_mockAssemblyPath, _settings);
+            var result = LoadMockAssembly();
 
             Assert.That(result.IsSuite);
             Assert.That(result, Is.TypeOf<TestAssembly>());
-            Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY));
+#if SILVERLIGHT || PORTABLE
+            Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY_NAME));
+#else
+            Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY_FILE));
+#endif
             Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.Runnable));
             Assert.That(result.TestCaseCount, Is.EqualTo(MockAssembly.Tests));
         }
@@ -87,7 +93,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void Load_FileNotFound_ReturnsNonRunnableSuite()
         {
-            var result = _runner.Load(MISSING_FILE, _settings);
+            var result = _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
 
             Assert.That(result.IsSuite);
             Assert.That(result, Is.TypeOf<TestAssembly>());
@@ -95,16 +101,16 @@ namespace NUnit.Framework.Api
             Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.NotRunnable));
             Assert.That(result.TestCaseCount, Is.EqualTo(0));
 #if NETCF
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("File or assembly name").And.Contains(MISSING_FILE));
+            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("File or assembly name"));
 #else
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("Could not load").And.Contains(MISSING_FILE));
+            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("Could not load"));
 #endif
         }
 
         [Test]
         public void Load_BadFile_ReturnsNonRunnableSuite()
         {
-            var result = _runner.Load(BAD_FILE, _settings);
+            var result = _runner.Load(BAD_FILE, EMPTY_SETTINGS);
 
             Assert.That(result.IsSuite);
             Assert.That(result, Is.TypeOf<TestAssembly>());
@@ -117,13 +123,15 @@ namespace NUnit.Framework.Api
             Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("Could not load").And.Contains(BAD_FILE));
 #endif
         }
-        #endregion
 
-        #region CountTestCases
+#endregion
+
+#region CountTestCases
+
         [Test]
         public void CountTestCases_AfterLoad_ReturnsCorrectCount()
         {
-            _runner.Load(_mockAssemblyPath, _settings);
+            LoadMockAssembly();
             Assert.That(_runner.CountTestCases(TestFilter.Empty), Is.EqualTo(MockAssembly.Tests));
         }
 
@@ -138,23 +146,25 @@ namespace NUnit.Framework.Api
         [Test]
         public void CountTestCases_FileNotFound_ReturnsZero()
         {
-            _runner.Load(MISSING_FILE, _settings);
+            _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
             Assert.That(_runner.CountTestCases(TestFilter.Empty), Is.EqualTo(0));
         }
 
         [Test]
         public void CountTestCases_BadFile_ReturnsZero()
         {
-            _runner.Load(BAD_FILE, _settings);
+            _runner.Load(BAD_FILE, EMPTY_SETTINGS);
             Assert.That(_runner.CountTestCases(TestFilter.Empty), Is.EqualTo(0));
         }
-        #endregion
 
-        #region Run
+#endregion
+
+#region Run
+
         [Test]
         public void Run_AfterLoad_ReturnsRunnableSuite()
         {
-            _runner.Load(_mockAssemblyPath, _settings);
+            LoadMockAssembly();
             var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
 
             Assert.That(result.Test.IsSuite);
@@ -171,7 +181,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void Run_AfterLoad_SendsExpectedEvents()
         {
-            _runner.Load(_mockAssemblyPath, _settings);
+            LoadMockAssembly();
             var result = _runner.Run(this, TestFilter.Empty);
 
             Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests));
@@ -194,7 +204,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void Run_FileNotFound_ReturnsNonRunnableSuite()
         {
-            _runner.Load(MISSING_FILE, _settings);
+            _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
             var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
 
             Assert.That(result.Test.IsSuite);
@@ -203,16 +213,16 @@ namespace NUnit.Framework.Api
             Assert.That(result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
 #if NETCF
-            Assert.That(result.Message, Does.StartWith("File or assembly name").And.Contains(MISSING_FILE));
+            Assert.That(result.Message, Does.StartWith("File or assembly name"));
 #else
-            Assert.That(result.Message, Does.StartWith("Could not load").And.Contains(MISSING_FILE));
+            Assert.That(result.Message, Does.StartWith("Could not load"));
 #endif
         }
 
         [Test]
         public void Run_BadFile_ReturnsNonRunnableSuite()
         {
-            _runner.Load(BAD_FILE, _settings);
+            _runner.Load(BAD_FILE, EMPTY_SETTINGS);
             var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
 
             Assert.That(result.Test.IsSuite);
@@ -226,13 +236,15 @@ namespace NUnit.Framework.Api
             Assert.That(result.Message, Does.StartWith("Could not load").And.Contains(BAD_FILE));
 #endif
         }
-        #endregion
 
-        #region RunAsync
+#endregion
+
+#region RunAsync
+
         [Test]
         public void RunAsync_AfterLoad_ReturnsRunnableSuite()
         {
-            _runner.Load(_mockAssemblyPath, _settings);
+            LoadMockAssembly();
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
@@ -251,7 +263,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunAsync_AfterLoad_SendsExpectedEvents()
         {
-            _runner.Load(_mockAssemblyPath, _settings);
+            LoadMockAssembly();
             _runner.RunAsync(this, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
@@ -275,7 +287,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void RunAsync_FileNotFound_ReturnsNonRunnableSuite()
         {
-            _runner.Load(MISSING_FILE, _settings);
+            _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
@@ -286,16 +298,16 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(_runner.Result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
 #if NETCF
-            Assert.That(_runner.Result.Message, Does.StartWith("File or assembly name").And.Contains(MISSING_FILE));
+            Assert.That(_runner.Result.Message, Does.StartWith("File or assembly name"));
 #else
-            Assert.That(_runner.Result.Message, Does.StartWith("Could not load").And.Contains(MISSING_FILE));
+            Assert.That(_runner.Result.Message, Does.StartWith("Could not load"));
 #endif
         }
 
         [Test]
         public void RunAsync_BadFile_ReturnsNonRunnableSuite()
         {
-            _runner.Load(BAD_FILE, _settings);
+            _runner.Load(BAD_FILE, EMPTY_SETTINGS);
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
@@ -311,9 +323,11 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Message, Does.StartWith("Could not load").And.Contains(BAD_FILE));
 #endif
         }
-        #endregion
 
-        #region StopRun
+#endregion
+
+#region StopRun
+
         [Test]
         public void StopRun_WhenNoTestIsRunning_Succeeds()
         {
@@ -323,7 +337,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void StopRun_WhenTestIsRunning_StopsTest()
         {
-            var tests = _runner.Load(_slowTestsPath, _settings);
+            var tests = LoadSlowTests();
             var count = tests.TestCaseCount;
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.StopRun(false);
@@ -338,9 +352,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region Cancel Run
+#region Cancel Run
 
         [Test]
         public void CancelRun_WhenNoTestIsRunning_Succeeds()
@@ -351,7 +365,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void CancelRun_WhenTestIsRunning_StopsTest()
         {
-            var tests = _runner.Load(_slowTestsPath, _settings);
+            var tests = LoadSlowTests();
             var count = tests.TestCaseCount;
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.StopRun(true);
@@ -369,9 +383,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region ITestListener Implementation
+#region ITestListener Implementation
 
         void ITestListener.TestStarted(ITest test)
         {
@@ -403,7 +417,36 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
+
+#region Helper Methods
+
+        private ITest LoadMockAssembly()
+        {
+#if PORTABLE
+            return _runner.Load(
+                typeof(MockAssembly).GetTypeInfo().Assembly, 
+                EMPTY_SETTINGS);
+#elif SILVERLIGHT
+            return _runner.Load(MOCK_ASSEMBLY_NAME, EMPTY_SETTINGS);
+#else
+            return _runner.Load(
+                Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE), 
+                EMPTY_SETTINGS);
+#endif
+        }
+
+        private ITest LoadSlowTests()
+        {
+#if PORTABLE
+            return _runner.Load(typeof(SlowTests).GetTypeInfo().Assembly, EMPTY_SETTINGS);
+#elif SILVERLIGHT
+            return _runner.Load(typeof(SlowTests).GetTypeInfo().Assembly.FullName, EMPTY_SETTINGS);
+#else
+            return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SLOW_TESTS_FILE), EMPTY_SETTINGS);
+#endif
+        }
+
+#endregion
     }
 }
-#endif

--- a/src/NUnitFramework/tests/WorkItemTests.cs
+++ b/src/NUnitFramework/tests/WorkItemTests.cs
@@ -1,0 +1,98 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Threading;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Execution
+{
+    public class WorkItemTests
+    {
+        private WorkItem _workItem;
+        private TestExecutionContext _context;
+
+        [SetUp]
+        public void CreateWorkItems()
+        {
+            IMethodInfo method = new MethodWrapper(typeof(DummyFixture), "DummyTest");
+            ITest test = new TestMethod(method);
+            _workItem = WorkItem.CreateWorkItem(test, TestFilter.Empty);
+
+            _context = new TestExecutionContext();
+            _workItem.InitializeContext(_context);
+        }
+
+        [Test]
+        public void ConstructWorkItem()
+        {
+            Assert.That(_workItem, Is.TypeOf<SimpleWorkItem>());
+            Assert.That(_workItem.Test.Name, Is.EqualTo("DummyTest"));
+            Assert.That(_workItem.State, Is.EqualTo(WorkItemState.Ready));
+        }
+
+        [Test]
+        public void ExecuteWorkItem()
+        {
+            _workItem.Execute();
+
+            Assert.That(_workItem.State, Is.EqualTo(WorkItemState.Complete));
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.Success));
+            Assert.That(_context.ExecutionStatus, Is.EqualTo(TestExecutionStatus.Running));
+        }
+
+        [Test]
+        public void CanStopRun()
+        {
+            _context.ExecutionStatus = TestExecutionStatus.StopRequested;
+            _workItem.Execute();
+            Assert.That(_workItem.State, Is.EqualTo(WorkItemState.Complete));
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.Success));
+            Assert.That(_context.ExecutionStatus, Is.EqualTo(TestExecutionStatus.StopRequested));
+        }
+
+        Thread _thread;
+
+        private void StartExecution()
+        {
+            _thread = new Thread(ThreadProc);
+            _thread.Start();
+        }
+
+        private void ThreadProc()
+        {
+            _workItem.Execute();
+        }
+
+        // Use static for simplicity
+        static class DummyFixture
+        {
+            public static int Delay = 0;
+
+            public static void DummyTest()
+            {
+                if (Delay > 0)
+                    Thread.Sleep(Delay);
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -286,6 +286,10 @@
       <Project>{D6FBBB3A-F6B8-45BB-B657-A7226AB96624}</Project>
       <Name>nunit.framework-portable</Name>
     </ProjectReference>
+    <ProjectReference Include="..\slow-tests\slow-nunit-tests-portable.csproj">
+      <Project>{74cb429e-69d7-4525-bbdf-bbc47dbc7070}</Project>
+      <Name>slow-nunit-tests-portable</Name>
+    </ProjectReference>
     <ProjectReference Include="..\testdata\nunit.testdata-portable.csproj">
       <Project>{9ED200E4-2026-4955-87E0-D8CEA7BD9E7F}</Project>
       <Name>nunit.testdata-portable</Name>

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -323,6 +323,10 @@
       <Project>{0a5f920a-1bf5-4dac-b799-0c618b203797}</Project>
       <Name>nunitlite-sl-5.0</Name>
     </ProjectReference>
+    <ProjectReference Include="..\slow-tests\slow-nunit-tests-sl-5.0.csproj">
+      <Project>{a2b973c4-ea96-4b00-b2be-04bfd9d5aa39}</Project>
+      <Name>slow-nunit-tests-sl-5.0</Name>
+    </ProjectReference>
     <ProjectReference Include="..\testdata\nunit.testdata-sl-5.0.csproj">
       <Project>{a76794da-29a4-4d63-9850-e0e363a2fafd}</Project>
       <Name>nunit.testdata-sl-5.0</Name>


### PR DESCRIPTION
This PR started as a supplement to #1202, adding tests of the test assembly runner that were missing in the silverlight and portable builds. That's included here.

In addition, I found that Silverlight tests were hanging since #1202. I believe it is due to an earlier change creating a hidden bug that #1202 activated. The hang did not occur when running silverlight tests under .NET 4.5, only when run directly by our silverlight runner. Consequently, the CI build did not catch it.

I also turned up a bug in one of the ValueSourceTests, which I commented out for now. I filed #1232 to cover that one, which is a bit of a can of worms. In fact, it's possible that the underlying cause of #1232 will turn out to have something to do with the problem in #1202 leading to a modification of the fix I just made.