### PR TITLE
Loose ends

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -84,8 +84,6 @@ namespace NUnit.Framework.Internal
 
         private Randomizer _randomGenerator;
 
-        private IWorkItemDispatcher _dispatcher;
-
         /// <summary>
         /// The current culture
         /// </summary>
@@ -344,17 +342,7 @@ namespace NUnit.Framework.Internal
         /// The current WorkItemDispatcher. Made public for 
         /// use by nunitlite.tests
         /// </summary>
-        public IWorkItemDispatcher Dispatcher
-        {
-            get
-            {
-                //if (_dispatcher == null)
-                //    _dispatcher = new SimpleWorkItemDispatcher();
-
-                return _dispatcher;
-            }
-            set { _dispatcher = value; }
-        }
+        public IWorkItemDispatcher Dispatcher { get; set; }
 
         /// <summary>
         /// The ParallelScope to be used by tests running in this context.

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -195,7 +195,7 @@ namespace NUnitLite
             {
                 xmlWriter.WriteStartElement("test-suite");
                 xmlWriter.WriteAttributeString("type", suite.TestType);
-                xmlWriter.WriteAttributeString("name", suite.TestType == "Assembly"
+                xmlWriter.WriteAttributeString("name", suite.TestType == "Assembly" || suite.TestType == "Project"
                     ? result.Test.FullName
                     : result.Test.Name);
             }

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -8,7 +8,7 @@ using NUnit.TestUtilities;
 namespace NUnit.Framework.Tests.Attributes
 {
     [TestFixture]
-    class TestOrderAttributeTests
+    public class TestOrderAttributeTests
     {
         [Test]
         public void CheckOrderIsCorrect()


### PR DESCRIPTION
This PR fixes a few loose ends from earlier commits:

1. Removes commented out lazy initialization code in TestExecutionContext.Dispatcher making that property automatic.

2. Makes a TestOrderAttributeTests public

3. Applies fix for #1189 to NUnitLite as well