### PR TITLE
Temporary fix #1018

### DIFF
--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>nunit3-console.tests.dll</Commandlineparameters>
+    <Commandlineparameters>net-4.5/nunit.framework.tests.dll</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -197,6 +197,9 @@ namespace NUnit.Engine.Services
             Guid agentId = Guid.NewGuid();
             string arglist = agentId.ToString() + " " + ServerUrl + " " + agentArgs;
 
+            if (targetRuntime.ClrVersion.Build < 0)
+                targetRuntime = RuntimeFramework.GetBestAvailableFramework(targetRuntime);
+
             switch( targetRuntime.Runtime )
             {
                 case RuntimeType.Mono:
@@ -205,17 +208,14 @@ namespace NUnit.Engine.Services
                     if (debugTests || debugAgent) monoOptions += " --debug";
                     p.StartInfo.Arguments = string.Format("{0} \"{1}\" {2}", monoOptions, agentExePath, arglist);
                     break;
+
                 case RuntimeType.Net:
                     p.StartInfo.FileName = agentExePath;
-
-                    if (targetRuntime.ClrVersion.Build < 0)
-                        targetRuntime = RuntimeFramework.GetBestAvailableFramework(targetRuntime);
-
                     string envVar = "v" + targetRuntime.ClrVersion.ToString(3);
                     p.StartInfo.EnvironmentVariables["COMPLUS_Version"] = envVar;
-
                     p.StartInfo.Arguments = arglist;
                     break;
+
                 default:
                     p.StartInfo.FileName = agentExePath;
                     p.StartInfo.Arguments = arglist;


### PR DESCRIPTION
I put in a temporary fix, which results in an exception being thrown when any test assembly does not exist. This is not really desirable, but it's better behavior than we had, since the message actually describes the reason for throwing.

One undesirable side effect is that we will fail to run multiple assemblies if **any** assembly is not found. This is somewhat OK for the console runner but not so good for the gui.