### PR TITLE
ITestRunner.StopRun throws exception of type 'System.MissingMethodException'.

### DIFF
--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -126,7 +126,7 @@ namespace NUnit.Engine.Drivers
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
         public void StopRun(bool force)
         {
-            CreateObject(STOP_RUN_ACTION, _frameworkController, force);
+            CreateObject(STOP_RUN_ACTION, _frameworkController, force, new CallbackHandler());
         }
 
         /// <summary>


### PR DESCRIPTION
Calling ITestRunner.StopRun throws an exception with following stack trace:

```
System.MissingMethodException: Constructor on type 'NUnit.Framework.Api.FrameworkController+StopRunAction' not found.
   at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, StackCrawlMark& stackMark)
   at System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)
   at System.Activator.CreateInstance(String assemblyString, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityInfo, StackCrawlMark& stackMark)
   at System.Activator.CreateInstance(String assemblyName, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityInfo)
   at System.AppDomain.CreateInstance(String assemblyName, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityAttributes)
   at System.AppDomain.CreateInstanceAndUnwrap(String assemblyName, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityAttributes)
   at System.AppDomain.CreateInstanceAndUnwrap(String assemblyName, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityAttributes)
   at NUnit.Engine.Drivers.NUnit3FrameworkDriver.StopRun(Boolean force)
   at NUnit.Engine.Runners.DirectTestRunner.StopRun(Boolean force)
   at NUnit.Engine.Runners.MasterTestRunner.StopRun(Boolean force)
   at <StartupCode$Piljarde>.$TestManager.idle@129-7.Invoke(Unit unitVar0) in E:\Projects\piljarde\Piljarde\TestManager.fs:line 129
   at <StartupCode$FSharp-Core>.$Control.handler@2021.Invoke(Object _arg4)}
```

Following the stack trace reveals, that object is created with wrong constructor arguments (invocation is missing handler argument). This pull request adds missing argument.