### PR TITLE
Add new interfaces. Expose IAvailableRuntimes as service.

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/IAvailableRuntimes.cs
+++ b/src/NUnitEngine/nunit.engine.api/IAvailableRuntimes.cs
@@ -1,0 +1,38 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// Interface that returns a list of available runtime frameworks.
+    /// </summary>
+    public interface IAvailableRuntimes
+    {
+        /// <summary>
+        /// Gets a list of available runtime frameworks.
+        /// </summary>
+        IList<IRuntimeFramework> AvailableRuntimes { get; }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
@@ -1,0 +1,62 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// Interface implemented by objects representing a runtime framework.
+    /// </summary>
+    public interface IRuntimeFramework
+    {
+        /// <summary>
+        /// Gets a RuntimeType enum value for this framework implementation.
+        /// </summary>
+        RuntimeType Runtime { get; }
+
+        /// <summary>
+        /// Gets the display name of the framework
+        /// </summary>
+        string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the framework version: usually contains two components, Major
+        /// and Minor, which match the corresponding CLR components, but not always.
+        /// </summary>
+        Version FrameworkVersion { get; }
+
+        /// <summary>
+        /// Gets the Version of the CLR for this framework
+        /// </summary>
+        Version ClrVersion { get; }
+
+        /// <summary>
+        /// Gets a string representing the particular profile installed,
+        /// or null if there is no provile. Currently defined values are
+        /// Full and Client.
+        /// 
+        /// </summary>
+        string Profile { get; }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
@@ -31,14 +31,12 @@ namespace NUnit.Engine
     public interface IRuntimeFramework
     {
         /// <summary>
-        /// Gets a string representing this framework implementation.
-        /// Strings used are well known values used by clients as an
-        /// abbrreviation for the runtime in question.
+        /// Gets the inique Id for this runtime, such as "net-4.5"
         /// </summary>
-        string Runtime { get; }
+        string Id { get;  }
 
         /// <summary>
-        /// Gets the display name of the framework
+        /// Gets the display name of the framework, such as ".NET 4.5"
         /// </summary>
         string DisplayName { get; }
 
@@ -55,9 +53,8 @@ namespace NUnit.Engine
 
         /// <summary>
         /// Gets a string representing the particular profile installed,
-        /// or null if there is no provile. Currently defined values are
-        /// Full and Client.
-        /// 
+        /// or null if there is no profile. Currently. the only defined 
+        /// values are Full and Client.
         /// </summary>
         string Profile { get; }
     }

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
@@ -31,9 +31,11 @@ namespace NUnit.Engine
     public interface IRuntimeFramework
     {
         /// <summary>
-        /// Gets a RuntimeType enum value for this framework implementation.
+        /// Gets a string representing this framework implementation.
+        /// Strings used are well known values used by clients as an
+        /// abbrreviation for the runtime in question.
         /// </summary>
-        RuntimeType Runtime { get; }
+        string Runtime { get; }
 
         /// <summary>
         /// Gets the display name of the framework

--- a/src/NUnitEngine/nunit.engine.api/RuntimeType.cs
+++ b/src/NUnitEngine/nunit.engine.api/RuntimeType.cs
@@ -1,0 +1,24 @@
+﻿namespace NUnit.Engine
+{
+    /// <summary>
+    /// Enumeration identifying a common language
+    /// runtime implementation.
+    /// </summary>
+    public enum RuntimeType
+    {
+        /// <summary>Any supported runtime framework</summary>
+        Any,
+        /// <summary>Microsoft .NET Framework</summary>
+        Net,
+        /// <summary>Microsoft .NET Compact Framework</summary>
+        NetCF,
+        /// <summary>Microsoft Shared Source CLI</summary>
+        SSCLI,
+        /// <summary>Mono</summary>
+        Mono,
+        /// <summary>Silverlight</summary>
+        Silverlight,
+        /// <summary>MonoTouch</summary>
+        MonoTouch
+    }
+}

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -70,6 +70,8 @@
     <Compile Include="Extensibility\IProject.cs" />
     <Compile Include="Extensibility\IProjectLoader.cs" />
     <Compile Include="Extensibility\IResultWriter.cs" />
+    <Compile Include="IRuntimeFramework.cs" />
+    <Compile Include="IAvailableRuntimes.cs" />
     <Compile Include="IResultService.cs" />
     <Compile Include="IRuntimeFrameworkService.cs" />
     <Compile Include="IService.cs" />
@@ -86,6 +88,7 @@
     <Compile Include="ITestRunner.cs" />
     <Compile Include="NUnitEngineException.cs" />
     <Compile Include="IRecentFiles.cs" />
+    <Compile Include="RuntimeType.cs" />
     <Compile Include="TestEngineActivator.cs" />
     <Compile Include="TestFilter.cs" />
     <Compile Include="TestPackage.cs" />

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -88,7 +88,6 @@
     <Compile Include="ITestRunner.cs" />
     <Compile Include="NUnitEngineException.cs" />
     <Compile Include="IRecentFiles.cs" />
-    <Compile Include="RuntimeType.cs" />
     <Compile Include="TestEngineActivator.cs" />
     <Compile Include="TestFilter.cs" />
     <Compile Include="TestPackage.cs" />

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -80,5 +80,14 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(package.GetSetting("RunAsX86", false), Is.EqualTo(runAsX86));
             Assert.That(framework.ClrVersion.ToString(), Is.EqualTo(expectedVersion));
         }
+
+        [Test]
+        public void AvailableFrameworks()
+        {
+            var available = _runtimeService.AvailableRuntimes;
+            Assert.That(available.Count, Is.GreaterThan(0));
+            foreach (var framework in available)
+                Console.WriteLine("Available: {0}", framework.DisplayName);
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/NUnitConfiguration.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/NUnitConfiguration.cs
@@ -24,119 +24,48 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Configuration;
-using System.Collections.Specialized;
-using System.Threading;
 using Microsoft.Win32;
 
 namespace NUnit.Engine.Internal
 {
     /// <summary>
-    /// Provides static methods for accessing the NUnit config
-    /// file 
+    /// Provides static methods for accessing configuration info
     /// </summary>
     public static class NUnitConfiguration
     {
         #region Public Properties
 
-        #region BuildConfiguration
-        public static string BuildConfiguration
-        {
-            get
-            {
-#if DEBUG
-                    return "Debug";
-#else
-                    return "Release";
-#endif
-            }
-        }
-        #endregion
+        #region EngineDirectory
 
-        #region NUnitLibDirectory
-        private static string nunitLibDirectory;
-        /// <summary>
-        /// Gets the path to the lib directory for the version and build
-        /// of NUnit currently executing.
-        /// </summary>
-        public static string NUnitLibDirectory
+        private static string _engineDirectory;
+        public static string EngineDirectory
         {
             get
             {
-                if (nunitLibDirectory == null)
-                {
-                    nunitLibDirectory =
+                if (_engineDirectory == null)
+                    _engineDirectory =
                         AssemblyHelper.GetDirectoryName(Assembly.GetExecutingAssembly());
-                }
 
-                return nunitLibDirectory;
+                return _engineDirectory;
             }
         }
-        #endregion
 
-        #region NUnitBinDirectory
-        private static string nunitBinDirectory;
-        public static string NUnitBinDirectory
-        {
-            get
-            {
-                if (nunitBinDirectory == null)
-                {
-                    nunitBinDirectory = NUnitLibDirectory;
-                    if (Path.GetFileName(nunitBinDirectory).ToLower() == "lib")
-                        nunitBinDirectory = Path.GetDirectoryName(nunitBinDirectory);
-                }
-
-                return nunitBinDirectory;
-            }
-        }
-        #endregion
-
-        #region AddinDirectory
-        private static string addinDirectory;
-        public static string AddinDirectory
-        {
-            get
-            {
-                if (addinDirectory == null)
-                {
-                    addinDirectory = Path.Combine(NUnitBinDirectory, "addins");
-                }
-
-                return addinDirectory;
-            }
-        }
-        #endregion
-
-        #region TestAgentExePath
-        //private static string testAgentExePath;
-        //private static string TestAgentExePath
-        //{
-        //    get
-        //    {
-        //        if (testAgentExePath == null)
-        //            testAgentExePath = Path.Combine(NUnitBinDirectory, "nunit-agent.exe");
-
-        //        return testAgentExePath;
-        //    }
-        //}
         #endregion
 
         #region MonoExePath
-        private static string monoExePath;
+
+        private static string _monoExePath;
         public static string MonoExePath
         {
             get
             {
-                if (monoExePath == null)
+                if (_monoExePath == null)
                 {
                     string[] searchNames = IsWindows()
                         ? new string[] { "mono.bat", "mono.cmd", "mono.exe" }
                         : new string[] { "mono", "mono.exe" };
                     
-                    monoExePath = FindOneOnPath(searchNames);
-
-                    if (monoExePath == null && IsWindows())
+                    if (_monoExePath == null && IsWindows())
                     {
                         RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Novell\Mono");
                         if (key != null)
@@ -149,89 +78,45 @@ namespace NUnit.Engine.Internal
                                 {
                                     string installDir = key.GetValue("SdkInstallRoot") as string;
                                     if (installDir != null)
-                                        monoExePath = Path.Combine(installDir, @"bin\mono.exe");
+                                        _monoExePath = Path.Combine(installDir, @"bin\mono.exe");
                                 }
                             }
                         }
                     }
 
-                    if (monoExePath == null)
-                        return "mono";
+                    if (_monoExePath == null)
+                        _monoExePath = "mono";
                 }
 
-                return monoExePath;
+                return _monoExePath;
             }
-        }
-
-        private static string FindOneOnPath(string[] names)
-        {
-            //foreach (string dir in Environment.GetEnvironmentVariable("path").Split(new char[] { Path.PathSeparator }))
-            //    foreach (string name in names)
-            //    {
-            //        string fullPath = Path.Combine(dir, name);
-            //        if (File.Exists(fullPath))
-            //            return name;
-            //    }
-
-            return null;
         }
 
         private static bool IsWindows()
         {
             return Environment.OSVersion.Platform == PlatformID.Win32NT;
         }
+
         #endregion
 
         #region ApplicationDataDirectory
-        private static string applicationDirectory;
+
+        private static string _applicationDirectory;
         public static string ApplicationDirectory
         {
             get
             {
-                if (applicationDirectory == null)
+                if (_applicationDirectory == null)
                 {
-                    applicationDirectory = Path.Combine(
+                    _applicationDirectory = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                         "NUnit");
                 }
 
-                return applicationDirectory;
+                return _applicationDirectory;
             }
         }
-        #endregion
 
-        #region HelpUrl
-        public static string HelpUrl
-        {
-            get
-            {
-                string helpUrl = ConfigurationManager.AppSettings["helpUrl"];
-
-                if (helpUrl == null)
-                {
-                    helpUrl = "http://nunit.org";
-                    string dir = Path.GetDirectoryName(NUnitBinDirectory);
-                    if ( dir != null )
-                    {
-                        dir = Path.GetDirectoryName(dir);
-                        if ( dir != null )
-                        {
-                            string localPath = Path.Combine(dir, @"doc/index.html");
-                            if (File.Exists(localPath))
-                            {
-                                UriBuilder uri = new UriBuilder();
-                                uri.Scheme = "file";
-                                uri.Host = "localhost";
-                                uri.Path = localPath;
-                                helpUrl = uri.ToString();
-                            }
-                        }
-                    }
-                }
-
-                return helpUrl;
-            }
-        }
         #endregion
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -166,6 +166,53 @@ namespace NUnit.Engine
 
         #endregion
 
+        #region IRuntimeFramework Explicit Implementation
+
+        /// <summary>
+        /// Gets the inique Id for this runtime, such as "net-4.5"
+        /// </summary>
+        string IRuntimeFramework.Id
+        {
+            get { return this.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets the display name of the framework, such as ".NET 4.5"
+        /// </summary>
+        string IRuntimeFramework.DisplayName
+        {
+            get { return this.DisplayName; }
+        }
+
+        /// <summary>
+        /// Gets the framework version: usually contains two components, Major
+        /// and Minor, which match the corresponding CLR components, but not always.
+        /// </summary>
+        Version IRuntimeFramework.FrameworkVersion
+        {
+            get { return this.FrameworkVersion; }
+        }
+
+        /// <summary>
+        /// Gets the Version of the CLR for this framework
+        /// </summary>
+        Version IRuntimeFramework.ClrVersion
+        {
+            get { return this.ClrVersion; }
+        }
+
+        /// <summary>
+        /// Gets a string representing the particular profile installed,
+        /// or null if there is no profile. Currently. the only defined 
+        /// values are Full and Client.
+        /// </summary>
+        string IRuntimeFramework.Profile
+        {
+            get { return Profile.ToString(); }
+        }
+
+        #endregion
+
         #region Properties
         /// <summary>
         /// Static method to return a RuntimeFramework object
@@ -291,10 +338,6 @@ namespace NUnit.Engine
         /// The type of this runtime framework
         /// </summary>
         public RuntimeType Runtime { get; private set; }
-
-        string IRuntimeFramework.Runtime {  get { return Runtime.ToString();  } }
-
-        string IRuntimeFramework.Profile { get { return Profile.ToString(); } }
 
         /// <summary>
         /// The framework version for this runtime framework

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -292,6 +292,8 @@ namespace NUnit.Engine
         /// </summary>
         public RuntimeType Runtime { get; private set; }
 
+        string IRuntimeFramework.Runtime {  get { return Runtime.ToString();  } }
+
         string IRuntimeFramework.Profile { get { return Profile.ToString(); } }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/RuntimeType.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeType.cs
@@ -12,13 +12,9 @@
         Net,
         /// <summary>Microsoft .NET Compact Framework</summary>
         NetCF,
-        /// <summary>Microsoft Shared Source CLI</summary>
-        SSCLI,
         /// <summary>Mono</summary>
         Mono,
         /// <summary>Silverlight</summary>
-        Silverlight,
-        /// <summary>MonoTouch</summary>
-        MonoTouch
+        Silverlight
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Services
         private ISettings _settingsService;
 
         // Default settings used if SettingsService is unavailable
-        private string _shadowCopyPath = Path.Combine(NUnitConfiguration.NUnitBinDirectory, "ShadowCopyCache");
+        private string _shadowCopyPath = Path.Combine(NUnitConfiguration.EngineDirectory, "ShadowCopyCache");
 
         #region Create and Unload Domains
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
 using NUnit.Common;
@@ -29,9 +30,17 @@ using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
 {
-    public class RuntimeFrameworkService : Service, IRuntimeFrameworkService
+    public class RuntimeFrameworkService : Service, IRuntimeFrameworkService, IAvailableRuntimes
     {
         static Logger log = InternalTrace.GetLogger(typeof(RuntimeFrameworkService));
+
+        /// <summary>
+        /// Gets a list of available runtimes.
+        /// </summary>
+        public IList<IRuntimeFramework> AvailableRuntimes
+        {
+            get { return RuntimeFramework.AvailableFrameworks; }
+        }
 
         /// <summary>
         /// Returns true if the runtime framework represented by

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -283,7 +283,7 @@ namespace NUnit.Engine.Services
         private static string GetNUnitBinDirectory(Version v)
         {
             // Get current bin directory
-            string dir = NUnitConfiguration.NUnitBinDirectory;
+            string dir = NUnitConfiguration.EngineDirectory;
 
             // Return current directory if current and requested
             // versions are both >= 2 or both 1
@@ -331,14 +331,14 @@ namespace NUnit.Engine.Services
 
         private static string GetTestAgentExePath(Version v, bool requires32Bit)
         {
-            string binDir = NUnitConfiguration.NUnitBinDirectory;
-            if (binDir == null) return null;
+            string engineDir = NUnitConfiguration.EngineDirectory;
+            if (engineDir == null) return null;
 
             string agentName = v.Major > 1 && requires32Bit
                 ? "nunit-agent-x86.exe"
                 : "nunit-agent.exe";
 
-            string agentExePath = Path.Combine(binDir, agentName);
+            string agentExePath = Path.Combine(engineDir, agentName);
             return File.Exists(agentExePath) ? agentExePath : null;
         }
 

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -133,6 +133,7 @@
     <Compile Include="IProjectService.cs" />
     <Compile Include="Runners\ParallelTaskWorkerPool.cs" />
     <Compile Include="Runners\TestExecutionTask.cs" />
+    <Compile Include="RuntimeType.cs" />
     <Compile Include="Services\ExtensionService.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />


### PR DESCRIPTION
This fixes #1283, providing an IAvailableRuntimes service as part of the API.

The Engine API has been changed by the addition of two new interfaces and an enum. Existing interfaces have not been changed.