### PR TITLE
Fix #1171

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -48,11 +48,11 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (actual == null)
-                throw new System.ArgumentException("The actual value must be a non-null string, IEnumerable or DirectoryInfo", "actual");
-
-            if (actual is string)
+            // NOTE: actual is string will fail for a null typed as string
+            if (typeof(TActual) == typeof(string))
                 realConstraint = new EmptyStringConstraint();
+            else if (actual == null)
+                throw new System.ArgumentException("The actual value must be a string or a non-null IEnumerable or DirectoryInfo", "actual");
 #if !SILVERLIGHT && !PORTABLE
             else if (actual is System.IO.DirectoryInfo)
                 realConstraint = new EmptyDirectoryConstraint();

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -63,6 +63,13 @@ namespace NUnit.Framework.Constraints
             Assert.Throws<ArgumentException>(() => theConstraint.ApplyTo(data));
         }
 
+        [Test]
+        public void NullStringGivesFailureResult()
+        {
+            string actual = null;
+            var result = theConstraint.ApplyTo(actual);
+            Assert.That(result.Status, Is.EqualTo(ConstraintStatus.Failure));
+        }
     }
 
     [TestFixture]
@@ -78,12 +85,13 @@ namespace NUnit.Framework.Constraints
 
         static object[] SuccessData = new object[] 
         {
-            string.Empty,
+            string.Empty
         };
 
         static object[] FailureData = new object[]
         {
             new TestCaseData( "Hello", "\"Hello\"" ),
+            new TestCaseData( null, "null")
         };
     }
 


### PR DESCRIPTION
This modifies the checks so that a null value, if typed as string, causes a failure rather than an argument exception. Other nulls, including untyped nulls, still throw an ArgumentException.