### PR TITLE
(#1386) Refactored check for IEquatable interfaces to account for explicit implementations

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -237,64 +237,45 @@ namespace NUnit.Framework.Constraints
                     return ((TimeSpan)x - (TimeSpan)y).Duration() <= amount;
             }
 
-            if (FirstImplementsIEquatableOfSecond(xType, yType))
-                return InvokeFirstIEquatableEqualsSecond(x, y);
-            else if (xType != yType && FirstImplementsIEquatableOfSecond(yType, xType))
-                return InvokeFirstIEquatableEqualsSecond(y, x);
+            MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
+            if (equals != null)
+                return InvokeFirstIEquatableEqualsSecond(x, y, equals);
+            if (xType != yType && (equals = FirstImplementsIEquatableOfSecond(yType, xType)) != null)
+                return InvokeFirstIEquatableEqualsSecond(y, x, equals);
             
             return x.Equals(y);
         }
 
-        private static bool FirstImplementsIEquatableOfSecond(Type first, Type second)
+        private static MethodInfo FirstImplementsIEquatableOfSecond(Type first, Type second)
         {
             foreach (var xEquatableArgument in GetEquatableGenericArguments(first))
-                if (xEquatableArgument.IsAssignableFrom(second))
-                    return true;
+                if (xEquatableArgument.Key.IsAssignableFrom(second))
+                    return xEquatableArgument.Value;
 
-            return false;
+            return null;
         }
 
-        private static IList<Type> GetEquatableGenericArguments(Type type)
+        private static IList<KeyValuePair<Type, MethodInfo>> GetEquatableGenericArguments(Type type)
         {
             // NOTE: Original implementation used Array.ConvertAll and
             // Array.FindAll, which don't exist in the compact framework.
-            var genericArgs = new List<Type>();
+            var genericArgs = new List<KeyValuePair<Type, MethodInfo>>();
 
             foreach (Type @interface in type.GetInterfaces())
             {
                 if (@interface.GetTypeInfo().IsGenericType && @interface.GetGenericTypeDefinition().Equals(typeof(IEquatable<>)))
                 {
-                    genericArgs.Add(@interface.GetGenericArguments()[0]);
+                    genericArgs.Add(new KeyValuePair<Type, MethodInfo>(
+                        @interface.GetGenericArguments()[0], @interface.GetMethod("Equals")));
                 }
             }
 
             return genericArgs;
         }
 
-        private static bool InvokeFirstIEquatableEqualsSecond(object first, object second)
+        private static bool InvokeFirstIEquatableEqualsSecond(object first, object second, MethodInfo equals)
         {
-            MethodInfo equals = GetCorrectGenericEqualsMethod(first.GetType(), second.GetType());
-
             return equals != null ? (bool)equals.Invoke(first, new object[] { second }) : false;
-        }
-
-        private static MethodInfo GetCorrectGenericEqualsMethod(Type first, Type second)
-        {
-            MethodInfo[] methods = first.GetMethods();
-            foreach(var method in methods)
-            {
-                if(method.Name == "Equals")
-                {
-                    ParameterInfo[] prms = method.GetParameters();
-                    if (prms.Length == 1 &&
-                        prms[0].ParameterType != typeof(Object) &&
-                        prms[0].ParameterType.IsAssignableFrom(second))
-                    {
-                        return method;
-                    }
-                }
-            }
-            return null;
         }
         
         #endregion

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -150,6 +150,24 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void IEquatableSuccess_WhenExplicitInterfaceImplementation()
+        {
+            IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
+            IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(1);
+
+            Assert.IsTrue(comparer.AreEqual(x, y, ref tolerance));
+        }
+
+        [Test]
+        public void IEquatableFailure_WhenExplicitInterfaceImplementationWithDifferentValues()
+        {
+            IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
+            IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(2);
+
+            Assert.IsFalse(comparer.AreEqual(x, y, ref tolerance));
+        }
+
+        [Test]
         public void ReferenceEqualityHasPrecedenceOverIEquatable()
         {
             NeverEqualIEquatable z = new NeverEqualIEquatable();
@@ -366,7 +384,22 @@ namespace NUnit.Framework.Constraints
             return value.Equals(other.value);
         }
     }
-    
+
+    public class IEquatableWithExplicitImplementation : IEquatable<IEquatableWithExplicitImplementation>
+    {
+        private readonly int value;
+
+        public IEquatableWithExplicitImplementation(int value)
+        {
+            this.value = value;
+        }
+
+        bool IEquatable<IEquatableWithExplicitImplementation>.Equals(IEquatableWithExplicitImplementation other)
+        {
+            return value.Equals(other.value);
+        }
+    }
+
     public class EquatableObject : IEquatable<EquatableObject>
     {
         public int SomeProperty { get; set; }


### PR DESCRIPTION
Ended up getting the method during the check for `IEquatable<T>` existence and passing it through so that the check and the invocation are consistent. Re #1386.