### PR TITLE
Avoid error when already running in a 32-bit process

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -237,8 +237,16 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
         }
 
-        [Test]
-        public void X86AndInProcessAreNotCompatible()
+        [Test, Platform("32-Bit")]
+        public void X86AndInProcessAreCompatibleIn32BitProcess()
+        {
+            ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
+            Assert.True(options.Validate());
+            Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
+        }
+
+        [Test, Platform("64-Bit")]
+        public void X86AndInProcessAreNotCompatibleIn64BitProcess()
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
             Assert.False(options.Validate(), "Should be invalid");

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -83,7 +83,9 @@ namespace NUnit.Common
         {
             base.CheckOptionCombinations();
 
-            if (RunAsX86 && ProcessModel == "InProcess")
+            // Normally, console is run in a 64-bit process on a 64-bit machine
+            // but this might vary if the process is started by some other program.
+            if (IntPtr.Size == 8 && RunAsX86 && ProcessModel == "InProcess")
                 ErrorMessages.Add("The --x86 and --inprocess options are incompatible.");
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -89,7 +89,8 @@ namespace NUnit.Engine.Runners
             // be used to determine how to run the assembly.
             _runtimeService.SelectRuntimeFramework(TestPackage);
 
-            if (TestPackage.GetSetting(PackageSettings.ProcessModel, "") == "InProcess" &&
+            if (IntPtr.Size == 8 &&
+                TestPackage.GetSetting(PackageSettings.ProcessModel, "") == "InProcess" &&
                 TestPackage.GetSetting(PackageSettings.RunAsX86, false))
             {
                 throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");


### PR DESCRIPTION
This fixes #1548 by eliminating the check for running as 32 bits in process unless we are in a 64 bit process.

The change in MasterTestRunner should resolve the current adapter issue nunit/nunit3-vs-adapter#181

The change in the console runner is not currently causing a problem but could do so if someone managed to get the console started in a 32-bit process.