### PR TITLE
Add CF Tests to CI Script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -171,33 +171,29 @@ Task("CheckForError")
 
 Task("TestAllFrameworks")
   .IsDependentOn("Build")
-    .OnError(exception =>
+  .OnError(exception =>
+  {
+    ErrorDetail.Add(exception.Message);
+  })
+  .Does(() =>
+  {
+    foreach(string runtime in AllFrameworks)
     {
-        ErrorDetail.Add(exception.Message);
-    })
-	.Does(() =>
-	{
-		foreach(string runtime in AllFrameworks)
-		{
-			if (runtime != "netcf-3.5")
-			{
-				RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+      if (runtime != "netcf-3.5")
+      {
+        RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
 
-				if (runtime == "sl-5.0")
-					RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, "nunitlite.tests.dll", runtime, ref ErrorDetail);
-				else
-					RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_TESTS), BIN_DIR, runtime, ref ErrorDetail);
-			}
-            else
-            {
-                // Commenting out will work on it in another Issue/PR
-                //if(IsRunningOnWindows())
-                //{
-                //    RunTest(BIN_DIR + File(runtime + "/" + COMPACT_RUNNER), BIN_DIR + "/" + runtime, runtime, ref ErrorDetail);
-                //}
-            }
-		}
-	});
+        if (runtime == "sl-5.0")
+          RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, "nunitlite.tests.dll", runtime, ref ErrorDetail);
+        else
+          RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_TESTS), BIN_DIR, runtime, ref ErrorDetail);
+      }
+      else if(IsRunningOnWindows())
+      {
+        RunTest(BIN_DIR + File(runtime + "/" + COMPACT_RUNNER), BIN_DIR + "/" + runtime, runtime, ref ErrorDetail);
+      }
+    }
+  });
 
 Task("TestFramework")
   .IsDependentOn("Build")

--- a/build.cake
+++ b/build.cake
@@ -46,11 +46,12 @@ var IMAGE_DIR = PROJECT_DIR + "images/";
 // Test Runners
 var NUNIT3_CONSOLE = BIN_DIR + "nunit3-console.exe";
 var NUNITLITE_RUNNER = "nunitlite-runner.exe";
-var COMPACT_RUNNER = "nunit.framework.tests.exe";
 
 // Test Assemblies
 var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
-var NUNITLITE_TESTS = "nunitlite.tests.exe";
+var EXECUTABLE_FRAMEWORK_TESTS = "nunit.framework.tests.exe";
+var NUNITLITE_TESTS = "nunitlite.tests.dll";
+var EXECUTABLE_NUNITLITE_TESTS = "nunitlite.tests.exe";
 var ENGINE_TESTS = "nunit.engine.tests.dll";
 var PORTABLE_AGENT_TESTS = "agents/nunit.portable.agent.tests.dll";
 var ADDIN_TESTS = "addins/tests/addin-tests.dll";
@@ -69,9 +70,9 @@ var ZIP_PACKAGE_CF = PACKAGE_DIR + "NUnitCF-" + packageVersion + ".zip";
 
 Task("Clean")
     .Does(() =>
-{
-    CleanDirectory(BIN_DIR);
-});
+    {
+        CleanDirectory(BIN_DIR);
+    });
 
 
 //////////////////////////////////////////////////////////////////////
@@ -80,7 +81,7 @@ Task("Clean")
 
 Task("InitializeBuild")
     .Does(() =>
-{
+    {
     if (IsRunningOnWindows())
         NuGetRestore("./nunit.sln");
     else
@@ -169,63 +170,72 @@ Task("BuildCppTestFiles")
 Task("CheckForError")
     .Does(() => CheckForError(ref ErrorDetail));
 
-Task("TestAllFrameworks")
-  .IsDependentOn("Build")
-  .OnError(exception =>
-  {
-    ErrorDetail.Add(exception.Message);
-  })
-  .Does(() =>
-  {
-    foreach(string runtime in AllFrameworks)
-    {
-      if (runtime != "netcf-3.5")
-      {
-        RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
-
-        if (runtime == "sl-5.0")
-          RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + runtime, "nunitlite.tests.dll", runtime, ref ErrorDetail);
-        else
-          RunTest(BIN_DIR + File(runtime + "/" + NUNITLITE_TESTS), BIN_DIR, runtime, ref ErrorDetail);
-      }
-      else if(IsRunningOnWindows())
-      {
-        RunTest(BIN_DIR + File(runtime + "/" + COMPACT_RUNNER), BIN_DIR + "/" + runtime, runtime, ref ErrorDetail);
-      }
-    }
-  });
-
-Task("TestFramework")
-  .IsDependentOn("Build")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+Task("Test45")
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
 	.Does(() =>
 	{
-		RunTest(BIN_DIR + File(framework + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + framework, FRAMEWORK_TESTS, framework, ref ErrorDetail);
+	    var runtime = "net-4.5";
+	    var dir = BIN_DIR + runtime + "/";
+		RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+		RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
 	});
 
-Task("TestNUnitLite")
-  .IsDependentOn("BuildFramework")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+Task("Test40")
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
 	.Does(() =>
 	{
-			if (framework == "sl-5.0")
-				RunTest(BIN_DIR + File(framework + "/" + NUNITLITE_RUNNER), BIN_DIR + "/" + framework, "nunitlite.tests.dll", framework, ref ErrorDetail);
-			else
-				RunTest(BIN_DIR + File(framework + "/" + NUNITLITE_TESTS), BIN_DIR, framework, ref ErrorDetail);
+	    var runtime = "net-4.0";
+	    var dir = BIN_DIR + runtime + "/";
+		RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+		RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
+	});
+
+Task("Test20")
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
+	.Does(() =>
+	{
+	    var runtime = "net-2.0";
+	    var dir = BIN_DIR + runtime + "/";
+		RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+		RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
+	});
+
+Task("TestPortable")
+	.WithCriteria(IsRunningOnWindows())
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
+	.Does(() =>
+	{
+	    var runtime = "portable";
+	    var dir = BIN_DIR + runtime + "/";
+		RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+		RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
+	});
+
+Task("TestSL")
+	.WithCriteria(IsRunningOnWindows())
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
+	.Does(() =>
+	{
+	    var runtime = "sl-5.0";
+	    var dir = BIN_DIR + runtime + "/";
+		RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+		RunTest(dir + NUNITLITE_RUNNER, dir, NUNITLITE_TESTS, runtime, ref ErrorDetail);
+	});
+
+Task("TestCF")
+	.WithCriteria(IsRunningOnWindows())
+	.OnError(exception => {ErrorDetail.Add(exception.Message); })
+	.Does(() =>
+	{
+	    var runtime = "netcf-3.5";
+	    var dir = BIN_DIR + runtime + "/";
+        RunTest(dir + EXECUTABLE_FRAMEWORK_TESTS, dir, runtime, ref ErrorDetail);
+		RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
 	});
 
 Task("TestEngine")
   .IsDependentOn("Build")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+    .OnError(exception => { ErrorDetail.Add(exception.Message); })
   .Does(() =>
 	{
 		RunTest(NUNIT3_CONSOLE, BIN_DIR, ENGINE_TESTS, "TestEngine", ref ErrorDetail);
@@ -240,10 +250,7 @@ Task("TestDriver")
 	});
 
 Task("TestAddins")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+    .OnError(exception => { ErrorDetail.Add(exception.Message); })
   .IsDependentOn("Build")
   .Does(() =>
 	{
@@ -252,10 +259,7 @@ Task("TestAddins")
 
 Task("TestV2Driver")
   .IsDependentOn("Build")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+    .OnError(exception => { ErrorDetail.Add(exception.Message); })
   .Does(() =>
 	{
 		RunTest(NUNIT3_CONSOLE, BIN_DIR, V2_PORTABLE_AGENT_TESTS,"TestV2Driver", ref ErrorDetail);
@@ -263,10 +267,7 @@ Task("TestV2Driver")
 
 Task("TestConsole")
   .IsDependentOn("Build")
-    .OnError(exception =>
-    {
-        ErrorDetail.Add(exception.Message);
-    })
+    .OnError(exception => { ErrorDetail.Add(exception.Message); })
   .Does(() =>
 	{
 		RunTest(NUNIT3_CONSOLE, BIN_DIR, CONSOLE_TESTS, "TestConsole", ref ErrorDetail);
@@ -579,9 +580,18 @@ Teardown(() =>
     // Executed AFTER the last task.
     CheckForError(ref ErrorDetail);
 });
+
 //////////////////////////////////////////////////////////////////////
-// HELPER METHODS
+// HELPER METHODS - GENERAL
 //////////////////////////////////////////////////////////////////////
+
+void RunGitCommand(string arguments)
+{
+	StartProcess("git", new ProcessSettings()
+	{
+		Arguments = arguments
+	});
+}
 
 void CheckForError(ref List<string> errorDetail)
 {
@@ -594,6 +604,10 @@ void CheckForError(ref List<string> errorDetail)
                               + copyError.Aggregate((x,y) => x + "\n" + y));
     }
 }
+
+//////////////////////////////////////////////////////////////////////
+// HELPER METHODS - BUILD
+//////////////////////////////////////////////////////////////////////
 
 void BuildFramework(string configuration, string framework)
 {
@@ -722,6 +736,10 @@ void BuildProject(string projectPath, string configuration, MSBuildPlatform buil
     }
 }
 
+//////////////////////////////////////////////////////////////////////
+// HELPER METHODS - TEST
+//////////////////////////////////////////////////////////////////////
+
 void RunTest(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
 {
 	int rc = StartProcess(
@@ -753,14 +771,6 @@ void RunTest(FilePath exePath, DirectoryPath workingDir, string arguments, strin
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
 }
 
-void RunGitCommand(string arguments)
-{
-	StartProcess("git", new ProcessSettings()
-	{
-		Arguments = arguments
-	});
-}
-
 //////////////////////////////////////////////////////////////////////
 // TASK TARGETS
 //////////////////////////////////////////////////////////////////////
@@ -771,7 +781,7 @@ Task("Build")
   .IsDependentOn("BuildConsole");
 
 Task("Rebuild")
-  .IsDependentOn("Clean")
+    .IsDependentOn("Clean")
 	.IsDependentOn("Build");
 
 Task("TestAll")
@@ -781,15 +791,25 @@ Task("TestAll")
 	.IsDependentOn("TestAddins")
 	.IsDependentOn("TestV2Driver")
 	.IsDependentOn("TestConsole");
-    
+
+// NOTE: Test has been changed to now be a synonym of TestAll    
 Task("Test")
-	.IsDependentOn("TestFramework")
-	.IsDependentOn("TestNUnitLite")
+	.IsDependentOn("TestAllFrameworks")
 	.IsDependentOn("TestEngine")
     .IsDependentOn("TestDriver")
 	.IsDependentOn("TestAddins")
 	.IsDependentOn("TestV2Driver")
 	.IsDependentOn("TestConsole");
+
+Task("TestAllFrameworks")
+    .IsDependentOn("Build")
+	.IsDependentOn("Test45")
+	.IsDependentOn("Test40")
+	.IsDependentOn("Test20")
+// NOTE: The following tasks use Criteria and will be skipped on Linux
+	.IsDependentOn("TestPortable")
+	.IsDependentOn("TestSL")
+	.IsDependentOn("TestCF");
 
 Task("Package")
     .IsDependentOn("CheckForError")

--- a/nunitCF35.sln
+++ b/nunitCF35.sln
@@ -59,7 +59,6 @@ Global
 		{D8D5220D-E155-4A60-AB63-0DEC87A54C87}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{D8D5220D-E155-4A60-AB63-0DEC87A54C87}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8D5220D-E155-4A60-AB63-0DEC87A54C87}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D8D5220D-E155-4A60-AB63-0DEC87A54C87}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -59,6 +59,16 @@ namespace NUnit.Framework.Api
         private int _skipCount;
         private int _inconclusiveCount;
 
+        private static bool REALLY_RUNNING_ON_CF = false;
+
+#if NETCF
+        static TestAssemblyRunnerTests()
+        {
+            // We may be running on the desktop using assembly unification
+            REALLY_RUNNING_ON_CF = Type.GetType("System.ConsoleColor") == null;
+        }
+#endif
+
         [SetUp]
         public void CreateRunner()
         {
@@ -100,11 +110,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Name, Is.EqualTo(MISSING_FILE));
             Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.NotRunnable));
             Assert.That(result.TestCaseCount, Is.EqualTo(0));
-#if NETCF
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("File or assembly name"));
-#else
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("Could not load"));
-#endif
+            Assert.That(result.Properties.Get(PropertyNames.SkipReason),
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load"));
         }
 
         [Test]
@@ -117,11 +124,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Name, Is.EqualTo(BAD_FILE));
             Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.NotRunnable));
             Assert.That(result.TestCaseCount, Is.EqualTo(0));
-#if NETCF
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("File or assembly name").And.Contains(BAD_FILE));
-#else
-            Assert.That(result.Properties.Get(PropertyNames.SkipReason), Does.StartWith("Could not load").And.Contains(BAD_FILE));
-#endif
+            Assert.That(result.Properties.Get(PropertyNames.SkipReason),
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load").And.Contains(BAD_FILE));
         }
 
 #endregion
@@ -212,11 +216,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
-#if NETCF
-            Assert.That(result.Message, Does.StartWith("File or assembly name"));
-#else
-            Assert.That(result.Message, Does.StartWith("Could not load"));
-#endif
+            Assert.That(result.Message,
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load"));
         }
 
         [Test]
@@ -230,11 +231,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
-#if NETCF
-            Assert.That(result.Message, Does.StartWith("File or assembly name").And.Contains(BAD_FILE));
-#else
-            Assert.That(result.Message, Does.StartWith("Could not load").And.Contains(BAD_FILE));
-#endif
+            Assert.That(result.Message,
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load"));
         }
 
 #endregion
@@ -297,11 +295,8 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(_runner.Result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(_runner.Result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
-#if NETCF
-            Assert.That(_runner.Result.Message, Does.StartWith("File or assembly name"));
-#else
-            Assert.That(_runner.Result.Message, Does.StartWith("Could not load"));
-#endif
+            Assert.That(_runner.Result.Message,
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load"));
         }
 
         [Test]
@@ -317,11 +312,8 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(_runner.Result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(_runner.Result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
-#if NETCF
-            Assert.That(_runner.Result.Message, Does.StartWith("File or assembly name").And.Contains(BAD_FILE));
-#else
-            Assert.That(_runner.Result.Message, Does.StartWith("Could not load").And.Contains(BAD_FILE));
-#endif
+            Assert.That(_runner.Result.Message,
+                Does.StartWith(REALLY_RUNNING_ON_CF ? "File or assembly name" : "Could not load"));
         }
 
 #endregion

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -35,10 +35,14 @@ namespace NUnit.Framework.Tests.Compatibility
     [TestFixture]
     public class ReflectionExtensionsTests
     {
+        private static bool REALLY_RUNNING_ON_CF = false;
+
 #if NETCF
-        private const bool ONLY_ON_CF = true;
-#else
-        private const bool ONLY_ON_CF = false;
+        static ReflectionExtensionsTests()
+        {
+            // We may be running on the desktop using assembly unification
+            REALLY_RUNNING_ON_CF = Type.GetType("System.ConsoleColor") == null;
+        }
 #endif
 
         [Test]
@@ -142,23 +146,21 @@ namespace NUnit.Framework.Tests.Compatibility
             Assert.That(result.Length, Is.GreaterThan(0));
         }
 
-#if NETCF
         [Test]
-        public void GetsPrivateMemberOnBaseClass()
+        public void CanGetPrivatePropertiesOnBaseClassOnlyOnCF()
         {
-            var result = typeof(DerivedTestClass).GetMember("Private", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            var result = typeof(DerivedTestClass).GetMember("Private", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result.Length, Is.EqualTo(REALLY_RUNNING_ON_CF ? 1 : 0));
         }
-#else
+
         [Test]
-        public void DoesNotGetPrivateMemberOnBaseClass()
+        public void CanGetPrivateMethodsOnBaseClassOnlyOnCF()
         {
-            var result = typeof(DerivedTestClass).GetMember("Private", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            var result = typeof(DerivedTestClass).GetMember("Goodbye", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Length, Is.EqualTo(0));
+            Assert.That(result.Length, Is.EqualTo(REALLY_RUNNING_ON_CF ? 1 : 0));
         }
-#endif
 
         [Test]
         public void CanGetPublicField()
@@ -193,7 +195,6 @@ namespace NUnit.Framework.Tests.Compatibility
         [TestCase(typeof(BaseTestClass), "Name", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, true)]
         [TestCase(typeof(DerivedTestClass), "Name", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, true)]
         [TestCase(typeof(BaseTestClass), "Private", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, true)]
-        [TestCase(typeof(DerivedTestClass), "Private", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, ONLY_ON_CF)]
         [TestCase(typeof(BaseTestClass), "StaticString", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, false)]
         [TestCase(typeof(DerivedTestClass), "StaticString", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, false)]
         [TestCase(typeof(BaseTestClass), "Name", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, false)]
@@ -211,7 +212,6 @@ namespace NUnit.Framework.Tests.Compatibility
         [TestCase(typeof(BaseTestClass), "Name", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
         [TestCase(typeof(DerivedTestClass), "Name", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
         [TestCase(typeof(BaseTestClass), "Private", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, true)]
-        [TestCase(typeof(DerivedTestClass), "Private", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, ONLY_ON_CF)]
         [TestCase(typeof(BaseTestClass), "StaticString", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
         [TestCase(typeof(DerivedTestClass), "StaticString", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
         [TestCase(typeof(BaseTestClass), "PubPriv", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance, true)]
@@ -253,7 +253,6 @@ namespace NUnit.Framework.Tests.Compatibility
         [TestCase(typeof(BaseTestClass), "StaticMethod", BindingFlags.Public | BindingFlags.Static, true)]
         [TestCase(typeof(DerivedTestClass), "StaticMethod", BindingFlags.Public | BindingFlags.Static, false)]
         [TestCase(typeof(BaseTestClass), "Goodbye", BindingFlags.NonPublic | BindingFlags.Instance, true)]
-        [TestCase(typeof(DerivedTestClass), "Goodbye", BindingFlags.NonPublic | BindingFlags.Instance, ONLY_ON_CF)]
         public void CanGetMethodByNameAndBindingFlags(Type type, string name, BindingFlags flags, bool shouldFind)
         {
             var result = type.GetMethod(name, flags);

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -111,11 +111,12 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void NotEmptyDirectory()
         {
-            var testPath = new DirectoryInfo(NUnit.Env.DefaultWorkDirectory);
-            Assume.That(testPath, Does.Exist);
-#if !PORTABLE
-            Assert.That(testPath, Is.Not.Empty, "{0} should not be empty", testPath.FullName);
-#endif
+            using (var testDir = new TestDirectory())
+            {
+                var stream = File.Create(Path.Combine(testDir.Directory.FullName, "DUMMY.FILE"));
+                stream.Close();
+                Assert.That(testDir.Directory, Is.Not.Empty);
+            }
         }
     }
 #endif


### PR DESCRIPTION
Fixes #1317.

In addition to the CF tests I added some refactoring to the build script and some new commands.

Summary:

* Added detection of "really running on CF" to the CF tests so that they would pass when running on a desktop system under assembly unification.

* Activated the CF tests under Appveyor

* Removed non-functional  TestFramework and TestNUnitLite  targets from build.cake. These targets depend on passing the desired runtime as an argument and only work when running build.cake directly, which is what I was doing at the time I added them. When running build.ps1, there is no way to pass in the argument.

* Added targets Test45, Test40, Test20, TestPortable, TestSL and TestCF. These  targets simply run the tests without building, making them useful for developers to run from the command-line after a build. TestAllFrameworks now depends on these, in addition to Build.

* Did some general refactoring of the build script.
