### PR TITLE
Issue 1181

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -296,7 +296,19 @@ namespace NUnit.Engine.Services
             resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyName));
             resolver.AddSearchDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
             var parameters = new ReaderParameters() { AssemblyResolver = resolver };
-            var module = AssemblyDefinition.ReadAssembly(assemblyName, parameters).MainModule;
+
+            ModuleDefinition module;
+
+            try
+            {
+                module = AssemblyDefinition.ReadAssembly(assemblyName, parameters).MainModule;
+            }
+            catch (BadImageFormatException)
+            {
+                //Thrown if assembly is unmanaged
+                return;
+            }
+
             foreach (var type in module.GetTypes())
             {
                 CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");


### PR DESCRIPTION
This catches the crash found in #1181. Under certain circumstances, the ExtensionService will scan every dll in the executing directory to look for extensions. If an unmanaged dll is encountered at this point, NUnit crashes.

(#1181 was closed as a sub-issue of #1009, although this PR only catches the single case found in #1181 - I haven't done anything further to investigate other cases.)