### PR TITLE
Make ApartmentState work on suites, including assembly

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -251,14 +251,20 @@ namespace NUnit.Framework.Internal.Execution
             {
                 if (_childFilter.Pass(test))
                 {
+                    var child = WorkItem.CreateWorkItem(test, _childFilter);
+#if !PORTABLE && !SILVERLIGHT && !NETCF
+                    if (child.TargetApartment == ApartmentState.Unknown && TargetApartment != ApartmentState.Unknown)
+                        child.TargetApartment = TargetApartment;
+#endif
+
                     if (test.Properties.ContainsKey(PropertyNames.Order))
                     {
-                        _children.Insert(0, WorkItem.CreateWorkItem(test, _childFilter));
+                        _children.Insert(0, child);
                         _countOrder++;
                     }
                     else
                     {
-                        _children.Insert(_children.Count, WorkItem.CreateWorkItem(test, _childFilter));
+                        _children.Add(child);
                     }
                 }
             }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -85,6 +85,11 @@ namespace NUnit.Framework.Internal.Execution
             _test = test;
             Result = test.MakeTestResult();
             _state = WorkItemState.Ready;
+#if !PORTABLE && !SILVERLIGHT && !NETCF
+            TargetApartment = _test.Properties.ContainsKey(PropertyNames.ApartmentState)
+                ? (ApartmentState)_test.Properties.Get(PropertyNames.ApartmentState)
+                : ApartmentState.Unknown;
+#endif
         }
 
         /// <summary>
@@ -201,15 +206,7 @@ namespace NUnit.Framework.Internal.Execution
         public TestResult Result { get; protected set; }
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
-        internal ApartmentState TargetApartment
-        {
-            get
-            {
-                return Test.Properties.ContainsKey(PropertyNames.ApartmentState)
-                    ? (ApartmentState)_test.Properties.Get(PropertyNames.ApartmentState)
-                    : ApartmentState.Unknown;
-            }
-        }
+        internal ApartmentState TargetApartment { get; set; }
 #endif
 
         #endregion


### PR DESCRIPTION
The apartment state is now set to be the same as the containing parent item, so long as the test has no other apartment indicated.