### PR TITLE
Improved OS X compatibility

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -105,7 +105,7 @@ namespace NUnit.ConsoleRunner.Tests
             };
 
             var actualSummary = GetReportLines(_reporter.WriteSummaryReport);
-            Assert.That(expected, Is.EqualTo(actualSummary));
+            Assert.That(actualSummary, Is.EqualTo(expected));
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace NUnit.ConsoleRunner.Tests
             };
 
             var report = GetReportLines(_reporter.WriteNotRunReport);
-            Assert.That(expected, Is.EqualTo(report));
+            Assert.That(report, Is.EqualTo(expected));
         }
 
         #region Helper Methods

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -140,7 +140,7 @@ namespace NUnit.ConsoleRunner
 
             _writer.WriteLabelLine("  Start time: ", startTime.ToString("u"));
             _writer.WriteLabelLine("    End time: ", endTime.ToString("u"));
-            _writer.WriteLabelLine("    Duration: ", string.Format("{0} seconds", duration.ToString("0.000")));
+            _writer.WriteLabelLine("    Duration: ", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000} seconds", duration));
             _writer.WriteLine();
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
@@ -87,8 +87,8 @@ namespace NUnit.Engine.Internal.Tests
 		}
 
 		[Test]
-		[Platform(Exclude="Linux")]
-		public void RelativePath()
+		[Platform(Exclude="Linux,UNIX,MacOSX")]
+        public void RelativePath()
 		{
 			Assert.AreEqual( @"folder2\folder3", PathUtils.RelativePath( 
 				@"c:\folder1", @"c:\folder1\folder2\folder3" ) );

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -90,7 +90,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var configFileName = "nunit.engine.tests.dll.config";
             var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, configFileName);
-            Assert.That(expectedPath, Is.EqualTo(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile));
+            Assert.That(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile, Is.EqualTo(expectedPath));
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
@@ -238,7 +238,7 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
             double time;
             var timeString = RequiredAttribute(_fixtureNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
-            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,null, out time);
+            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,System.Globalization.NumberFormatInfo.InvariantInfo, out time);
             Assert.That(success, "{0} is an invalid value for time", timeString);
 #endif
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/NUnit2XmlResultWriterTests.cs
@@ -236,8 +236,10 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
             RequiredAttribute(suiteNode, "time");
 #else
             double time;
+            var timeString = RequiredAttribute(_fixtureNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
-            Assert.That(double.TryParse(RequiredAttribute(_fixtureNode, "time"),System.Globalization.NumberStyles.Float,null, out time), "Invalid value for time");
+            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,null, out time);
+            Assert.That(success, "{0} is an invalid value for time", timeString);
 #endif
         }
 

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -216,7 +216,7 @@ namespace NUnitLite.Tests
             double time;
             var timeString = RequiredAttribute(suiteNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
-            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,null, out time);
+            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,System.Globalization.NumberFormatInfo.InvariantInfo, out time);
             Assert.That(success, "{0} is an invalid value for time", timeString);
 #endif
         }

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -214,8 +214,10 @@ namespace NUnitLite.Tests
             RequiredAttribute(suiteNode, "time");
 #else
             double time;
+            var timeString = RequiredAttribute(suiteNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
-            Assert.That(double.TryParse(RequiredAttribute(suiteNode, "time"),System.Globalization.NumberStyles.Float,null, out time), "Invalid value for time");
+            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,null, out time);
+            Assert.That(success, "{0} is an invalid value for time", timeString);
 #endif
         }
 

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -354,7 +354,7 @@ namespace NUnitLite
 
             _writer.WriteLabelLine("  Start time: ", summary.StartTime.ToString("u"));
             _writer.WriteLabelLine("    End time: ", summary.EndTime.ToString("u"));
-            _writer.WriteLabelLine("    Duration: ", summary.Duration.ToString("0.000") + " seconds");
+            _writer.WriteLabelLine("    Duration: ", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000} seconds", summary.Duration));
             _writer.WriteLine();
         }
 

--- a/src/NUnitFramework/tests/Constraints/ConstraintTestBase.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintTestBase.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void ProvidesProperDescription()
         {
-            Assert.That(expectedDescription, Is.EqualTo(theConstraint.Description));
+            Assert.That(theConstraint.Description, Is.EqualTo(expectedDescription));
         }
 
         [Test]


### PR DESCRIPTION
The commits within this PR were things I had to do locally in order to get `./build -t TestAll` to execute successfully on my Mac with OS X 10.11.5 and Mono 4.2.3. 

7346a5a3db86e0b6e1bb79338a2c16fe10639e77 is more of convenience and consistency, since `Assert.That()` takes `actual` as the first parameter and `expected` constraint as the second. I fixed this everywhere I found it, because a related test failed, claiming the reverse of what was in the test data, which made me confused.