### PR TITLE
Detect Portable, Silverlight and Compact and give error message

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -59,7 +59,8 @@ namespace NUnit.Engine.Services.Tests
         {
             var driver = _driverService.GetDriver(
                 AppDomain.CurrentDomain,
-                Path.Combine(TestContext.CurrentContext.TestDirectory, fileName));
+                Path.Combine(TestContext.CurrentContext.TestDirectory, fileName),
+                null);
 
             Assert.That(driver, Is.InstanceOf(expectedType));
         }

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -80,7 +80,7 @@ namespace NUnit.Engine.Drivers
             }
             catch (SerializationException ex)
             {
-                throw new NUnitEngineException("The NUnit 3.0 driver does not support the portable version of NUnit. Use a platform specific runner.", ex);
+                throw new NUnitEngineException("The NUnit 3.0 driver cannot support this test assembly. Use a platform specific runner.", ex);
             }
 
             CallbackHandler handler = new CallbackHandler();

--- a/src/NUnitEngine/nunit.engine/IDriverService.cs
+++ b/src/NUnitEngine/nunit.engine/IDriverService.cs
@@ -37,7 +37,8 @@ namespace NUnit.Engine
         /// </summary>
         /// <param name="domain">The AppDomain in which to run the tests</param>
         /// <param name="assemblyPath">The path to the test assembly</param>
+        /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <returns></returns>
-        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath);
+        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -101,10 +101,14 @@ namespace NUnit.Engine.Runners
                 if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()
                     && subPackage.GetSetting(PackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
                 {
+                    // It's OK to do this in the loop because the Add method 
+                    // checks to see if the path is already present.
                     _assemblyResolver.AddPathFromFile(testFile);
                 }
 
-                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile);
+                var targetFramework = subPackage.GetSetting(PackageSettings.ImageTargetFrameworkName, (string)null);
+
+                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework);
                 driver.ID = TestPackage.ID;
                 result.Add(driver.Load(testFile, subPackage.Settings));
                 _drivers.Add(driver);

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -47,14 +47,22 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="domain">The AppDomain to use for the tests</param>
         /// <param name="assemblyPath">The full path to the test assembly</param>
+        /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <returns></returns>
-        public IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath)
+        public IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework)
         {
             if (!File.Exists(assemblyPath))
                 return new NotRunnableFrameworkDriver(assemblyPath, "File not found: " + assemblyPath);
 
             if (!PathUtils.IsAssemblyFileType(assemblyPath))
                 return new NotRunnableFrameworkDriver(assemblyPath, "File type is not supported");
+
+            if (targetFramework != null)
+            {
+                var platform = targetFramework.Split(new char[] { ',' })[0];
+                if (platform == "Silverlight" || platform == ".NETPortable" || platform == ".NETCompactFramework")
+                    return new NotRunnableFrameworkDriver(assemblyPath, platform + " test assemblies are not yet supported by the engine");
+            }
 
             try
             {

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -211,6 +211,20 @@ namespace NUnit.Engine.Services
                         requiresAssemblyResolver = true;
                     }
                 }
+
+                if (frameworkName == null)
+                {
+                    foreach (var reference in module.AssemblyReferences)
+                        if (reference.Name == "mscorlib" && BitConverter.ToUInt64(reference.PublicKeyToken, 0) == 0xac22333d05b89d96)
+                        {
+                            // We assume 3.5, since that's all we are supporting
+                            // Could be extended to other versions if necessary
+                            // Format for FrameworkName is invented - it is not
+                            // known if any compilers supporting CF use the attribute
+                            frameworkName = ".NETCompactFramework,Version=3.5";
+                            break;
+                        }
+                }
             }
 
             if (targetVersion.Major > 0)


### PR DESCRIPTION
This is a small step toward resolving #1138. It correctly detects Portable and Silverlight builds by use of the TargetFrameworkAttribute and CF builds by the public key token that is used. For each of these, the driver service refuses to work and returns an error. The error applies only to the specific assembly, in case multiple assemblies are being run, and the execution is not terminated.