### PR TITLE
Ensure only one event is processed at a time

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -31,6 +31,8 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public class TestEventDispatcher : MarshalByRefObject, ITestEventListener
     {
+        private object _eventLock = new object();
+
         public TestEventDispatcher()
         {
             Listeners = new List<ITestEventListener>();
@@ -40,8 +42,11 @@ namespace NUnit.Engine.Runners
 
         public void OnTestEvent(string report)
         {
-            foreach (var listener in Listeners)
-                listener.OnTestEvent(report);
+            lock (_eventLock)
+            {
+                foreach (var listener in Listeners)
+                    listener.OnTestEvent(report);
+            }
         }
 
         public override object InitializeLifetimeService()


### PR DESCRIPTION
All events that go to ITestEventListeners flow through a single point of control in the engine. They can come on multiple threads: one for each simultaneously executing assembly.

This PR fixes #1432 by using a lock statement in TestEventHandler, through which all the events flow.

@NikolayPianikov I believe this small fix is sufficient to take care of the problem of issue #1432, but it would be good if you could pull it down and test to be sure.