### PR TITLE
Removal of some non-thread-safe code involving lazy initialization

### DIFF
--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -154,7 +154,8 @@ namespace NUnit.Framework.Api
         {
             Settings = settings;
 
-            Randomizer.InitialSeed = GetInitialSeed(settings);
+            if (settings.Contains(PackageSettings.RandomSeed))
+                Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assemblyName, settings);
         }
@@ -169,7 +170,8 @@ namespace NUnit.Framework.Api
         {
             Settings = settings;
 
-            Randomizer.InitialSeed = GetInitialSeed(settings);
+            if (settings.Contains(PackageSettings.RandomSeed))
+                Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assembly, settings);
         }
@@ -369,13 +371,6 @@ namespace NUnit.Framework.Api
                     count += CountTestCases(child, filter);
 
             return count;
-        }
-
-        private static int GetInitialSeed(IDictionary settings)
-        {
-            return settings.Contains(PackageSettings.RandomSeed)
-                ? (int)settings[PackageSettings.RandomSeed]
-                : new Random().Next();
         }
 
 #if PARALLEL

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -41,6 +41,7 @@ namespace NUnit.Framework.Internal.Execution
         //        static Logger log = InternalTrace.GetLogger("CompositeWorkItem");
 
         private TestSuite _suite;
+        private TestSuiteResult _suiteResult;
         private ITestFilter _childFilter;
         private TestCommand _setupCommand;
         private TestCommand _teardownCommand;
@@ -72,6 +73,7 @@ namespace NUnit.Framework.Internal.Execution
             : base(suite)
         {
             _suite = suite;
+            _suiteResult = Result as TestSuiteResult;
             _childFilter = childFilter;
             _countOrder = 0;
         }
@@ -320,7 +322,7 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     TestResult childResult = child.MakeTestResult();
                     childResult.SetResult(resultState, message);
-                    Result.AddResult(childResult);
+                    _suiteResult.AddResult(childResult);
 
                     // Some runners may depend on getting the TestFinished event
                     // even for tests that have been skipped at a higher level.
@@ -363,7 +365,7 @@ namespace NUnit.Framework.Internal.Execution
                 if (childTask != null)
                 {
                     childTask.Completed -= new EventHandler(OnChildCompleted);
-                    Result.AddResult(childTask.Result);
+                    _suiteResult.AddResult(childTask.Result);
 
                     if (Context.StopOnError && childTask.Result.ResultState.Status == TestStatus.Failed)
                         Context.ExecutionStatus = TestExecutionStatus.StopRequested;
@@ -382,7 +384,7 @@ namespace NUnit.Framework.Internal.Execution
                 if (Context.ExecutionStatus != TestExecutionStatus.AbortRequested)
                     PerformOneTimeTearDown();
 
-                foreach (var childResult in this.Result.Children)
+                foreach (var childResult in _suiteResult.Children)
                     if (childResult.ResultState == ResultState.Cancelled)
                     {
                         this.Result.SetResult(ResultState.Cancelled, "Cancelled by user");

--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -52,27 +52,34 @@ namespace NUnit.Framework.Internal
     {
         #region Static Members
 
-        /// <summary>
-        /// Initial seed used to create randomizers for this run
-        /// </summary>
-        public static int InitialSeed { get; set; }
+        // Static constructor initializes values
+        static Randomizer()
+        {
+            InitialSeed = new Random().Next();
+            Randomizers = new Dictionary<MemberInfo, Randomizer>();
+        }
 
         // Static Random instance used exclusively for the generation
         // of seed values for new Randomizers.
         private static Random _seedGenerator;
-        private static Random SeedGenerator
-        {
-            get
-            {
-                if (_seedGenerator == null)
-                    _seedGenerator = new Random(InitialSeed);
 
-                return _seedGenerator;
+        /// <summary>
+        /// Initial seed used to create randomizers for this run
+        /// </summary>
+        public static int InitialSeed
+        {
+            get { return _initialSeed; }
+            set
+            {
+                _initialSeed = value;
+                // Setting or resetting the initial seed creates seed generator
+                _seedGenerator = new Random(_initialSeed);
             }
         }
+        private static int _initialSeed;
 
         // Lookup Dictionary used to find randomizers for each member
-        private static Dictionary<MemberInfo, Randomizer> Randomizers = new Dictionary<MemberInfo, Randomizer>();
+        private static Dictionary<MemberInfo, Randomizer> Randomizers;
 
         /// <summary>
         /// Get a Randomizer for a particular member, returning
@@ -112,7 +119,7 @@ namespace NUnit.Framework.Internal
         /// <returns></returns>
         public static Randomizer CreateRandomizer()
         {
-            return new Randomizer(SeedGenerator.Next());
+            return new Randomizer(_seedGenerator.Next());
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Results/TestCaseResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestCaseResult.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
@@ -36,6 +37,8 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="test">A TestMethod to which the result applies.</param>
         public TestCaseResult(TestMethod test) : base(test) { }
+
+        #region Overrides
 
         /// <summary>
         /// Gets the number of test cases that failed
@@ -72,5 +75,23 @@ namespace NUnit.Framework.Internal
         {
             get { return ResultState.Status == TestStatus.Inconclusive ? 1 : 0; }
         }
+
+        /// <summary>
+        /// Indicates whether this result has any child results.
+        /// </summary>
+        public override bool HasChildren
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        /// Gets the collection of child results.
+        /// </summary>
+        public override IList<ITestResult> Children
+        {
+            get { return new ITestResult[0]; }
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -52,11 +53,6 @@ namespace NUnit.Framework.Internal
         internal const double MIN_DURATION = 0.000001d;
 
 //        static Logger log = InternalTrace.GetLogger("TestResult");
-
-        /// <summary>
-        /// List of child results
-        /// </summary>
-        private System.Collections.Generic.List<ITestResult> _children;
 
         private StringBuilder _output = new StringBuilder();
         private double _duration;
@@ -175,27 +171,13 @@ namespace NUnit.Framework.Internal
 
         /// <summary>
         /// Indicates whether this result has any child results.
-        /// Test HasChildren before accessing Children to avoid
-        /// the creation of an empty collection.
         /// </summary>
-        public bool HasChildren
-        {
-            get { return _children != null && _children.Count > 0; }
-        }
+        public abstract bool HasChildren { get; }
 
         /// <summary>
         /// Gets the collection of child results.
         /// </summary>
-        public System.Collections.Generic.IList<ITestResult> Children
-        {
-            get
-            {
-                if (_children == null)
-                    _children = new System.Collections.Generic.List<ITestResult>();
-
-                return _children;
-            }
-        }
+        public abstract IList<ITestResult> Children { get; }
 
         /// <summary>
         /// Gets a TextWriter, which will write output to be included in the result.
@@ -212,7 +194,7 @@ namespace NUnit.Framework.Internal
 
 #endregion
 
-#region IXmlNodeBuilder Members
+        #region IXmlNodeBuilder Members
 
         /// <summary>
         /// Returns the Xml representation of the result.
@@ -281,52 +263,9 @@ namespace NUnit.Framework.Internal
             return thisNode;
         }
 
-#endregion
+        #endregion
 
-        /// <summary>
-        /// Adds a child result to this result, setting this result's
-        /// ResultState to Failure if the child result failed.
-        /// </summary>
-        /// <param name="result">The result to be added</param>
-        public virtual void AddResult(ITestResult result)
-        {
-            Children.Add(result);
-
-            //AssertCount += result.AssertCount;
-
-            // If this result is marked cancelled, don't change it
-            if (ResultState != ResultState.Cancelled)
-                switch (result.ResultState.Status)
-                {
-                    case TestStatus.Passed:
-
-                        if (ResultState.Status == TestStatus.Inconclusive)
-                            SetResult(ResultState.Success);
-
-                        break;
-
-                    case TestStatus.Failed:
-
-
-                        if (ResultState.Status != TestStatus.Failed)
-                            SetResult(ResultState.ChildFailure, CHILD_ERRORS_MESSAGE);
-
-                        break;
-
-                    case TestStatus.Skipped:
-
-                        if (result.ResultState.Label == "Ignored")
-                            if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
-                                SetResult(ResultState.Ignored, CHILD_IGNORE_MESSAGE);
-
-                        break;
-
-                    default:
-                        break;
-                }
-        }
-
-#region Other Public Methods
+        #region Other Public Methods
 
         /// <summary>
         /// Set the result of the test
@@ -470,9 +409,9 @@ namespace NUnit.Framework.Internal
             SetResult(resultState, message, stackTrace);
         }
 
-#endregion
+        #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
         /// <summary>
         /// Adds a reason element to a node and returns it.
@@ -508,6 +447,6 @@ namespace NUnit.Framework.Internal
             return targetNode.AddElementWithCDATA("output", Output);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -59,7 +59,6 @@ namespace NUnit.Framework.Internal
         private System.Collections.Generic.List<ITestResult> _children;
 
         private StringBuilder _output = new StringBuilder();
-        private TextWriter _outWriter;
         private double _duration;
 
         #endregion
@@ -74,6 +73,12 @@ namespace NUnit.Framework.Internal
         {
             Test = test;
             ResultState = ResultState.Inconclusive;
+
+#if PORTABLE || SILVERLIGHT
+            OutWriter = new StringWriter(_output);
+#else
+            OutWriter = TextWriter.Synchronized(new StringWriter(_output));
+#endif
         }
 
         #endregion
@@ -195,20 +200,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets a TextWriter, which will write output to be included in the result.
         /// </summary>
-        public TextWriter OutWriter
-        {
-            get
-            {
-                if (_outWriter == null)
-#if PORTABLE || SILVERLIGHT
-                    _outWriter = new StringWriter(_output);
-#else
-                    _outWriter = TextWriter.Synchronized(new StringWriter(_output));
-#endif
-
-                return _outWriter;
-            }
-        }
+        public TextWriter OutWriter { get; private set; }
 
         /// <summary>
         /// Gets any text output written to this result.

--- a/src/NUnitFramework/tests/Internal/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestResultTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     public abstract class TestResultTests
     {
         protected TestResult testResult;
-        protected TestResult suiteResult;
+        protected TestSuiteResult suiteResult;
         protected TestMethod test;
 
         protected double expectedDuration;
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Internal
             suite.Properties.Set(PropertyNames.Description, "Suite description");
             suite.Properties.Add(PropertyNames.Category, "Fast");
             suite.Properties.Add("Value", 3);
-            suiteResult = suite.MakeTestResult();
+            suiteResult = (TestSuiteResult)suite.MakeTestResult();
 
             SimulateTestRun();
         }


### PR DESCRIPTION
This will fix #1425 as far as I think we should in a single issue.

This PR does the following:

1. Remove lazy initialization of TestResult.OutputWriter
2. Remove lazy initialization of Randomizer.SeedGenerator
3. Move implementation of TestResult.Children to TestSuiteResult and eliminate the lazy initialization.

@oznetmaster points out in the comments on #1425 a number of much bigger problems than were initially described. These will be documented and followed up in separate issues, for two reasons:

1. We prefer to do work in smaller increments where possible.
2. I'm about to go on vacation and this is all I have time for. :-)

