### PR TITLE
Return non-0 code on test fixture setup failure

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -44,7 +44,8 @@ namespace NUnit.ConsoleRunner
         public static readonly int OK = 0;
         public static readonly int INVALID_ARG = -1;
         public static readonly int INVALID_ASSEMBLY = -2;
-        public static readonly int FIXTURE_NOT_FOUND = -3;
+        //public static readonly int FIXTURE_NOT_FOUND = -3;    //No longer in use
+        public static readonly int INVALID_TEST_FIXTURE = -4;
         public static readonly int UNEXPECTED_ERROR = -100;
 
         #endregion
@@ -201,8 +202,11 @@ namespace NUnit.ConsoleRunner
             if (reporter.Summary.UnexpectedError)
                 return ConsoleRunner.UNEXPECTED_ERROR;
 
-            return reporter.Summary.InvalidAssemblies > 0
-                    ? ConsoleRunner.INVALID_ASSEMBLY
+            if (reporter.Summary.InvalidAssemblies > 0)
+                return ConsoleRunner.INVALID_ASSEMBLY;
+
+            return reporter.Summary.InvalidTestFixtures > 0
+                    ? ConsoleRunner.INVALID_TEST_FIXTURE
                     : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;
 
         }

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -141,6 +141,11 @@ namespace NUnit.ConsoleRunner
         /// </summary>
         public bool UnexpectedError { get; private set; }
 
+        /// <summary>
+        /// Invalid test fixture(s) were found
+        /// </summary>
+        public int InvalidTestFixtures { get; private set; }
+
         #endregion
 
         #region Helper Methods
@@ -201,8 +206,11 @@ namespace NUnit.ConsoleRunner
                     break;
 
                 case "test-suite":
-                    if (type == "Assembly" && status == "Failed" && label == "Invalid")
-                        InvalidAssemblies++;
+                    if (status == "Failed" && label == "Invalid")
+                    {
+                        if (type == "Assembly") InvalidAssemblies++;
+                        else InvalidTestFixtures++;
+                    }
                     if (type == "Assembly" && status == "Failed" && label == "Error")
                     {
                         InvalidAssemblies++;

--- a/src/NUnitFramework/nunitlite/ResultSummary.cs
+++ b/src/NUnitFramework/nunitlite/ResultSummary.cs
@@ -135,6 +135,11 @@ namespace NUnitLite
         public int ExplicitCount { get; private set; }
 
         /// <summary>
+        /// Invalid Test Fixtures
+        /// </summary>
+        public int InvalidTestFixtures { get; private set; }
+
+        /// <summary>
         /// Gets the ResultState of the test result, which 
         /// indicates the success or failure of the test.
         /// </summary>
@@ -174,16 +179,21 @@ namespace NUnitLite
 
         private void Summarize(ITestResult result)
         {
+            var label = result.ResultState.Label;
+            var status = result.ResultState.Status;
+
             if (result.Test.IsSuite)
             {
+                if (status == TestStatus.Failed && label == "Invalid")
+                    InvalidTestFixtures++;
+
                 foreach (ITestResult r in result.Children)
                     Summarize(r);
             }
             else
             {
                 TestCount++;
-                var label = result.ResultState.Label;
-                switch (result.ResultState.Status)
+                switch (status)
                 {
                     case TestStatus.Passed:
                         PassCount++;

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -62,8 +62,10 @@ namespace NUnitLite
         public const int INVALID_ARG = -1;
         /// <summary>File not found</summary>
         public const int FILE_NOT_FOUND = -2;
-        /// <summary>Test fixture not found</summary>
-        public const int FIXTURE_NOT_FOUND = -3;
+        /// <summary>Test fixture not found - No longer in use</summary>
+        //public const int FIXTURE_NOT_FOUND = -3;
+        /// <summary>Invalid test suite</summary>
+        public const int INVALID_TEST_FIXTURE = -4;
         /// <summary>Unexpected error occurred</summary>
         public const int UNEXPECTED_ERROR = -100;
 
@@ -285,6 +287,8 @@ namespace NUnitLite
                     outputManager.WriteResultFile(result, spec, runSettings, filter);
             }
 #endif
+            if (Summary.InvalidTestFixtures > 0)
+                return INVALID_TEST_FIXTURE;
 
             return Summary.FailureCount + Summary.ErrorCount + Summary.InvalidCount;
         }


### PR DESCRIPTION
Fixes #1379 - if a test fixture setup fails, then an error code of zero is returned.