### PR TITLE
Enable use of TestContext.TestDirectory when tests are being loaded.

### DIFF
--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -158,6 +158,7 @@ namespace NUnit.Framework.Api
                 Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assemblyName, settings);
+
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -104,7 +105,16 @@ namespace NUnit.Framework
         /// </summary>
         public string TestDirectory
         {
-            get { return AssemblyHelper.GetDirectoryName(_testExecutionContext.CurrentTest.TypeInfo.Assembly); }
+            get
+            {
+                Test test = _testExecutionContext.CurrentTest;
+                if (test != null)
+                    return AssemblyHelper.GetDirectoryName(test.TypeInfo.Assembly);
+
+                // Test is null, we may be loading tests rather than executing.
+                // Assume that calling assembly is the test assembly.
+                return AssemblyHelper.GetDirectoryName(Assembly.GetCallingAssembly());
+            }
         }
 #endif
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.IO;
+using System.Collections.Generic;
 using NUnit.Framework.Interfaces;
 using NUnit.TestData.TestContextData;
 using NUnit.TestUtilities;
@@ -54,6 +55,17 @@ namespace NUnit.Framework.Tests
         public void ConstructorCanAccessTestDirectory()
         {
             Assert.That(_testDirectory, Is.Not.Null);
+        }
+
+        [TestCaseSource("MySource")]
+        public void TestCaseSourceCanAccessTestDirectory(string testDirectory)
+        {
+            Assert.That(testDirectory, Is.EqualTo(_testDirectory));
+        }
+
+        static IEnumerable<string> MySource()
+        {
+            yield return TestContext.CurrentContext.TestDirectory;
         }
 #endif
 


### PR DESCRIPTION
Fixes #1241.

I ended up checking for a null CurrentTest and using the calling assembly in that case. This allows TestContext.TestDirectory to work from within a TestCaseSource method, for example.

At the same time, I did some refactoring of TestExecutionContext to make it easier to understand the three different approaches used to hold current context depending on the build platform.