### PR TITLE
Temporary fix for #1348

### DIFF
--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -108,7 +108,7 @@ namespace NUnit.ConsoleRunner
                     return ConsoleRunner.OK;
                 }
 
-                using (ITestEngine engine = TestEngineActivator.CreateInstance())
+                using (ITestEngine engine = TestEngineActivator.CreateInstance(false))
                 {
                     if (Options.WorkDirectory != null)
                         engine.WorkDirectory = Options.WorkDirectory;

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+    <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />


### PR DESCRIPTION
Made loading the engine use local only. Also fixed the .NET 3.5 tests which were broken between two PR merges.