### PR TITLE
Fixes 1529

### DIFF
--- a/src/NUnitEngine/Portable/nunit.portable.agent/NUnitPortableDriver.cs
+++ b/src/NUnitEngine/Portable/nunit.portable.agent/NUnitPortableDriver.cs
@@ -74,7 +74,7 @@ namespace NUnit.Engine
             _frameworkAssembly = frameworkAssembly;
             _testAssembly = testAssembly;
 
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssembly, idPrefix, (System.Collections.IDictionary)settings);
+            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssembly, idPrefix, settings);
             if (_frameworkController == null)
                 throw new NUnitPortableDriverException(INVALID_FRAMEWORK_MESSAGE);
 

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -76,7 +76,7 @@ namespace NUnit.Engine.Drivers
             _testAssemblyPath = testAssemblyPath;
             try
             {
-                _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, (System.Collections.IDictionary)settings);
+                _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, settings);
             }
             catch (SerializationException ex)
             {

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -130,7 +130,9 @@ namespace NUnit.Framework.Api
 
             try
             {
-                IList fixtureNames = options[PackageSettings.LOAD] as IList;
+                IList fixtureNames = null;
+                if (options.ContainsKey (PackageSettings.LOAD))
+                    fixtureNames = options[PackageSettings.LOAD] as IList;
                 var fixtures = GetFixtures(assembly, fixtureNames);
 
                 testAssembly = BuildTestAssembly(assembly, assemblyPath, fixtures);

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Api
         /// <returns>
         /// A TestSuite containing the tests found in the assembly
         /// </returns>
-        public ITest Build(Assembly assembly, IDictionary options)
+        public ITest Build(Assembly assembly, IDictionary<string, object> options)
         {
 #if PORTABLE
             log.Debug("Loading {0}", assembly.FullName);
@@ -99,7 +99,7 @@ namespace NUnit.Framework.Api
         /// <returns>
         /// A TestSuite containing the tests found in the assembly
         /// </returns>
-        public ITest Build(string assemblyName, IDictionary options)
+        public ITest Build(string assemblyName, IDictionary<string, object> options)
         {
 #if PORTABLE
             log.Debug("Loading {0}", assemblyName);
@@ -124,7 +124,7 @@ namespace NUnit.Framework.Api
             return testAssembly;
         }
 
-        private TestSuite Build(Assembly assembly, string assemblyPath, IDictionary options)
+        private TestSuite Build(Assembly assembly, string assemblyPath, IDictionary<string, object> options)
         {
             TestSuite testAssembly = null;
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Api
         /// <param name="assemblyNameOrPath">The AssemblyName or path to the test assembly</param>
         /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
-        public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary settings)
+        public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary<string, object> settings)
         {
             this.Builder = new DefaultTestAssemblyBuilder();
             this.Runner = new NUnitTestAssemblyRunner(this.Builder);
@@ -82,7 +82,7 @@ namespace NUnit.Framework.Api
         /// <param name="assembly">The test assembly</param>
         /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
-        public FrameworkController(Assembly assembly, string idPrefix, IDictionary settings)
+        public FrameworkController(Assembly assembly, string idPrefix, IDictionary<string, object> settings)
             : this(assembly.FullName, idPrefix, settings)
         {
             _testAssembly = assembly;
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Api
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         /// <param name="runnerType">The Type of the test runner</param>
         /// <param name="builderType">The Type of the test builder</param>
-        public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary settings, string runnerType, string builderType)
+        public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary<string, object> settings, string runnerType, string builderType)
         {
             Builder = (ITestAssemblyBuilder)Reflect.Construct(Type.GetType(builderType));
             Runner = (ITestAssemblyRunner)Reflect.Construct(Type.GetType(runnerType), new object[] { Builder });
@@ -117,27 +117,27 @@ namespace NUnit.Framework.Api
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         /// <param name="runnerType">The Type of the test runner</param>
         /// <param name="builderType">The Type of the test builder</param>
-        public FrameworkController(Assembly assembly, string idPrefix, IDictionary settings, string runnerType, string builderType)
+        public FrameworkController(Assembly assembly, string idPrefix, IDictionary<string, object> settings, string runnerType, string builderType)
             : this(assembly.FullName, idPrefix, settings, runnerType, builderType)
         {
             _testAssembly = assembly;
         }
 
-        private void Initialize(string assemblyPath, IDictionary settings)
+        private void Initialize(string assemblyPath, IDictionary<string, object> settings)
         {
             AssemblyNameOrPath = assemblyPath;
             Settings = settings;
 
-            if (settings.Contains(PackageSettings.InternalTraceLevel))
+            if (settings.ContainsKey(PackageSettings.InternalTraceLevel))
             {
                 var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)settings[PackageSettings.InternalTraceLevel], true);
 
-                if (settings.Contains(PackageSettings.InternalTraceWriter))
+                if (settings.ContainsKey(PackageSettings.InternalTraceWriter))
                     InternalTrace.Initialize((TextWriter)settings[PackageSettings.InternalTraceWriter], traceLevel);
 #if !PORTABLE && !SILVERLIGHT
                 else
                 {
-                    var workDirectory = settings.Contains(PackageSettings.WorkDirectory) ? (string)settings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
+                    var workDirectory = settings.ContainsKey(PackageSettings.WorkDirectory) ? (string)settings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
                     var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
@@ -174,7 +174,7 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Gets a dictionary of settings for the FrameworkController
         /// </summary>
-        public IDictionary Settings { get; private set; }
+        public IDictionary<string, object> Settings { get; private set; }
 
         #endregion
 
@@ -420,7 +420,7 @@ namespace NUnit.Framework.Api
         /// <param name="targetNode">Target node</param>
         /// <param name="settings">Settings dictionary</param>
         /// <returns>The new node</returns>
-        public static TNode InsertSettingsElement(TNode targetNode, IDictionary settings)
+        public static TNode InsertSettingsElement(TNode targetNode, IDictionary<string, object> settings)
         {
             TNode settingsNode = new TNode("settings");
             targetNode.ChildNodes.Insert(0, settingsNode);
@@ -430,7 +430,7 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // Add default values for display
-            if (!settings.Contains(PackageSettings.NumberOfTestWorkers))
+            if (!settings.ContainsKey(PackageSettings.NumberOfTestWorkers))
                 AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 #endif
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -129,18 +129,18 @@ namespace NUnit.Framework.Api
             AssemblyNameOrPath = assemblyPath;
 
             var newSettings = settings as IDictionary<string, object>;
-            Settings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
+            InternalSettings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
 
-            if (Settings.ContainsKey(PackageSettings.InternalTraceLevel))
+            if (InternalSettings.ContainsKey(PackageSettings.InternalTraceLevel))
             {
-                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)Settings[PackageSettings.InternalTraceLevel], true);
+                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)InternalSettings[PackageSettings.InternalTraceLevel], true);
 
-                if (Settings.ContainsKey(PackageSettings.InternalTraceWriter))
-                    InternalTrace.Initialize((TextWriter)Settings[PackageSettings.InternalTraceWriter], traceLevel);
+                if (InternalSettings.ContainsKey(PackageSettings.InternalTraceWriter))
+                    InternalTrace.Initialize((TextWriter)InternalSettings[PackageSettings.InternalTraceWriter], traceLevel);
 #if !PORTABLE && !SILVERLIGHT
                 else
                 {
-                    var workDirectory = Settings.ContainsKey(PackageSettings.WorkDirectory) ? (string)Settings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
+                    var workDirectory = InternalSettings.ContainsKey(PackageSettings.WorkDirectory) ? (string)InternalSettings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
                     var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
@@ -177,7 +177,15 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Gets a dictionary of settings for the FrameworkController
         /// </summary>
-        public IDictionary<string, object> Settings { get; private set; }
+        public IDictionary Settings
+        {
+            get { return (IDictionary)InternalSettings; }
+        }
+
+        /// <summary>
+        /// Gets a dictionary of settings for the FrameworkController
+        /// </summary>
+        internal IDictionary<string, object> InternalSettings { get; private set; }
 
         #endregion
 
@@ -190,9 +198,9 @@ namespace NUnit.Framework.Api
         public string LoadTests()
         {
             if (_testAssembly != null)
-                Runner.Load(_testAssembly, Settings);
+                Runner.Load(_testAssembly, InternalSettings);
             else
-                Runner.Load(AssemblyNameOrPath, Settings);
+                Runner.Load(AssemblyNameOrPath, InternalSettings);
 
             return Runner.LoadedTest.ToXml(false).OuterXml;
         }
@@ -225,8 +233,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(null), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (Settings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, Settings);
+            if (InternalSettings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, InternalSettings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif
@@ -277,8 +285,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (Settings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, Settings);
+            if (InternalSettings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, InternalSettings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif
@@ -353,8 +361,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (Settings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, Settings);
+            if (InternalSettings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, InternalSettings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -129,6 +129,7 @@ namespace NUnit.Framework.Api
             AssemblyNameOrPath = assemblyPath;
 
             var newSettings = settings as IDictionary<string, object>;
+            Settings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
 
             if (Settings.ContainsKey(PackageSettings.InternalTraceLevel))
             {

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -129,18 +129,18 @@ namespace NUnit.Framework.Api
             AssemblyNameOrPath = assemblyPath;
 
             var newSettings = settings as IDictionary<string, object>;
-            InternalSettings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
+            Settings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
 
-            if (InternalSettings.ContainsKey(PackageSettings.InternalTraceLevel))
+            if (Settings.ContainsKey(PackageSettings.InternalTraceLevel))
             {
-                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)InternalSettings[PackageSettings.InternalTraceLevel], true);
+                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)Settings[PackageSettings.InternalTraceLevel], true);
 
-                if (InternalSettings.ContainsKey(PackageSettings.InternalTraceWriter))
-                    InternalTrace.Initialize((TextWriter)InternalSettings[PackageSettings.InternalTraceWriter], traceLevel);
+                if (Settings.ContainsKey(PackageSettings.InternalTraceWriter))
+                    InternalTrace.Initialize((TextWriter)Settings[PackageSettings.InternalTraceWriter], traceLevel);
 #if !PORTABLE && !SILVERLIGHT
                 else
                 {
-                    var workDirectory = InternalSettings.ContainsKey(PackageSettings.WorkDirectory) ? (string)InternalSettings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
+                    var workDirectory = Settings.ContainsKey(PackageSettings.WorkDirectory) ? (string)Settings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
                     var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
@@ -177,15 +177,7 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Gets a dictionary of settings for the FrameworkController
         /// </summary>
-        public IDictionary Settings
-        {
-            get { return (IDictionary)InternalSettings; }
-        }
-
-        /// <summary>
-        /// Gets a dictionary of settings for the FrameworkController
-        /// </summary>
-        internal IDictionary<string, object> InternalSettings { get; private set; }
+        internal IDictionary<string, object> Settings { get; private set; }
 
         #endregion
 
@@ -198,9 +190,9 @@ namespace NUnit.Framework.Api
         public string LoadTests()
         {
             if (_testAssembly != null)
-                Runner.Load(_testAssembly, InternalSettings);
+                Runner.Load(_testAssembly, Settings);
             else
-                Runner.Load(AssemblyNameOrPath, InternalSettings);
+                Runner.Load(AssemblyNameOrPath, Settings);
 
             return Runner.LoadedTest.ToXml(false).OuterXml;
         }
@@ -233,8 +225,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(null), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (InternalSettings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, InternalSettings);
+            if (Settings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, Settings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif
@@ -285,8 +277,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (InternalSettings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, InternalSettings);
+            if (Settings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, Settings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif
@@ -361,8 +353,8 @@ namespace NUnit.Framework.Api
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
-            if (InternalSettings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, InternalSettings);
+            if (Settings != null) // Some platforms don't have settings
+                InsertSettingsElement(result, Settings);
 #if !PORTABLE && !SILVERLIGHT
             InsertEnvironmentElement(result);
 #endif

--- a/src/NUnitFramework/framework/Api/ITestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/ITestAssemblyBuilder.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
 
@@ -41,7 +42,7 @@ namespace NUnit.Framework.Api
         /// <param name="assembly">The assembly from which tests are to be built</param>
         /// <param name="options">A dictionary of options to use in building the suite</param>
         /// <returns>A TestSuite containing the tests found in the assembly</returns>
-        ITest Build(Assembly assembly, IDictionary options);
+        ITest Build(Assembly assembly, IDictionary<string, object> options);
 
         /// <summary>
         /// Build a suite of tests given the filename of an assembly
@@ -49,6 +50,6 @@ namespace NUnit.Framework.Api
         /// <param name="assemblyName">The filename of the assembly from which tests are to be built</param>
         /// <param name="options">A dictionary of options to use in building the suite</param>
         /// <returns>A TestSuite containing the tests found in the assembly</returns>
-        ITest Build(string assemblyName, IDictionary options);
+        ITest Build(string assemblyName, IDictionary<string, object> options);
     }
 }

--- a/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
 
@@ -74,7 +75,7 @@ namespace NUnit.Framework.Api
         /// <param name="assemblyName">File name of the assembly to load</param>
         /// <param name="settings">Dictionary of options to use in loading the test</param>
         /// <returns>An ITest representing the loaded tests</returns>
-        ITest Load(string assemblyName, System.Collections.IDictionary settings);
+        ITest Load(string assemblyName, IDictionary<string, object> settings);
 
         /// <summary>
         /// Loads the tests found in an Assembly, returning an
@@ -83,7 +84,7 @@ namespace NUnit.Framework.Api
         /// <param name="assembly">The assembly to load</param>
         /// <param name="settings">Dictionary of options to use in loading the test</param>
         /// <returns>An ITest representing the loaded tests</returns>
-        ITest Load(Assembly assembly, System.Collections.IDictionary settings);
+        ITest Load(Assembly assembly, IDictionary<string, object> settings);
 
         /// <summary>
         /// Count Test Cases using a filter

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -30,6 +30,7 @@ using NUnit.Common;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
+using System.Collections.Generic;
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
 using System.Diagnostics;
@@ -128,7 +129,7 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Our settings, specified when loading the assembly
         /// </summary>
-        private IDictionary Settings { get; set; }
+        private IDictionary<string, object> Settings { get; set; }
 
         /// <summary>
         /// The top level WorkItem created for the assembly as a whole
@@ -150,11 +151,11 @@ namespace NUnit.Framework.Api
         /// <param name="assemblyName">File name of the assembly to load</param>
         /// <param name="settings">Dictionary of option settings for loading the assembly</param>
         /// <returns>True if the load was successful</returns>
-        public ITest Load(string assemblyName, IDictionary settings)
+        public ITest Load(string assemblyName, IDictionary<string, object> settings)
         {
             Settings = settings;
 
-            if (settings.Contains(PackageSettings.RandomSeed))
+            if (settings.ContainsKey(PackageSettings.RandomSeed))
                 Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assemblyName, settings);
@@ -167,11 +168,11 @@ namespace NUnit.Framework.Api
         /// <param name="assembly">The assembly to load</param>
         /// <param name="settings">Dictionary of option settings for loading the assembly</param>
         /// <returns>True if the load was successful</returns>
-        public ITest Load(Assembly assembly, IDictionary settings)
+        public ITest Load(Assembly assembly, IDictionary<string, object> settings)
         {
             Settings = settings;
 
-            if (settings.Contains(PackageSettings.RandomSeed))
+            if (settings.ContainsKey(PackageSettings.RandomSeed))
                 Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assembly, settings);
@@ -260,7 +261,7 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // Queue and pump events, unless settings have SynchronousEvents == false
-            if (!Settings.Contains(PackageSettings.SynchronousEvents) || !(bool)Settings[PackageSettings.SynchronousEvents])
+            if (!Settings.ContainsKey(PackageSettings.SynchronousEvents) || !(bool)Settings[PackageSettings.SynchronousEvents])
             {
                 QueuingEventListener queue = new QueuingEventListener();
                 Context.Listener = queue;
@@ -272,12 +273,12 @@ namespace NUnit.Framework.Api
 
 #if !NETCF
             if (!System.Diagnostics.Debugger.IsAttached &&
-                Settings.Contains(PackageSettings.DebugTests) &&
+                Settings.ContainsKey(PackageSettings.DebugTests) &&
                 (bool)Settings[PackageSettings.DebugTests])
                 System.Diagnostics.Debugger.Launch();
 
 #if !SILVERLIGHT && !PORTABLE
-            if (Settings.Contains(PackageSettings.PauseBeforeRun) &&
+            if (Settings.ContainsKey(PackageSettings.PauseBeforeRun) &&
                 (bool)Settings[PackageSettings.PauseBeforeRun])
                 PauseBeforeRun();
 
@@ -316,12 +317,12 @@ namespace NUnit.Framework.Api
             Context = new TestExecutionContext();
 
             // Apply package settings to the context
-            if (Settings.Contains(PackageSettings.DefaultTimeout))
+            if (Settings.ContainsKey(PackageSettings.DefaultTimeout))
                 Context.TestCaseTimeout = (int)Settings[PackageSettings.DefaultTimeout];
-            if (Settings.Contains(PackageSettings.StopOnError))
+            if (Settings.ContainsKey(PackageSettings.StopOnError))
                 Context.StopOnError = (bool)Settings[PackageSettings.StopOnError];
 
-            if (Settings.Contains(PackageSettings.WorkDirectory))
+            if (Settings.ContainsKey(PackageSettings.WorkDirectory))
                 Context.WorkDirectory = (string)Settings[PackageSettings.WorkDirectory];
             else
                 Context.WorkDirectory = Env.DefaultWorkDirectory;
@@ -377,7 +378,7 @@ namespace NUnit.Framework.Api
 #if PARALLEL
         private int GetLevelOfParallelism()
         {
-            return Settings.Contains(PackageSettings.NumberOfTestWorkers)
+            return Settings.ContainsKey(PackageSettings.NumberOfTestWorkers)
                 ? (int)Settings[PackageSettings.NumberOfTestWorkers]
                 : (LoadedTest.Properties.ContainsKey(PropertyNames.LevelOfParallelism)
                    ? (int)LoadedTest.Properties.Get(PropertyNames.LevelOfParallelism)

--- a/src/NUnitFramework/nunitlite/OutputManager.cs
+++ b/src/NUnitFramework/nunitlite/OutputManager.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -54,7 +55,9 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The test result</param>
         /// <param name="spec">An output specification</param>
-        public void WriteResultFile(ITestResult result, OutputSpecification spec, IDictionary runSettings, TestFilter filter)
+        /// <param name="runSettings">Settings</param>
+        /// <param name="filter">Filter</param>
+        public void WriteResultFile(ITestResult result, OutputSpecification spec, IDictionary<string, object> runSettings, TestFilter filter)
         {
             string outputPath = Path.Combine(_workDirectory, spec.OutputPath);
             OutputWriter outputWriter = null;

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -57,7 +57,9 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The test result for the run</param>
         /// <param name="writer">The TextWriter to which the xml will be written</param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
+        /// <param name="runSettings"></param>
+        /// <param name="filter"></param>
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary<string, object> runSettings, TestFilter filter)
         {
             // NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
             // but does implement Close(). Hence we cannot use a 'using' clause.

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -61,7 +62,9 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result">The result to be written to a file</param>
         /// <param name="writer">A TextWriter to which the result is written</param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
+        /// <param name="runSettings"></param>
+        /// <param name="filter"></param>
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary<string, object> runSettings, TestFilter filter)
         {
             XmlWriterSettings xmlSettings = new XmlWriterSettings();
             xmlSettings.Indent = true;
@@ -72,7 +75,7 @@ namespace NUnitLite
             }
         }
 
-        private void WriteXmlResultOutput(ITestResult result, XmlWriter xmlWriter, IDictionary runSettings, TestFilter filter)
+        private void WriteXmlResultOutput(ITestResult result, XmlWriter xmlWriter, IDictionary<string, object> runSettings, TestFilter filter)
         {
             TNode resultNode = result.ToXml(true);
 

--- a/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using NUnit.Framework.Interfaces;
@@ -42,7 +43,7 @@ namespace NUnitLite
         /// <param name="result">The result to be written</param>
         /// <param name="outputPath">Path to the file to which the result is written</param>
         /// <param name="runSettings">A dictionary of settings used for this test run</param>
-        public void WriteResultFile(ITestResult result, string outputPath, IDictionary runSettings, TestFilter filter)
+        public void WriteResultFile(ITestResult result, string outputPath, IDictionary<string, object> runSettings, TestFilter filter)
         {
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
             {
@@ -69,7 +70,8 @@ namespace NUnitLite
         /// <param name="result">The result to be written</param>
         /// <param name="writer">A TextWriter to which the result is written</param>
         /// <param name="runSettings">A dictionary of settings used for this test run</param>
-        public abstract void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter);
+        /// <param name="filter"></param>
+        public abstract void WriteResultFile(ITestResult result, TextWriter writer, IDictionary<string, object> runSettings, TestFilter filter);
 
         /// <summary>
         /// Abstract method that writes test info to a TextWriter

--- a/src/NUnitFramework/nunitlite/OutputWriters/TestCaseOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/TestCaseOutputWriter.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -52,7 +53,9 @@ namespace NUnitLite
         /// </summary>
         /// <param name="result"></param>
         /// <param name="writer"></param>
-        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary runSettings, TestFilter filter)
+        /// <param name="runSettings"></param>
+        /// <param name="filter"></param>
+        public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary<string, object> runSettings, TestFilter filter)
         {
             WriteTestFile(result.Test, writer);
         }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -262,7 +262,7 @@ namespace NUnitLite
 
         #region Helper Methods
 
-        public int RunTests(TestFilter filter, IDictionary runSettings)
+        public int RunTests(TestFilter filter, IDictionary<string, object> runSettings)
         {
             var startTime = DateTime.UtcNow;
 

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -80,6 +80,7 @@ namespace NUnit.Framework.Api
             Assert.That(_controller.AssemblyNameOrPath, Is.EqualTo(MOCK_ASSEMBLY_PATH));
 #endif
             Assert.That(_controller.Settings, Is.SameAs(_settings));
+            Assert.That(_controller.InternalSettings, Is.SameAs(_settings));
         }
         #endregion
 

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Api
         private static readonly string MOCK_ASSEMBLY_PATH = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE);
 #endif
 
-        private IDictionary _settings = new Dictionary<string, object>();
+        private IDictionary<string, object> _settings = new Dictionary<string, object>();
         private FrameworkController _controller;
         private ICallbackEventHandler _handler;
 

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -80,7 +80,6 @@ namespace NUnit.Framework.Api
             Assert.That(_controller.AssemblyNameOrPath, Is.EqualTo(MOCK_ASSEMBLY_PATH));
 #endif
             Assert.That(_controller.Settings, Is.SameAs(_settings));
-            Assert.That(_controller.InternalSettings, Is.SameAs(_settings));
         }
         #endregion
 

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Api
         private static readonly string MOCK_ASSEMBLY_PATH = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE);
 #endif
 
-        private IDictionary<string, object> _settings = new Dictionary<string, object>();
+        private IDictionary _settings = new Dictionary<string, object>();
         private FrameworkController _controller;
         private ICallbackEventHandler _handler;
 

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Api
         private static readonly string MOCK_ASSEMBLY_NAME = typeof(MockAssembly).GetTypeInfo().Assembly.FullName;
 #endif
 
-        private static readonly IDictionary EMPTY_SETTINGS = new Dictionary<string, object>();
+        private static readonly IDictionary<string, object> EMPTY_SETTINGS = new Dictionary<string, object>();
 
         private ITestAssemblyRunner _runner;
 

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Tests
 
             ActionAttributeFixture.ClearResults();
 
-            IDictionary options = new Hashtable();
+            IDictionary<string, object> options = new Dictionary<string, object>();
             options["LOAD"] = new string[] { "NUnit.TestData.ActionAttributeTests" };
             // No need for the overhead of parallel execution here
             options["NumberOfTestWorkers"] = 0;

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -7,6 +7,7 @@
 // TODO: Figure out how to make test work in SILVERLIGHT, since they support SetUpFixture
 #if !SILVERLIGHT && !PORTABLE
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Common;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
@@ -39,7 +40,7 @@ namespace NUnit.Framework.Internal
 
         private ITestResult runTests(string nameSpace, TestFilter filter)
         {
-            IDictionary options = new Hashtable();
+            IDictionary<string, object> options = new Dictionary<string, object>();
             if (nameSpace != null)
                 options["LOAD"] = new string[] { nameSpace };
             // No need for the overhead of parallel execution here
@@ -61,7 +62,7 @@ namespace NUnit.Framework.Internal
         public void NamespaceSetUpFixtureReplacesNamespaceNodeInTree()
         {
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace1";
-            IDictionary options = new Hashtable();
+            IDictionary<string, object> options = new Dictionary<string, object>();
             options["LOAD"] = new string[] { nameSpace };
             ITest suite = builder.Build(testAssembly, options);
 
@@ -95,7 +96,7 @@ namespace NUnit.Framework.Internal
         [NUnit.Framework.Test]
         public void AssemblySetUpFixtureReplacesAssemblyNodeInTree()
         {
-            IDictionary options = new Hashtable();
+            IDictionary<string, object> options = new Dictionary<string, object>();
             ITest suite = builder.Build(testAssembly, options);
 
             Assert.IsNotNull(suite);
@@ -110,7 +111,7 @@ namespace NUnit.Framework.Internal
         public void InvalidAssemblySetUpFixtureIsLoadedCorrectly()
         {
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace6";
-            IDictionary options = new Hashtable();
+            IDictionary<string, object> options = new Dictionary<string, object>();
             options["LOAD"] = new string[] { nameSpace };
             ITest suite = builder.Build(testAssembly, options);
 


### PR DESCRIPTION
Fixes #1529 

Implements the change suggested in issue #1529.

Uses `IDictionary<string, object>` instead of `IDictionary` for all settings/options references.