### PR TITLE
Use Type.IsGenericType instead of String.EndsWith

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -54,8 +54,9 @@ namespace NUnit.Framework.Constraints
 
             _displayName = new Lazy<string>(() =>
             {
-                var displayName = this.GetType().Name;
-                if (displayName.EndsWith("`1", StringComparison.Ordinal) || displayName.EndsWith("`2", StringComparison.Ordinal))
+                var type = this.GetType();
+                var displayName = type.Name;
+                if (type.IsGenericType)
                     displayName = displayName.Substring(0, displayName.Length - 2);
                 if (displayName.EndsWith("Constraint", StringComparison.Ordinal))
                     displayName = displayName.Substring(0, displayName.Length - 10);

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -22,8 +22,10 @@
 // ***********************************************************************
 
 using NUnit.Framework.Internal;
+using NUnit.Compatibility;
 using System.Collections;
 using System;
+using System.Reflection;
 
 namespace NUnit.Framework.Constraints
 {
@@ -56,7 +58,7 @@ namespace NUnit.Framework.Constraints
             {
                 var type = this.GetType();
                 var displayName = type.Name;
-                if (type.IsGenericType)
+                if (type.GetTypeInfo().IsGenericType)
                     displayName = displayName.Substring(0, displayName.Length - 2);
                 if (displayName.EndsWith("Constraint", StringComparison.Ordinal))
                     displayName = displayName.Substring(0, displayName.Length - 10);


### PR DESCRIPTION
This PR implements @InPermutation's suggestion in #1557 to use `Type.IsGenericType` instead of:

```c#
displayName.EndsWith("`1", StringComparison.Ordinal) || displayName.EndsWith("`2", StringComparison.Ordinal)
```

I don't know how well `Constraint.DisplayName` is tested, but I hope that since everything's green after running `./build -t TestAll`, I haven't broken anything. If I have, please let me know.