### PR TITLE
Fixed the NUnit.Console NuGet package

### DIFF
--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -36,4 +36,5 @@
       </group>
     </dependencies>
   </metadata>
+  <files></files>
 </package>


### PR DESCRIPTION
Fixes #1323 

These changes are already packaged and pushed to NuGet.org. Because it needed to be versioned 3.2.0.1 but still depend on 3.2.0 packages, that was slightly jury-rigged.