### PR TITLE
Lock assembly version to "3.0.0.0" at least for nunit.framework.dll

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -551,13 +551,27 @@ Task("PackageCF")
 //////////////////////////////////////////////////////////////////////
 Setup(() =>
 {
-    // Executed BEFORE the first task.
-	});
+	// Executed BEFORE the first task.
+	var datetimeNow = DateTime.Now;
+	var daysPart = (datetimeNow - new DateTime(2000, 1, 1)).Days;
+	var secondsPart = (long)datetimeNow.TimeOfDay.TotalSeconds/2;
+	var assemblyInfo = new AssemblyInfoSettings
+	{
+		Version = "3.0.0.0",
+		FileVersion = string.Format("3.0.{0}.{1}", daysPart, secondsPart)
+	};
+	CreateAssemblyInfo("src/NUnitConsole/ConsoleVersion.cs", assemblyInfo);
+	CreateAssemblyInfo("src/NUnitEngine/EngineVersion.cs", assemblyInfo);
+	CreateAssemblyInfo("src/NUnitFramework/FrameworkVersion.cs", assemblyInfo);
+
+	assemblyInfo.FileVersion = "3.0.1";
+	CreateAssemblyInfo("src/NUnitEngine/EngineApiVersion.cs", assemblyInfo);
+});
 
 Teardown(() =>
 {
-    // Executed AFTER the last task.
-    CheckForError(ref ErrorDetail);
+	// Executed AFTER the last task.
+	CheckForError(ref ErrorDetail);
 });
 //////////////////////////////////////////////////////////////////////
 // HELPER METHODS


### PR DESCRIPTION
There is best practice to lock major version number and leave remaining numbers as zeroes in AssemblyVersion, and use AssemblyFileVersion to communicate actual version to users.
Autogenerated AssemblyVersion breaks things like bindingRedirect on any update of nunit now.

Suppose you are building a framework assembly for your project which is used by lot of developers while building the application assemblies. If you release new version of assembly very frequently, say once every day, and if assemblies are strong named, Developers will have to change the reference every time you release new assembly. This can be quite cumbersome and may lead to wrong references also. A better option in such closed group and volatile scenarios would be to fix he 'Assembly Version' and change only the 'Assembly File Version'. Use the assembly file version number to communicate the latest release of assembly. In this case, developers will not have to change the references and they can simply overwrite the assembly in reference path. In central/final release builds it makes more sense to change the 'Assembly Version' and most keep the 'Assembly File Version' same as assembly version.

It's easy to autogenerate versions because nunit already uses cake for build. In this PR versions are generated like C# compiler does (3rd number is days count from 1 january 2000, 4th number is seconds count from midnight divided by two).

I don't know if NunitApiEngineVersion.cs needs version "3.0.1.0" specified, but I leaved this behavior in this PR.

What do you think about this PR?