### PR TITLE
Make teamcity event handler an engine extension

### DIFF
--- a/nunit.sln
+++ b/nunit.sln
@@ -212,6 +212,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit.testdata-3.5", "src\N
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit.framework.tests-3.5", "src\NUnitFramework\tests\nunit.framework.tests-3.5.csproj", "{B93FC354-D59D-4650-84E4-7FCA7D51689A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "teamcity-event-listener", "src\NUnitEngine\Addins\teamcity-event-listener\teamcity-event-listener.csproj", "{A867079B-A172-4DAE-9549-63B331092A23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -470,6 +472,10 @@ Global
 		{B93FC354-D59D-4650-84E4-7FCA7D51689A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B93FC354-D59D-4650-84E4-7FCA7D51689A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B93FC354-D59D-4650-84E4-7FCA7D51689A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A867079B-A172-4DAE-9549-63B331092A23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A867079B-A172-4DAE-9549-63B331092A23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A867079B-A172-4DAE-9549-63B331092A23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A867079B-A172-4DAE-9549-63B331092A23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -552,6 +558,7 @@ Global
 		{C6156B98-923A-474B-B257-29107476E93C} = {49BF96D3-3F1B-4553-BE55-296FA7C3F659}
 		{520F4C89-51B6-49D6-9ED7-4523048C0154} = {49BF96D3-3F1B-4553-BE55-296FA7C3F659}
 		{B93FC354-D59D-4650-84E4-7FCA7D51689A} = {49BF96D3-3F1B-4553-BE55-296FA7C3F659}
+		{A867079B-A172-4DAE-9549-63B331092A23} = {B923C1E7-54DD-4E79-A1A9-B21123863B04}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\NUnitFramework\tests\nunitlite.tests-2.0.csproj

--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -48,7 +48,7 @@ namespace NUnit.Common
 
         internal CommandLineOptions(IDefaultOptionsProvider defaultOptionsProvider, params string[] args)
         {
-            // Apply default oprions
+            // Apply default options
             if (defaultOptionsProvider == null) throw new ArgumentNullException("defaultOptionsProvider");
 #if !PORTABLE
             TeamCity = defaultOptionsProvider.TeamCity;

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -67,7 +67,6 @@
     <Compile Include="MakeTestPackageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultReporterTests.cs" />
-    <Compile Include="TeamCityServiceMessagePublisherTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestListWithEmptyLine.tst">

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -55,6 +55,7 @@ namespace NUnit.ConsoleRunner
         private ConsoleOptions _options;
         private IResultService _resultService;
         private ITestFilterService _filterService;
+        private IExtensionService _extensionService;
 
         private ExtendedTextWriter _outWriter;
         private TextWriter _errorWriter = Console.Error;
@@ -80,6 +81,10 @@ namespace NUnit.ConsoleRunner
 
             _resultService = _engine.Services.GetService<IResultService>();
             _filterService = _engine.Services.GetService<ITestFilterService>();
+            _extensionService = _engine.Services.GetService<IExtensionService>();
+
+            // Enable TeamCityEventListener immediately, before the console is redirected
+            _extensionService.EnableExtension("NUnit.Engine.Listeners.TeamCityEventListener", _options.TeamCity);
         }
 
         #endregion
@@ -172,7 +177,7 @@ namespace NUnit.ConsoleRunner
                 using (ITestRunner runner = _engine.GetRunner(package))
                 using (var output = CreateOutputWriter())
                 {
-                    var eventHandler = new TestEventHandler(output, labels, _options.TeamCity); 
+                    var eventHandler = new TestEventHandler(output, labels); 
 
                     result = runner.Run(eventHandler, filter);
                 }

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -38,16 +38,11 @@ namespace NUnit.ConsoleRunner
     {
         private readonly string _displayLabels;
         private readonly TextWriter _outWriter;
-        private readonly TeamCityServiceMessagePublisher _teamCity;
 
-        public TestEventHandler(TextWriter outWriter, string displayLabels, bool teamCity)
+        public TestEventHandler(TextWriter outWriter, string displayLabels)
         {
             _displayLabels = displayLabels;
             _outWriter = outWriter;
-            if (teamCity)
-            {
-                _teamCity = new TeamCityServiceMessagePublisher(outWriter);
-            }
         }
 
         #region ITestEventHandler Members
@@ -68,11 +63,6 @@ namespace NUnit.ConsoleRunner
                     SuiteFinished(testEvent);
                     break;
             }
-
-            if (_teamCity != null)
-            {
-                _teamCity.RegisterMessage(testEvent);
-            }            
         }
 
         #endregion

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -113,7 +113,6 @@
     <Compile Include="Utilities\SaveConsoleOutput.cs" />
     <Compile Include="ResultReporter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utilities\TeamCityServiceMessagePublisher.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/NUnitEngine/Addins/addin-tests/TeamCityEventListenerTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/TeamCityEventListenerTests.cs
@@ -25,15 +25,14 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using NUnit.Framework;
-using NUnit.ConsoleRunner.Utilities;
 
-namespace NUnit.ConsoleRunner.Tests
+namespace NUnit.Engine.Listeners
 {
     using System;
 
     [TestFixture]
     
-    public class TeamCityServiceMessagePublisherTests
+    public class TeamCityEventListenerTests
     {
         private StringBuilder _output;
         private StringWriter _outputWriter;
@@ -378,9 +377,9 @@ namespace NUnit.ConsoleRunner.Tests
             return CreateMessage(string.Format("<test-case id=\"{0}\" {1} name=\"{2}\" fullname=\"{2}\" runstate=\"Runnable\" result=\"Failed\" duration=\"{3}\" asserts=\"0\"><properties><property name=\"_CATEGORIES\" value=\"F\" /></properties><failure><message><![CDATA[{4}]]></message><stack-trace><![CDATA[{5}]]></stack-trace></failure></test-case>", id, GetNamedAttr("parentId", parentId), name, duration, message, stackTrace));
         }
 
-        private TeamCityServiceMessagePublisher CreateInstance()
+        private TeamCityEventListener CreateInstance()
         {
-            return new TeamCityServiceMessagePublisher(_outputWriter);
+            return new TeamCityEventListener(_outputWriter);
         }
 
         private static string GetNamedAttr(string attrName, string attrValue)

--- a/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
+++ b/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="NUnitProjectLoaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="resources\TestResource.cs" />
+    <Compile Include="TeamCityEventListenerTests.cs" />
     <Compile Include="TempResourceFile.cs" />
     <Compile Include="VisualStudioProjectLoaderTests.cs" />
     <Compile Include="VSProjectTests.cs" />
@@ -54,6 +55,10 @@
     <ProjectReference Include="..\nunit-project-loader\nunit-project-loader.csproj">
       <Project>{E71A76CA-0089-4E1A-A7FB-210429DBED6E}</Project>
       <Name>nunit-project-loader</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\teamcity-event-listener\teamcity-event-listener.csproj">
+      <Project>{a867079b-a172-4dae-9549-63b331092a23}</Project>
+      <Name>teamcity-event-listener</Name>
     </ProjectReference>
     <ProjectReference Include="..\vs-project-loader\vs-project-loader.csproj">
       <Project>{96181317-7B6F-49F0-B283-6E804D41C8AF}</Project>

--- a/src/NUnitEngine/Addins/teamcity-event-listener/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("teamcity-event-listener")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("teamcity-event-listener")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a867079b-a172-4dae-9549-63b331092a23")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/teamcity-event-listener/SafeAttributeAccess.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/SafeAttributeAccess.cs
@@ -1,0 +1,53 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Xml;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
+    sealed class ExtensionAttribute : Attribute { }
+}
+
+namespace NUnit.Engine.Listeners
+{
+    /// <summary>
+    /// SafeAttributeAccess provides an extension method for accessing XML attributes.
+    /// </summary>
+    public static class SafeAttributeAccess
+    {
+        /// <summary>
+        /// Gets the value of the given attribute.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="name">The name.</param>
+        /// <returns></returns>
+        public static string GetAttribute(this XmlNode result, string name)
+        {
+            XmlAttribute attr = result.Attributes[name];
+
+            return attr == null ? null : attr.Value;
+        }
+    }
+}

--- a/src/NUnitEngine/Addins/teamcity-event-listener/teamcity-event-listener.csproj
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/teamcity-event-listener.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A867079B-A172-4DAE-9549-63B331092A23}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>teamcity_event_listener</RootNamespace>
+    <AssemblyName>teamcity-event-listener</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\bin\Debug\addins\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\bin\Release\addins\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TeamCityEventListener.cs" />
+    <Compile Include="SafeAttributeAccess.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\nunit.engine.api\nunit.engine.api.csproj">
+      <Project>{775fad50-3623-4922-97c4-dfb29a8be4c7}</Project>
+      <Name>nunit.engine.api</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Internal.Tests
         [TestCase("*/v2-tests/*.dll", 2)]
         [TestCase("add*/v?-*/*.dll", 2)]
         [TestCase("**/v2-tests/*.dll", 2)]
-        [TestCase("addins/**/*.dll", 7)]
+        [TestCase("addins/**/*.dll", 8)]
         [TestCase("addins/../net-*/nunit.framework.dll", 4)]
         public void GetFiles(string pattern, int count)
         {

--- a/src/NUnitEngine/nunit.engine/nunit.engine.addins
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.addins
@@ -2,3 +2,4 @@
 addins/nunit-v2-result-writer.dll
 addins/nunit-project-loader.dll
 addins/vs-project-loader.dll
+addins/teamcity-event-listener.dll


### PR DESCRIPTION
Fixes #1225 

I made the code that was previously part of the console runner into an extension for the engine, making minimal changes so it would work. All teamcity-related code is now gone from the console runner except for:
 * Recognizing the --teamcity option
 * Recognizing the environment variable set by TeamCity
 * Enabling / Disabling the extension as needed.

I'd like  both @rprouse and @NikolayPianikov to review this before we merge.