### PR TITLE
Adding a DeclaringClassName property to Test class. Required for nunit/nunit3-vs-adapter#133.

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -51,6 +51,16 @@ namespace NUnit.Framework.Internal
         /// </summary>
         protected MethodInfo[] tearDownMethods;
 
+        /// <summary>
+        /// Used to cache the declaring type for this MethodInfo
+        /// </summary>
+        protected ITypeInfo DeclaringTypeInfo;
+
+        /// <summary>
+        /// Method property backing field
+        /// </summary>
+        private IMethodInfo _method;
+
         #endregion
 
         #region Construction
@@ -143,19 +153,29 @@ namespace NUnit.Framework.Internal
         public string FullName { get; set; }
 
         /// <summary>
-        /// Gets the name of the class containing this test. Returns
-        /// null if the test is not associated with a class.
+        /// Gets the name of the class where this test was declared.
+        /// Returns null if the test is not associated with a class.
         /// </summary>
         public string ClassName
-        { 
+        {
             get
             {
-                if (TypeInfo == null)
+                ITypeInfo typeInfo = TypeInfo;
+
+                if (Method != null)
+                {
+                    if (DeclaringTypeInfo == null)
+                        DeclaringTypeInfo = new TypeWrapper(Method.MethodInfo.DeclaringType);
+
+                    typeInfo = DeclaringTypeInfo;
+                }
+
+                if (typeInfo == null)
                     return null;
 
-                return TypeInfo.IsGenericType
-                    ? TypeInfo.GetGenericTypeDefinition().FullName
-                    : TypeInfo.FullName;
+                return typeInfo.IsGenericType
+                    ? typeInfo.GetGenericTypeDefinition().FullName
+                    : typeInfo.FullName;
             }
         }
 
@@ -178,7 +198,15 @@ namespace NUnit.Framework.Internal
         /// Gets a MethodInfo for the method implementing this test.
         /// Returns null if the test is not implemented as a method.
         /// </summary>
-        public IMethodInfo Method { get; set; } // public setter needed by NUnitTestCaseBuilder
+        public IMethodInfo Method
+        {
+            get { return _method; }
+            set
+            {
+                DeclaringTypeInfo = null;
+                _method = value;
+            }
+        } // public setter needed by NUnitTestCaseBuilder
 
         /// <summary>
         /// Whether or not the test should be run

--- a/src/NUnitFramework/tests/Internal/TestNamingTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNamingTests.cs
@@ -31,7 +31,6 @@ namespace NUnit.Framework.Internal.Tests
         protected const string OUTER_CLASS = "NUnit.Framework.Internal.Tests.TestNamingTests";
 
         protected abstract string FixtureName { get; }
-        protected abstract string ClassName { get; }
 
         protected TestContext.TestAdapter CurrentTest
         {
@@ -41,25 +40,25 @@ namespace NUnit.Framework.Internal.Tests
         [Test]
         public void SimpleTest()
         {
-            CheckNames("SimpleTest", "SimpleTest");
+            CheckNames("SimpleTest", "SimpleTest", OUTER_CLASS);
         }
 
         [TestCase(5, 7, "ABC")]
         public void ParameterizedTest(int x, int y, string s)
         {
-            CheckNames("ParameterizedTest(5,7,\"ABC\")", "ParameterizedTest");
+            CheckNames("ParameterizedTest(5,7,\"ABC\")", "ParameterizedTest", OUTER_CLASS);
         }
 
         [TestCase("abcdefghijklmnopqrstuvwxyz")]
         public void TestCaseWithLongStringArgument(string s)
         {
-            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnopqrstuvwxyz\")", "TestCaseWithLongStringArgument");
+            CheckNames("TestCaseWithLongStringArgument(\"abcdefghijklmnopqrstuvwxyz\")", "TestCaseWithLongStringArgument", OUTER_CLASS);
         }
 
         [TestCase(42)]
         public void GenericTest<T>(T arg)
         {
-            CheckNames("GenericTest<Int32>(42)", "GenericTest");
+            CheckNames("GenericTest<Int32>(42)", "GenericTest", OUTER_CLASS);
         }
 
         [TestCase()]
@@ -78,25 +77,28 @@ namespace NUnit.Framework.Internal.Tests
 
             sb.Append(")");
 
-            CheckNames(sb.ToString(), "TestWithParamsArgument");
+            CheckNames(sb.ToString(), "TestWithParamsArgument", OUTER_CLASS);
         }
 
-        private void CheckNames(string expectedTestName, string expectedMethodName)
+        private void CheckNames(string expectedTestName, string expectedMethodName, string expectedClassName)
         {
             Assert.That(CurrentTest.Name, Is.EqualTo(expectedTestName));
             Assert.That(CurrentTest.FullName, Is.EqualTo(OUTER_CLASS + "+" + FixtureName + "." + expectedTestName));
             Assert.That(CurrentTest.MethodName, Is.EqualTo(expectedMethodName));
-            Assert.That(CurrentTest.ClassName, Is.EqualTo(OUTER_CLASS + "+" + ClassName));
+            Assert.That(CurrentTest.ClassName, Is.EqualTo(expectedClassName));
         }
 
         public class SimpleFixture : TestNamingTests
         {
-            protected override string FixtureName
+            protected const string CURRENT_CLASS = "SimpleFixture";
+
+            [Test]
+            public void SimpleTestInDerivedClass()
             {
-                get { return "SimpleFixture"; }
+                CheckNames("SimpleTestInDerivedClass", "SimpleTestInDerivedClass", OUTER_CLASS + "+" + CURRENT_CLASS);
             }
 
-            protected override string ClassName
+            protected override string FixtureName
             {
                 get { return "SimpleFixture"; }
             }
@@ -105,62 +107,74 @@ namespace NUnit.Framework.Internal.Tests
         [TestFixture(typeof(int))]
         public class GenericFixture<T> : TestNamingTests
         {
+            protected const string CURRENT_CLASS = "GenericFixture`1";
+
+            [Test]
+            public void SimpleTestInDerivedClass()
+            {
+                CheckNames("SimpleTestInDerivedClass", "SimpleTestInDerivedClass", OUTER_CLASS + "+" + CURRENT_CLASS);
+            }
+
             protected override string FixtureName
             {
                 get { return "GenericFixture<Int32>"; }
-            }
-
-            protected override string ClassName
-            {
-                get { return "GenericFixture`1"; }
             }
         }
 
         [TestFixture(42, "Forty-two")]
         public class ParameterizedFixture : TestNamingTests
         {
+            protected const string CURRENT_CLASS = "ParameterizedFixture";
+
+            [Test]
+            public void SimpleTestInDerivedClass()
+            {
+                CheckNames("SimpleTestInDerivedClass", "SimpleTestInDerivedClass", OUTER_CLASS + "+" + CURRENT_CLASS);
+            }
+
             public ParameterizedFixture(int x, string s) { }
 
             protected override string FixtureName
             {
                 get { return "ParameterizedFixture(42,\"Forty-two\")"; }
             }
-
-            protected override string ClassName
-            {
-                get { return "ParameterizedFixture"; }
-            }
         }
 
         [TestFixture("This is really much too long to be used in the test name!")]
         public class ParameterizedFixtureWithLongStringArgument : TestNamingTests
         {
+            protected const string CURRENT_CLASS = "ParameterizedFixtureWithLongStringArgument";
+
+            [Test]
+            public void SimpleTestInDerivedClass()
+            {
+                CheckNames("SimpleTestInDerivedClass", "SimpleTestInDerivedClass", OUTER_CLASS + "+" + CURRENT_CLASS);
+            }
+
             public ParameterizedFixtureWithLongStringArgument(string s) { }
 
             protected override string FixtureName
             {
                 get { return "ParameterizedFixtureWithLongStringArgument(\"This is really much too long to be us...\")"; }
             }
-
-            protected override string ClassName
-            {
-                get { return "ParameterizedFixtureWithLongStringArgument"; }
-            }
         }
 
         [TestFixture(typeof(int), typeof(string), 42, "Forty-two")]
         public class GenericParameterizedFixture<T1,T2> : TestNamingTests
         {
+            protected const string CURRENT_CLASS = "GenericParameterizedFixture`2";
+
+            [Test]
+            public void SimpleTestInDerivedClass()
+            {
+                CheckNames("SimpleTestInDerivedClass", "SimpleTestInDerivedClass", OUTER_CLASS + "+" + CURRENT_CLASS);
+            }
+
             public GenericParameterizedFixture(T1 x, T2 y) { }
 
             protected override string FixtureName
             {
                 get { return "GenericParameterizedFixture<Int32,String>(42,\"Forty-two\")"; }
-            }
-
-            protected override string ClassName
-            {
-                get { return "GenericParameterizedFixture`2"; }
             }
         }
     }


### PR DESCRIPTION
If a method is added as a test through inheritance the ClassName property of Test class will contain the name of the derived class. This makes it impossible in the VS adapter to figure out the source location for that method.
DeclaringClassName will be set to the class where the method was declared as that’s the class that can be used to find the source location when using DiaSession.