### PR TITLE
Enable / Disable Extensions

### DIFF
--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>net-4.5/nunit.framework.tests.dll --wait --inprocess</Commandlineparameters>
+    <Commandlineparameters>nunit.engine.tests.dll --inprocess</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
@@ -1,0 +1,62 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Engine
+{
+    public interface IExtensionNode
+    {
+        /// <summary>
+        /// Gets the full name of the Type of the extension object.
+        /// </summary>
+        string TypeName { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
+        /// </summary>
+        /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        bool Enabled { get; set; }
+    
+        /// <summary>
+        /// Gets the unique string identifying the ExtensionPoint for which 
+        /// this Extension is intended. This identifier may be supplied by the attribute
+        /// marking the extension or deduced by NUnit from the Type of the extension class.
+        /// </summary>
+        string Path { get; }
+
+        /// <summary>
+        /// Gets an optional description of what the extension does.
+        /// </summary>
+        string Description { get; }
+    
+        /// <summary>
+        /// Gets the values for a named property. If the property
+        /// is not present, 
+        /// </summary>
+        /// <returns>The properties.</returns>
+        /// <param name="name">Name.</param>
+        IEnumerable<string> GetProperties(string name);
+    }
+}

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionPoint.cs
@@ -22,8 +22,9 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 
-namespace NUnit.Engine
+namespace NUnit.Engine.Extensibility
 {
     /// <summary>
     /// An ExtensionPoint represents a single point in the TestEngine
@@ -40,6 +41,16 @@ namespace NUnit.Engine
         /// Gets the description of this extension point. May be null.
         /// </summary>
         string Description { get; }
+
+        /// <summary>
+        /// Gets the FullName of the Type required for any extension to be installed at this extension point.
+        /// </summary>
+        string TypeName { get; }
+
+        /// <summary>
+        /// Gets an enumeration of IExtensionNodes for extensions installed on this extension point.
+        /// </summary>
+        IEnumerable<IExtensionNode> Extensions { get; }
     }
 }
 

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionPoint.cs
@@ -1,0 +1,45 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// An ExtensionPoint represents a single point in the TestEngine
+    /// that may be extended by user addins and extensions.
+    /// </summary>
+    public interface IExtensionPoint
+    {
+        /// <summary>
+        /// Gets the unique path identifying this extension point.
+        /// </summary>
+        string Path { get; }
+    
+        /// <summary>
+        /// Gets the description of this extension point. May be null.
+        /// </summary>
+        string Description { get; }
+    }
+}
+

--- a/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
@@ -23,49 +23,45 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Engine.Extensibility;
 
-namespace NUnit.Engine.Extensibility
+namespace NUnit.Engine
 {
     /// <summary>
-    /// The IExtensionNode interface is implemented by a class that represents a 
-    /// single extension being installed on a particular extension point.
+    /// The IExtensionService interface allows a runner to manage extensions.
     /// </summary>
-    public interface IExtensionNode
+    public interface IExtensionService
     {
-        /// <summary>
-        /// Gets the full name of the Type of the extension object.
-        /// </summary>
-        string TypeName { get; }
+        #region Public Properties
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="NUnit.Engine.Extensibility.IExtensionNode"/> is enabled.
+        /// Gets an enumeration of all ExtensionPoints in the engine.
         /// </summary>
-        /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
-        bool Enabled { get; }
-    
-        /// <summary>
-        /// Gets the unique string identifying the ExtensionPoint for which 
-        /// this Extension is intended. This identifier may be supplied by the attribute
-        /// marking the extension or deduced by NUnit from the Type of the extension class.
-        /// </summary>
-        string Path { get; }
+        IEnumerable<IExtensionPoint> ExtensionPoints { get; }
 
         /// <summary>
-        /// Gets an optional description of what the extension does.
+        /// Gets an enumeration of all installed Extensions.
         /// </summary>
-        string Description { get; }
+        IEnumerable<IExtensionNode> Extensions { get; }
 
         /// <summary>
-        /// Gets a collection of the names of all this extension's properties
+        /// Get an ExtensionPoint based on it's unique identifying path.
         /// </summary>
-        IEnumerable<string> PropertyNames { get; }
+        IExtensionPoint GetExtensionPoint(string path);
 
         /// <summary>
-        /// Gets a collection of the values of a particular named property
-        /// If none are present, returns an empty enumerator.
+        /// Get an enumeration of ExtensionNodes based on their identifying path.
         /// </summary>
-        /// <param name="name">The property name</param>
-        /// <returns>A collection of values</returns>
-        IEnumerable<string> GetValues(string name);
+        IEnumerable<IExtensionNode> GetExtensionNodes(string path);
+
+        /// <summary>
+        /// Enable or disable an extension
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <param name="enabled"></param>
+        void EnableExtension(string typeName, bool enabled);
+
+        #endregion
     }
 }
+

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -92,6 +92,8 @@
     <Compile Include="TestFilter.cs" />
     <Compile Include="TestPackage.cs" />
     <Compile Include="ITestRun.cs" />
+    <Compile Include="Extensibility\IExtensionPoint.cs" />
+    <Compile Include="Extensibility\IExtensionNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\nunit.snk">

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ITestRun.cs" />
     <Compile Include="Extensibility\IExtensionPoint.cs" />
     <Compile Include="Extensibility\IExtensionNode.cs" />
+    <Compile Include="IExtensionService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\nunit.snk">

--- a/src/NUnitEngine/nunit.engine.tests/DummyExtensions.cs
+++ b/src/NUnitEngine/nunit.engine.tests/DummyExtensions.cs
@@ -162,4 +162,13 @@ namespace NUnit.Engine.Tests
             throw new NotImplementedException();
         }
     }
+
+    [Extension(Enabled=false)]
+    public class DummyDisabledExtension : ITestEventListener
+    {
+        public void OnTestEvent(string report)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAttributeTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAttributeTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2015 Charlie Poole
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,40 +22,31 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework;
 
 namespace NUnit.Engine.Extensibility
 {
-    /// <summary>
-    /// The ExtensionAttribute is used to identify a class that is intended
-    /// to serve as an extension.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
-    public class ExtensionAttribute : Attribute
+    public class ExtensionAttributeTests
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NUnit.Engine.Extensibility.ExtensionAttribute"/> class.
-        /// </summary>
-        public ExtensionAttribute()
+        [Test]
+        public void IsEnabledByDefault()
         {
-            Enabled = true;
+            Assert.True(new ExtensionAttribute().Enabled);
         }
 
-        /// <summary>
-        /// A unique string identifying the ExtensionPoint for which this Extension is 
-        /// intended. This is an optional field provided NUnit is able to deduce the
-        /// ExtensionPoint from the Type of the extension class.
-        /// </summary>
-        public string Path { get; set; }
+        [Test]
+        public void MayBeExplicitlyDisabled()
+        {
+            var attr = new ExtensionAttribute() { Enabled = false };
+            Assert.False(attr.Enabled);
+        }
 
-        /// <summary>
-        /// An optional description of what the extension does.
-        /// </summary>
-        public string Description { get; set; }
-
-        /// <summary>
-        /// Flag indicating whether the extension is enabled.
-        /// </summary>
-        /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
-        public bool Enabled { get; set; }
+        [Test]
+        public void MayBeExplicitlyEnabled()
+        {
+            var attr = new ExtensionAttribute() { Enabled = true };
+            Assert.True(attr.Enabled);
+        }
     }
 }
+

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -133,7 +133,10 @@ namespace NUnit.Engine.Services.Tests
         {
             foreach (ExtensionNode node in _extensionService.Extensions)
                 if (node.TypeName == typeName)
+                {
+                    Assert.True(node.Enabled);
                     return;
+                }
             
             Assert.Fail("Couldn't find known Extension {0}", typeName);
         }
@@ -144,7 +147,34 @@ namespace NUnit.Engine.Services.Tests
             var ep = _extensionService.GetExtensionPoint(path);
             Assume.That(ep, Is.Not.Null);
 
-            Assert.That(ep.Extensions.Count, Is.EqualTo(1));
+            Assert.That(ep.Extensions.Count, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void ExtensionMayBeDisabledByDefault()
+        {
+            foreach (ExtensionNode node in _extensionService.Extensions)
+                if (node.TypeName == "NUnit.Engine.Tests.DummyDisabledExtension")
+                {
+                    Assert.False(node.Enabled);
+                    return;
+                }
+
+            Assert.Fail("Could not find DummyDisabledExtension");
+        }
+
+        [Test]
+        public void DisabledExtensionMayBeEnabled()
+        {
+            _extensionService.EnableExtension("NUnit.Engine.Tests.DummyDisabledExtension");
+            foreach (ExtensionNode node in _extensionService.Extensions)
+                if (node.TypeName == "NUnit.Engine.Tests.DummyDisabledExtension")
+                {
+                    Assert.True(node.Enabled);
+                    return;
+                }
+
+            Assert.Fail("Could not find DummyDisabledExtension");
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Services\TestFilteringTests.cs" />
     <Compile Include="TempResourceFile.cs" />
     <Compile Include="TestEngineResultTests.cs" />
+    <Compile Include="Extensibility\ExtensionAttributeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\NUnitFramework\framework\nunit.framework-2.0.csproj">
@@ -152,4 +153,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="Extensibility\" />
+  </ItemGroup>
 </Project>

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Extensibility
     /// on a particular extension point. It stores information needed to
     /// activate the extension object on a just-in-time basis.
     /// </summary>
-    public class ExtensionNode
+    public class ExtensionNode : IExtensionNode
     {
         private object _extensionObject;
         private Dictionary<string, List<string>> _properties = new Dictionary<string, List<string>>();
@@ -57,12 +57,12 @@ namespace NUnit.Engine.Extensibility
         public string AssemblyPath { get; private set; }
 
         /// <summary>
-        /// Gets the full name of the Type of the assembly object.
+        /// Gets the full name of the Type of the extension object.
         /// </summary>
         public string TypeName { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
+        /// Gets or sets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
         public bool Enabled	{ get; set; }

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -34,8 +34,6 @@ namespace NUnit.Engine.Extensibility
     public class ExtensionNode
     {
         private object _extensionObject;
-        private string _assemblyPath;
-        private string _typeName;
         private Dictionary<string, List<string>> _properties = new Dictionary<string, List<string>>();
 
 
@@ -46,8 +44,9 @@ namespace NUnit.Engine.Extensibility
         /// <param name="typeName">The full name of the Type of the extension object.</param>
         public ExtensionNode(string assemblyPath, string typeName)
         {
-            _assemblyPath = assemblyPath;
-            _typeName = typeName;
+            AssemblyPath = assemblyPath;
+            TypeName = typeName;
+			Enabled = true; // By default
         }
 
         #region Properties
@@ -55,18 +54,18 @@ namespace NUnit.Engine.Extensibility
         /// <summary>
         /// Gets the path to the assembly where the extension is defined.
         /// </summary>
-        public string AssemblyPath
-        {
-            get { return _assemblyPath;  }
-        }
+        public string AssemblyPath { get; private set; }
 
         /// <summary>
         /// Gets the full name of the Type of the assembly object.
         /// </summary>
-        public string TypeName
-        {
-            get { return _typeName;  }
-        }
+        public string TypeName { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
+        /// </summary>
+        /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        public bool Enabled	{ get; set; }
 
         /// <summary>
         /// Gets an object of the specified extension type, loading the Assembly
@@ -106,7 +105,7 @@ namespace NUnit.Engine.Extensibility
         /// </summary>
         public object CreateExtensionObject(params object[] args)
         {
-            return AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(_assemblyPath, _typeName, false, 0, null, args, null, null, null);
+            return AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(AssemblyPath, TypeName, false, 0, null, args, null, null, null);
         }
 
         public void AddProperty(string name, string val)

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -46,15 +46,10 @@ namespace NUnit.Engine.Extensibility
         {
             AssemblyPath = assemblyPath;
             TypeName = typeName;
-			Enabled = true; // By default
+            Enabled = true; // By default
         }
 
-        #region Properties
-
-        /// <summary>
-        /// Gets the path to the assembly where the extension is defined.
-        /// </summary>
-        public string AssemblyPath { get; private set; }
+        #region IExtensionNode Members
 
         /// <summary>
         /// Gets the full name of the Type of the extension object.
@@ -66,6 +61,49 @@ namespace NUnit.Engine.Extensibility
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
         public bool Enabled	{ get; set; }
+
+        /// <summary>
+        /// Gets and sets the unique string identifying the ExtensionPoint for which 
+        /// this Extension is intended. This identifier may be supplied by the attribute
+        /// marking the extension or deduced by NUnit from the Type of the extension class.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// An optional description of what the extension does.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets a collection of the names of all this extension's properties
+        /// </summary>
+        public IEnumerable<string> PropertyNames
+        {
+            get { return _properties.Keys; }
+        }
+
+        /// <summary>
+        /// Gets a collection of the values of a particular named property.
+        /// If none are present, returns an empty enumerator.
+        /// </summary>
+        /// <param name="name">The property name</param>
+        /// <returns>A collection of values</returns>
+        public IEnumerable<string> GetValues(string name)
+        {
+            if (_properties.ContainsKey(name))
+                return _properties[name];
+            else
+                return new string[0];
+        }
+
+        #endregion
+
+        #region Other Properties
+
+        /// <summary>
+        /// Gets the path to the assembly where the extension is defined.
+        /// </summary>
+        public string AssemblyPath { get; private set; }
 
         /// <summary>
         /// Gets an object of the specified extension type, loading the Assembly
@@ -83,18 +121,6 @@ namespace NUnit.Engine.Extensibility
                 return _extensionObject;
             }
         }
-
-        /// <summary>
-        /// Gets and sets the unique string identifying the ExtensionPoint for which 
-        /// this Extension is intended. This identifier may be supplied by the attribute
-        /// marking the extension or deduced by NUnit from the Type of the extension class.
-        /// </summary>
-        public string Path { get; set; }
-
-        /// <summary>
-        /// An optional description of what the extension does.
-        /// </summary>
-        public string Description { get; set; }
 
         #endregion
 
@@ -118,16 +144,6 @@ namespace NUnit.Engine.Extensibility
                 list.Add(val);
                 _properties.Add(name, list);
             }
-        }
-
-        public IEnumerable<string> GetProperties(string name)
-        {
-            return _properties.ContainsKey(name) ? _properties[name] : new List<string>();
-        }
-
-        public string GetProperty(string name)
-        {
-            return _properties.ContainsKey(name) ? _properties[name][0] : null;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
@@ -27,10 +27,10 @@ using System.Collections.Generic;
 namespace NUnit.Engine.Extensibility
 {
     /// <summary>
-    /// ExtensionPoint represents a single point in the TestEngine
+    /// An ExtensionPoint represents a single point in the TestEngine
     /// that may be extended by user addins and extensions.
     /// </summary>
-    public class ExtensionPoint
+    public class ExtensionPoint : IExtensionPoint
     {
         /// <summary>
         /// Construct an ExtensionPoint

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
@@ -40,9 +40,11 @@ namespace NUnit.Engine.Extensibility
         public ExtensionPoint(string path, Type type)
         {
             Path = path;
-            Type = type;
+            TypeName = type.FullName;
             Extensions = new List<ExtensionNode>();
         }
+
+        #region IExtensionPoint Members
 
         /// <summary>
         /// Gets the unique path identifying this extension point.
@@ -50,19 +52,35 @@ namespace NUnit.Engine.Extensibility
         public string Path { get; private set; }
 
         /// <summary>
-        /// Gets the Type of any extension object to be installed at this extension point.
-        /// </summary>
-        public Type Type { get; private set; }
-
-        /// <summary>
         /// Gets and sets the optional description of this extension point.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
+        /// Gets the FullName of the Type required for any extension to be installed at this extension point.
+        /// </summary>
+        public string TypeName { get; private set; }
+
+        /// <summary>
+        /// Gets an enumeration of IExtensionNodes for extensions installed on this extension point.
+        /// </summary>
+        IEnumerable<IExtensionNode> IExtensionPoint.Extensions
+        {
+            get { return this.Extensions.ToArray(); }
+        }
+
+        #endregion
+
+        #region Other Properties
+
+        /// <summary>
         /// Gets a list of ExtensionNodes for extensions installed on this extension point.
         /// </summary>
         public List<ExtensionNode> Extensions { get; private set; }
+
+        #endregion
+
+        #region Public Methods
 
         /// <summary>
         /// Install an extension at this extension point. If the
@@ -94,5 +112,7 @@ namespace NUnit.Engine.Extensibility
         {
             Extensions.Remove(extension);
         }
+
+        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Services
     /// maintains them in a database. It can return extension nodes or 
     /// actual extension objects on request.
     /// </summary>
-    public class ExtensionService : Service
+    public class ExtensionService : Service, IExtensionService
     {
         static Logger log = InternalTrace.GetLogger(typeof(ExtensionService));
 
@@ -46,16 +46,49 @@ namespace NUnit.Engine.Services
 
         private List<ExtensionNode> _extensions = new List<ExtensionNode>();
 
-        #region Public Properties
+        #region IExtensionService Members
 
-        public IEnumerable<ExtensionPoint> ExtensionPoints
+        /// <summary>
+        /// Gets an enumeration of all ExtensionPoints in the engine.
+        /// </summary>
+        public IEnumerable<IExtensionPoint> ExtensionPoints
         {
-            get { return _extensionPoints; }
+            get { return _extensionPoints.ToArray(); }
         }
 
-        public IEnumerable<ExtensionNode> Extensions
+        /// <summary>
+        /// Gets an enumeration of all installed Extensions.
+        /// </summary>
+        public IEnumerable<IExtensionNode> Extensions
         {
-            get { return _extensions;  }
+            get { return _extensions.ToArray();  }
+        }
+
+        /// <summary>
+        /// Get an ExtensionPoint based on it's unique identifying path.
+        /// </summary>
+        IExtensionPoint IExtensionService.GetExtensionPoint(string path)
+        {
+            return this.GetExtensionPoint(path);
+        }
+
+        /// <summary>
+        /// Get an enumeration of ExtensionNodes based on their identifying path.
+        /// </summary>
+        IEnumerable<IExtensionNode> IExtensionService.GetExtensionNodes(string path)
+        {
+            foreach (var node in this.GetExtensionNodes(path))
+                yield return node;
+        }
+
+        /// <summary>
+        /// Enable or disable an extension
+        /// </summary>
+        public void EnableExtension(string typeName, bool enabled)
+        {
+            foreach (var node in _extensions)
+                if (node.TypeName == typeName)
+                    node.Enabled = enabled;
         }
 
         #endregion
@@ -76,7 +109,7 @@ namespace NUnit.Engine.Services
         public ExtensionPoint GetExtensionPoint(Type type)
         {
             foreach (var ep in _extensionPoints)
-                if (ep.Type == type)
+                if (ep.TypeName == type.FullName)
                     return ep;
 
             return null;
@@ -88,7 +121,7 @@ namespace NUnit.Engine.Services
         public ExtensionPoint GetExtensionPoint(TypeReference type)
         {
             foreach (var ep in _extensionPoints)
-                if (ep.Type.FullName == type.FullName)
+                if (ep.TypeName == type.FullName)
                     return ep;
 
             return null;
@@ -126,13 +159,6 @@ namespace NUnit.Engine.Services
         {
             foreach (var node in GetExtensionNodes<T>())
               	 yield return (T)node.ExtensionObject;
-        }
-
-        public void EnableExtension(string typeName)
-        {
-            foreach (var node in Extensions)
-                if (node.TypeName == typeName)
-                    node.Enabled = true;
         }
 
         #endregion
@@ -190,7 +216,7 @@ namespace NUnit.Engine.Services
                 _extensionPoints.Add(ep);
                 _pathIndex.Add(ep.Path, ep);
 
-                log.Info("  Found Path={0}, Type={1}", ep.Path, ep.Type.Name);
+                log.Info("  Found Path={0}, Type={1}", ep.Path, ep.TypeName);
             }
 
             foreach (Type type in assembly.GetExportedTypes())
@@ -215,7 +241,7 @@ namespace NUnit.Engine.Services
                     _extensionPoints.Add(ep);
                     _pathIndex.Add(path, ep);
 
-                    log.Info("  Found Path={0}, Type={1}", ep.Path, ep.Type.Name);
+                    log.Info("  Found Path={0}, Type={1}", ep.Path, ep.TypeName);
                 }
             }
         }

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -109,7 +109,7 @@ namespace NUnit.Engine.Services
                     {
                         foreach (var node in extensionService.GetExtensionNodes<IProjectLoader>())
                         {
-                            foreach (string ext in node.GetProperties("FileExtension"))
+                            foreach (string ext in node.GetValues("FileExtension"))
                             {
                                 if (ext != null)
                                 {

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -43,12 +43,9 @@ namespace NUnit.Engine.Services
                     var formatList = new List<string>(BUILT_IN_FORMATS);
 
                     foreach (var node in _extensionNodes)
-                    {
-                        var format = node.GetProperty("Format");
-                        if (format != null)
+                        foreach (var format in node.GetValues("Format"))
                             formatList.Add(format);
-                    }
-
+ 
                     _formats = formatList.ToArray();
                 }
 
@@ -74,8 +71,9 @@ namespace NUnit.Engine.Services
                     return new XmlTransformResultWriter(args);
                 default:
                     foreach (var node in _extensionNodes)
-                        if (node.GetProperty("Format") == format)
-                            return node.ExtensionObject as IResultWriter;
+                        foreach (var supported in node.GetValues("Format"))
+                            if (supported == format)
+                                return node.ExtensionObject as IResultWriter;
 
                     return null;
             }


### PR DESCRIPTION
This PR is the first step in adding the feature described in #1010. Since I'm working on this in stages, it can be merged whenever we like and I'll just continue using a new PR.

The initial commit implements the ability for extensions to be enabled and disabled individually. These classic example of needing this would be for an extension to handle team city service messages. We would not want the messages to be issued all the time, but only when running under team city. A property of the TestPackage (NYI) could be used to "turn on" the extension.

 * Extensions continue to be enabled by default, as this is what works best for most extensions
 * Extensions that are present but should only be enabled by command may be initially disabled by adding a named property to the ExtensionAttribute.
 * ExtensionService now has an entry that allows enabling an extension by specifying its full type name.
 * Disabled extensions are never instantiated.
 * The tests demonstrates that all defaults still work and that existing extensions are enabled. A dummy disabled extension is used to test default behavior and enabling the extension.

Whether we merge right away or not, this would be a good point to review the API changes.