### PR TITLE
TestCase with generic return type causes NullReferenceException

### DIFF
--- a/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
@@ -67,7 +67,9 @@ at wrapping a non-async method invocation in an async region was done");
 
         public static bool IsAsyncOperation(MethodInfo method)
         {
-            return method.ReturnType.FullName.StartsWith(TaskTypeName) ||
+            var name = method.ReturnType.FullName;
+            if (name == null) return false;
+            return name.StartsWith(TaskTypeName) ||
                    method.GetCustomAttributes(false).Any(attr => AsyncAttributeTypeName == attr.GetType().FullName);
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -28,6 +28,15 @@ using NUnit.Framework.Internal;
 using NUnit.TestData.TestCaseAttributeFixture;
 using NUnit.TestUtilities;
 
+#if NET_4_0 || NET_4_5 || PORTABLE
+using System;
+using System.Threading.Tasks;
+#endif
+
+#if NET_4_0
+using Task = System.Threading.Tasks.TaskEx;
+#endif
+
 namespace NUnit.Framework.Attributes
 {
     [TestFixture]
@@ -506,6 +515,20 @@ namespace NUnit.Framework.Attributes
             return a;
         }
 
-        #endregion
+        [TestCase(1, ExpectedResult = 1)]
+        public T TestWithGenericReturnType<T>(T arg1)
+        {
+            return arg1;
+        }
+
+#if NET_4_0 || NET_4_5 || PORTABLE
+        [TestCase(1, ExpectedResult = 1)]
+        public async Task<T> TestWithAsyncGenericReturnType<T>(T arg1)
+        {
+            return await Task.Run(() => arg1);
+        }
+#endif
+
+#endregion
     }
 }


### PR DESCRIPTION
Fixes #1481 

Thanks to @mbcrawfo for doing the legwork on this one. :+1: 