### PR TITLE
Direct output from tests

### DIFF
--- a/src/Common/nunit/ColorConsole.cs
+++ b/src/Common/nunit/ColorConsole.cs
@@ -30,7 +30,7 @@ namespace NUnit.Common
     /// </summary>
     public class ColorConsole : IDisposable
     {
-#if !NETCF
+#if !SILVERLIGHT && !NETCF
         private ConsoleColor _originalColor;
 #endif
 

--- a/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
@@ -1,0 +1,100 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.ConsoleRunner.Tests
+{
+    public class TestEventHandlerTests
+    {
+        private StringBuilder _output;
+        private TextWriter _writer;
+
+        private string Output {  get { return _output.ToString(); } }
+
+        [SetUp]
+        public void CreateWriter()
+        {
+            _output = new StringBuilder();
+            _writer = new StringWriter(_output);
+        }
+
+        [TestCaseSource("EventData")]
+        public void EventsWriteExpectedOutput(string report, string labels, string expected)
+        {
+            var handler = new TestEventHandler(_writer, labels);
+
+            handler.OnTestEvent(report);
+
+            if (Environment.NewLine != "\r\n")
+                expected = expected.Replace("\r\n", Environment.NewLine);
+            Assert.That(Output, Is.EqualTo(expected));
+        }
+
+        static TestCaseData[] EventData = new TestCaseData[]
+        {
+            // Start Events
+            new TestCaseData("<start-test/>", "Off", ""),
+            new TestCaseData("<start-test/>", "On", ""),
+            new TestCaseData("<start-test/>", "All", ""),
+            new TestCaseData("<start-suite/>", "Off", ""),
+            new TestCaseData("<start-suite/>", "On", ""),
+            new TestCaseData("<start-suite/>", "All", ""),
+            // Finish Events - No Output
+            new TestCaseData("<test-case fullname='SomeName'/>", "Off", ""),
+            new TestCaseData("<test-case fullname='SomeName'/>", "On", ""),
+            new TestCaseData("<test-case fullname='SomeName'/>", "All", "=> SomeName\r\n"),
+            new TestCaseData("<test-suite fullname='SomeName'/>", "Off", ""),
+            new TestCaseData("<test-suite fullname='SomeName'/>", "On", ""),
+            new TestCaseData("<test-suite fullname='SomeName'/>", "All", ""),
+            // Finish Events - With Output
+            new TestCaseData(
+                "<test-case fullname='SomeName'><output>OUTPUT</output></test-case>",
+                "Off",
+                "OUTPUT\r\n"),
+            new TestCaseData(
+                "<test-case fullname='SomeName'><output>OUTPUT</output></test-case>",
+                "On",
+                "=> SomeName\r\nOUTPUT\r\n"),
+            new TestCaseData(
+                "<test-case fullname='SomeName'><output>OUTPUT</output></test-case>",
+                "All", 
+                "=> SomeName\r\nOUTPUT\r\n"),
+            new TestCaseData(
+                "<test-suite fullname='SomeName'><output>OUTPUT</output></test-suite>",
+                "Off", 
+                "OUTPUT\r\n"),
+            new TestCaseData(
+                "<test-suite fullname='SomeName'><output>OUTPUT</output></test-suite>",
+                "On",
+                "=> SomeName\r\nOUTPUT\r\n"),
+            new TestCaseData(
+                "<test-suite fullname='SomeName'><output>OUTPUT</output></test-suite>",
+                "All",
+                "=> SomeName\r\nOUTPUT\r\n")
+        };
+    }
+}

--- a/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
@@ -94,7 +94,20 @@ namespace NUnit.ConsoleRunner.Tests
             new TestCaseData(
                 "<test-suite fullname='SomeName'><output>OUTPUT</output></test-suite>",
                 "All",
-                "=> SomeName\r\nOUTPUT\r\n")
+                "=> SomeName\r\nOUTPUT\r\n"),
+            // Output Events
+            new TestCaseData(
+                "<test-output>OUTPUT</test-output>",
+                "Off",
+                "OUTPUT\r\n"),
+            new TestCaseData(
+                "<test-output>OUTPUT</test-output>",
+                "On",
+                "OUTPUT\r\n"),
+            new TestCaseData(
+                "<test-output>OUTPUT</test-output>",
+                "All",
+                "OUTPUT\r\n")
         };
     }
 }

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="MakeTestPackageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultReporterTests.cs" />
+    <Compile Include="TestEventHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestListWithEmptyLine.tst">

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -64,7 +64,7 @@ namespace NUnit.ConsoleRunner
                     break;
 
                 case "test-output":
-                    WriteTestOutput(testEvent);
+                    TestOutput(testEvent);
                     break;
             }
         }
@@ -79,14 +79,14 @@ namespace NUnit.ConsoleRunner
             var outputNode = testResult.SelectSingleNode("output");
 
             if (_displayLabels == "ALL")
-                WriteTestLabel(testName);
+                WriteLabelLine(testName);
 
             if (outputNode != null)
             {
                 if (_displayLabels == "ON")
-                    WriteTestLabel(testName);
+                    WriteLabelLine(testName);
 
-                WriteTestOutput(outputNode);
+                WriteOutputLine(outputNode.InnerText);
             }
         }
 
@@ -98,25 +98,43 @@ namespace NUnit.ConsoleRunner
             if (outputNode != null)
             {
                 if (_displayLabels == "ON" || _displayLabels == "ALL")
-                    WriteTestLabel(suiteName);
+                    WriteLabelLine(suiteName);
 
-                WriteTestOutput(outputNode);
+                WriteOutputLine(outputNode.InnerText);
             }
         }
 
-        private void WriteTestLabel(string name)
+        private void TestOutput(XmlNode outputNode)
         {
-            using (new ColorConsole(ColorStyle.SectionHeader))
-                _outWriter.WriteLine("=> {0}", name);
+            var testName = outputNode.GetAttribute("testname");
+
+            if (_displayLabels == "ON" && testName != null)
+                WriteLabelLine(testName);
+
+            WriteOutputLine(outputNode.InnerText);
         }
 
-        private void WriteTestOutput(XmlNode outputNode)
+        private string _currentLabel;
+
+        private void WriteLabelLine(string label)
+        {
+            if (label != _currentLabel)
+            {
+                using (new ColorConsole(ColorStyle.SectionHeader))
+                    _outWriter.WriteLine("=> {0}", label);
+
+                _currentLabel = label;
+            }
+        }
+
+        private void WriteOutputLine(string text)
         {
             using (new ColorConsole(ColorStyle.Output))
             {
-                _outWriter.Write(outputNode.InnerText);
+                _outWriter.Write(text);
+
                 // Some labels were being shown on the same line as the previous output
-                if (!outputNode.InnerText.EndsWith("\n"))
+                if (!text.EndsWith("\n"))
                 {
                     _outWriter.WriteLine();
                 }

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -147,11 +147,6 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        private void WriteErrorLine(string text)
-        {
-
-        }
-
         #endregion
 
         #region InitializeLifetimeService

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -41,7 +41,7 @@ namespace NUnit.ConsoleRunner
 
         public TestEventHandler(TextWriter outWriter, string displayLabels)
         {
-            _displayLabels = displayLabels;
+            _displayLabels = displayLabels.ToUpperInvariant();
             _outWriter = outWriter;
         }
 

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -62,6 +62,10 @@ namespace NUnit.ConsoleRunner
                 case "test-suite":
                     SuiteFinished(testEvent);
                     break;
+
+                case "test-output":
+                    WriteTestOutput(testEvent);
+                    break;
             }
         }
 

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -107,11 +107,12 @@ namespace NUnit.ConsoleRunner
         private void TestOutput(XmlNode outputNode)
         {
             var testName = outputNode.GetAttribute("testname");
+            var stream = outputNode.GetAttribute("stream");
 
             if (_displayLabels == "ON" && testName != null)
                 WriteLabelLine(testName);
 
-            WriteOutputLine(outputNode.InnerText);
+            WriteOutputLine(outputNode.InnerText, stream == "Error" ? ColorStyle.Error : ColorStyle.Output);
         }
 
         private string _currentLabel;
@@ -129,7 +130,12 @@ namespace NUnit.ConsoleRunner
 
         private void WriteOutputLine(string text)
         {
-            using (new ColorConsole(ColorStyle.Output))
+            WriteOutputLine(text, ColorStyle.Output);
+        }
+
+        private void WriteOutputLine(string text, ColorStyle color)
+        {
+            using (new ColorConsole(color))
             {
                 _outWriter.Write(text);
 
@@ -139,6 +145,11 @@ namespace NUnit.ConsoleRunner
                     _outWriter.WriteLine();
                 }
             }
+        }
+
+        private void WriteErrorLine(string text)
+        {
+
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -40,8 +40,6 @@ namespace NUnit.Engine.Runners
         private IRuntimeFrameworkService _runtimeService;
         private ExtensionService _extensionService;
 
-        private TestEventDispatcher _eventDispatcher;
-
         public MasterTestRunner(IServiceLocator services, TestPackage package)
             : base(services, package)
         {

--- a/src/NUnitFramework/framework/Interfaces/ITestListener.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestListener.cs
@@ -42,5 +42,11 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
         /// <param name="result">The result of the test</param>
         void TestFinished(ITestResult result);
+
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        void TestOutput(TestOutput output);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/TestOutput.cs
+++ b/src/NUnitFramework/framework/Interfaces/TestOutput.cs
@@ -32,15 +32,18 @@ namespace NUnit.Framework.Interfaces
 	public class TestOutput
 	{
         /// <summary>
-        /// Construct with text and an ouput destination type
+        /// Construct with text, ouput destination type and
+        /// the name of the test that produced the output.
         /// </summary>
         /// <param name="text">Text to be output</param>
         /// <param name="stream">Destination of output</param>
-		public TestOutput(string text, string stream)
-		{
-			Text = text;
-			Stream = stream;
-		}
+        /// <param name="testName">Name of teset that produced the output</param>
+		public TestOutput(string text, string stream, string testName)
+        {
+            Text = text;
+            Stream = stream;
+            TestName = testName;
+        }
 
         /// <summary>
         /// Return string representation of the object for debugging
@@ -62,11 +65,18 @@ namespace NUnit.Framework.Interfaces
 		public string Stream { get; private set; }
 
         /// <summary>
+        /// Get the name of the test that created the output
+        /// </summary>
+        public string TestName { get; private set; }
+
+        /// <summary>
         /// Convert the TestOutput object to an XML string
         /// </summary>
         public string ToXml()
         {
-            return string.Format("<test-output stream='{0}'>{1}</test-output>", Stream, Text);
+            return TestName != null
+                ? string.Format("<test-output stream='{0}' testname='{1}'>{2}</test-output>", Stream, TestName, Text)
+                : string.Format("<test-output stream='{0}'>{1}</test-output>", Stream, Text);
         }
- 	}
+    }
 }

--- a/src/NUnitFramework/framework/Interfaces/TestOutput.cs
+++ b/src/NUnitFramework/framework/Interfaces/TestOutput.cs
@@ -61,9 +61,12 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
 		public string Stream { get; private set; }
 
+        /// <summary>
+        /// Convert the TestOutput object to an XML string
+        /// </summary>
         public string ToXml()
         {
-            return string.Format("<test-output stream={0}>{1}</test-output>", Stream, Text);
+            return string.Format("<test-output stream='{0}'>{1}</test-output>", Stream, Text);
         }
  	}
 }

--- a/src/NUnitFramework/framework/Interfaces/TestOutput.cs
+++ b/src/NUnitFramework/framework/Interfaces/TestOutput.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2009 Charlie Poole
+// Copyright (c) 2007 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,45 +22,48 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Framework.Interfaces;
 
-namespace NUnit.Framework.Internal
+namespace NUnit.Framework.Interfaces
 {
     /// <summary>
-    /// TestListener provides an implementation of ITestListener that
-    /// does nothing. It is used only through its NULL property.
+    /// The TestOutput class holds a unit of output from 
+    /// a test to a specific output stream
     /// </summary>
-    public class TestListener : ITestListener
-    {
+	public class TestOutput
+	{
         /// <summary>
-        /// Called when a test has just started
+        /// Construct with text and an ouput destination type
         /// </summary>
-        /// <param name="test">The test that is starting</param>
-        public void TestStarted(ITest test){}
+        /// <param name="text">Text to be output</param>
+        /// <param name="stream">Destination of output</param>
+		public TestOutput(string text, string stream)
+		{
+			Text = text;
+			Stream = stream;
+		}
 
         /// <summary>
-        /// Called when a test case has finished
+        /// Return string representation of the object for debugging
         /// </summary>
-        /// <param name="result">The result of the test</param>
-        public void TestFinished(ITestResult result){}
+        /// <returns></returns>
+		public override string ToString()
+		{
+			return Stream + ": " + Text;
+		}
 
         /// <summary>
-        /// Called when a test produces output for immediate display
+        /// Get the text 
         /// </summary>
-        /// <param name="output">A TestOutput object containing the text to display</param>
-        public void TestOutput(TestOutput output) { }
+		public string Text { get; private set; }
 
         /// <summary>
-        /// Construct a new TestListener - private so it may not be used.
+        /// Get the output type
         /// </summary>
-        private TestListener() { }
+		public string Stream { get; private set; }
 
-        /// <summary>
-        /// Get a listener that does nothing
-        /// </summary>
-        public static ITestListener NULL
+        public string ToXml()
         {
-            get { return new TestListener();}
+            return string.Format("<test-output stream={0}>{1}</test-output>", Stream, Text);
         }
-    }
+ 	}
 }

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Internal.Execution
 	public class EventListenerTextWriter : TextWriter
 	{
         private TextWriter _defaultWriter;
-		private ITestListener _listener;
 		private string _streamName;
 
 		public EventListenerTextWriter( string streamName, TextWriter defaultWriter )

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -70,7 +70,10 @@ namespace NUnit.Framework.Internal.Execution
             if (context == null || context.Listener == null)
                 return false;
 
-            context.Listener.TestOutput(new TestOutput(text, _streamName));
+            string testName = context.CurrentTest != null
+                ? context.CurrentTest.FullName
+                : null;
+            context.Listener.TestOutput(new TestOutput(text, _streamName, testName));
             return true;
         }
 	}

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PARALLEL
+#if !NETCF && !SILVERLIGHT && !PORTABLE
 using System;
 using System.IO;
 using System.Text;
@@ -29,35 +29,58 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Execution
 {
+    /// <summary>
+    /// EventListenerTextWriter sends text output to the currently active
+    /// ITestEventListener in the form of a TestOutput object. If no event 
+    /// listener is active in the contet, or if there is no context,
+    /// the output is forwarded to the supplied default writer.
+    /// </summary>
 	public class EventListenerTextWriter : TextWriter
 	{
         private TextWriter _defaultWriter;
 		private string _streamName;
 
+        /// <summary>
+        /// Construct an EventListenerTextWriter
+        /// </summary>
+        /// <param name="streamName">The name of the stream to use for events</param>
+        /// <param name="defaultWriter">The default writer to use if no listener is available</param>
 		public EventListenerTextWriter( string streamName, TextWriter defaultWriter )
 		{
 			_streamName = streamName;
             _defaultWriter = defaultWriter;
 		}
 
+        /// <summary>
+        /// Write a single char
+        /// </summary>
         override public void Write(char aChar)
         {
             if (!TrySendToListener(aChar.ToString()))
                 _defaultWriter.Write(aChar);
         }
 
+        /// <summary>
+        /// Write a string
+        /// </summary>
         override public void Write(string aString)
         {
             if (!TrySendToListener(aString))
                 _defaultWriter.Write(aString);
         }
 
+        /// <summary>
+        /// Write a string followed by a newline
+        /// </summary>
         override public void WriteLine(string aString)
         {
             if (!TrySendToListener(aString + Environment.NewLine))
                 _defaultWriter.WriteLine(aString);
         }
 
+        /// <summary>
+        /// Get the Encoding for this TextWriter
+        /// </summary>
         override public System.Text.Encoding Encoding
 		{
 			get { return Encoding.Default; }

--- a/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
@@ -63,12 +63,6 @@ namespace NUnit.Framework.Internal.Execution
         #region Instance Variables
 
         /// <summary>
-        /// The handle on which a thread enqueuing an event with <see cref="Event.IsSynchronous"/> == <c>true</c>
-        /// waits, until the EventPump has sent the event to its listeners.
-        /// </summary>
-        private readonly AutoResetEvent _synchronousEventSent = new AutoResetEvent(false);
-
-        /// <summary>
         /// The downstream listener to which we send events
         /// </summary>
         private readonly ITestListener _eventListener;
@@ -134,7 +128,6 @@ namespace NUnit.Framework.Internal.Execution
         public void Dispose()
         {
             Stop();
-            ((IDisposable)_synchronousEventSent).Dispose();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class TestFinishedEvent : Event
     {
-        private readonly ITestResult result;
+        private readonly ITestResult _result;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestFinishedEvent"/> class.
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="result">The result.</param>
         public TestFinishedEvent(ITestResult result)
         {
-            this.result = result;
+            _result = result;
         }
 
         /// <summary>
@@ -102,11 +102,37 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="listener">The listener.</param>
         public override void Send(ITestListener listener)
         {
-            listener.TestFinished(result);
+            listener.TestFinished(_result);
         }
     }
 
-#endregion
+    /// <summary>
+    /// TestOutputEvent holds information needed to call the TestOutput method.
+    /// </summary>
+    public class TestOutputEvent : Event
+    {
+        private readonly TestOutput _output;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestOutputEvent"/> class.
+        /// </summary>
+        /// <param name="output">The output object.</param>
+        public TestOutputEvent(TestOutput output)
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// Calls TestOutput on the specified listener.
+        /// </summary>
+        /// <param name="listener">The listener.</param>
+        public override void Send(ITestListener listener)
+        {
+            listener.TestOutput(_output);
+        }
+    }
+
+    #endregion
 
     /// <summary>
     /// Implements a queue of work items each of which

--- a/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
@@ -197,7 +197,7 @@ namespace NUnit.Framework.Internal.Execution
                 break;
             } while (true);
 
-            Thread.Sleep(0);  // give EventPump thread a chance to process the event
+            Thread.Sleep(1);  // give EventPump thread a chance to process the event
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/QueuingEventListener.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/QueuingEventListener.cs
@@ -38,6 +38,9 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public EventQueue Events { get; private set; }
 
+        /// <summary>
+        /// Construct a QueuingEventListener
+        /// </summary>
         public QueuingEventListener()
         {
             Events = new EventQueue();

--- a/src/NUnitFramework/framework/Internal/Execution/QueuingEventListener.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/QueuingEventListener.cs
@@ -62,6 +62,12 @@ namespace NUnit.Framework.Internal.Execution
             events.Enqueue( new TestFinishedEvent( result ) );
         }
 
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        public void TestOutput(TestOutput output) { }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -209,7 +209,7 @@ namespace NUnit.Framework.Internal
         {
             get
             {
-                var current = (TestExecutionContext)Thread.GetData(contextSlot);
+                var current = GetTestExecutionContext();
                 if (current == null)
                 {
                     current = new TestExecutionContext();
@@ -222,6 +222,14 @@ namespace NUnit.Framework.Internal
             {
                 Thread.SetData(contextSlot, value);
             }
+        }
+
+        /// <summary>
+        /// Get the current context or return null if none is found.
+        /// </summary>
+        public static TestExecutionContext GetTestExecutionContext()
+        {
+            return (TestExecutionContext)Thread.GetData(contextSlot);
         }
 #else
         // In all other builds, we use the CallContext

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -176,6 +176,12 @@ namespace NUnit.Framework.Internal
             }
         }
 
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        public void TestOutput(TestOutput output) { }
+
         #endregion
 
         #region Helper Methods

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -49,84 +49,6 @@ namespace NUnit.Framework.Internal
 
         #region ITestListener Members
 
-        ///// <summary>
-        ///// Called when a test run has just started
-        ///// </summary>
-        ///// <param name="test">The test that is starting</param>
-        //public void RunStarted(ITest test)
-        //{
-        //    try
-        //    {
-        //        string report = string.Format(
-        //            "<start-run id=\"{0}\" name=\"{1}\" fullname=\"{2}\"/>",
-        //            test.Id,
-        //            XmlHelper.FormatAttributeValue(test.Name),
-        //            XmlHelper.FormatAttributeValue(test.FullName));
-
-        //        handler.RaiseCallbackEvent(report);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        log.Error("Exception processing " + test.FullName + NUnit.Env.NewLine + ex.ToString());
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Called when a test has finished. Sends a result summary to the callback.
-        ///// to 
-        ///// </summary>
-        ///// <param name="result">The result of the test</param>
-        //public void RunFinished(ITestResult result)
-        //{
-        //    try
-        //    {
-        //        handler.RaiseCallbackEvent(result.ToXml(false).OuterXml);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        log.Error("Exception processing " + result.FullName + NUnit.Env.NewLine + ex.ToString());
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Called when a test has just started
-        ///// </summary>
-        ///// <param name="test">The test that is starting</param>
-        //public void SuiteStarted(ITest test)
-        //{
-        //    try
-        //    {
-        //        string report = string.Format(
-        //            "<start-suite id=\"{0}\" name=\"{1}\" fullname=\"{2}\"/>",
-        //            test.Id,
-        //            XmlHelper.FormatAttributeValue(test.Name),
-        //            XmlHelper.FormatAttributeValue(test.FullName));
-
-        //        handler.RaiseCallbackEvent(report);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        log.Error("Exception processing " + test.FullName + NUnit.Env.NewLine + ex.ToString());
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Called when a test has finished. Sends a result summary to the callback.
-        ///// to 
-        ///// </summary>
-        ///// <param name="result">The result of the test</param>
-        //public void SuiteFinished(ITestResult result)
-        //{
-        //    try
-        //    {
-        //        handler.RaiseCallbackEvent(result.ToXml(false).OuterXml);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        log.Error("Exception processing " + result.FullName + NUnit.Env.NewLine + ex.ToString());
-        //    }
-        //}
-
         /// <summary>
         /// Called when a test has just started
         /// </summary>
@@ -180,7 +102,17 @@ namespace NUnit.Framework.Internal
         /// Called when a test produces output for immediate display
         /// </summary>
         /// <param name="output">A TestOutput object containing the text to display</param>
-        public void TestOutput(TestOutput output) { }
+        public void TestOutput(TestOutput output)
+        {
+            try
+            {
+                handler.RaiseCallbackEvent(output.ToXml());
+            }
+            catch (Exception ex)
+            {
+                log.Error("Exception processing TestOutput event" + NUnit.Env.NewLine + ex.ToString());
+            }
+        }
 
         #endregion
 

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -27,6 +27,7 @@ using System.Reflection;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Execution;
 
 namespace NUnit.Framework
 {
@@ -74,6 +75,18 @@ namespace NUnit.Framework
         {
             get { return TestExecutionContext.CurrentContext.OutWriter; }
         }
+
+#if !SILVERLIGHT && !PORTABLE
+        /// <summary>
+        /// Gets a TextWriter that will send output directly to Console.Error
+        /// </summary>
+        public static TextWriter Error = new EventListenerTextWriter("Error", Console.Error);
+
+        /// <summary>
+        /// Gets a TextWriter for use in displaying immediate progress messages
+        /// </summary>
+        public static readonly TextWriter Progress = new EventListenerTextWriter("Progress", Console.Error);
+#endif
 
         /// <summary>
         /// Get a representation of the current test.

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -76,7 +76,7 @@ namespace NUnit.Framework
             get { return TestExecutionContext.CurrentContext.OutWriter; }
         }
 
-#if !SILVERLIGHT && !PORTABLE
+#if !NETCF && !SILVERLIGHT && !PORTABLE
         /// <summary>
         /// Gets a TextWriter that will send output directly to Console.Error
         /// </summary>

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
     <Compile Include="Interfaces\TestOutput.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Internal\Execution\CommandBuilder.cs" />
     <Compile Include="Internal\Execution\CompositeWorkItem.cs" />
     <Compile Include="Internal\Execution\CountdownEvent.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -325,6 +325,7 @@
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -360,6 +360,7 @@
     <Compile Include="Internal\Commands\TestCommand.cs" />
     <Compile Include="Internal\Commands\TestMethodCommand.cs" />
     <Compile Include="Internal\Commands\TheoryResultCommand.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\FullNameFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -382,6 +382,7 @@
     <Compile Include="Internal\Execution\CommandBuilder.cs" />
     <Compile Include="Internal\Execution\CompositeWorkItem.cs" />
     <Compile Include="Internal\Execution\CountdownEvent.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -327,6 +327,7 @@
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Internal\Execution\CommandBuilder.cs" />
     <Compile Include="Internal\Execution\CompositeWorkItem.cs" />
     <Compile Include="Internal\Execution\CountdownEvent.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Internal\Execution\CommandBuilder.cs" />
     <Compile Include="Internal\Execution\CompositeWorkItem.cs" />
     <Compile Include="Internal\Execution\CountdownEvent.cs" />
+    <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -343,6 +343,7 @@
     <Compile Include="Interfaces\IXmlNodeBuilder.cs" />
     <Compile Include="Interfaces\ResultState.cs" />
     <Compile Include="Interfaces\RunState.cs" />
+    <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -66,7 +66,15 @@ namespace NUnit.Tests
                         + CDataTestFixure.Suites
                         + TestNameEscaping.Suites
                         + NamespaceSuites;
-            
+
+            public const int TestStartedEvents = Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests;
+            public const int TestFinishedEvents = Tests;
+#if PORTABLE || SILVERLIGHT
+            public const int TestOutputEvents = 0;
+#else
+            public const int TestOutputEvents = 1;
+#endif
+
             public const int Nodes = Tests + Suites;
             
             public const int ExplicitFixtures = 1;
@@ -128,6 +136,9 @@ namespace NUnit.Tests
             [Test]
             public void FailingTest()
             {
+#if !PORTABLE && !SILVERLIGHT
+                Console.Error.WriteLine("Immediate Error Message");
+#endif
                 Assert.Fail("Intentional failure");
             }
 

--- a/src/NUnitFramework/nunitlite-runner/Program.cs
+++ b/src/NUnitFramework/nunitlite-runner/Program.cs
@@ -41,7 +41,11 @@ namespace NUnitLite
     {
         static int Main(string[] args)
         {
+#if SILVERLIGHT || PORTABLE
             return new TextRunner().Execute(new ColorConsoleWriter(), Console.In, args);
+#else
+            return new TextRunner().Execute(args);
+#endif
         }
     }
 }

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-2.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-2.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>1699,1591</NoWarn>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-3.5.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-3.5.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-portable.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-portable.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\portable\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-sl-5.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-sl-5.0.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
+++ b/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
@@ -96,6 +96,12 @@ namespace NUnitLite
                 }
         }
 
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        public void TestOutput(TestOutput output) { }
+
         #region Helper Methods
 
         private void TC_TestSuiteStarted(string name)

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -467,6 +467,12 @@ namespace NUnitLite
 #endif
         }
 
-#endregion
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        public void TestOutput(TestOutput output) { }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -471,7 +471,10 @@ namespace NUnitLite
         /// Called when a test produces output for immediate display
         /// </summary>
         /// <param name="output">A TestOutput object containing the text to display</param>
-        public void TestOutput(TestOutput output) { }
+        public void TestOutput(TestOutput output)
+        {
+            _textUI.TestOutput(output);
+        }
 
         #endregion
     }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -285,7 +285,7 @@ namespace NUnitLite
                 if (output.TestName != null)
                     WriteLabelLine(output.TestName);
 
-            WriteOutputLine(output.Text);
+            WriteOutputLine(output.Stream == "Error" ? ColorStyle.Error : ColorStyle.Output, output.Text);
         }
 
         #endregion
@@ -602,9 +602,16 @@ namespace NUnitLite
 
         private void WriteOutputLine(string text)
         {
-            _writer.Write(ColorStyle.Output, text);
+            WriteOutputLine(ColorStyle.Output, text);
+        }
+
+        private void WriteOutputLine(ColorStyle color, string text)
+        {
+            _writer.Write(color, text);
+
             if (!text.EndsWith(Environment.NewLine))
                 _writer.WriteLine();
+
             _testCreatedOutput = true;
         }
 

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -250,14 +250,13 @@ namespace NUnitLite
 
             if (!isSuite && labels == "ALL" || !isSuite && labels == "ON" && result.Output.Length > 0)
             {
-                _writer.WriteLine(ColorStyle.SectionHeader, "=> " + result.Test.FullName);
-                _testCreatedOutput = true;
+                WriteLabelLine(result.Test.FullName);
             }
 
             if (result.Output.Length > 0)
             {
-                _writer.Write(ColorStyle.Output, result.Output);
-                _testCreatedOutput = true;
+                WriteOutputLine(result.Output);
+
                 if (!result.Output.EndsWith("\n"))
                     _writer.WriteLine();
             }
@@ -275,8 +274,18 @@ namespace NUnitLite
 
         public void TestOutput(TestOutput output)
         {
-            _writer.Write(ColorStyle.Output, output.Text);
-            _testCreatedOutput = true;
+            var labels = "ON";
+
+#if !SILVERLIGHT
+            if (_options.DisplayTestLabels != null)
+                labels = _options.DisplayTestLabels.ToUpperInvariant();
+#endif
+
+            if (labels == "ON" || labels == "All")
+                if (output.TestName != null)
+                    WriteLabelLine(output.TestName);
+
+            WriteOutputLine(output.Text);
         }
 
         #endregion
@@ -577,6 +586,26 @@ namespace NUnitLite
         private void WriteHelpLine(string text)
         {
             _writer.WriteLine(ColorStyle.Help, text);
+        }
+
+        private string _currentLabel;
+
+        private void WriteLabelLine(string label)
+        {
+            if (label != _currentLabel)
+            {
+                _writer.WriteLine(ColorStyle.SectionHeader, "=> " + label);
+                _testCreatedOutput = true;
+                _currentLabel = label;
+            }
+        }
+
+        private void WriteOutputLine(string text)
+        {
+            _writer.Write(ColorStyle.Output, text);
+            if (!text.EndsWith(Environment.NewLine))
+                _writer.WriteLine();
+            _testCreatedOutput = true;
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -271,6 +271,16 @@ namespace NUnitLite
 
         #endregion
 
+        #region TestOutput
+
+        public void TestOutput(TestOutput output)
+        {
+            _writer.Write(ColorStyle.Output, output.Text);
+            _testCreatedOutput = true;
+        }
+
+        #endregion
+
         #region WaitForUser
 
         public void WaitForUser(string message)

--- a/src/NUnitFramework/testdata/TextOutputFixture.cs
+++ b/src/NUnitFramework/testdata/TextOutputFixture.cs
@@ -1,0 +1,47 @@
+﻿// **********************************************************************************
+// Copyright (c) 2016 Charlie Poole
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// **********************************************************************************
+
+#if !SILVERLIGHT && !PORTABLE
+using System;
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+    public class TextOutputFixture
+    {
+        private const string ERROR_TEXT = "Written directly to console";
+
+        [Test]
+        public void WriteToError()
+        {
+            Console.Error.Write(ERROR_TEXT);
+        }
+
+        [Test]
+        public void WriteLineToError()
+        {
+            Console.Error.WriteLine(ERROR_TEXT);
+        }
+    }
+}
+#endif
+

--- a/src/NUnitFramework/testdata/TextOutputFixture.cs
+++ b/src/NUnitFramework/testdata/TextOutputFixture.cs
@@ -20,7 +20,7 @@
 // 
 // **********************************************************************************
 
-#if !SILVERLIGHT && !PORTABLE
+#if !SILVERLIGHT && !PORTABLE && !NETCF
 using System;
 using NUnit.Framework;
 

--- a/src/NUnitFramework/testdata/TextOutputFixture.cs
+++ b/src/NUnitFramework/testdata/TextOutputFixture.cs
@@ -31,15 +31,27 @@ namespace NUnit.TestData
         private const string ERROR_TEXT = "Written directly to console";
 
         [Test]
-        public void WriteToError()
+        public void ConsoleErrorWrite()
         {
             Console.Error.Write(ERROR_TEXT);
         }
 
         [Test]
-        public void WriteLineToError()
+        public void ConsoleErrorWriteLine()
         {
             Console.Error.WriteLine(ERROR_TEXT);
+        }
+
+        [Test]
+        public void TestContextErrorWriteLine()
+        {
+            TestContext.Error.WriteLine(ERROR_TEXT);
+        }
+
+        [Test]
+        public void TestContextProgressWriteLine()
+        {
+            TestContext.Progress.WriteLine(ERROR_TEXT);
         }
     }
 }

--- a/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ActionAttributeFixture.cs" />
     <Compile Include="AsyncDummyFixture.cs" />
     <Compile Include="AsyncRealFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="RepeatingTestsFixtureBase.cs" />
     <Compile Include="RetryFixture.cs" />
     <Compile Include="GenericTestMethodData.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
@@ -84,6 +84,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
@@ -106,6 +106,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
@@ -89,6 +89,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-netcf-3.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netcf-3.5.csproj
@@ -94,6 +94,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
@@ -87,6 +87,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-sl-5.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-sl-5.0.csproj
@@ -103,6 +103,7 @@
     <Compile Include="TestFixtureSourceData.cs" />
     <Compile Include="TestMethodSignatureFixture.cs" />
     <Compile Include="TestOfFixture.cs" />
+    <Compile Include="TextOutputFixture.cs" />
     <Compile Include="TheoryFixture.cs" />
     <Compile Include="TimeoutFixture.cs" />
     <Compile Include="UnexpectedExceptionFixture.cs" />

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -192,7 +192,9 @@ namespace NUnit.Framework.Api
 
             Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.TestStartedEvents));
             Assert.That(_testFinishedCount, Is.EqualTo(MockAssembly.TestFinishedEvents));
+#if !NETCF && !PORTABLE && !SILVERLIGHT
             Assert.That(_testOutputCount, Is.EqualTo(MockAssembly.TestOutputEvents));
+#endif
 
             Assert.That(_successCount, Is.EqualTo(MockAssembly.Success));
             Assert.That(_failCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -409,9 +409,15 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        /// <summary>
+        /// Called when a test produces output for immediate display
+        /// </summary>
+        /// <param name="output">A TestOutput object containing the text to display</param>
+        public void TestOutput(TestOutput output) { }
 
-#region Helper Methods
+        #endregion
+
+        #region Helper Methods
 
         private ITest LoadMockAssembly()
         {

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Api
 
         private int _testStartedCount;
         private int _testFinishedCount;
+        private int _testOutputCount;
         private int _successCount;
         private int _failCount;
         private int _skipCount;
@@ -76,6 +77,7 @@ namespace NUnit.Framework.Api
 
             _testStartedCount = 0;
             _testFinishedCount = 0;
+            _testOutputCount = 0;
             _successCount = 0;
             _failCount = 0;
             _skipCount = 0;
@@ -188,8 +190,9 @@ namespace NUnit.Framework.Api
             LoadMockAssembly();
             var result = _runner.Run(this, TestFilter.Empty);
 
-            Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests));
-            Assert.That(_testFinishedCount, Is.EqualTo(MockAssembly.Tests));
+            Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.TestStartedEvents));
+            Assert.That(_testFinishedCount, Is.EqualTo(MockAssembly.TestFinishedEvents));
+            Assert.That(_testOutputCount, Is.EqualTo(MockAssembly.TestOutputEvents));
 
             Assert.That(_successCount, Is.EqualTo(MockAssembly.Success));
             Assert.That(_failCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));
@@ -413,11 +416,14 @@ namespace NUnit.Framework.Api
         /// Called when a test produces output for immediate display
         /// </summary>
         /// <param name="output">A TestOutput object containing the text to display</param>
-        public void TestOutput(TestOutput output) { }
+        public void TestOutput(TestOutput output)
+        {
+            _testOutputCount++;
+        }
 
         #endregion
 
-        #region Helper Methods
+#region Helper Methods
 
         private ITest LoadMockAssembly()
         {

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -40,9 +40,11 @@ namespace NUnit.Framework.Internal.Execution
         private static readonly Event[] events =
         {
             new TestStartedEvent(null),
+            new TestOutputEvent(null),
             new TestStartedEvent(null),
             new TestFinishedEvent(null),
             new TestStartedEvent(null),
+            new TestOutputEvent(null),
             new TestFinishedEvent(null),
             new TestFinishedEvent(null),
         };

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -178,30 +178,6 @@ namespace NUnit.Framework.Tests
             Assert.That(fixture.stateList, Is.EqualTo("Inconclusive=>=>Skipped:Ignored"));
         }
 
-        private const string SOME_TEXT = "Should go to the result";
-        private static readonly string NL = NUnit.Env.NewLine;
-
-        [Test]
-        public void TestContextOut_WritesToResult()
-        {
-            TestContext.Out.WriteLine(SOME_TEXT);
-            Assert.That(Internal.TestExecutionContext.CurrentContext.CurrentResult.Output, Is.EqualTo(SOME_TEXT + NL));
-        }
-
-        [Test]
-        public void TestContextWrite_WritesToResult()
-        {
-            TestContext.Write(SOME_TEXT);
-            Assert.That(Internal.TestExecutionContext.CurrentContext.CurrentResult.Output, Is.EqualTo(SOME_TEXT));
-        }
-
-        [Test]
-        public void TestContextWriteLine_WritesToResult()
-        {
-            TestContext.WriteLine(SOME_TEXT);
-            Assert.That(Internal.TestExecutionContext.CurrentContext.CurrentResult.Output, Is.EqualTo(SOME_TEXT + NL));
-        }
-
         [Test]
         public void TestContextStoresFailureInfoForTearDown()
         {

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests
         [Test]
         public void ConsoleErrorWrite_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "WriteToError");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWrite");
             var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Tests
         [Test]
         public void ConsoleErrorWriteLine_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "WriteLineToError");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWriteLine");
             var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
@@ -91,8 +91,43 @@ namespace NUnit.Framework.Tests
         public void MultipleWrites()
         {
             // Test purely for display purposes
-            Console.Error.WriteLine("This displays on console directly");
-            Console.WriteLine("This is added to the result");
+            TestContext.Progress.WriteLine("TestContext.Progress displays immediately");
+            TestContext.Error.WriteLine("TestContext.Error displays immediately as well");
+            Console.Error.WriteLine("Console.Error also displays immediately");
+            Console.WriteLine("This line is added to the result and displayed when test ends");
+            Console.WriteLine("As is this line");
+        }
+
+        [Test]
+        public void TestContextError_WritesToListener()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextErrorWriteLine");
+            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            work.Context.Listener = this;
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+            Assert.That(result.Output, Is.EqualTo(""));
+
+            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT + Environment.NewLine));
+            Assert.That(_testOutput.Stream, Is.EqualTo("Error"));
+        }
+
+        [Test]
+        public void TestContextProgress_WritesToListener()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextProgressWriteLine");
+            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            work.Context.Listener = this;
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+            Assert.That(result.Output, Is.EqualTo(""));
+
+            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT + Environment.NewLine));
+            Assert.That(_testOutput.Stream, Is.EqualTo("Progress"));
         }
 #endif
 

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -88,10 +88,11 @@ namespace NUnit.Framework.Tests
         }
 
         [Test]
-        public void ShowWriteToConsoleError()
+        public void MultipleWrites()
         {
             // Test purely for display purposes
-            Console.Error.WriteLine("Write to Console.Error displays on console directly");
+            Console.Error.WriteLine("This displays on console directly");
+            Console.WriteLine("This is added to the result");
         }
 #endif
 

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Tests
             get { return TestExecutionContext.CurrentContext.CurrentResult.Output; }
         }
 
-#if !SILVERLIGHT && !PORTABLE
+#if !SILVERLIGHT && !PORTABLE && !NETCF
         [Test]
         public void ConsoleWrite_WritesToResult()
         {

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -1,0 +1,82 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Tests
+{
+    public class TextOutputTests
+    {
+        private const string SOME_TEXT = "Should go to the result";
+        private const string ERROR_TEXT = "This should be written directly to console";
+        private static readonly string NL = NUnit.Env.NewLine;
+
+        private string CapturedOutput
+        {
+            get { return TestExecutionContext.CurrentContext.CurrentResult.Output; }
+        }
+
+        [Test]
+        public void ConsoleWrite_WritesToResult()
+        {
+            Console.Write(SOME_TEXT);
+            Assert.That(CapturedOutput, Is.EqualTo(SOME_TEXT));
+        }
+
+        [Test]
+        public void ConsoleWriteLine_WritesToResult()
+        {
+            Console.WriteLine(SOME_TEXT);
+            Assert.That(CapturedOutput, Is.EqualTo(SOME_TEXT + NL));
+        }
+
+        [Test]
+        public void ConsoleError_WritesToResult()
+        {
+            Console.Error.WriteLine(SOME_TEXT);
+            Assert.That(CapturedOutput, Is.EqualTo(SOME_TEXT + NL));
+        }
+
+        [Test]
+        public void TestContextOut_WritesToResult()
+        {
+            TestContext.Out.WriteLine(SOME_TEXT);
+            Assert.That(CapturedOutput, Is.EqualTo(SOME_TEXT + NL));
+        }
+
+        [Test]
+        public void TestContextWrite_WritesToResult()
+        {
+            TestContext.Write(SOME_TEXT);
+            Assert.That(CapturedOutput, Is.EqualTo(SOME_TEXT));
+        }
+
+        [Test]
+        public void TestContextWriteLine_WritesToResult()
+        {
+            TestContext.WriteLine(SOME_TEXT);
+            Assert.That(Internal.TestExecutionContext.CurrentContext.CurrentResult.Output, Is.EqualTo(SOME_TEXT + NL));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -282,6 +282,7 @@
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="Constraints\ExactCountConstraintTests.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
     <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -282,6 +282,7 @@
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="Constraints\ExactCountConstraintTests.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
     <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -279,6 +279,8 @@
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="Constraints\ExactCountConstraintTests.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
+    <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Threading.Tasks">

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -282,6 +282,8 @@
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
+    <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -289,6 +289,7 @@
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework-netcf-3.5.csproj">

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -272,6 +272,8 @@
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="Constraints\ExactCountConstraintTests.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
+    <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TestImage1.jpg" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -308,6 +308,8 @@
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />
     <Compile Include="TestUtilities\UniqueValues.cs" />
+    <Compile Include="TextOutputTests.cs" />
+    <Compile Include="ThrowsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">


### PR DESCRIPTION
Fixes #1139 

Console.Error output is now sent to the console using an event, as in NUnit V2. Additionally, TestContext.Error and TestContext.Progress may also be used. Console.Error and TestContext.Error output display in red on the color console, while TestContext.Progress uses the standard output color.

Also fixes #1528
