### PR TITLE
Give error when trying to run using --x86 in process

### DIFF
--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -170,7 +170,7 @@ namespace NUnit.Common
         {
             if (!validated)
             {
-                // Additional Checks here
+                CheckOptionCombinations();
 
                 validated = true;
             }
@@ -178,9 +178,14 @@ namespace NUnit.Common
             return ErrorMessages.Count == 0;
         }
 
-#endregion
-        
-#region Helper Methods
+        #endregion
+
+        #region Helper Methods
+
+        protected virtual void CheckOptionCombinations()
+        {
+
+        }
 
         /// <summary>
         /// Case is ignored when val is compared to validValues. When a match is found, the

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -237,6 +237,14 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
+        public void X86AndInProcessAreNotCompatible()
+        {
+            ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
+            Assert.False(options.Validate(), "Should be invalid");
+            Assert.AreEqual("The --x86 and --inprocess options are incompatible.", options.ErrorMessages[0]);
+        }
+
+        [Test]
         public void InvalidOption()
         {
             ConsoleOptions options = new ConsoleOptions("-assembly:nunit.tests.dll");

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -77,6 +77,18 @@ namespace NUnit.Common
 
         #endregion
 
+        #region Overrides
+
+        protected override void CheckOptionCombinations()
+        {
+            base.CheckOptionCombinations();
+
+            if (RunAsX86 && ProcessModel == "InProcess")
+                ErrorMessages.Add("The --x86 and --inprocess options are incompatible.");
+        }
+
+        #endregion
+
         #region Configure Additional Options for Console
 
         protected override void ConfigureOptions()

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -89,6 +89,12 @@ namespace NUnit.Engine.Runners
             // be used to determine how to run the assembly.
             _runtimeService.SelectRuntimeFramework(TestPackage);
 
+            if (TestPackage.GetSetting(PackageSettings.ProcessModel, "") == "InProcess" &&
+                TestPackage.GetSetting(PackageSettings.RunAsX86, false))
+            {
+                throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");
+            }
+
             _realRunner = TestRunnerFactory.MakeTestRunner(TestPackage);
 
             return _realRunner.Load().Aggregate(TEST_RUN_ELEMENT, TestPackage.Name, TestPackage.FullName);


### PR DESCRIPTION
This fixes #1161.

Two error cases are handled...

* Use of both --x86 and --inprocess is detected in processing the command-line and reported as an error.
* If the engine discovers that the test needs to be run as 32-bit and --inprocess was used it throws an exception.