### PR TITLE
Makes ParallelWorkItemDispatcher and WorkItemQueue lockless threadsafe

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System.Threading/LazyThreadSafetyMode.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/LazyThreadSafetyMode.cs
@@ -1,0 +1,51 @@
+//
+// Lazy.cs
+//
+// Authors:
+//  Rodrigo Kumpera (kumpera@gmail.com)
+//
+// Copyright (C) 2010 Novell
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+namespace System.Threading
+{
+    /// <summary>
+    /// 
+    /// </summary>
+	public enum LazyThreadSafetyMode
+	{
+        /// <summary>
+        /// 
+        /// </summary>
+		None,
+        /// <summary>
+        /// 
+        /// </summary>
+		PublicationOnly,
+        /// <summary>
+        /// 
+        /// </summary>
+		ExecutionAndPublication
+	}
+}

--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -1,0 +1,144 @@
+// SpinWait.cs
+//
+// Copyright (c) 2008 Jérémie "Garuma" Laval
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+using System;
+using System.Diagnostics;
+
+namespace System.Threading
+{
+    /// <summary>
+    /// 
+    /// </summary>
+	public struct SpinWait
+	{
+		// The number of step until SpinOnce yield on multicore machine
+		const           int  step = 10;
+		const           int  maxTime = 200;
+#if NETCF
+		static readonly bool isSingleCpu = true;
+#else
+		static readonly bool isSingleCpu = (Environment.ProcessorCount == 1);
+#endif
+
+		int ntime;
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public void SpinOnce ()
+		{
+			ntime += 1;
+
+			if (isSingleCpu) {
+                // On a single-CPU system, spinning does no good
+#if NET_2_0 || NET_3_5 || NETCF
+                Thread.Sleep(ntime % step == 0 ? 1 : 0);
+#else
+                Thread.Yield ();
+#endif
+			} 
+#if !NETCF
+			else {
+				if (ntime % step == 0)
+#if NET_2_0 || NET_3_5
+                    Thread.Sleep(1);
+#else
+                    Thread.Yield ();
+#endif
+                else
+                    // Multi-CPU system might be hyper-threaded, let other thread run
+                    Thread.SpinWait (Math.Min (ntime, maxTime) << 1);
+			}
+#endif
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="condition"></param>
+		public static void SpinUntil (Func<bool> condition)
+		{
+			SpinWait sw = new SpinWait ();
+			while (!condition ())
+				sw.SpinOnce ();
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+		public static bool SpinUntil (Func<bool> condition, TimeSpan timeout)
+		{
+			return SpinUntil (condition, (int)timeout.TotalMilliseconds);
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="millisecondsTimeout"></param>
+        /// <returns></returns>
+		public static bool SpinUntil (Func<bool> condition, int millisecondsTimeout)
+		{
+			SpinWait sw = new SpinWait ();
+			Stopwatch watch = Stopwatch.StartNew ();
+
+			while (!condition ()) {
+				if (watch.ElapsedMilliseconds > millisecondsTimeout)
+					return false;
+				sw.SpinOnce ();
+			}
+
+			return true;
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public void Reset ()
+		{
+			ntime = 0;
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public bool NextSpinWillYield {
+			get {
+				return isSingleCpu ? true : ntime % step == 0;
+			}
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public int Count {
+			get {
+				return ntime;
+			}
+		}
+	}
+}

--- a/src/NUnitFramework/framework/Compatibility/System/Lazy.cs
+++ b/src/NUnitFramework/framework/Compatibility/System/Lazy.cs
@@ -1,0 +1,236 @@
+//
+// Lazy.cs
+//
+// Authors:
+//  Zoltan Varga (vargaz@gmail.com)
+//  Marek Safar (marek.safar@gmail.com)
+//
+// Copyright (C) 2009 Novell
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.Serialization;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Threading;
+using System.Diagnostics;
+
+namespace System
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+	[SerializableAttribute]
+	[ComVisibleAttribute(false)]
+#if !NETCF
+	[HostProtectionAttribute(SecurityAction.LinkDemand, Synchronization = true, ExternalThreading = true)]
+	[DebuggerDisplay ("ThreadSafetyMode={mode}, IsValueCreated={IsValueCreated}, IsValueFaulted={exception != null}, Value={value}")]
+#endif
+	public class Lazy<T> 
+	{
+		T value;
+		Func<T> factory;
+		object monitor;
+		Exception exception;
+		LazyThreadSafetyMode mode;
+		bool inited;
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public Lazy ()
+			: this (LazyThreadSafetyMode.ExecutionAndPublication)
+		{
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="valueFactory"></param>
+		public Lazy (Func<T> valueFactory)
+			: this (valueFactory, LazyThreadSafetyMode.ExecutionAndPublication)
+		{
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="isThreadSafe"></param>
+		public Lazy (bool isThreadSafe)
+			: this (Activator.CreateInstance<T>, isThreadSafe ? LazyThreadSafetyMode.ExecutionAndPublication : LazyThreadSafetyMode.None)
+		{
+		}
+		
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="valueFactory"></param>
+        /// <param name="isThreadSafe"></param>
+		public Lazy (Func<T> valueFactory, bool isThreadSafe)
+			: this (valueFactory, isThreadSafe ? LazyThreadSafetyMode.ExecutionAndPublication : LazyThreadSafetyMode.None)
+		{
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mode"></param>
+		public Lazy (LazyThreadSafetyMode mode)
+			: this (Activator.CreateInstance<T>, mode)
+		{
+		}
+		
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="valueFactory"></param>
+        /// <param name="mode"></param>
+		public Lazy (Func<T> valueFactory, LazyThreadSafetyMode mode)
+		{
+			if (valueFactory == null)
+				throw new ArgumentNullException ("valueFactory");
+			this.factory = valueFactory;
+			if (mode != LazyThreadSafetyMode.None)
+				monitor = new object ();
+			this.mode = mode;
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+		// Don't trigger expensive initialization
+#if !NETCF
+		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
+#endif
+		public T Value {
+			get {
+				if (inited)
+					return value;
+				if (exception != null)
+					throw exception;
+
+				return InitValue ();
+			}
+		}
+
+		T InitValue ()
+		{
+			Func<T> init_factory;
+			T v;
+			
+			switch (mode) {
+			case LazyThreadSafetyMode.None:
+				init_factory = factory;
+				if (init_factory == null) {
+					if (exception == null)
+						throw new InvalidOperationException ("The initialization function tries to access Value on this instance");
+					throw exception;
+				}
+
+				try {
+					factory = null;
+					v = init_factory ();
+					value = v;
+					Thread.MemoryBarrier ();
+					inited = true;
+				} catch (Exception ex) {
+					exception = ex;
+					throw;
+				}
+				break;
+
+			case LazyThreadSafetyMode.PublicationOnly:
+				init_factory = factory;
+
+				//exceptions are ignored
+				if (init_factory != null)
+					v = init_factory ();
+				else
+					v = default (T);
+
+				lock (monitor) {
+					if (inited)
+						return value;
+					value = v;
+					Thread.MemoryBarrier ();
+					inited = true;
+					factory = null;
+				}
+				break;
+
+			case LazyThreadSafetyMode.ExecutionAndPublication:
+				lock (monitor) {
+					if (inited)
+						return value;
+
+					if (factory == null) {
+						if (exception == null)
+							throw new InvalidOperationException ("The initialization function tries to access Value on this instance");
+
+						throw exception;
+					}
+
+					init_factory = factory;
+					try {
+						factory = null;
+						v = init_factory ();
+						value = v;
+						Thread.MemoryBarrier ();
+						inited = true;
+					} catch (Exception ex) {
+						exception = ex;
+						throw;
+					}
+				}
+				break;
+
+			default:
+				throw new InvalidOperationException ("Invalid LazyThreadSafetyMode " + mode);
+			}
+
+			return value;
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+		public bool IsValueCreated {
+			get {
+				return inited;
+			}
+		}
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+		public override string ToString ()
+		{
+			if (inited)
+				return value.ToString ();
+			else
+				return "Value is not created";
+		}
+	}		
+}
+	

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -34,22 +34,22 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class ParallelWorkItemDispatcher : IWorkItemDispatcher
     {
-        private static Logger log = InternalTrace.GetLogger("WorkItemDispatcher");
+        private static readonly Logger log = InternalTrace.GetLogger("WorkItemDispatcher");
 
-        private int _levelOfParallelism;
+        private readonly int _levelOfParallelism;
         private int _itemsDispatched;
 
         // Non-STA
-        private WorkShift _parallelShift = new WorkShift("Parallel");
-        private WorkShift _nonParallelShift = new WorkShift("NonParallel");
-        private Lazy<WorkItemQueue> _parallelQueue;
-        private Lazy<WorkItemQueue> _nonParallelQueue;
+        private readonly WorkShift _parallelShift = new WorkShift("Parallel");
+        private readonly WorkShift _nonParallelShift = new WorkShift("NonParallel");
+        private readonly Lazy<WorkItemQueue> _parallelQueue;
+        private readonly Lazy<WorkItemQueue> _nonParallelQueue;
 
         // STA
 #if !NETCF
-        private WorkShift _nonParallelSTAShift = new WorkShift("NonParallelSTA");
-        private Lazy<WorkItemQueue> _parallelSTAQueue;
-        private Lazy<WorkItemQueue> _nonParallelSTAQueue;
+        private readonly WorkShift _nonParallelSTAShift = new WorkShift("NonParallelSTA");
+        private readonly Lazy<WorkItemQueue> _parallelSTAQueue;
+        private readonly Lazy<WorkItemQueue> _nonParallelSTAQueue;
 #endif
 
         // The first WorkItem to be dispatched, assumed to be top-level item

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -67,17 +67,17 @@ namespace NUnit.Framework.Internal.Execution
         private readonly ConcurrentQueue<WorkItem> _innerQueue = new ConcurrentQueue<WorkItem>();
 
         /* This event is used solely for the purpose of having an optimized sleep cycle when
-		 * we have to wait on an external event (Add or Remove for instance)
-		 */
+	     * we have to wait on an external event (Add or Remove for instance)
+	     */
         private readonly ManualResetEventSlim _mreAdd = new ManualResetEventSlim(false);
 
         /* The whole idea is to use these two values in a transactional
-		 * way to track and manage the actual data inside the underlying lock-free collection
-		 * instead of directly working with it or using external locking.
-		 *
-		 * They are manipulated with CAS and are guaranteed to increase over time and use
-		 * of the instance thus preventing ABA problems.
-		 */
+         * way to track and manage the actual data inside the underlying lock-free collection
+         * instead of directly working with it or using external locking.
+         *
+         * They are manipulated with CAS and are guaranteed to increase over time and use
+         * of the instance thus preventing ABA problems.
+         */
         private int _addId = int.MinValue;
         private int _removeId = int.MinValue;
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -87,10 +87,10 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="name">The name of the queue.</param>
         public WorkItemQueue(string name)
         {
-            this.Name = name;
-            this.State = WorkItemQueueState.Paused;
-            this.MaxCount = 0;
-            this.ItemsProcessed = 0;
+            Name = name;
+            State = WorkItemQueueState.Paused;
+            MaxCount = 0;
+            ItemsProcessed = 0;
         }
 
         #region Properties
@@ -169,9 +169,7 @@ namespace NUnit.Framework.Internal.Execution
                 _mreAdd.Set();
 
                 return;
-
             } while (true);
-            
         }
 
         /// <summary>
@@ -246,7 +244,6 @@ namespace NUnit.Framework.Internal.Execution
 
             if (Interlocked.Exchange(ref _state, (int)WorkItemQueueState.Stopped) != (int)WorkItemQueueState.Stopped)
                 _mreAdd.Set();
-            
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -67,8 +67,8 @@ namespace NUnit.Framework.Internal.Execution
         private readonly ConcurrentQueue<WorkItem> _innerQueue = new ConcurrentQueue<WorkItem>();
 
         /* This event is used solely for the purpose of having an optimized sleep cycle when
-	     * we have to wait on an external event (Add or Remove for instance)
-	     */
+         * we have to wait on an external event (Add or Remove for instance)
+         */
         private readonly ManualResetEventSlim _mreAdd = new ManualResetEventSlim(false);
 
         /* The whole idea is to use these two values in a transactional

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -37,6 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\nunit.framework.xml</DocumentationFile>
+    <NoWarn>1699,1591</NoWarn>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -144,6 +145,9 @@
     <Compile Include="Compatibility\System.Linq\SortContext.cs" />
     <Compile Include="Compatibility\System.Linq\SortDirection.cs" />
     <Compile Include="Compatibility\System.Linq\SortSequenceContext.cs" />
+    <Compile Include="Compatibility\System.Threading\LazyThreadSafetyMode.cs" />
+    <Compile Include="Compatibility\System.Threading\SpinWait.cs" />
+    <Compile Include="Compatibility\System\Lazy.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraint.cs" />
     <Compile Include="Constraints\EqualConstraintResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -125,6 +125,9 @@
     <Compile Include="Compatibility\System.Collections.Concurrent\ConcurrentQueue.cs" />
     <Compile Include="Compatibility\System.Collections.Concurrent\IProducerConsumerCollection.cs" />
     <Compile Include="Compatibility\System.Collections\CollectionDebuggerView.cs" />
+    <Compile Include="Compatibility\System.Threading\LazyThreadSafetyMode.cs" />
+    <Compile Include="Compatibility\System.Threading\SpinWait.cs" />
+    <Compile Include="Compatibility\System\Lazy.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraint.cs" />
     <Compile Include="Constraints\EqualConstraintResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -203,6 +203,9 @@
     <Compile Include="Compatibility\ReaderWriterLockSlim.cs" />
     <Compile Include="Compatibility\System.Collections.Concurrent\ConcurrentQueue.cs" />
     <Compile Include="Compatibility\System.Collections.Concurrent\IProducerConsumerCollection.cs" />
+    <Compile Include="Compatibility\System.Threading\LazyThreadSafetyMode.cs" />
+    <Compile Include="Compatibility\System.Threading\SpinWait.cs" />
+    <Compile Include="Compatibility\System\Lazy.cs" />
     <Compile Include="Constraints\AllItemsConstraint.cs" />
     <Compile Include="Constraints\AndConstraint.cs" />
     <Compile Include="Constraints\AssignableFromConstraint.cs" />

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
@@ -25,6 +25,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <Externalconsole>true</Externalconsole>
     <IntermediateOutputPath>obj\$(Configuration)\net-2.0\</IntermediateOutputPath>
+    <NoWarn>1699,1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1699,1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Internal.Execution
 
             while (iters-- > 0 && alive > 0)
             {
-                Thread.Sleep(20);  // Allow time for workers to stop
+                Thread.Sleep(60);  // Allow time for workers to stop
 
                 alive = 0;
                 foreach (var worker in workers)


### PR DESCRIPTION
Fixes #1435 

Makes both ParallelWorkItemDispatcher and WorkItemQueue lockless threadsafe.

It adds the mono SpinWait, Lazy and LazyThreadSafetyMode to the 2.0, 3.5, and CF builds.