### PR TITLE
Apply same fix to nunitlite as to nunit3-console

### DIFF
--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -194,7 +194,7 @@ namespace NUnitLite
             if (suite != null)
             {
                 xmlWriter.WriteStartElement("test-suite");
-                xmlWriter.WriteAttributeString("type", suite.TestType);
+                xmlWriter.WriteAttributeString("type", suite.TestType == "ParameterizedMethod" ? "ParameterizedTest" : suite.TestType);
                 xmlWriter.WriteAttributeString("name", suite.TestType == "Assembly" || suite.TestType == "Project"
                     ? result.Test.FullName
                     : result.Test.Name);


### PR DESCRIPTION
Made the equivalent one-line change to nunitlite as was made to nunit3-console.

NOTE: the two codebases are separate because the console builds it's output from the nunit3 XML while nunitlite uses the internal object references in the framework. For a small loss in efficiency, we could make the nunitlite version work the same as the console version. This might be advisable.