### PR TITLE
Added Test.WorkerId

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -94,6 +94,12 @@ namespace NUnit.Framework.Interfaces
         ITest Parent { get; }
 
         /// <summary>
+        /// Gets the name of the TestWorker that
+        /// is executing this test.
+        /// </summary>
+        string WorkerId {get;}
+
+        /// <summary>
         /// Returns true if this is a test suite
         /// </summary>
         bool IsSuite { get; }

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -116,7 +116,10 @@ namespace NUnit.Framework.Internal.Execution
 
                     if (Busy != null)
                         Busy(this, EventArgs.Empty);
+
+                    _currentWorkItem.Test.WorkerId = Name;
                     _currentWorkItem.Execute();
+
                     if (Idle != null)
                         Idle(this, EventArgs.Empty);
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -51,6 +51,8 @@ namespace NUnit.Framework.Internal
         /// </summary>
         protected MethodInfo[] tearDownMethods;
 
+        private string _workerId;
+
         #endregion
 
         #region Construction
@@ -234,6 +236,20 @@ namespace NUnit.Framework.Internal
         /// Used by the core to set the parent.
         /// </summary>
         public ITest Parent { get; set; }
+
+        /// <summary>
+        /// Gets the name of the TestWorker that
+        /// is executing this test.
+        /// </summary>
+        public string WorkerId
+        {
+            get {
+                if (_workerId != null) return _workerId;
+                if (Parent != null) return Parent.WorkerId;
+                return null;
+            }
+            internal set { _workerId = value; }
+        }
 
         /// <summary>
         /// Gets this test's child tests

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -326,6 +326,15 @@ namespace NUnit.Framework
             }
 
             /// <summary>
+            /// Gets the name of the TestWorker that
+            /// is executing this test.
+            /// </summary>
+            public string WorkerId
+            {
+                get { return _test.WorkerId; }
+            }
+
+            /// <summary>
             /// The properties of the test.
             /// </summary>
             public IPropertyBag Properties


### PR DESCRIPTION
- Implemented `WorkerId` property for identifying the worker that is
  running the current test. This is useful for projects which implement an
  instance-per-worker model.