### PR TITLE
EmptyConstraint - allow null string

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -50,8 +50,10 @@ namespace NUnit.Framework.Constraints
         {
             var actualType = GetBaseType(actual);
 
-            if (actual is string || actualType == typeof(string))
+            if (actualType == typeof(string))
                 realConstraint = new EmptyStringConstraint();
+            else if (actual == null)
+                throw new System.ArgumentException("The actual value must be a non-null string, IEnumerable or DirectoryInfo", "actual");
 #if !SILVERLIGHT && !PORTABLE
             else if (actual is System.IO.DirectoryInfo || actualType == typeof(System.IO.DirectoryInfo))
                 realConstraint = new EmptyDirectoryConstraint();

--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -48,19 +48,25 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (actual == null)
-                throw new System.ArgumentException("The actual value must be a non-null string, IEnumerable or DirectoryInfo", "actual");
+            var actualType = GetBaseType(actual);
 
-            if (actual is string)
+            if (actual is string || actualType == typeof(string))
                 realConstraint = new EmptyStringConstraint();
 #if !SILVERLIGHT && !PORTABLE
-            else if (actual is System.IO.DirectoryInfo)
+            else if (actual is System.IO.DirectoryInfo || actualType == typeof(System.IO.DirectoryInfo))
                 realConstraint = new EmptyDirectoryConstraint();
 #endif
-            else
+            else if (actual is System.Collections.IEnumerable || actualType == typeof(System.Collections.IEnumerable))
                 realConstraint = new EmptyCollectionConstraint();
+            else
+                throw new System.ArgumentException("The actual value must be a non-null string, IEnumerable or DirectoryInfo", "actual");
 
             return realConstraint.ApplyTo(actual);
+        }
+
+        private System.Type GetBaseType<T>(T input)
+        {
+            return typeof(T);
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -218,6 +218,99 @@ namespace NUnit.Framework.Assertions
             Assert.That(result.AssertCount, Is.EqualTo(totalCount), "Fixture count is not correct");
         }
 
+        [Test]
+        public void AssertionIsNull()
+        {
+            Assert.That(null, Is.Null);
+        }
+
+        [Test]
+        public void AssertionNullIsNullOrEmpty()
+        {
+            Assert.That(null, Is.Null.Or.Empty);
+        }
+
+        [Test]
+        public void AssertionIsNotNull()
+        {
+            Assert.Throws<AssertionException>(() =>
+                Assert.That(null, Is.Not.Null));
+        }
+
+        [Test]
+        public void AssertionTypedNullIsNotEmpty()
+        {
+            string actual = null;
+            Assert.That(actual, Is.Not.Empty);
+        }
+
+        [Test]
+        public void AssertionTypedNullIsEmptyFails()
+        {
+            string actual = null;
+            Assert.Throws<AssertionException>(() =>
+                Assert.That(actual, Is.Empty));
+        }
+
+#if !NET_2_0 && !SL_5_0
+        [Test]
+        public void AssertionUntypedNullEmptyThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                Assert.That(null, Is.Empty));
+        }
+
+        [Test]
+        public void AssertionIntEmptyThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                Assert.That(1, Is.Empty));
+        }
+#endif
+
+        [Test]
+        public void AssertionIsEmpty()
+        {
+            Assert.That("", Is.Empty);
+        }
+
+        [Test]
+        public void AssertionIsNotEmpty()
+        {
+            Assert.Throws<AssertionException>(() =>
+                Assert.That("", Is.Not.Empty));
+        }
+
+        [Test]
+        public void AssertionThatWithDoubleNegative()
+        {
+            Assert.That("", Is.Not.Not.Empty);
+        }
+
+        [Test]
+        public void AssertionNullIsNotNullAndNotEmpty()
+        {
+            string actual = null;
+            Assert.Throws<AssertionException>(() =>
+                Assert.That(actual, Is.Not.Null.And.Not.Empty));
+        }
+
+        [Test]
+        public void AssertionEmptyIsNotNullOrEmpty()
+        {
+            // ok because it evaluates to:
+            // var expected = "";
+            // if (expected != null || expected == "")
+            Assert.That("", Is.Not.Null.Or.Empty);
+        }
+
+        [Test]
+        public void AssertionEmptyIsNotNullOrNotEmpty()
+        {
+            Assert.Throws<AssertionException>(() =>
+                Assert.That("", Is.Not.Null.And.Not.Empty));
+        }
+
         private int ReturnsFive()
         {
             return 5;

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -63,6 +63,13 @@ namespace NUnit.Framework.Constraints
             Assert.Throws<ArgumentException>(() => theConstraint.ApplyTo(data));
         }
 
+        [Test]
+        public void StringNullThrowsAssertionException()
+        {
+            string input = null;
+            var actual = theConstraint.ApplyTo(input);
+            Assert.AreEqual(ConstraintStatus.Failure, actual.Status);
+        }
     }
 
     [TestFixture]
@@ -85,6 +92,14 @@ namespace NUnit.Framework.Constraints
         {
             new TestCaseData( "Hello", "\"Hello\"" ),
         };
+
+        [Test]
+        public void StringNullReturnsNotSuccess()
+        {
+            string input = null;
+            var actual = theConstraint.ApplyTo(input);
+            Assert.AreEqual(ConstraintStatus.Failure, actual.Status);
+        }
     }
 
 #if !SILVERLIGHT && !PORTABLE


### PR DESCRIPTION
fix #1171 

The cases `Assert.That(null, Is.Not.Empty)` and `Is.Not.Null.Or.Empty` will continue to fail as they are written. The 'null' value cannot be checked to see if the EmptyConstraint types can be applied because this is lost.

If the test were rewritten as:
````
string actual = null;
Assert.That(actual, Is.Empty);

//or

Assert.That((string)null, Is.Empty);
````

I think that most tests will have the type information like the rewritten test cases as opposed to having just `null`.

These tests throw the AssertionException as expected. If the type cannot be applied, (not string, collection, or DirectoryInfo), the ArgumentException will be thrown.
