### PR TITLE
Make Arguments a separate array from OriginalArguments

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -50,8 +50,8 @@ namespace NUnit.Framework.Internal
         public TestParameters(object[] args)
         {
             RunState = RunState.Runnable;
+            InitializeAguments(args);
             Properties = new PropertyBag();
-            OriginalArguments = Arguments = args;
         }
 
         /// <summary>
@@ -77,10 +77,21 @@ namespace NUnit.Framework.Internal
             Properties = new PropertyBag();
 
             TestName = data.TestName;
-            OriginalArguments = Arguments = data.Arguments;
+
+            InitializeAguments(data.Arguments);
 
             foreach (string key in data.Properties.Keys)
                 this.Properties[key] = data.Properties[key];
+        }
+
+        private void InitializeAguments(object[] args)
+        {
+            OriginalArguments = args;
+
+            // We need to copy args, since we may change them
+            var numArgs = args.Length;
+            Arguments = new object[numArgs];
+            Array.Copy(args, Arguments, numArgs);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/TestNamingTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNamingTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using System.Text;
 
 namespace NUnit.Framework.Internal.Tests
 {
@@ -59,6 +60,25 @@ namespace NUnit.Framework.Internal.Tests
         public void GenericTest<T>(T arg)
         {
             CheckNames("GenericTest<Int32>(42)", "GenericTest");
+        }
+
+        [TestCase()]
+        [TestCase(1)]
+        [TestCase(1, 2)]
+        [TestCase(1, 2, 3)]
+        public void TestWithParamsArgument(params int[] array)
+        {
+            var sb = new StringBuilder("TestWithParamsArgument(");
+
+            foreach (int n in array)
+            {
+                if (n > 1) sb.Append(",");
+                sb.Append(n.ToString());
+            }
+
+            sb.Append(")");
+
+            CheckNames(sb.ToString(), "TestWithParamsArgument");
         }
 
         private void CheckNames(string expectedTestName, string expectedMethodName)


### PR DESCRIPTION
This fixes #1282. It turns out that OriginalArguments and Arguments were both references to the same array, so that when the content of the Arguments array was modified for certain cases, the OriginalArguments were also modified, defeating the entire purpose of having two properties.