### PR TITLE
Apply Assembly attributes to context correctly

### DIFF
--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -312,6 +312,7 @@ namespace NUnit.Framework.Api
         {
             Context = new TestExecutionContext();
 
+            // Apply package settings to the context
             if (Settings.Contains(PackageSettings.DefaultTimeout))
                 Context.TestCaseTimeout = (int)Settings[PackageSettings.DefaultTimeout];
             if (Settings.Contains(PackageSettings.StopOnError))
@@ -322,22 +323,16 @@ namespace NUnit.Framework.Api
             else
                 Context.WorkDirectory = Env.DefaultWorkDirectory;
 
-            // Overriding runners may replace this
+            // Apply attributes to the context
+
+            // Set the listener - overriding runners may replace this
             Context.Listener = listener;
 
 #if PARALLEL
             int levelOfParallelism = GetLevelOfParallelism();
 
             if (levelOfParallelism > 0)
-            {
                 Context.Dispatcher = new ParallelWorkItemDispatcher(levelOfParallelism);
-                // Assembly does not have IApplyToContext attributes applied
-                // when the test is built, so  we do it here.
-                // TODO: Generalize this
-                if (LoadedTest.Properties.ContainsKey(PropertyNames.ParallelScope))
-                    Context.ParallelScope =
-                        (ParallelScope)LoadedTest.Properties.Get(PropertyNames.ParallelScope) & ~ParallelScope.Self;
-            }
             else
                 Context.Dispatcher = new SimpleWorkItemDispatcher();
 #else

--- a/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 
@@ -35,9 +36,9 @@ namespace NUnit.Framework.Internal.Commands
     /// </summary>
     class ApplyChangesToContextCommand : DelegatingTestCommand
     {
-        private IApplyToContext[] _changes;
+        private IEnumerable<IApplyToContext> _changes;
 
-        public ApplyChangesToContextCommand(TestCommand innerCommand, IApplyToContext[] changes)
+        public ApplyChangesToContextCommand(TestCommand innerCommand, IEnumerable<IApplyToContext> changes)
             : base(innerCommand)
         {
             _changes = changes;

--- a/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
@@ -52,18 +52,26 @@ namespace NUnit.Framework.Internal.Execution
             TestCommand command = new OneTimeSetUpCommand(suite, setUpTearDown, actions);
 
             // Prefix with any IApplyToContext items from attributes
+            IList<IApplyToContext> changes = null;
+
             if (suite.TypeInfo != null)
+                changes = suite.TypeInfo.GetCustomAttributes<IApplyToContext>(true);
+            else if (suite.Method != null)
+                changes = suite.Method.GetCustomAttributes<IApplyToContext>(true);
+            else
             {
-                IApplyToContext[] changes = suite.TypeInfo.GetCustomAttributes<IApplyToContext>(true);
-                if (changes.Length > 0)
-                    command = new ApplyChangesToContextCommand(command, changes);
+                var testAssembly = suite as TestAssembly;
+                if (testAssembly != null)
+#if PORTABLE
+                    // TODO: Fix this code! It's really quite ugly!
+                    changes = new List<IApplyToContext>(testAssembly.Assembly.GetAttributes<IApplyToContext>());
+#else
+                    changes = (IApplyToContext[])testAssembly.Assembly.GetCustomAttributes(typeof(IApplyToContext), true);
+#endif
             }
-            if (suite.Method!=null)
-            {
-                IApplyToContext[] changes = suite.Method.GetCustomAttributes<IApplyToContext>(true);
-                if (changes.Length > 0)
-                    command = new ApplyChangesToContextCommand(command, changes);
-            }
+
+            if (changes != null && changes.Count > 0)
+                command = new ApplyChangesToContextCommand(command, changes);
 
             return command;
         }

--- a/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
@@ -63,7 +63,6 @@ namespace NUnit.Framework.Internal.Execution
                 var testAssembly = suite as TestAssembly;
                 if (testAssembly != null)
 #if PORTABLE
-                    // TODO: Fix this code! It's really quite ugly!
                     changes = new List<IApplyToContext>(testAssembly.Assembly.GetAttributes<IApplyToContext>());
 #else
                     changes = (IApplyToContext[])testAssembly.Assembly.GetCustomAttributes(typeof(IApplyToContext), true);


### PR DESCRIPTION
Fixes #1266 

The code in CommandBuilder that adds an ApplyChangesToContextCommand to the command chain was only looking at fixtures and methods, not assemblies.

I verified the fix by stepping through the code after temporarily adding various attributes to the assembly. We need tests for all our attributes at the assembly level, but that's a bit hard to do without proliferating test assemblies.