### PR TITLE
IsExplicitMatch correctly overriden for CompositeFilters. In a Compos…

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -74,6 +74,20 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         /// <summary>
+        /// Checks whether the AndFilter is explicit matched by a test.
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        /// <returns>True if all the component filters explicit match, otherwise false</returns>
+        public override bool IsExplicitMatch( ITest test )
+        {
+            foreach( TestFilter filter in Filters )
+                if ( !filter.IsExplicitMatch( test ) )
+                    return false;
+
+            return true;
+        }
+
+        /// <summary>
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -64,6 +64,24 @@ namespace NUnit.Framework.Internal.Filters
         public IList<ITestFilter> Filters { get; private set; }
 
         /// <summary>
+        /// Checks whether the CompositeFilter is matched by a test.
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        public abstract override bool Pass(ITest test);
+
+        /// <summary>
+        /// Checks whether the CompositeFilter is matched by a test.
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        public abstract override bool Match(ITest test);
+
+        /// <summary>
+        /// Checks whether the CompositeFilter is explicit matched by a test.
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        public abstract override bool IsExplicitMatch(ITest test);
+
+        /// <summary>
         /// Adds an XML node
         /// </summary>
         /// <param name="parentNode">Parent node</param>

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -74,6 +74,20 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         /// <summary>
+        /// Checks whether the OrFilter is explicit matched by a test
+        /// </summary>
+        /// <param name="test">The test to be matched</param>
+        /// <returns>True if any of the component filters explicit match, otherwise false</returns>
+        public override bool IsExplicitMatch( ITest test )
+        {
+            foreach( TestFilter filter in Filters )
+                if ( filter.IsExplicitMatch( test ) )
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>

--- a/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
@@ -71,6 +71,91 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
+        public void ExplicitMatchWithNotTest()
+        {
+            var filter = new AndFilter(
+                new NotFilter(
+                    new CategoryFilter("Dummy")),
+                new NotFilter(
+                    new IdFilter(_dummyFixture.Id)));
+
+            Assert.False(filter.IsExplicitMatch(_topLevelSuite));
+            Assert.False(filter.IsExplicitMatch(_dummyFixture));
+            Assert.False(filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+
+            Assert.That(filter.Match(_anotherFixture), "4");
+        }
+
+        /// <summary>
+        /// Generic combination tests for the <see cref="AndFilter"/>. This test checks that the
+        /// <see cref="AndFilter"/> correctly combines the results from its sub-filters.
+        /// Furthermore it checks that the result from the correct match-function of the
+        /// sub-filters is used to calculate the AND combination.
+        /// 
+        /// The input is an array of booleans (<paramref name="inputBooleans"/>). For each boolean
+        /// value a <see cref="MockTestFilter"/> is added to the <see cref="AndFilter"/>
+        /// whose match-function (defined through the paramter <paramref name="matchFunction"/>)
+        /// evaluates to the boolean value indicated.
+        /// Afterwrards the requested match-function (<paramref name="matchFunction"/>) is called
+        /// on the <see cref="AndFilter"/> and is compared to the expected result
+        /// (<paramref name="expectedResult"/>).
+        /// This tests also throws an exception if the match-function call from the
+        /// <see cref="AndFilter"/> calls not the same match-function on the
+        /// <see cref="MockTestFilter"/>, thus checking that the <see cref="AndFilter"/>
+        /// combines the correct results from the sub-filters.
+        /// 
+        /// See also <see cref="MockTestFilter"/>.
+        /// </summary>
+        [TestCase(new bool[] { false, false}, false, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { true, false }, false, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { false, true }, false, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { true, false }, false, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { false, true }, false, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { true, false }, false, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { false, true }, false, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.Pass)]
+        public void CombineTest(IEnumerable<bool> inputBooleans, bool expectedResult,
+            MockTestFilter.MatchFunction matchFunction)
+        {
+            var filters = new List<MockTestFilter>();
+            foreach (var inputBool in inputBooleans)
+            {
+                var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
+                Assert.AreEqual(inputBool, ExecuteMatchFunction(strictFilter, matchFunction));
+
+                filters.Add(strictFilter);
+            }
+
+            var filter = new AndFilter(filters.ToArray());
+            bool calculatedResult = ExecuteMatchFunction(filter, matchFunction);
+            Assert.AreEqual(expectedResult, calculatedResult);
+        }
+
+        /// <summary>
+        /// Executes the requested <paramref name="matchFunction"/> on the <paramref name="filter"/>.
+        /// </summary>
+        private bool ExecuteMatchFunction(
+            TestFilter filter, MockTestFilter.MatchFunction matchFunction)
+        {
+            switch (matchFunction)
+            {
+                case MockTestFilter.MatchFunction.IsExplicitMatch:
+                    return filter.IsExplicitMatch(_dummyFixture);
+                case MockTestFilter.MatchFunction.Match:
+                    return filter.Match(_dummyFixture);
+                case MockTestFilter.MatchFunction.Pass:
+                    return filter.Pass(_dummyFixture);
+                default:
+                    throw new ArgumentException(
+                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", "matchFunction");
+            }
+        }
+
+        [Test]
         public void BuildFromXml()
         {
             TestFilter filter = TestFilter.FromXml(

--- a/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
@@ -1,0 +1,114 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    /// <summary>
+    /// Mocks a <see cref="TestFilter"/>. Checks that only one specific match-function 
+    /// (<see cref=MatchFunction"/> is called and only for a specific <see cref="ITest"/>.
+    /// 
+    /// For the specific test and match-function one could set the return value of the function.
+    /// Furthermore one could read out the number of valid calls to the match-function through
+    /// <see cref="NumberOfMatchCalls"/>.
+    /// 
+    /// It would be better to use a Mocking-Framework for this.
+    /// </summary>
+    [Serializable]
+    public class MockTestFilter : TestFilter
+    {
+        public enum MatchFunction
+        {
+            Match,
+            IsExplicitMatch,
+            Pass
+        }
+
+        /// <summary>
+        /// The test, for which the match-function is allowed to be called.
+        /// </summary>
+        private readonly ITest _expectedTest;
+
+        /// <summary>
+        /// The one and only match-function, which is allowed to be called.
+        /// </summary>
+        private readonly MatchFunction _expectedFunctionToBeCalled;
+
+        /// <summary>
+        /// The result of the match-function <see cref="_expectedFunctionToBeCalled"/>
+        /// for the teste <see cref="_expectedTest"/>.
+        /// </summary>
+        private readonly bool _matchFunctionResult;
+
+        /// <summary>
+        /// Gets the number of valid calls of the match-function that have been executed.
+        /// </summary>
+        public int NumberOfMatchCalls { get; private set; }
+
+        /// <summary>
+        /// Construct an <see cref="MockTestFilter"/>.
+        /// </summary>
+        /// <param name="expectedTest">The test for which calling the match-function is allowed.</param>
+        /// <param name="expectedMatchFunction">The matching function that should be called.</param>
+        /// <param name="matchFunctionResult">The result of the match function for the expected
+        /// test.</param>
+        public MockTestFilter(
+            ITest expectedTest, MatchFunction expectedMatchFunction, bool matchFunctionResult) : base()
+        {
+            _expectedTest = expectedTest;
+            _expectedFunctionToBeCalled = expectedMatchFunction;
+            _matchFunctionResult = matchFunctionResult;
+            NumberOfMatchCalls = 0;
+        }
+
+        public override bool Match(ITest test)
+        {
+            return AssertAndGetEquality(test, MatchFunction.Match);
+        }
+
+        public override bool IsExplicitMatch(ITest test)
+        {
+            return AssertAndGetEquality(test, MatchFunction.IsExplicitMatch);
+        }
+
+        public override bool Pass(ITest test)
+        {
+            return AssertAndGetEquality(test, MatchFunction.Pass);
+        }
+
+        private bool AssertAndGetEquality(ITest test, MatchFunction calledFunction)
+        {
+            Assert.AreSame(_expectedTest, test);
+            Assert.AreEqual(_expectedFunctionToBeCalled, calledFunction);
+            NumberOfMatchCalls += 1;
+            return _matchFunctionResult;
+        }
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -76,6 +76,75 @@ namespace NUnit.Framework.Internal.Filters
             Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
         }
 
+        /// <summary>
+        /// Generic combination tests for the <see cref="OrFilter"/>. This test checks that the
+        /// <see cref="OrFilter"/> correctly combines the results from its sub-filters.
+        /// Furthermore it checks that the result from the correct match-function of the
+        /// sub-filters is used to calculate the OR combination.
+        /// 
+        /// The input is an array of booleans (<paramref name="inputBooleans"/>). For each boolean
+        /// value a <see cref="MockTestFilter"/> is added to the <see cref="OrFilter"/>
+        /// whose match-function (defined through the paramter <paramref name="matchFunction"/>)
+        /// evaluates to the boolean value indicated.
+        /// Afterwrards the requested match-function (<paramref name="matchFunction"/>) is called
+        /// on the <see cref="OrFilter"/> and is compared to the expected result
+        /// (<paramref name="expectedResult"/>).
+        /// This tests also throws an exception if the match-function call from the
+        /// <see cref="OrFilter"/> calls not the same match-function on the
+        /// <see cref="MockTestFilter"/>, thus checking that the <see cref="OrFilter"/>
+        /// combines the correct results from the sub-filters.
+        /// 
+        /// See also <see cref="MockTestFilter"/>.
+        /// </summary>
+        [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { true, false }, true, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { false, true }, true, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.IsExplicitMatch)]
+        [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { true, false }, true, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { false, true }, true, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.Match)]
+        [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { true, false }, true, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { false, true }, true, MockTestFilter.MatchFunction.Pass)]
+        [TestCase(new bool[] { true, true }, true, MockTestFilter.MatchFunction.Pass)]
+        public void CombineTest(IEnumerable<bool> inputBooleans, bool expectedResult,
+            MockTestFilter.MatchFunction matchFunction)
+        {
+            var filters = new List<MockTestFilter>();
+            foreach (var inputBool in inputBooleans)
+            {
+                var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
+                Assert.AreEqual(inputBool, ExecuteMatchFunction(strictFilter, matchFunction));
+
+                filters.Add(strictFilter);
+            }
+
+            var filter = new OrFilter(filters.ToArray());
+            bool calculatedResult = ExecuteMatchFunction(filter, matchFunction);
+            Assert.AreEqual(expectedResult, calculatedResult);
+        }
+
+        /// <summary>
+        /// Executes the requested <paramref name="matchFunction"/> on the <paramref name="filter"/>.
+        /// </summary>
+        private bool ExecuteMatchFunction(
+            TestFilter filter, MockTestFilter.MatchFunction matchFunction)
+        {
+            switch (matchFunction)
+            {
+                case MockTestFilter.MatchFunction.IsExplicitMatch:
+                    return filter.IsExplicitMatch(_dummyFixture);
+                case MockTestFilter.MatchFunction.Match:
+                    return filter.Match(_dummyFixture);
+                case MockTestFilter.MatchFunction.Pass:
+                    return filter.Pass(_dummyFixture);
+                default:
+                    throw new ArgumentException(
+                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", "matchFunction");
+            }
+        }
+
         [Test]
         public void BuildFromXml()
         {

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />
+    <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
     <Compile Include="Internal\GenericMethodHelperTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
+    <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestFixtureSourceTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />
+	<Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
+    <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
+	<Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />


### PR DESCRIPTION
…iteFilter the IsExplicitMatch function must always be correctly combined by calling the sub-filters IsExplicitMatch function. Fixes #1141 