### PR TITLE
Lazy load or hard code constraint DisplayNames

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
@@ -39,10 +39,16 @@ namespace NUnit.Framework.Constraints
         public AllItemsConstraint(IConstraint itemConstraint)
             : base(itemConstraint)
         {
-            this.DisplayName = "All";
-            this.descriptionPrefix = "all items";
+            DescriptionPrefix = "all items";
         }
 
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "All"; } }
 
         /// <summary>
         /// Apply the item constraint to each item in the collection,
@@ -56,7 +62,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("The actual value must be an IEnumerable", "actual");
 
             foreach (object item in (IEnumerable)actual)
-                if (!baseConstraint.ApplyTo(item).IsSuccess)
+                if (!BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Failure);
 
             return new ConstraintResult(this, actual, ConstraintStatus.Success);

--- a/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
             : base(baseConstraint)
         {
             this.expectedType = type;
-            this.descriptionPrefix = "attribute " + expectedType.FullName;
+            this.DescriptionPrefix = "attribute " + expectedType.FullName;
 
             if (!typeof(Attribute).GetTypeInfo().IsAssignableFrom(expectedType.GetTypeInfo()))
                 throw new ArgumentException(string.Format(
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException(string.Format("Attribute {0} was not found", expectedType), "actual");
 
             attrFound = attrs[0];
-            return baseConstraint.ApplyTo(attrFound);
+            return BaseConstraint.ApplyTo(attrFound);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return string.Format("<attribute {0} {1}>", expectedType, baseConstraint);
+            return string.Format("<attribute {0} {1}>", expectedType, BaseConstraint);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
@@ -39,9 +39,16 @@ namespace NUnit.Framework.Constraints
         public CollectionContainsConstraint(object expected)
             : base(expected)
         {
-            this.Expected = expected;
-            this.DisplayName = "Contains";
+            Expected = expected;
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "Contains"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class CollectionEquivalentConstraint : CollectionItemsEqualConstraint
     {
-        private readonly IEnumerable expected;
+        private readonly IEnumerable _expected;
 
         /// <summary>
         /// Construct a CollectionEquivalentConstraint
@@ -40,9 +40,16 @@ namespace NUnit.Framework.Constraints
         public CollectionEquivalentConstraint(IEnumerable expected)
             : base(expected)
         {
-            this.expected = expected;
-            this.DisplayName = "Equivalent";
+            _expected = expected;
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "Equivalent"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for
@@ -50,7 +57,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "equivalent to " + MsgUtils.FormatValue(expected); }
+            get { return "equivalent to " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>
@@ -61,11 +68,11 @@ namespace NUnit.Framework.Constraints
         protected override bool Matches(IEnumerable actual)
         {
             // This is just an optimization
-            if (expected is ICollection && actual is ICollection)
-                if (((ICollection)actual).Count != ((ICollection)expected).Count)
+            if (_expected is ICollection && actual is ICollection)
+                if (((ICollection)actual).Count != ((ICollection)_expected).Count)
                     return false;
 
-            CollectionTally tally = Tally(expected);
+            CollectionTally tally = Tally(_expected);
             return tally.TryRemove(actual) && tally.Count == 0;
         }
 

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -45,8 +45,15 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionOrderedConstraint()
         {
-            this.DisplayName = "Ordered";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "Ordered"; } }
 
         ///<summary>
         /// If used performs a reverse comparison

--- a/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class CollectionSubsetConstraint : CollectionItemsEqualConstraint
     {
-        private IEnumerable expected;
+        private IEnumerable _expected;
 
         /// <summary>
         /// Construct a CollectionSubsetConstraint
@@ -39,9 +39,16 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The collection that the actual value is expected to be a subset of</param>
         public CollectionSubsetConstraint(IEnumerable expected) : base(expected)
         {
-            this.expected = expected;
-            this.DisplayName = "SubsetOf";
+            _expected = expected;
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "SubsetOf"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for
@@ -49,7 +56,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "subset of " + MsgUtils.FormatValue(expected); }
+            get { return "subset of " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>
@@ -60,7 +67,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
-            return Tally(expected).TryRemove( actual );
+            return Tally(_expected).TryRemove( actual );
         }
 
 

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class CollectionSupersetConstraint : CollectionItemsEqualConstraint
     {
-        private IEnumerable expected;
+        private IEnumerable _expected;
 
         /// <summary>
         /// Construct a CollectionSupersetConstraint
@@ -41,9 +41,16 @@ namespace NUnit.Framework.Constraints
         public CollectionSupersetConstraint(IEnumerable expected)
             : base(expected)
         {
-            this.expected = expected;
-            this.DisplayName = "SupersetOf";
+            _expected = expected;
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "SupersetOf"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for
@@ -51,7 +58,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "superset of " + MsgUtils.FormatValue(expected); }
+            get { return "superset of " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>
@@ -62,7 +69,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
-            return Tally(actual).TryRemove(expected);
+            return Tally(actual).TryRemove(_expected);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -23,6 +23,7 @@
 
 using NUnit.Framework.Internal;
 using System.Collections;
+using System;
 
 namespace NUnit.Framework.Constraints
 {
@@ -50,9 +51,9 @@ namespace NUnit.Framework.Constraints
             Arguments = args;
 
             DisplayName = this.GetType().Name;
-            if (DisplayName.EndsWith("`1") || DisplayName.EndsWith("`2"))
+            if (DisplayName.EndsWith("`1", StringComparison.Ordinal) || DisplayName.EndsWith("`2", StringComparison.Ordinal))
                 DisplayName = DisplayName.Substring(0, DisplayName.Length - 2);
-            if (DisplayName.EndsWith("Constraint"))
+            if (DisplayName.EndsWith("Constraint", StringComparison.Ordinal))
                 DisplayName = DisplayName.Substring(0, DisplayName.Length - 10);
         }
 

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -40,6 +40,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public abstract class Constraint : IConstraint
     {
+        Lazy<string> _displayName;
+
         #region Constructor
 
         /// <summary>
@@ -50,11 +52,15 @@ namespace NUnit.Framework.Constraints
         {
             Arguments = args;
 
-            DisplayName = this.GetType().Name;
-            if (DisplayName.EndsWith("`1", StringComparison.Ordinal) || DisplayName.EndsWith("`2", StringComparison.Ordinal))
-                DisplayName = DisplayName.Substring(0, DisplayName.Length - 2);
-            if (DisplayName.EndsWith("Constraint", StringComparison.Ordinal))
-                DisplayName = DisplayName.Substring(0, DisplayName.Length - 10);
+            _displayName = new Lazy<string>(() =>
+            {
+                var displayName = this.GetType().Name;
+                if (displayName.EndsWith("`1", StringComparison.Ordinal) || displayName.EndsWith("`2", StringComparison.Ordinal))
+                    displayName = displayName.Substring(0, displayName.Length - 2);
+                if (displayName.EndsWith("Constraint", StringComparison.Ordinal))
+                    displayName = displayName.Substring(0, displayName.Length - 10);
+                return displayName;
+            });
         }
 
         #endregion
@@ -67,7 +73,7 @@ namespace NUnit.Framework.Constraints
         /// trailing "Constraint" removed. Derived classes may set
         /// this to another name in their constructors.
         /// </summary>
-        public string DisplayName { get; protected set; }
+        public virtual string DisplayName { get { return _displayName.Value; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return string.Format("{0} after {1} millisecond delay", baseConstraint.Description, delayInMilliseconds); }
+            get { return string.Format("{0} after {1} millisecond delay", BaseConstraint.Description, delayInMilliseconds); }
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Constraints
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
                     nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(pollingInterval));
 
-                    ConstraintResult result = baseConstraint.ApplyTo(actual);
+                    ConstraintResult result = BaseConstraint.ApplyTo(actual);
                     if (result.IsSuccess)
                         return new ConstraintResult(this, actual, true);
                 }
@@ -99,7 +99,7 @@ namespace NUnit.Framework.Constraints
             if ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 Thread.Sleep((int)TimestampDiff(delayEnd, now).TotalMilliseconds);
 
-            return new ConstraintResult(this, actual, baseConstraint.ApplyTo(actual).IsSuccess);
+            return new ConstraintResult(this, actual, BaseConstraint.ApplyTo(actual).IsSuccess);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Constraints
 
                     try
                     {
-                        ConstraintResult result = baseConstraint.ApplyTo(actual);
+                        ConstraintResult result = BaseConstraint.ApplyTo(actual);
                         if (result.IsSuccess)
                             return new ConstraintResult(this, actual, true);
                     }
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Constraints
                 Thread.Sleep((int)TimestampDiff(delayEnd, now).TotalMilliseconds);
 
             actual = InvokeDelegate(del);
-            return new ConstraintResult(this, actual, baseConstraint.ApplyTo(actual).IsSuccess);
+            return new ConstraintResult(this, actual, BaseConstraint.ApplyTo(actual).IsSuccess);
         }
 
         private static object InvokeDelegate<T>(ActualValueDelegate<T> del)
@@ -177,7 +177,7 @@ namespace NUnit.Framework.Constraints
 
                     try
                     {
-                        ConstraintResult result = baseConstraint.ApplyTo(actual);
+                        ConstraintResult result = BaseConstraint.ApplyTo(actual);
                         if (result.IsSuccess)
                             return new ConstraintResult(this, actual, true);
                     }
@@ -190,7 +190,7 @@ namespace NUnit.Framework.Constraints
             if ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 Thread.Sleep((int)TimestampDiff(delayEnd, now).TotalMilliseconds);
 
-            return new ConstraintResult(this, actual, baseConstraint.ApplyTo(actual).IsSuccess);
+            return new ConstraintResult(this, actual, BaseConstraint.ApplyTo(actual).IsSuccess);
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return string.Format("<after {0} {1}>", delayInMilliseconds, baseConstraint);
+            return string.Format("<after {0} {1}>", delayInMilliseconds, BaseConstraint);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -39,8 +39,15 @@ namespace NUnit.Framework.Constraints
         public DictionaryContainsKeyConstraint(object expected)
             : base(expected)
         {
-            DisplayName = "ContainsKey";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "ContainsKey"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -39,8 +39,15 @@ namespace NUnit.Framework.Constraints
         public DictionaryContainsValueConstraint(object expected)
             : base(expected)
         {
-            DisplayName = "ContainsValue";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "ContainsValue"; } }
 
         /// <summary>
         /// The Description of what this constraint tests, for

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Constraints
             : base(itemConstraint)
         {
             this.expectedCount = expectedCount;
-            this.descriptionPrefix = expectedCount == 0
+            this.DescriptionPrefix = expectedCount == 0
                 ? "no item"
                 : expectedCount == 1
                     ? "exactly one item"
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints
 
             int count = 0;
             foreach (object item in (IEnumerable)actual)
-                if (baseConstraint.ApplyTo(item).IsSuccess)
+                if (BaseConstraint.ApplyTo(item).IsSuccess)
                     count++;
 
             return new ConstraintResult(this, actual, count == expectedCount);

--- a/src/NUnitFramework/framework/Constraints/ExactTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactTypeConstraint.cs
@@ -38,8 +38,15 @@ namespace NUnit.Framework.Constraints
         public ExactTypeConstraint(Type type)
             : base(type, string.Empty)
         {
-            this.DisplayName = "TypeOf";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "TypeOf"; } }
 
         /// <summary>
         /// Apply the constraint to an actual value, returning true if it succeeds

--- a/src/NUnitFramework/framework/Constraints/InstanceOfTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/InstanceOfTypeConstraint.cs
@@ -40,8 +40,15 @@ namespace NUnit.Framework.Constraints
         public InstanceOfTypeConstraint(Type type)
             : base(type, "instance of ")
         {
-            this.DisplayName = "InstanceOf";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "InstanceOf"; } }
 
         /// <summary>
         /// Apply the constraint to an actual value, returning true if it succeeds

--- a/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
@@ -39,9 +39,16 @@ namespace NUnit.Framework.Constraints
         public NoItemConstraint(IConstraint itemConstraint)
             : base(itemConstraint)
         {
-            this.DisplayName = "None";
-            this.descriptionPrefix = "no item";
+            DescriptionPrefix = "no item";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "None"; } }
 
         /// <summary>
         /// Apply the item constraint to each item in the collection,
@@ -55,7 +62,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("The actual value must be an IEnumerable", "actual");
 
             foreach (object item in (IEnumerable)actual)
-                if (baseConstraint.ApplyTo(item).IsSuccess)
+                if (BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Failure);
 
             return new ConstraintResult(this, actual, ConstraintStatus.Success);

--- a/src/NUnitFramework/framework/Constraints/NotConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NotConstraint.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
         public NotConstraint(IConstraint baseConstraint)
             : base(baseConstraint) 
         {
-            this.descriptionPrefix = "not";
+            this.DescriptionPrefix = "not";
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for if the base constraint fails, false if it succeeds</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            var baseResult = baseConstraint.ApplyTo(actual);
+            var baseResult = BaseConstraint.ApplyTo(actual);
             return new ConstraintResult(this, baseResult.ActualValue, !baseResult.IsSuccess);
         }
 

--- a/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
@@ -31,12 +31,12 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// The base constraint
         /// </summary>
-        protected IConstraint baseConstraint;
+        protected IConstraint BaseConstraint { get; set; }
 
         /// <summary>
         /// Prefix used in forming the constraint description
         /// </summary>
-        protected string descriptionPrefix;
+        protected string DescriptionPrefix { get; set; }
 
         /// <summary>
         /// Construct given a base constraint
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
         {
             Guard.ArgumentNotNull(baseConstraint, "baseConstraint");
 
-            this.baseConstraint = baseConstraint.Resolve();
+            BaseConstraint = baseConstraint.Resolve();
         }
 
         /// <summary>
@@ -59,9 +59,9 @@ namespace NUnit.Framework.Constraints
             get
             {
                 return string.Format(
-                    baseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}", 
-                    descriptionPrefix, 
-                    baseConstraint.Description);
+                    BaseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}", 
+                    DescriptionPrefix, 
+                    BaseConstraint.Description);
             }
         }
     }

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
             : base(baseConstraint)
         {
             this.name = name;
-            this.descriptionPrefix = "property " + name;
+            this.DescriptionPrefix = "property " + name;
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException(string.Format("Property {0} was not found", name), "name");
 
             propValue = property.GetValue(actual, null);
-            return new ConstraintResult(this, propValue, baseConstraint.ApplyTo(propValue).IsSuccess);
+            return new ConstraintResult(this, propValue, BaseConstraint.ApplyTo(propValue).IsSuccess);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override string GetStringRepresentation()
         {
-            return string.Format("<property {0} {1}>", name, baseConstraint);
+            return string.Format("<property {0} {1}>", name, BaseConstraint);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -39,9 +39,16 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint(IConstraint itemConstraint)
             : base(itemConstraint)
         {
-            this.DisplayName = "Some";
-            this.descriptionPrefix = "some item";
+            DescriptionPrefix = "some item";
         }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "Some"; } }
 
         /// <summary>
         /// Apply the item constraint to each item in the collection,
@@ -55,7 +62,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("The actual value must be an IEnumerable", "actual");
 
             foreach (object item in (IEnumerable)actual)
-                if (baseConstraint.ApplyTo(item).IsSuccess)
+                if (BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Success);
 
             return new ConstraintResult(this, actual, ConstraintStatus.Failure);

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return baseConstraint.Description; }
+            get { return BaseConstraint.Description; }
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Constraints
                 this,
                 caughtException,
                 caughtException != null
-                    ? baseConstraint.ApplyTo(caughtException)
+                    ? BaseConstraint.ApplyTo(caughtException)
                     : null);
         }
 


### PR DESCRIPTION
Fixes #1555 

First, I applied the quick fix recommended by @jskeet and use `StringComparison.Ordinal` when constructing the `DisplayName`. I walked out from the `DisplayName` and as far as I can tell, it is only used in our tests, but I am reluctant to change a published API, so I changed it to be lazy loaded on the base `Constraint` class and hard coded on constraints that override it.

This results in a breaking change for any custom constraints that expect the base `Constraint.DisplayName` to be settable. They will have to override `DisplayName` instead. `IConstraint.DisplayName` only has a getter though, so it is not breaking the API.