### PR TITLE
 #1483 Remoting exceptions during test execution

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -43,5 +43,10 @@ namespace NUnit.Engine.Runners
             foreach (var listener in Listeners)
                 listener.OnTestEvent(report);
         }
+
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Give the TestEventDispatcher infinite life time to prevent it from being
disconnected during a long running test run. Somewhere between 2 and 3 minutes
test running time was enough for all test results after that test to fail to report back.

I've not added a unit test for this change, since the time required to reproduce the error was 3 minutes. I've verified that this test case now works.

    [TestFixture]
    public class LongRunningTest`
    {
        public static IEnumerable<TimeSpan> SleepTimes
        {
            get
            {
                yield return TimeSpan.FromSeconds(120); // Succeeded before
                yield return TimeSpan.FromSeconds(180); // Failed before this change
            }
        }

        [Test]
        [TestCaseSource(nameof(SleepTimes))]
        public void ShallBeAbleToExecuteForSeconds(TimeSpan executionTime)
        {
            Thread.Sleep(executionTime);
            TestContext.WriteLine($"Slept for {executionTime}");
        }
    }