### PR TITLE
Move AssertionHelper tests to a separate class

### DIFF
--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class ExceptionHelper
     {
-#if !NET_4_5 && !PORTABLE && !SILVERLIGHT
+#if !NET_4_5 && !PORTABLE && !SILVERLIGHT && !NETCF
         private static readonly Action<Exception> PreserveStackTrace;
 
         static ExceptionHelper()

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Assertions
     /// Summary description for ArrayEqualTests.
     /// </summary>
     [TestFixture]
-    public class ArrayEqualsFixture : AssertionHelper
+    public class ArrayEqualsFixture
     {
 #pragma warning disable 183, 184 // error number varies in different runtimes
         // Used to detect runtimes where ArraySegments implement IEnumerable
@@ -44,7 +44,6 @@ namespace NUnit.Framework.Assertions
             string[] array = { "one", "two", "three" };
             Assert.That( array, Is.SameAs(array) );
             Assert.AreEqual( array, array );
-            Expect(array, EqualTo(array));
         }
 
         [Test]
@@ -54,9 +53,7 @@ namespace NUnit.Framework.Assertions
             string[] array2 = { "one", "two", "three" };
             Assert.IsFalse( array1 == array2 );
             Assert.AreEqual(array1, array2);
-            Expect(array1, EqualTo(array2));
             Assert.AreEqual(array2, array1);
-            Expect(array2, EqualTo(array1));
         }
 
         [Test]
@@ -66,8 +63,6 @@ namespace NUnit.Framework.Assertions
             int[] b = new int[] { 1, 2, 3 };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -77,8 +72,6 @@ namespace NUnit.Framework.Assertions
             double[] b = new double[] { 1.0, 2.0, 3.0 };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -88,8 +81,6 @@ namespace NUnit.Framework.Assertions
             decimal[] b = new decimal[] { 1.0m, 2.0m, 3.0m };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -99,8 +90,6 @@ namespace NUnit.Framework.Assertions
             double[] b = new double[] { 1.0, 2.0, 3.0 };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -110,8 +99,6 @@ namespace NUnit.Framework.Assertions
             object[] array2 = { "one", "two", "three" };
             Assert.AreEqual( array1, array2, "String[] not equal to Object[]" );
             Assert.AreEqual( array2, array1, "Object[] not equal to String[]" );
-            Expect(array1, EqualTo(array2), "String[] not equal to Object[]");
-            Expect(array2, EqualTo(array1), "Object[] not equal to String[]");
         }
 
         [Test]
@@ -122,8 +109,6 @@ namespace NUnit.Framework.Assertions
             object[] array2 = new object[] { 1.0d, 2, 3.5, 7, "Hello", now };
             Assert.AreEqual( array1, array2 );
             Assert.AreEqual(array2, array1);
-            Expect(array1, EqualTo(array2));
-            Expect(array2, EqualTo(array1));
         }
 
         [Test]
@@ -133,8 +118,6 @@ namespace NUnit.Framework.Assertions
             int[,] b = new int[,] { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 } };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -144,7 +127,6 @@ namespace NUnit.Framework.Assertions
             int[,,] actual = new int[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
 
             Assert.AreEqual(expected, actual);
-            Expect(actual, EqualTo(expected));
         }
 
         [Test]
@@ -154,7 +136,6 @@ namespace NUnit.Framework.Assertions
             int[, , , ,] actual = new int[2, 2, 2, 2, 2] { { { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } }, { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } } }, { { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } }, { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } } } };
 
             Assert.AreEqual(expected, actual);
-            Expect(actual, EqualTo(expected));
         }
 
         [Test]
@@ -164,8 +145,6 @@ namespace NUnit.Framework.Assertions
             int[][] b = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 }, new int[] { 7, 8, 9 } };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -175,7 +154,6 @@ namespace NUnit.Framework.Assertions
             int[][] actual = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6, 7 }, new int[] { 8, 9 } };
 
             Assert.AreEqual(expected, actual);
-            Expect(actual, EqualTo(expected));
         }
 
         [Test]
@@ -185,8 +163,6 @@ namespace NUnit.Framework.Assertions
             object b = new double[] { 1.0, 2.0, 3.0 };
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -196,8 +172,6 @@ namespace NUnit.Framework.Assertions
             ICollection b = new SimpleObjectCollection( 1, 2, 3 );
             Assert.AreEqual(a, b);
             Assert.AreEqual(b, a);
-            Expect(a, EqualTo(b));
-            Expect(b, EqualTo(a));
         }
 
         [Test]
@@ -207,8 +181,7 @@ namespace NUnit.Framework.Assertions
             int[,] actual = new int[,] { { 1, 2 }, { 3, 4 } };
 
             Assert.AreNotEqual(expected, actual);
-            Expect(actual, Not.EqualTo(expected));
-            Expect(actual, EqualTo(expected).AsCollection);
+            Assert.That(actual, Is.EqualTo(expected).AsCollection);
         }
 
         [Test]
@@ -218,8 +191,7 @@ namespace NUnit.Framework.Assertions
             int[,] actual = new int[,] { { 1, 2 }, { 3, 4 }, { 5, 6 } };
 
             Assert.AreNotEqual(expected, actual);
-            Expect(actual, Not.EqualTo(expected));
-            Expect(actual, EqualTo(expected).AsCollection);
+            Assert.That(actual, Is.EqualTo(expected).AsCollection);
         }
 
 #if !NETCF && !SILVERLIGHT && !PORTABLE

--- a/src/NUnitFramework/tests/Assertions/ArrayNotEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayNotEqualFixture.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Assertions
     /// Summary description for ArrayNotEqualFixture.
     /// </summary>
     [TestFixture]
-    public class ArrayNotEqualFixture : AssertionHelper
+    public class ArrayNotEqualFixture
     {
         [Test]
         public void DifferentLengthArrays()
@@ -39,8 +39,6 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreNotEqual(array1, array2);
             Assert.AreNotEqual(array2, array1);
-            Expect(array1, Not.EqualTo(array2));
-            Expect(array2, Not.EqualTo(array1));
         }
 
         [Test]
@@ -50,8 +48,6 @@ namespace NUnit.Framework.Assertions
             string[] array2 = { "one", "two", "ten" };
             Assert.AreNotEqual(array1, array2);
             Assert.AreNotEqual(array2, array1);
-            Expect(array1, Not.EqualTo(array2));
-            Expect(array2, Not.EqualTo(array1));
         }
 
         [Test]
@@ -60,8 +56,6 @@ namespace NUnit.Framework.Assertions
             string[] array1 = { "one", "two", "three" };
             object[] array2 = { "one", "three", "two" };
             Assert.AreNotEqual(array1, array2);
-            Expect(array1, Not.EqualTo(array2));
-            Expect(array2, Not.EqualTo(array1));
         }
 
     }

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -1,0 +1,939 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework.Constraints;
+using NUnit.TestUtilities.Comparers;
+
+namespace NUnit.Framework.Syntax
+{
+    class AssertionHelperTests : AssertionHelper
+    {
+#if !PORTABLE
+        private static readonly string DEFAULT_PATH_CASE = Path.DirectorySeparatorChar == '\\' ? "ignorecase" : "respectcase";
+#endif
+
+        #region Not
+
+        [Test]
+        public void NotNull()
+        {
+            var expression = Not.Null;
+            Expect(expression, TypeOf<NullConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo("<not <null>>"));
+        }
+
+        [Test]
+        public void NotNotNotNull()
+        {
+            var expression = Not.Not.Not.Null;
+            Expect(expression, TypeOf<NullConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo("<not <not <not <null>>>>"));
+        }
+
+        #endregion
+
+        #region All
+
+        [Test]
+        public void AllItems()
+        {
+            var expression = All.GreaterThan(0);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AllItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<all <greaterthan 0>>"));
+        }
+
+        #endregion
+
+        #region Some
+
+        [Test]
+        public void Some_EqualTo()
+        {
+            var expression = Some.EqualTo(3);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<SomeItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<some <equal 3>>"));
+        }
+
+        [Test]
+        public void Some_BeforeBinaryOperators()
+        {
+            var expression = Some.GreaterThan(0).And.LessThan(100).Or.EqualTo(999);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<SomeItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<some <or <and <greaterthan 0> <lessthan 100>> <equal 999>>>"));
+        }
+
+        [Test]
+        public void Some_Nested()
+        {
+            var expression = Some.With.Some.LessThan(100);
+            Expect(expression, TypeOf<LessThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<SomeItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<some <some <lessthan 100>>>"));
+        }
+
+        [Test]
+        public void Some_AndSome()
+        {
+            var expression = Some.GreaterThan(0).And.Some.LessThan(100);
+            Expect(expression, TypeOf<LessThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AndConstraint>());
+            Expect(constraint.ToString(), EqualTo("<and <some <greaterthan 0>> <some <lessthan 100>>>"));
+        }
+
+        #endregion
+
+        #region None
+
+        [Test]
+        public void NoItems()
+        {
+            var expression = None.LessThan(0);
+            Expect(expression, TypeOf<LessThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NoItemConstraint>());
+            Expect(constraint.ToString(), EqualTo("<none <lessthan 0>>"));
+        }
+
+        #endregion
+
+        #region Property
+
+        [Test]
+        public void Property()
+        {
+            var expression = Property("X");
+            Expect(expression, TypeOf<ResolvableConstraintExpression>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyExistsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<propertyexists X>"));
+        }
+
+        [Test]
+        public void Property_FollowedByAnd()
+        {
+            var expression = Property("X").And.EqualTo(7);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AndConstraint>());
+            Expect(constraint.ToString(), EqualTo("<and <propertyexists X> <equal 7>>"));
+        }
+
+        [Test]
+        public void Property_FollowedByConstraint()
+        {
+            var expression = Property("X").GreaterThan(5);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyConstraint>());
+            Expect(constraint.ToString(), EqualTo("<property X <greaterthan 5>>"));
+        }
+
+        [Test]
+        public void Property_FollowedByNot()
+        {
+            var expression = Property("X").Not.GreaterThan(5);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyConstraint>());
+            Expect(constraint.ToString(), EqualTo("<property X <not <greaterthan 5>>>"));
+        }
+
+        [Test]
+        public void LengthProperty()
+        {
+            var expression = Length.GreaterThan(5);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyConstraint>());
+            Expect(constraint.ToString(), EqualTo("<property Length <greaterthan 5>>"));
+        }
+
+        [Test]
+        public void CountProperty()
+        {
+            var expression = Count.EqualTo(5);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyConstraint>());
+            Expect(constraint.ToString(), EqualTo("<property Count <equal 5>>"));
+        }
+
+        [Test]
+        public void MessageProperty()
+        {
+            var expression = Message.StartsWith("Expected");
+            Expect(expression, TypeOf<StartsWithConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<PropertyConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<property Message <startswith ""Expected"">>"));
+        }
+
+        #endregion
+
+        #region Attribute
+
+#if !PORTABLE
+        [Test]
+        public void AttributeExistsTest()
+        {
+            var expression = Attribute(typeof(TestFixtureAttribute));
+            Expect(expression, TypeOf<ResolvableConstraintExpression>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AttributeExistsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<attributeexists NUnit.Framework.TestFixtureAttribute>"));
+        }
+
+        [Test]
+        public void AttributeTest_FollowedByConstraint()
+        {
+            var expression = Attribute(typeof(TestFixtureAttribute)).Property("Description").Not.Null;
+            Expect(expression, TypeOf<NullConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AttributeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<attribute NUnit.Framework.TestFixtureAttribute <property Description <not <null>>>>"));
+        }
+
+        [Test]
+        public void AttributeExistsTest_Generic()
+        {
+            var expression = Attribute<TestFixtureAttribute>();
+            Expect(expression, TypeOf<ResolvableConstraintExpression>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AttributeExistsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<attributeexists NUnit.Framework.TestFixtureAttribute>"));
+        }
+
+        [Test]
+        public void AttributeTest_FollowedByConstraint_Generic()
+        {
+            var expression = Attribute<TestFixtureAttribute>().Property("Description").Not.Null;
+            Expect(expression, TypeOf<NullConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AttributeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<attribute NUnit.Framework.TestFixtureAttribute <property Description <not <null>>>>"));
+        }
+#endif
+
+        #endregion
+
+        #region Null
+
+        [Test]
+        public void NullTest()
+        {
+            var constraint = Null;
+            Expect(constraint, TypeOf<NullConstraint>());
+            Expect(constraint.ToString(), EqualTo("<null>"));
+        }
+
+        #endregion
+
+        #region True
+
+        [Test]
+        public void TrueTest()
+        {
+            var constraint = True;
+            Expect(constraint, TypeOf<TrueConstraint>());
+            Expect(constraint.ToString(), EqualTo("<true>"));
+        }
+
+        #endregion
+
+        #region False
+
+        [Test]
+        public void FalseTest()
+        {
+            var constraint = False;
+            Expect(constraint, TypeOf<FalseConstraint>());
+            Expect(constraint.ToString(), EqualTo("<false>"));
+        }
+
+        #endregion
+
+        #region Positive
+
+        [Test]
+        public void PositiveTest()
+        {
+            var constraint = Positive;
+            Expect(constraint, TypeOf<GreaterThanConstraint>());
+            Expect(constraint.ToString(), EqualTo("<greaterthan 0>"));
+        }
+
+        #endregion
+
+        #region Negative
+
+        [Test]
+        public void NegativeTest()
+        {
+            var constraint = Negative;
+            Expect(constraint, TypeOf<LessThanConstraint>());
+            Expect(constraint.ToString(), EqualTo("<lessthan 0>"));
+        }
+
+        #endregion
+
+        #region Zero
+
+        [Test]
+        public void ZeroTest()
+        {
+            var constraint = Zero;
+            Expect(constraint, TypeOf<EqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<equal 0>"));
+        }
+
+        #endregion
+
+        #region NaN
+
+        [Test]
+        public void NaNTest()
+        {
+            var constraint = NaN;
+            Expect(constraint, TypeOf<NaNConstraint>());
+            Expect(constraint.ToString(), EqualTo("<nan>"));
+        }
+
+        #endregion
+
+        #region After
+
+#if !PORTABLE
+        [Test]
+        public void After()
+        {
+            var constraint = EqualTo(10).After(1000);
+            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<after 1000 <equal 10>>"));
+        }
+
+        [Test]
+        public void After_Property()
+        {
+            var constraint = Property("X").EqualTo(10).After(1000);
+            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<after 1000 <property X <equal 10>>>"));
+        }
+
+        [Test]
+        public void After_And()
+        {
+            var constraint = GreaterThan(0).And.LessThan(10).After(1000);
+            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<after 1000 <and <greaterthan 0> <lessthan 10>>>"));
+        }
+#endif
+
+        #endregion
+
+        #region Unique
+
+        [Test]
+        public void UniqueItems()
+        {
+            var constraint = Unique;
+            Expect(constraint, TypeOf<UniqueItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<uniqueitems>"));
+        }
+
+        #endregion
+
+        #region Ordered
+
+        [Test]
+        public void CollectionOrdered()
+        {
+            var constraint = Ordered;
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<ordered>"));
+        }
+
+        [Test]
+        public void CollectionOrdered_Descending()
+        {
+            var constraint = Ordered.Descending;
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<ordered descending>"));
+        }
+
+        [Test]
+        public void CollectionOrdered_Comparer()
+        {
+            var constraint = Ordered.Using(ObjectComparer.Default);
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<ordered NUnit.TestUtilities.Comparers.ObjectComparer>"));
+        }
+
+        [Test]
+        public void CollectionOrdered_Comparer_Descending()
+        {
+            var constraint = Ordered.Using(ObjectComparer.Default).Descending;
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<ordered descending NUnit.TestUtilities.Comparers.ObjectComparer>"));
+        }
+
+        #endregion
+
+        #region OrderedBy
+
+        [Test]
+        public void CollectionOrderedBy()
+        {
+            var constraint = Ordered.By("SomePropertyName");
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName>"));
+        }
+
+        [Test]
+        public void CollectionOrderedBy_Descending()
+        {
+            var constraint = Ordered.By("SomePropertyName").Descending;
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName descending>"));
+        }
+
+        [Test]
+        public void CollectionOrderedBy_Comparer()
+        {
+            var constraint = Ordered.By("SomePropertyName").Using(ObjectComparer.Default);
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName NUnit.TestUtilities.Comparers.ObjectComparer>"));
+        }
+
+        [Test]
+        public void CollectionOrderedBy_Comparer_Descending()
+        {
+            var constraint = Ordered.By("SomePropertyName").Using(ObjectComparer.Default).Descending;
+            Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+            Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName descending NUnit.TestUtilities.Comparers.ObjectComparer>"));
+        }
+
+        #endregion
+
+        #region Contains
+
+        [Test]
+        public void ContainsConstraint()
+        {
+            var constraint = Contains(42);
+            Expect(constraint, TypeOf<CollectionContainsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<contains 42>"));
+        }
+
+        #endregion
+
+        #region SubsetOf
+
+        [Test]
+        public void SubsetOfConstraint()
+        {
+            var constraint = SubsetOf(new int[] { 1, 2, 3 });
+            Expect(constraint, TypeOf<CollectionSubsetConstraint>());
+            Expect(constraint.ToString(), EqualTo("<subsetof System.Int32[]>"));
+        }
+
+        #endregion
+
+        #region EquivalentTo
+
+        [Test]
+        public void EquivalentConstraint()
+        {
+            var constraint = EquivalentTo(new int[] { 1, 2, 3 });
+            Expect(constraint, TypeOf<CollectionEquivalentConstraint>());
+            Expect(constraint.ToString(), EqualTo("<equivalent System.Int32[]>"));
+        }
+
+        #endregion
+
+        #region ComparisonConstraints
+
+        [Test]
+        public void GreaterThan()
+        {
+            var constraint = GreaterThan(7);
+            Expect(constraint, TypeOf<GreaterThanConstraint>());
+            Expect(constraint.ToString(), EqualTo("<greaterthan 7>"));
+        }
+
+        [Test]
+        public void GreaterThanOrEqual()
+        {
+            var constraint = GreaterThanOrEqualTo(7);
+            Expect(constraint, TypeOf<GreaterThanOrEqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<greaterthanorequal 7>"));
+        }
+
+        [Test]
+        public void AtLeast()
+        {
+            var constraint = AtLeast(7);
+            Expect(constraint, TypeOf<GreaterThanOrEqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<greaterthanorequal 7>"));
+        }
+
+        [Test]
+        public void LessThan()
+        {
+            var constraint = LessThan(7);
+            Expect(constraint, TypeOf<LessThanConstraint>());
+            Expect(constraint.ToString(), EqualTo("<lessthan 7>"));
+        }
+
+        [Test]
+        public void LessThanOrEqual()
+        {
+            var constraint = LessThanOrEqualTo(7);
+            Expect(constraint, TypeOf<LessThanOrEqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<lessthanorequal 7>"));
+        }
+
+        [Test]
+        public void AtMost()
+        {
+            var constraint = AtMost(7);
+            Expect(constraint, TypeOf<LessThanOrEqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<lessthanorequal 7>"));
+        }
+
+        #endregion
+
+        #region EqualTo
+
+        [Test]
+        public void EqualConstraint()
+        {
+            var constraint = EqualTo(999);
+            Expect(constraint, TypeOf<EqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<equal 999>"));
+        }
+
+        [Test]
+        public void Equal_IgnoreCase()
+        {
+            var constraint = EqualTo("X").IgnoreCase;
+            Expect(constraint, TypeOf<EqualConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<equal ""X"">"));
+        }
+
+        [Test]
+        public void Equal_WithinTolerance()
+        {
+            var constraint = EqualTo(0.7).Within(.005);
+            Expect(constraint, TypeOf<EqualConstraint>());
+            Expect(constraint.ToString(), EqualTo("<equal 0.7>"));
+        }
+
+        #endregion
+
+        #region And
+
+        [Test]
+        public void AndConstraint()
+        {
+            var expression = GreaterThan(5).And.LessThan(10);
+            Expect(expression, TypeOf<LessThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AndConstraint>());
+            Expect(constraint.ToString(), EqualTo("<and <greaterthan 5> <lessthan 10>>"));
+        }
+
+        [Test]
+        public void AndConstraint_ThreeAndsWithNot()
+        {
+            var expression = Not.Null.And.Not.LessThan(5).And.Not.GreaterThan(10);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<AndConstraint>());
+            Expect(constraint.ToString(), EqualTo("<and <not <null>> <and <not <lessthan 5>> <not <greaterthan 10>>>>"));
+        }
+
+        #endregion
+
+        #region Or
+
+        [Test]
+        public void OrConstraint()
+        {
+            var expression = LessThan(5).Or.GreaterThan(10);
+            Expect(expression, TypeOf<GreaterThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<OrConstraint>());
+            Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <greaterthan 10>>"));
+        }
+
+        [Test]
+        public void OrConstraint_ThreeOrs()
+        {
+            var expression = LessThan(5).Or.GreaterThan(10).Or.EqualTo(7);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<OrConstraint>());
+            Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <or <greaterthan 10> <equal 7>>>"));
+        }
+
+        [Test]
+        public void OrConstraint_PrecededByAnd()
+        {
+            var expression = LessThan(100).And.GreaterThan(0).Or.EqualTo(999);
+            Expect(expression, TypeOf<EqualConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<OrConstraint>());
+            Expect(constraint.ToString(), EqualTo("<or <and <lessthan 100> <greaterthan 0>> <equal 999>>"));
+        }
+
+        [Test]
+        public void OrConstraint_FollowedByAnd()
+        {
+            var expression = EqualTo(999).Or.GreaterThan(0).And.LessThan(100);
+            Expect(expression, TypeOf<LessThanConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<OrConstraint>());
+            Expect(constraint.ToString(), Is.EqualTo("<or <equal 999> <and <greaterthan 0> <lessthan 100>>>"));
+        }
+
+        #endregion
+
+        #region SamePath
+
+#if !PORTABLE
+        [Test]
+        public void SamePath()
+        {
+            var constraint = SamePath("/path/to/match");
+            Expect(constraint, TypeOf<SamePathConstraint>());
+            Expect(constraint.ToString(), EqualTo(
+                string.Format(@"<samepath ""/path/to/match"" {0}>", DEFAULT_PATH_CASE)));
+        }
+
+        [Test]
+        public void SamePath_IgnoreCase()
+        {
+            var constraint = SamePath("/path/to/match").IgnoreCase;
+            Expect(constraint, TypeOf<SamePathConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<samepath ""/path/to/match"" ignorecase>"));
+        }
+
+        [Test]
+        public void NotSamePath_IgnoreCase()
+        {
+            var expression = Not.SamePath("/path/to/match").IgnoreCase;
+            Expect(expression, TypeOf<SamePathConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<not <samepath ""/path/to/match"" ignorecase>>"));
+        }
+
+        [Test]
+        public void SamePath_RespectCase()
+        {
+            var constraint = SamePath("/path/to/match").RespectCase;
+            Expect(constraint, TypeOf<SamePathConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<samepath ""/path/to/match"" respectcase>"));
+        }
+
+        [Test]
+        public void NotSamePath_RespectCase()
+        {
+            var expression = Not.SamePath("/path/to/match").RespectCase;
+            Expect(expression, TypeOf<SamePathConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<not <samepath ""/path/to/match"" respectcase>>"));
+        }
+#endif
+
+#endregion
+
+#region SamePathOrUnder
+
+#if !PORTABLE
+        [Test]
+        public void SamePathOrUnder()
+        {
+            var constraint = SamePathOrUnder("/path/to/match");
+            Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+            Expect(constraint.ToString(), EqualTo(
+                string.Format(@"<samepathorunder ""/path/to/match"" {0}>", DEFAULT_PATH_CASE)));
+        }
+
+        [Test]
+        public void SamePathOrUnder_IgnoreCase()
+        {
+            var constraint = SamePathOrUnder("/path/to/match").IgnoreCase;
+            Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<samepathorunder ""/path/to/match"" ignorecase>"));
+        }
+
+        [Test]
+        public void NotSamePathOrUnder_IgnoreCase()
+        {
+            var expression = Not.SamePathOrUnder("/path/to/match").IgnoreCase;
+            Expect(expression, TypeOf<SamePathOrUnderConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<not <samepathorunder ""/path/to/match"" ignorecase>>"));
+        }
+
+        [Test]
+        public void SamePathOrUnder_RespectCase()
+        {
+            var constraint = SamePathOrUnder("/path/to/match").RespectCase;
+            Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<samepathorunder ""/path/to/match"" respectcase>"));
+        }
+
+        [Test]
+        public void NotSamePathOrUnder_RespectCase()
+        {
+            var expression = Not.SamePathOrUnder("/path/to/match").RespectCase;
+            Expect(expression, TypeOf<SamePathOrUnderConstraint>());
+            var constraint = Resolve(expression);
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<not <samepathorunder ""/path/to/match"" respectcase>>"));
+        }
+#endif
+
+        #endregion
+
+        #region BinarySerializable
+
+#if !NETCF && !SILVERLIGHT && !PORTABLE
+        [Test]
+        public void BinarySerializableConstraint()
+        {
+            var constraint = BinarySerializable;
+            Expect(constraint, TypeOf<BinarySerializableConstraint>());
+            Expect(constraint.ToString(), EqualTo("<binaryserializable>"));
+        }
+#endif
+
+        #endregion
+
+        #region XmlSerializable
+
+#if !SILVERLIGHT && !PORTABLE
+        [Test]
+        public void XmlSerializableConstraint()
+        {
+            var constraint = XmlSerializable;
+            Expect(constraint, TypeOf<XmlSerializableConstraint>());
+            Expect(constraint.ToString(), EqualTo("<xmlserializable>"));
+        }
+#endif
+
+        #endregion
+
+        #region Contains
+
+        [Test]
+        public void ContainsTest()
+        {
+            var constraint = Contains("X");
+            Expect(constraint, TypeOf<ContainsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<contains>"));
+        }
+
+        [Test]
+        public void ContainsTest_IgnoreCase()
+        {
+            var constraint = Contains("X").IgnoreCase;
+            Expect(constraint, TypeOf<ContainsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<contains>"));
+        }
+
+#endregion
+
+#region StartsWith
+
+        [Test]
+        public void StartsWithTest()
+        {
+            var constraint = StartsWith("X");
+            Expect(constraint, TypeOf<StartsWithConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<startswith ""X"">"));
+        }
+
+        [Test]
+        public void StartsWithTest_IgnoreCase()
+        {
+            var constraint = StartsWith("X").IgnoreCase;
+            Expect(constraint, TypeOf<StartsWithConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<startswith ""X"">"));
+        }
+
+#endregion
+
+#region EndsWith
+
+        [Test]
+        public void EndsWithTest()
+        {
+            var constraint = EndsWith("X");
+            Expect(constraint, TypeOf<EndsWithConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<endswith ""X"">"));
+        }
+
+        [Test]
+        public void EndsWithTest_IgnoreCase()
+        {
+            var constraint = EndsWith("X").IgnoreCase;
+            Expect(constraint, TypeOf<EndsWithConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<endswith ""X"">"));
+        }
+
+#endregion
+
+#region Matches
+
+        [Test]
+        public void MatchesTest()
+        {
+            var constraint = Matches("X");
+            Expect(constraint, TypeOf<RegexConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<regex ""X"">"));
+        }
+
+        [Test]
+        public void MatchesTest_IgnoreCase()
+        {
+            var constraint = Matches("X").IgnoreCase;
+            Expect(constraint, TypeOf<RegexConstraint>());
+            Expect(constraint.ToString(), EqualTo(@"<regex ""X"">"));
+        }
+
+#endregion
+
+#region TypeOf
+
+        [Test]
+        public void TypeOfTest()
+        {
+            var constraint = TypeOf(typeof(string));
+            Expect(constraint, TypeOf<ExactTypeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<typeof System.String>"));
+        }
+
+        [Test]
+        public void TypeOfTest_Generic()
+        {
+            var constraint = TypeOf<string>();
+            Expect(constraint, TypeOf<ExactTypeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<typeof System.String>"));
+        }
+
+#endregion
+
+#region InstanceOf
+
+        [Test]
+        public void InstanceOfTest()
+        {
+            var constraint = InstanceOf(typeof(string));
+            Expect(constraint, TypeOf<InstanceOfTypeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<instanceof System.String>"));
+        }
+
+        [Test]
+        public void InstanceOfTest_Generic()
+        {
+            var constraint = InstanceOf<string>();
+            Expect(constraint, TypeOf<InstanceOfTypeConstraint>());
+            Expect(constraint.ToString(), EqualTo("<instanceof System.String>"));
+        }
+
+#endregion
+
+#region AssignableFrom
+
+        [Test]
+        public void AssignableFromTest()
+        {
+            var constraint = AssignableFrom(typeof(string));
+            Expect(constraint, TypeOf<AssignableFromConstraint>());
+            Expect(constraint.ToString(), EqualTo("<assignablefrom System.String>"));
+        }
+
+        [Test]
+        public void AssignableFromTest_Generic()
+        {
+            var constraint = AssignableFrom<string>();
+            Expect(constraint, TypeOf<AssignableFromConstraint>());
+            Expect(constraint.ToString(), EqualTo("<assignablefrom System.String>"));
+        }
+
+#endregion
+
+#region AssignableTo
+
+        [Test]
+        public void AssignableToTest()
+        {
+            var constraint = AssignableTo(typeof(string));
+            Expect(constraint, TypeOf<AssignableToConstraint>());
+            Expect(constraint.ToString(), EqualTo("<assignableto System.String>"));
+        }
+
+        [Test]
+        public void AssignableToTest_Generic()
+        {
+            var constraint = AssignableTo<string>();
+            Expect(constraint, TypeOf<AssignableToConstraint>());
+            Expect(constraint.ToString(), EqualTo("<assignableto System.String>"));
+        }
+
+#endregion
+
+#region Operator Overrides
+
+        [Test]
+        public void NotOperator()
+        {
+            var constraint = !Null;
+            Expect(constraint, TypeOf<NotConstraint>());
+            Expect(constraint.ToString(), EqualTo("<not <null>>"));
+        }
+
+        [Test]
+        public void AndOperator()
+        {
+            var constraint = GreaterThan(5) & LessThan(10);
+            Expect(constraint, TypeOf<AndConstraint>());
+            Expect(constraint.ToString(), EqualTo("<and <greaterthan 5> <lessthan 10>>"));
+        }
+
+        [Test]
+        public void OrOperator()
+        {
+            var constraint = LessThan(5) | GreaterThan(10);
+            Expect(constraint, TypeOf<OrConstraint>());
+            Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <greaterthan 10>>"));
+        }
+
+#endregion
+
+#region Helper Methods
+
+        private static IConstraint Resolve(IResolveConstraint expression)
+        {
+            return ((IResolveConstraint)expression).Resolve();
+        }
+
+#endregion
+    }
+}

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -28,7 +28,7 @@ using System.Globalization;
 namespace NUnit.Framework.Internal
 {
     [TestFixture]
-    public class TextMessageWriterTests : AssertionHelper
+    public class TextMessageWriterTests
     {
         private static readonly string NL = NUnit.Env.NewLine;
 
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
 
             writer.DisplayStringDifferences(s72, "abcde", 5, false, true);
             string message = writer.ToString();
-            Expect(message, EqualTo(
+            Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(exp) + NL +
                 TextMessageWriter.Pfx_Actual + Q("abcde") + NL +
                 "  ----------------^" + NL));
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal
 
             writer.DisplayStringDifferences(s72, "abcde", 5, false, false);
             string message = writer.ToString();
-            Expect(message, EqualTo(
+            Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(s72) + NL +
                 TextMessageWriter.Pfx_Actual + Q("abcde") + NL +
                 "  ----------------^" + NL));
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
             writer.WriteMessageLine(0, message, null);
             message = writer.ToString();
 
-            Expect(message, EqualTo(expected));
+            Assert.That(message, Is.EqualTo(expected));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal
             writer.WriteMessageLine(0, message, arg0);
             message = writer.ToString();
 
-            Expect(message, EqualTo(expected));
+            Assert.That(message, Is.EqualTo(expected));
         }
 
         private string Q(string s)

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -35,7 +35,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<after 1000 <equal 10>>";
             staticSyntax = Is.EqualTo(10).After(1000);
-            inheritedSyntax = Helper().EqualTo(10).After(1000);
             builderSyntax = Builder().EqualTo(10).After(1000);
         }
     }
@@ -47,7 +46,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<after 1000 <property X <equal 10>>>";
             staticSyntax = Has.Property("X").EqualTo(10).After(1000);
-            inheritedSyntax = Helper().Property("X").EqualTo(10).After(1000);
             builderSyntax = Builder().Property("X").EqualTo(10).After(1000);
         }
     }
@@ -59,7 +57,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<after 1000 <and <greaterthan 0> <lessthan 10>>>";
             staticSyntax = Is.GreaterThan(0).And.LessThan(10).After(1000);
-            inheritedSyntax = Helper().GreaterThan(0).And.LessThan(10).After(1000);
             builderSyntax = Builder().GreaterThan(0).And.LessThan(10).After(1000);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/CollectionTests.cs
+++ b/src/NUnitFramework/tests/Syntax/CollectionTests.cs
@@ -34,7 +34,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<uniqueitems>";
             staticSyntax = Is.Unique;
-            inheritedSyntax = Helper().Unique;
             builderSyntax = Builder().Unique;
         }
     }
@@ -46,7 +45,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<ordered>";
             staticSyntax = Is.Ordered;
-            inheritedSyntax = Helper().Ordered;
             builderSyntax = Builder().Ordered;
         }
     }
@@ -58,7 +56,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<ordered descending>";
             staticSyntax = Is.Ordered.Descending;
-            inheritedSyntax = Helper().Ordered.Descending;
             builderSyntax = Builder().Ordered.Descending;
         }
     }
@@ -71,7 +68,6 @@ namespace NUnit.Framework.Syntax
             IComparer comparer = ObjectComparer.Default;
             parseTree = "<ordered NUnit.TestUtilities.Comparers.ObjectComparer>";
             staticSyntax = Is.Ordered.Using(comparer);
-            inheritedSyntax = Helper().Ordered.Using(comparer);
             builderSyntax = Builder().Ordered.Using(comparer);
         }
     }
@@ -84,7 +80,6 @@ namespace NUnit.Framework.Syntax
             IComparer comparer = ObjectComparer.Default;
             parseTree = "<ordered descending NUnit.TestUtilities.Comparers.ObjectComparer>";
             staticSyntax = Is.Ordered.Using(comparer).Descending;
-            inheritedSyntax = Helper().Ordered.Using(comparer).Descending;
             builderSyntax = Builder().Ordered.Using(comparer).Descending;
         }
     }
@@ -96,7 +91,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<orderedby SomePropertyName>";
             staticSyntax = Is.Ordered.By("SomePropertyName");
-            inheritedSyntax = Helper().Ordered.By("SomePropertyName");
             builderSyntax = Builder().Ordered.By("SomePropertyName");
         }
     }
@@ -108,7 +102,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<orderedby SomePropertyName descending>";
             staticSyntax = Is.Ordered.By("SomePropertyName").Descending;
-            inheritedSyntax = Helper().Ordered.By("SomePropertyName").Descending;
             builderSyntax = Builder().Ordered.By("SomePropertyName").Descending;
         }
     }
@@ -120,7 +113,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<orderedby SomePropertyName NUnit.TestUtilities.Comparers.ObjectComparer>";
             staticSyntax = Is.Ordered.By("SomePropertyName").Using(ObjectComparer.Default);
-            inheritedSyntax = Helper().Ordered.By("SomePropertyName").Using(ObjectComparer.Default);
             builderSyntax = Builder().Ordered.By("SomePropertyName").Using(ObjectComparer.Default);
         }
     }
@@ -132,7 +124,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<orderedby SomePropertyName descending NUnit.TestUtilities.Comparers.ObjectComparer>";
             staticSyntax = Is.Ordered.By("SomePropertyName").Using(ObjectComparer.Default).Descending;
-            inheritedSyntax = Helper().Ordered.By("SomePropertyName").Using(ObjectComparer.Default).Descending;
             builderSyntax = Builder().Ordered.By("SomePropertyName").Using(ObjectComparer.Default).Descending;
         }
     }
@@ -144,7 +135,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<contains 42>";
             staticSyntax = Has.Member(42);
-            inheritedSyntax = Helper().Contains(42);
             builderSyntax = Builder().Contains(42);
         }
     }
@@ -157,7 +147,6 @@ namespace NUnit.Framework.Syntax
             int[] ints = new int[] { 1, 2, 3 };
             parseTree = "<subsetof System.Int32[]>";
             staticSyntax = Is.SubsetOf(ints);
-            inheritedSyntax = Helper().SubsetOf(ints);
             builderSyntax = Builder().SubsetOf(ints);
         }
     }
@@ -170,7 +159,6 @@ namespace NUnit.Framework.Syntax
             int[] ints = new int[] { 1, 2, 3 };
             parseTree = "<equivalent System.Int32[]>";
             staticSyntax = Is.EquivalentTo(ints);
-            inheritedSyntax = Helper().EquivalentTo(ints);
             builderSyntax = Builder().EquivalentTo(ints);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/ComparisonTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ComparisonTests.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<greaterthan 7>";
             staticSyntax = Is.GreaterThan(7);
-            inheritedSyntax = Helper().GreaterThan(7);
             builderSyntax = Builder().GreaterThan(7);
         }
     }
@@ -44,7 +43,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<greaterthanorequal 7>";
             staticSyntax = Is.GreaterThanOrEqualTo(7);
-            inheritedSyntax = Helper().GreaterThanOrEqualTo(7);
             builderSyntax = Builder().GreaterThanOrEqualTo(7);
         }
     }
@@ -56,7 +54,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<greaterthanorequal 7>";
             staticSyntax = Is.AtLeast(7);
-            inheritedSyntax = Helper().AtLeast(7);
             builderSyntax = Builder().AtLeast(7);
         }
     }
@@ -68,7 +65,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<lessthan 7>";
             staticSyntax = Is.LessThan(7);
-            inheritedSyntax = Helper().LessThan(7);
             builderSyntax = Builder().LessThan(7);
         }
     }
@@ -80,7 +76,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<lessthanorequal 7>";
             staticSyntax = Is.LessThanOrEqualTo(7);
-            inheritedSyntax = Helper().LessThanOrEqualTo(7);
             builderSyntax = Builder().LessThanOrEqualTo(7);
         }
     }
@@ -92,7 +87,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<lessthanorequal 7>";
             staticSyntax = Is.AtMost(7);
-            inheritedSyntax = Helper().AtMost(7);
             builderSyntax = Builder().AtMost(7);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<equal 999>";
             staticSyntax = Is.EqualTo(999);
-            inheritedSyntax = Helper().EqualTo(999);
             builderSyntax = Builder().EqualTo(999);
         }
     }
@@ -45,7 +44,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<equal ""X"">";
             staticSyntax = Is.EqualTo("X").IgnoreCase;
-            inheritedSyntax = Helper().EqualTo("X").IgnoreCase;
             builderSyntax = Builder().EqualTo("X").IgnoreCase;
         }
     }
@@ -57,7 +55,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<equal 0.7>";
             staticSyntax = Is.EqualTo(0.7).Within(.005);
-            inheritedSyntax = Helper().EqualTo(0.7).Within(.005);
             builderSyntax = Builder().EqualTo(0.7).Within(.005);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
+++ b/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Constraints;
 namespace NUnit.Framework.Syntax
 {
     [TestFixture]
-    public class InvalidCodeTests : AssertionHelper
+    public class InvalidCodeTests
     {
         static readonly string template1 =
 @"using System;

--- a/src/NUnitFramework/tests/Syntax/OperatorOverrides.cs
+++ b/src/NUnitFramework/tests/Syntax/OperatorOverrides.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<not <null>>";
             staticSyntax = !Is.Null;
-            inheritedSyntax = !Helper().Null;
             builderSyntax = !Builder().Null;
         }
     }
@@ -45,7 +44,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<and <greaterthan 5> <lessthan 10>>";
             staticSyntax = Is.GreaterThan(5) & Is.LessThan(10);
-            inheritedSyntax = Helper().GreaterThan(5) & Is.LessThan(10);
             builderSyntax = Builder().GreaterThan(5) & Builder().LessThan(10);
         }
     }
@@ -57,7 +55,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<or <lessthan 5> <greaterthan 10>>";
             staticSyntax = Is.LessThan(5) | Is.GreaterThan(10);
-            inheritedSyntax = Helper().LessThan(5) | Is.GreaterThan(10);
             builderSyntax = Builder().LessThan(5) | Is.GreaterThan(10);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/OperatorTests.cs
+++ b/src/NUnitFramework/tests/Syntax/OperatorTests.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<not <null>>";
             staticSyntax = Is.Not.Null;
-            inheritedSyntax = Helper().Not.Null;
             builderSyntax = Builder().Not.Null;
         }
     }
@@ -45,7 +44,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<not <not <not <null>>>>";
             staticSyntax = Is.Not.Not.Not.Null;
-            inheritedSyntax = Helper().Not.Not.Not.Null;
             builderSyntax = Builder().Not.Not.Not.Null;
         }
     }
@@ -59,7 +57,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<all <greaterthan 0>>";
             staticSyntax = Is.All.GreaterThan(0);
-            inheritedSyntax = Helper().All.GreaterThan(0);
             builderSyntax = Builder().All.GreaterThan(0);
         }
     }
@@ -73,7 +70,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<some <equal 3>>";
             staticSyntax = Has.Some.EqualTo(3);
-            inheritedSyntax = Helper().Some.EqualTo(3);
             builderSyntax = Builder().Some.EqualTo(3);
         }
     }
@@ -85,7 +81,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<some <or <and <greaterthan 0> <lessthan 100>> <equal 999>>>";
             staticSyntax = Has.Some.GreaterThan(0).And.LessThan(100).Or.EqualTo(999);
-            inheritedSyntax = Helper().Some.GreaterThan(0).And.LessThan(100).Or.EqualTo(999);
             builderSyntax = Builder().Some.GreaterThan(0).And.LessThan(100).Or.EqualTo(999);
         }
     }
@@ -97,7 +92,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<some <some <lessthan 100>>>";
             staticSyntax = Has.Some.With.Some.LessThan(100);
-            inheritedSyntax = Helper().Some.With.Some.LessThan(100);
             builderSyntax = Builder().Some.With.Some.LessThan(100);
         }
         
@@ -110,7 +104,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<and <some <greaterthan 0>> <some <lessthan 100>>>";
             staticSyntax = Has.Some.GreaterThan(0).And.Some.LessThan(100);
-            inheritedSyntax = Helper().Some.GreaterThan(0).And.Some.LessThan(100);
             builderSyntax = Builder().Some.GreaterThan(0).And.Some.LessThan(100);
         }
     }
@@ -124,7 +117,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<none <lessthan 0>>";
             staticSyntax = Has.None.LessThan(0);
-            inheritedSyntax = Helper().None.LessThan(0);
             builderSyntax = Builder().None.LessThan(0);
         }
     }
@@ -138,7 +130,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<and <greaterthan 5> <lessthan 10>>";
             staticSyntax = Is.GreaterThan(5).And.LessThan(10);
-            inheritedSyntax = Helper().GreaterThan(5).And.LessThan(10);
             builderSyntax = Builder().GreaterThan(5).And.LessThan(10);
         }
     }
@@ -150,7 +141,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<and <not <null>> <and <not <lessthan 5>> <not <greaterthan 10>>>>";
             staticSyntax = Is.Not.Null.And.Not.LessThan(5).And.Not.GreaterThan(10);
-            inheritedSyntax = Helper().Not.Null.And.Not.LessThan(5).And.Not.GreaterThan(10);
             builderSyntax = Builder().Not.Null.And.Not.LessThan(5).And.Not.GreaterThan(10);
         }
     }
@@ -164,7 +154,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<or <lessthan 5> <greaterthan 10>>";
             staticSyntax = Is.LessThan(5).Or.GreaterThan(10);
-            inheritedSyntax = Helper().LessThan(5).Or.GreaterThan(10);
             builderSyntax = Builder().LessThan(5).Or.GreaterThan(10);
         }
     }
@@ -176,7 +165,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<or <lessthan 5> <or <greaterthan 10> <equal 7>>>";
             staticSyntax = Is.LessThan(5).Or.GreaterThan(10).Or.EqualTo(7);
-            inheritedSyntax = Helper().LessThan(5).Or.GreaterThan(10).Or.EqualTo(7);
             builderSyntax = Builder().LessThan(5).Or.GreaterThan(10).Or.EqualTo(7);
         }
     }
@@ -190,7 +178,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<or <and <lessthan 100> <greaterthan 0>> <equal 999>>";
             staticSyntax = Is.LessThan(100).And.GreaterThan(0).Or.EqualTo(999);
-            inheritedSyntax = Helper().LessThan(100).And.GreaterThan(0).Or.EqualTo(999);
             builderSyntax = Builder().LessThan(100).And.GreaterThan(0).Or.EqualTo(999);
         }
     }
@@ -202,7 +189,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<or <equal 999> <and <greaterthan 0> <lessthan 100>>>";
             staticSyntax = Is.EqualTo(999).Or.GreaterThan(0).And.LessThan(100);
-            inheritedSyntax = Helper().EqualTo(999).Or.GreaterThan(0).And.LessThan(100);
             builderSyntax = Builder().EqualTo(999).Or.GreaterThan(0).And.LessThan(100);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/PathConstraintTests.cs
+++ b/src/NUnitFramework/tests/Syntax/PathConstraintTests.cs
@@ -38,7 +38,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepath ""{0}"" {1}>", path, defaultCaseSensitivity);
             staticSyntax = Is.SamePath(path);
-            inheritedSyntax = Helper().SamePath(path);
             builderSyntax = Builder().SamePath(path);
         }
     }
@@ -52,7 +51,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepath ""{0}"" ignorecase>", path);
             staticSyntax = Is.SamePath(path).IgnoreCase;
-            inheritedSyntax = Helper().SamePath(path).IgnoreCase;
             builderSyntax = Builder().SamePath(path).IgnoreCase;
         }
     }
@@ -66,7 +64,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<not <samepath ""{0}"" ignorecase>>", path);
             staticSyntax = Is.Not.SamePath(path).IgnoreCase;
-            inheritedSyntax = Helper().Not.SamePath(path).IgnoreCase;
             builderSyntax = Builder().Not.SamePath(path).IgnoreCase;
         }
     }
@@ -80,7 +77,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepath ""{0}"" respectcase>", path);
             staticSyntax = Is.SamePath(path).RespectCase;
-            inheritedSyntax = Helper().SamePath(path).RespectCase;
             builderSyntax = Builder().SamePath(path).RespectCase;
         }
     }
@@ -94,7 +90,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<not <samepath ""{0}"" respectcase>>", path);
             staticSyntax = Is.Not.SamePath(path).RespectCase;
-            inheritedSyntax = Helper().Not.SamePath(path).RespectCase;
             builderSyntax = Builder().Not.SamePath(path).RespectCase;
         }
     }
@@ -110,7 +105,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepathorunder ""{0}"" {1}>", path, defaultCaseSensitivity);
             staticSyntax = Is.SamePathOrUnder(path);
-            inheritedSyntax = Helper().SamePathOrUnder(path);
             builderSyntax = Builder().SamePathOrUnder(path);
         }
     }
@@ -124,7 +118,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepathorunder ""{0}"" ignorecase>", path);
             staticSyntax = Is.SamePathOrUnder(path).IgnoreCase;
-            inheritedSyntax = Helper().SamePathOrUnder(path).IgnoreCase;
             builderSyntax = Builder().SamePathOrUnder(path).IgnoreCase;
         }
     }
@@ -138,7 +131,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<not <samepathorunder ""{0}"" ignorecase>>", path);
             staticSyntax = Is.Not.SamePathOrUnder(path).IgnoreCase;
-            inheritedSyntax = Helper().Not.SamePathOrUnder(path).IgnoreCase;
             builderSyntax = Builder().Not.SamePathOrUnder(path).IgnoreCase;
         }
     }
@@ -152,7 +144,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<samepathorunder ""{0}"" respectcase>", path);
             staticSyntax = Is.SamePathOrUnder(path).RespectCase;
-            inheritedSyntax = Helper().SamePathOrUnder(path).RespectCase;
             builderSyntax = Builder().SamePathOrUnder(path).RespectCase;
         }
     }
@@ -166,7 +157,6 @@ namespace NUnit.Framework.Syntax
 
             parseTree = string.Format(@"<not <samepathorunder ""{0}"" respectcase>>", path);
             staticSyntax = Is.Not.SamePathOrUnder(path).RespectCase;
-            inheritedSyntax = Helper().Not.SamePathOrUnder(path).RespectCase;
             builderSyntax = Builder().Not.SamePathOrUnder(path).RespectCase;
         }
     }

--- a/src/NUnitFramework/tests/Syntax/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Syntax/PropertyTests.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<propertyexists X>";
             staticSyntax = Has.Property("X");
-            inheritedSyntax = Helper().Property("X");
             builderSyntax = Builder().Property("X");
         }
     }
@@ -45,7 +44,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<and <propertyexists X> <equal 7>>";
             staticSyntax = Has.Property("X").And.EqualTo(7);
-            inheritedSyntax = Helper().Property("X").And.EqualTo(7);
             builderSyntax = Builder().Property("X").And.EqualTo(7);
         }
     }
@@ -57,7 +55,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<property X <greaterthan 5>>";
             staticSyntax = Has.Property("X").GreaterThan(5);
-            inheritedSyntax = Helper().Property("X").GreaterThan(5);
             builderSyntax = Builder().Property("X").GreaterThan(5);
         }
     }
@@ -69,7 +66,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<property X <not <greaterthan 5>>>";
             staticSyntax = Has.Property("X").Not.GreaterThan(5);
-            inheritedSyntax = Helper().Property("X").Not.GreaterThan(5);
             builderSyntax = Builder().Property("X").Not.GreaterThan(5);
         }
     }
@@ -81,7 +77,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<property Length <greaterthan 5>>";
             staticSyntax = Has.Length.GreaterThan(5);
-            inheritedSyntax = Helper().Length.GreaterThan(5);
             builderSyntax = Builder().Length.GreaterThan(5);
         }
     }
@@ -93,7 +88,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<property Count <equal 5>>";
             staticSyntax = Has.Count.EqualTo(5);
-            inheritedSyntax = Helper().Count.EqualTo(5);
             builderSyntax = Builder().Count.EqualTo(5);
         }
     }
@@ -105,7 +99,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<property Message <startswith ""Expected"">>";
             staticSyntax = Has.Message.StartsWith("Expected");
-            inheritedSyntax = Helper().Message.StartsWith("Expected");
             builderSyntax = Builder().Message.StartsWith("Expected");
         }
     }

--- a/src/NUnitFramework/tests/Syntax/SerializableConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/SerializableConstraints.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<binaryserializable>";
             staticSyntax = Is.BinarySerializable;
-            inheritedSyntax = Helper().BinarySerializable;
             builderSyntax = Builder().BinarySerializable;
         }
     }
@@ -47,7 +46,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<xmlserializable>";
             staticSyntax = Is.XmlSerializable;
-            inheritedSyntax = Helper().XmlSerializable;
             builderSyntax = Builder().XmlSerializable;
         }
     }

--- a/src/NUnitFramework/tests/Syntax/SimpleConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/SimpleConstraints.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<null>";
             staticSyntax = Is.Null;
-            inheritedSyntax = Helper().Null;
             builderSyntax = Builder().Null;
         }
     }
@@ -44,7 +43,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<true>";
             staticSyntax = Is.True;
-            inheritedSyntax = Helper().True;
             builderSyntax = Builder().True;
         }
     }
@@ -56,7 +54,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<false>";
             staticSyntax = Is.False;
-            inheritedSyntax = Helper().False;
             builderSyntax = Builder().False;
         }
     }
@@ -68,7 +65,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<greaterthan 0>";
             staticSyntax = Is.Positive;
-            inheritedSyntax = Helper().Positive;
             builderSyntax = Builder().Positive;
         }
     }
@@ -80,7 +76,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<lessthan 0>";
             staticSyntax = Is.Negative;
-            inheritedSyntax = Helper().Negative;
             builderSyntax = Builder().Negative;
         }
     }
@@ -92,7 +87,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<equal 0>";
             staticSyntax = Is.Zero;
-            inheritedSyntax = Helper().Zero;
             builderSyntax = Builder().Zero;
         }
     }
@@ -104,7 +98,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<nan>";
             staticSyntax = Is.NaN;
-            inheritedSyntax = Helper().NaN;
             builderSyntax = Builder().NaN;
         }
     }

--- a/src/NUnitFramework/tests/Syntax/StringConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/StringConstraints.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<contains>";
             staticSyntax = Does.Contain("X");
-            inheritedSyntax = Helper().Contains("X");
             builderSyntax = Builder().Contains("X");
         }
     }
@@ -44,7 +43,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<contains>";
             staticSyntax = Does.Contain("X").IgnoreCase;
-            inheritedSyntax = Helper().Contains("X").IgnoreCase;
             builderSyntax = Builder().Contains("X").IgnoreCase;
         }
     }
@@ -56,7 +54,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<startswith ""X"">";
             staticSyntax = Does.StartWith("X");
-            inheritedSyntax = Helper().StartsWith("X");
             builderSyntax = Builder().StartsWith("X");
         }
     }
@@ -68,7 +65,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<startswith ""X"">";
             staticSyntax = Does.StartWith("X");
-            inheritedSyntax = Helper().StartsWith("X");
             builderSyntax = Builder().StartsWith("X");
         }
     }
@@ -80,7 +76,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<startswith ""X"">";
             staticSyntax = Does.StartWith("X").IgnoreCase;
-            inheritedSyntax = Helper().StartsWith("X").IgnoreCase;
             builderSyntax = Builder().StartsWith("X").IgnoreCase;
         }
     }
@@ -92,7 +87,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<endswith ""X"">";
             staticSyntax = Does.EndWith("X");
-            inheritedSyntax = Helper().EndsWith("X");
             builderSyntax = Builder().EndsWith("X");
         }
     }
@@ -104,7 +98,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<endswith ""X"">";
             staticSyntax = Does.EndWith("X").IgnoreCase;
-            inheritedSyntax = Helper().EndsWith("X").IgnoreCase;
             builderSyntax = Builder().EndsWith("X").IgnoreCase;
         }
     }
@@ -116,7 +109,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<regex ""X"">";
             staticSyntax = Does.Match("X");
-            inheritedSyntax = Helper().Matches("X");
             builderSyntax = Builder().Matches("X");
         }
     }
@@ -128,7 +120,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<regex ""X"">";
             staticSyntax = Does.Match("X").IgnoreCase;
-            inheritedSyntax = Helper().Matches("X").IgnoreCase;
             builderSyntax = Builder().Matches("X").IgnoreCase;
         }
     }

--- a/src/NUnitFramework/tests/Syntax/SyntaxTest.cs
+++ b/src/NUnitFramework/tests/Syntax/SyntaxTest.cs
@@ -30,13 +30,7 @@ namespace NUnit.Framework.Syntax
     {
         protected string parseTree;
         protected IResolveConstraint staticSyntax;
-        protected IResolveConstraint inheritedSyntax;
         protected IResolveConstraint builderSyntax;
-
-        protected AssertionHelper Helper()
-        {
-            return new AssertionHelper();
-        }
 
         protected ConstraintExpression Builder()
         {
@@ -56,14 +50,6 @@ namespace NUnit.Framework.Syntax
         {
             Assert.That(
                 builderSyntax.Resolve().ToString(),
-                Is.EqualTo(parseTree).NoClip);
-        }
-
-        [Test]
-        public void SupportedByInheritedSyntax()
-        {
-            Assert.That(
-                inheritedSyntax.Resolve().ToString(),
                 Is.EqualTo(parseTree).NoClip);
         }
     }

--- a/src/NUnitFramework/tests/Syntax/TypeConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/TypeConstraints.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<typeof System.String>";
             staticSyntax = Is.TypeOf(typeof(string));
-            inheritedSyntax = Helper().TypeOf(typeof(string));
             builderSyntax = Builder().TypeOf(typeof(string));
         }
     }
@@ -46,7 +45,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<instanceof System.String>";
             staticSyntax = Is.InstanceOf(typeof(string));
-            inheritedSyntax = Helper().InstanceOf(typeof(string));
             builderSyntax = Builder().InstanceOf(typeof(string));
         }
     }
@@ -59,7 +57,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<assignablefrom System.String>";
             staticSyntax = Is.AssignableFrom(typeof(string));
-            inheritedSyntax = Helper().AssignableFrom(typeof(string));
             builderSyntax = Builder().AssignableFrom(typeof(string));
         }
     }
@@ -72,7 +69,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<assignableto System.String>";
             staticSyntax = Is.AssignableTo(typeof(string));
-            inheritedSyntax = Helper().AssignableTo(typeof(string));
             builderSyntax = Builder().AssignableTo(typeof(string));
         }
     }
@@ -86,7 +82,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<attributeexists NUnit.Framework.TestFixtureAttribute>";
             staticSyntax = Has.Attribute(typeof(TestFixtureAttribute));
-            inheritedSyntax = Helper().Attribute(typeof(TestFixtureAttribute));
             builderSyntax = Builder().Attribute(typeof(TestFixtureAttribute));
         }
     }
@@ -99,7 +94,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = @"<attribute NUnit.Framework.TestFixtureAttribute <property Description <not <null>>>>";
             staticSyntax = Has.Attribute(typeof(TestFixtureAttribute)).Property("Description").Not.Null;
-            inheritedSyntax = Helper().Attribute(typeof(TestFixtureAttribute)).Property("Description").Not.Null;
             builderSyntax = Builder().Attribute(typeof(TestFixtureAttribute)).Property("Description").Not.Null;
         }
     }
@@ -113,7 +107,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<typeof System.String>";
             staticSyntax = Is.TypeOf<string>();
-            inheritedSyntax = Helper().TypeOf<string>();
             builderSyntax = Builder().TypeOf<string>();
         }
     }
@@ -126,7 +119,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<instanceof System.String>";
             staticSyntax = Is.InstanceOf<string>();
-            inheritedSyntax = Helper().InstanceOf<string>();
             builderSyntax = Builder().InstanceOf<string>();
         }
     }
@@ -139,7 +131,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<assignablefrom System.String>";
             staticSyntax = Is.AssignableFrom<string>();
-            inheritedSyntax = Helper().AssignableFrom<string>();
             builderSyntax = Builder().AssignableFrom<string>();
         }
     }
@@ -152,7 +143,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<assignableto System.String>";
             staticSyntax = Is.AssignableTo<string>();
-            inheritedSyntax = Helper().AssignableTo<string>();
             builderSyntax = Builder().AssignableTo<string>();
         }
     }
@@ -166,7 +156,6 @@ namespace NUnit.Framework.Syntax
         {
             parseTree = "<attributeexists NUnit.Framework.TestFixtureAttribute>";
             staticSyntax = Has.Attribute<TestFixtureAttribute>();
-            inheritedSyntax = Helper().Attribute<TestFixtureAttribute>();
             builderSyntax = Builder().Attribute<TestFixtureAttribute>();
         }
     }

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
     <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\RetryAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Assertions\AssertFailTests.cs" />
     <Compile Include="Assertions\AssertIgnoreTests.cs" />
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Assertions\AssertFailTests.cs" />
     <Compile Include="Assertions\AssertIgnoreTests.cs" />
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Assertions\AssertFailTests.cs" />
     <Compile Include="Assertions\AssertIgnoreTests.cs" />
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Assertions\AssertFailTests.cs" />
     <Compile Include="Assertions\AssertIgnoreTests.cs" />
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Assertions\AssertFailTests.cs" />
     <Compile Include="Assertions\AssertIgnoreTests.cs" />
     <Compile Include="Assertions\AssertInconclusiveTests.cs" />
+    <Compile Include="Assertions\AssertionHelperTests.cs" />
     <Compile Include="Assertions\AssertPassTests.cs" />
     <Compile Include="Assertions\AssertThatTests.cs" />
     <Compile Include="Assertions\AssertThrowsAsyncTests.cs" />


### PR DESCRIPTION
This is in support of #1212 but does not complete it. I'd like to get it merged since it supports whichever path we follow with AssertionHelper by creating a separate test class for it and removing all other references throughout our tests. That way we can either migrate it to a separate project or simply drop it in the future.