### PR TITLE
Fix TestDriver target so the tests are run correctly

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -352,7 +352,7 @@ Task("TestDriver")
   .WithCriteria(IsRunningOnWindows)
   .Does(() =>
 	{
-		RunTest(NUNIT3_CONSOLE, BIN_DIR, PORTABLE_AGENT_TESTS, ref ErrorDetail);
+		RunTest(NUNIT3_CONSOLE, BIN_DIR, PORTABLE_AGENT_TESTS, "TestDriver", ref ErrorDetail);
 	});
 
 Task("TestAddins")


### PR DESCRIPTION
Simple fix, they were just broken in the re-org of the Cake script. Tests are now running and passing with the standard build targets.