### PR TITLE
Allow passing arguments into the test run

### DIFF
--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -86,6 +86,8 @@ namespace NUnit.Common
         private List<string> testList = new List<string>();
         public IList<string> TestList { get { return testList; } }
 
+        public string TestParameters { get; private set; }
+
         public string WhereClause { get; private set; }
         public bool WhereClauseSpecified { get { return WhereClause != null; } }
 
@@ -295,6 +297,23 @@ namespace NUnit.Common
 #endif
             this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
+
+            this.Add("params|D=", "Define a test parameter.",
+                v =>
+                {
+                    string parameters = RequiredValue( v, "--params");
+
+                    foreach (string param in parameters.Split(new[] { ';' }))
+                    {
+                        if (!param.Contains("="))
+                            ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
+                    }
+
+                    if (TestParameters == null)
+                        TestParameters = parameters;
+                    else
+                        TestParameters += ";" + parameters;
+                });
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
                 v => defaultTimeout = RequiredInt(v, "--timeout"));

--- a/src/Common/nunit/CommandLineOptions.cs
+++ b/src/Common/nunit/CommandLineOptions.cs
@@ -298,7 +298,7 @@ namespace NUnit.Common
             this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
 
-            this.Add("params|D=", "Define a test parameter.",
+            this.Add("params|p=", "Define a test parameter.",
                 v =>
                 {
                     string parameters = RequiredValue( v, "--params");

--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -198,6 +198,11 @@ namespace NUnit.Common
         /// </summary>
         public const string DefaultTestNamePattern = "DefaultTestNamePattern";
 
+        /// <summary>
+        /// Parameters to be passed on to the test
+        /// </summary>
+        public const string TestParameters = "TestParameters";
+
         #endregion
 
         #region Internal Settings - Used only within the engine

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -571,7 +571,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void TwoTestParametersInSeparateOptions()
         {
-            var options = new ConsoleOptions("-D:X=5", "-D:Y=7");
+            var options = new ConsoleOptions("-p:X=5", "-p:Y=7");
             Assert.That(options.errorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7"));
         }
@@ -579,7 +579,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ThreeTestParametersInTwoOptions()
         {
-            var options = new ConsoleOptions("--params:X=5;Y=7", "-D:Z=3");
+            var options = new ConsoleOptions("--params:X=5;Y=7", "-p:Z=3");
             Assert.That(options.errorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7;Z=3"));
         }

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.IO;
 using System.Reflection;
 using NUnit.Common;
@@ -206,6 +207,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--work")]
         [TestCase("--trace")]
         [TestCase("--test-name-format")]
+        [TestCase("--params")]
         public void MissingValuesAreReported(string option)
         {
             ConsoleOptions options = new ConsoleOptions(option + "=");
@@ -544,6 +546,64 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions("--testlist=" + testListPath);
             Assert.That(options.errorMessages, Is.Empty);
             Assert.That(options.TestList, Is.EqualTo(new[] {"AmazingTest"}));
+        }
+
+        #endregion
+
+        #region Test Parameters
+
+        [Test]
+        public void SingleTestParameter()
+        {
+            var options = new ConsoleOptions("--params=X=5");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5"));
+        }
+
+        [Test]
+        public void TwoTestParametersInOneOption()
+        {
+            var options = new ConsoleOptions("--params:X=5;Y=7");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7"));
+        }
+
+        [Test]
+        public void TwoTestParametersInSeparateOptions()
+        {
+            var options = new ConsoleOptions("-D:X=5", "-D:Y=7");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7"));
+        }
+
+        [Test]
+        public void ThreeTestParametersInTwoOptions()
+        {
+            var options = new ConsoleOptions("--params:X=5;Y=7", "-D:Z=3");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7;Z=3"));
+        }
+
+        [Test]
+        public void ParameterWithoutEqualSignIsInvalid()
+        {
+            var options = new ConsoleOptions("--params=X5");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DisplayTestParameters()
+        {
+            if (TestContext.Parameters.Count == 0)
+            {
+                Console.WriteLine("No Test Parameters were passed");
+                return;
+            }
+
+            Console.WriteLine("Test Parameters---");
+
+            foreach (var name in TestContext.Parameters.Names)
+                Console.WriteLine("   Name: {0} Value: {1}", name, TestContext.Parameters[name]);
         }
 
         #endregion

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -73,6 +73,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--workers=0", "NumberOfTestWorkers", 0)]
         [TestCase("--debug", "DebugTests", true)]
         [TestCase("--pause", "PauseBeforeRun", true)]
+        [TestCase("--params:X=5;Y=7", "TestParameters", "X=5;Y=7")]
 #if DEBUG
         [TestCase("--debug-agent", "DebugAgent", true)]
 #endif

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -365,6 +365,9 @@ namespace NUnit.ConsoleRunner
             if (options.DefaultTestNamePattern != null)
                 package.AddSetting(PackageSettings.DefaultTestNamePattern, options.DefaultTestNamePattern);
 
+            if (options.TestParameters != null)
+                package.AddSetting(PackageSettings.TestParameters, options.TestParameters);
+
             return package;
         }
 

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -133,6 +133,24 @@ namespace NUnit.Framework.Api
                 if (options.ContainsKey(PackageSettings.DefaultTestNamePattern))
                     TestNameGenerator.DefaultTestNamePattern = options[PackageSettings.DefaultTestNamePattern] as string;
 
+                if (options.ContainsKey(PackageSettings.TestParameters))
+                {
+                    string parameters = options[PackageSettings.TestParameters] as string;
+                    if (!string.IsNullOrEmpty(parameters))
+                        foreach (string param in parameters.Split(new[] { ';' }))
+                        {
+                            int eq = param.IndexOf("=");
+
+                            if (eq > 0 && eq < param.Length - 1)
+                            {
+                                var name = param.Substring(0, eq);
+                                var val = param.Substring(eq + 1);
+
+                                TestContext.Parameters.Add(name, val);
+                            }
+                        }
+                }
+
                 IList fixtureNames = null;
                 if (options.ContainsKey (PackageSettings.LOAD))
                     fixtureNames = options[PackageSettings.LOAD] as IList;

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework.Constraints;
@@ -87,6 +88,11 @@ namespace NUnit.Framework
         /// </summary>
         public static readonly TextWriter Progress = new EventListenerTextWriter("Progress", Console.Error);
 #endif
+
+        /// <summary>
+        /// TestParameters object holds parameters for the test run, if any are specified
+        /// </summary>
+        public static readonly TestParameters Parameters = new TestParameters();
 
         /// <summary>
         /// Get a representation of the current test.
@@ -458,7 +464,7 @@ namespace NUnit.Framework
 
             #endregion
         }
-        
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/TestParameters.cs
+++ b/src/NUnitFramework/framework/TestParameters.cs
@@ -44,17 +44,23 @@ namespace NUnit.Framework
         /// <returns>Value of the paramter or null if not present</returns>
         public string Get(string name)
         {
-            return _parameters.ContainsKey(name) ? _parameters[name] : null;
+            return this[name];
         }
 
         public string Get(string name, string defaultValue)
         {
-            return _parameters.ContainsKey(name) ? _parameters[name] : defaultValue;
+            return this[name] ?? defaultValue;
         }
-        
-        public int Get(string name, int defaultValue)
+
+        public int GetInt(string name)
         {
-            return _parameters.ContainsKey(name) ? int.Parse(_parameters[name]) : defaultValue;
+            return GetInt(name, 0);
+        }
+
+        public int GetInt(string name, int defaultValue)
+        {
+            string val = this[name];
+            return val != null ? int.Parse(val) : defaultValue;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/TestParameters.cs
+++ b/src/NUnitFramework/framework/TestParameters.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Indexer is the only public access to the internal dictionary
+        /// Indexer provides access to the internal dictionary
         /// </summary>
         /// <param name="name">Name of the parameter</param>
         /// <returns>Value of the parameter or null if not present</returns>
@@ -41,22 +41,39 @@ namespace NUnit.Framework
         /// Get method is a simple alternative to the indexer
         /// </summary>
         /// <param name="name">Name of the paramter</param>
-        /// <returns>Value of the paramter or null if not present</returns>
+        /// <returns>Value of the parameter or null if not present</returns>
         public string Get(string name)
         {
             return this[name];
         }
 
+        /// <summary>
+        /// Get the value of a parameter or a default string
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <param name="defaultValue">Default value of the parameter</param>
+        /// <returns>Value of the parameter or default value if not present</returns>
         public string Get(string name, string defaultValue)
         {
             return this[name] ?? defaultValue;
         }
 
+        /// <summary>
+        /// Get the int value of a parameter or zero
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <returns>Value of the parameter or default value if not present</returns>
         public int GetInt(string name)
         {
             return GetInt(name, 0);
         }
 
+        /// <summary>
+        /// Get the int value of a parameter or a default int
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <param name="defaultValue">Default value of the parameter</param>
+        /// <returns>Value of the parameter or default value if not present</returns>
         public int GetInt(string name, int defaultValue)
         {
             string val = this[name];

--- a/src/NUnitFramework/framework/TestParameters.cs
+++ b/src/NUnitFramework/framework/TestParameters.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// TestParameters class holds any named parameters supplied to the test run
+    /// </summary>
+    public class TestParameters
+    {
+        private readonly Dictionary<string, string> _parameters = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets the number of test parameters
+        /// </summary>
+        public int Count
+        {
+            get { return _parameters.Count; }
+        }
+
+        /// <summary>
+        /// Gets a collection of the test parameter names
+        /// </summary>
+        public ICollection<string> Names
+        {
+            get { return _parameters.Keys; }
+        }
+
+        /// <summary>
+        /// Indexer is the only public access to the internal dictionary
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <returns>Value of the parameter or null if not present</returns>
+        public string this[string name]
+        {
+            get { return _parameters.ContainsKey(name) ? _parameters[name] : null; }
+        }
+
+        /// <summary>
+        /// Get method is a simple alternative to the indexer
+        /// </summary>
+        /// <param name="name">Name of the paramter</param>
+        /// <returns>Value of the paramter or null if not present</returns>
+        public string Get(string name)
+        {
+            return _parameters.ContainsKey(name) ? _parameters[name] : null;
+        }
+
+        public string Get(string name, string defaultValue)
+        {
+            return _parameters.ContainsKey(name) ? _parameters[name] : defaultValue;
+        }
+        
+        public int Get(string name, int defaultValue)
+        {
+            return _parameters.ContainsKey(name) ? int.Parse(_parameters[name]) : defaultValue;
+        }
+
+        /// <summary>
+        /// Adds a parameter to the list
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <param name="value">Value of the parameter</param>
+        internal void Add(string name, string value)
+        {
+            _parameters[name] = value;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/TestParameters.cs
+++ b/src/NUnitFramework/framework/TestParameters.cs
@@ -28,13 +28,23 @@ namespace NUnit.Framework
         }
 
         /// <summary>
+        /// Gets a flag indicating whether a parameter with the specified name exists.N
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <returns>True if it exists, otherwise false</returns>
+        public bool Exists(string name)
+        {
+            return _parameters.ContainsKey(name);
+        }
+
+        /// <summary>
         /// Indexer provides access to the internal dictionary
         /// </summary>
         /// <param name="name">Name of the parameter</param>
         /// <returns>Value of the parameter or null if not present</returns>
         public string this[string name]
         {
-            get { return _parameters.ContainsKey(name) ? _parameters[name] : null; }
+            get { return Get(name); }
         }
 
         /// <summary>
@@ -44,7 +54,7 @@ namespace NUnit.Framework
         /// <returns>Value of the parameter or null if not present</returns>
         public string Get(string name)
         {
-            return this[name];
+            return Exists(name) ? _parameters[name] : null;
         }
 
         /// <summary>
@@ -55,29 +65,20 @@ namespace NUnit.Framework
         /// <returns>Value of the parameter or default value if not present</returns>
         public string Get(string name, string defaultValue)
         {
-            return this[name] ?? defaultValue;
+            return Get(name) ?? defaultValue;
         }
 
         /// <summary>
-        /// Get the int value of a parameter or zero
+        /// Get the value of a parameter or return a default
         /// </summary>
-        /// <param name="name">Name of the parameter</param>
-        /// <returns>Value of the parameter or default value if not present</returns>
-        public int GetInt(string name)
-        {
-            return GetInt(name, 0);
-        }
-
-        /// <summary>
-        /// Get the int value of a parameter or a default int
-        /// </summary>
+        /// <typeparam name="T">The return Type</typeparam>
         /// <param name="name">Name of the parameter</param>
         /// <param name="defaultValue">Default value of the parameter</param>
         /// <returns>Value of the parameter or default value if not present</returns>
-        public int GetInt(string name, int defaultValue)
+        public T Get<T>(string name, T defaultValue)
         {
-            string val = this[name];
-            return val != null ? int.Parse(val) : defaultValue;
+            string val = Get(name);
+            return val != null ? (T)Convert.ChangeType(val, typeof(T), null) : defaultValue;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -433,6 +433,7 @@
     <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
     <Compile Include="Internal\Results\TestCaseResult.cs" />
     <Compile Include="Internal\Results\TestSuiteResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -431,6 +431,7 @@
     <Compile Include="StringAssert.cs" />
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
     <Compile Include="Internal\Results\TestCaseResult.cs" />
     <Compile Include="Internal\Results\TestSuiteResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -422,6 +422,7 @@
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="TestFixtureData.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
     <Compile Include="Internal\Results\TestCaseResult.cs" />
     <Compile Include="Internal\Results\TestSuiteResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -426,6 +426,7 @@
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="TestFixtureData.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
     <Compile Include="Internal\Results\TestCaseResult.cs" />
     <Compile Include="Internal\Results\TestSuiteResult.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -449,6 +449,7 @@
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="TestFixtureData.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -431,6 +431,7 @@
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="TestFixtureData.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -445,6 +445,7 @@
     <Compile Include="TestCaseData.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="TestFixtureData.cs" />
+    <Compile Include="TestParameters.cs" />
     <Compile Include="Throws.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -29,7 +29,6 @@ using NUnit.TestData.TestCaseAttributeFixture;
 using NUnit.TestUtilities;
 
 #if NET_4_0 || NET_4_5 || PORTABLE
-using System;
 using System.Threading.Tasks;
 #endif
 

--- a/src/NUnitFramework/tests/TestParametersTests.cs
+++ b/src/NUnitFramework/tests/TestParametersTests.cs
@@ -13,105 +13,150 @@ namespace NUnit.Framework.Tests
         public void CreateTestParameters()
         {
             _parameters = new TestParameters();
+            _parameters.Add("IntParm", "5");
+            _parameters.Add("StringParm", "five");
         }
 
-        [Test]
-        public void InitiallyCountIsZero()
-        {
-            Assert.That(_parameters.Count, Is.EqualTo(0));
-        }
+        #region Add(string name, string value)
 
         [Test]
-        public void InitiallyValuesAreNull()
+        public void Add_CountIsCorrect()
         {
-            Assert.Null(_parameters["ABC"]);
-            Assert.Null(_parameters["XYZ"]);
-        }
-
-        [Test]
-        public void AddParameters_CountIsCorrect()
-        {
-            AddTwoItems();
-
             Assert.That(_parameters.Count, Is.EqualTo(2));
         }
 
         [Test]
-        public void AddParameters_NullKeyThrowsException()
+        public void Add_NullKeyThrowsException()
         {
             Assert.That(() => _parameters.Add((string)null, "X"), Throws.ArgumentNullException);
         }
 
-        [Test]
-        public void IndexParameters_ValuesAreCorrect()
-        {
-            AddTwoItems();
+        #endregion
 
-            Assert.That(_parameters["Parm1"], Is.EqualTo("5"));
-            Assert.That(_parameters["Parm2"], Is.EqualTo("five"));
+        #region this[string name]
+
+        [Test]
+        public void Index_ValuesAreCorrect()
+        {
+            Assert.That(_parameters["IntParm"], Is.EqualTo("5"));
+            Assert.That(_parameters["StringParm"], Is.EqualTo("five"));
         }
 
         [Test]
-        public void IndexParameters_MissingValuesAreNull()
+        public void Index_MissingValuesAreNull()
         {
-            AddTwoItems();
-
             Assert.Null(_parameters["ABC"]);
             Assert.Null(_parameters["XYZ"]);
         }
 
         [Test]
-        public void IndexParameters_NullKeyThrowsException()
+        public void Index_NullKeyThrowsException()
         {
             Assert.That(() => _parameters[null], Throws.ArgumentNullException);
         }
 
-        [Test]
-        public void GetParameters_ValuesAreCorrect()
-        {
-            AddTwoItems();
+        #endregion
 
-            Assert.That(_parameters.Get("Parm1"), Is.EqualTo("5"));
-            Assert.That(_parameters.Get("Parm2"), Is.EqualTo("five"));
+        #region Get(string name)
+
+        [Test]
+        public void Get_ValuesAreCorrect()
+        {
+            Assert.That(_parameters.Get("IntParm"), Is.EqualTo("5"));
+            Assert.That(_parameters.Get("StringParm"), Is.EqualTo("five"));
         }
 
         [Test]
-        public void GetParameters_MissingValuesAreNull()
+        public void Get_MissingValuesAreNull()
         {
-            AddTwoItems();
-
             Assert.Null(_parameters.Get("ABC"));
             Assert.Null(_parameters.Get("XYZ"));
         }
 
         [Test]
-        public void GetParameters_NullKeyThrowsException()
+        public void Get_NullKeyThrowsException()
         {
             Assert.That(() => _parameters.Get(null), Throws.ArgumentNullException);
         }
 
+        #endregion
+
+        #region Get(string name, string defaultValue)
+
         [Test]
         public void GetWithDefault_ValuesAreCorrect()
         {
-            AddTwoItems();
-
-            Assert.That(_parameters.Get("Parm1", 99), Is.EqualTo(5));
-            Assert.That(_parameters.Get("Parm2", "JUNK"), Is.EqualTo("five"));
+            Assert.That(_parameters.Get("StringParm", "JUNK"), Is.EqualTo("five"));
         }
 
         [Test]
         public void GetWithDefault_MissingValuesUseDefault()
         {
-            AddTwoItems();
-
-            Assert.That(_parameters.Get("ABC", 99), Is.EqualTo(99));
             Assert.That(_parameters.Get("XYZ", "JUNK"), Is.EqualTo("JUNK"));
         }
 
-        private void AddTwoItems()
+        [Test]
+        public void GetWithDefault_NullKeyThrowsException()
         {
-            _parameters.Add("Parm1", "5");
-            _parameters.Add("Parm2", "five");
+            Assert.That(() => _parameters.Get(null, "JUNK"), Throws.ArgumentNullException);
         }
+
+        #endregion
+
+        #region GetInt(string name)
+
+        [Test]
+        public void GetInt_ValuesAreCorrect()
+        {
+            Assert.That(_parameters.GetInt("IntParm"), Is.EqualTo(5));
+        }
+
+        [Test]
+        public void GetInt_MissingValuesUseZero()
+        {
+            Assert.That(_parameters.GetInt("ABC"), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetInt_NullKeyThrowsException()
+        {
+            Assert.That(() => _parameters.GetInt(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void GetInt_NonIntValueThrowsException()
+        {
+            Assert.That(() => _parameters.GetInt("StringParm"), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region GetInt(string name, int defaultValue)
+
+        [Test]
+        public void GetIntWithDefault_ValuesAreCorrect()
+        {
+            Assert.That(_parameters.GetInt("IntParm", 99), Is.EqualTo(5));
+        }
+
+        [Test]
+        public void GetIntWithDefault_MissingValuesUseDefault()
+        {
+            Assert.That(_parameters.GetInt("ABC", 99), Is.EqualTo(99));
+        }
+
+        [Test]
+        public void GetIntWithDefault_NullKeyThrowsException()
+        {
+            Assert.That(() => _parameters.GetInt(null, 99), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void GetIntWithDefault_NonIntValueThrowsException()
+        {
+            Assert.That(() => _parameters.GetInt("StringParm", 99), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/TestParametersTests.cs
+++ b/src/NUnitFramework/tests/TestParametersTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.Framework.Tests
+{
+    public class TestParametersTests
+    {
+        private TestParameters _parameters;
+
+        [SetUp]
+        public void CreateTestParameters()
+        {
+            _parameters = new TestParameters();
+        }
+
+        [Test]
+        public void InitiallyCountIsZero()
+        {
+            Assert.That(_parameters.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void InitiallyValuesAreNull()
+        {
+            Assert.Null(_parameters["ABC"]);
+            Assert.Null(_parameters["XYZ"]);
+        }
+
+        [Test]
+        public void AddParameters_CountIsCorrect()
+        {
+            AddTwoItems();
+
+            Assert.That(_parameters.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void AddParameters_NullKeyThrowsException()
+        {
+            Assert.That(() => _parameters.Add((string)null, "X"), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void IndexParameters_ValuesAreCorrect()
+        {
+            AddTwoItems();
+
+            Assert.That(_parameters["Parm1"], Is.EqualTo("5"));
+            Assert.That(_parameters["Parm2"], Is.EqualTo("five"));
+        }
+
+        [Test]
+        public void IndexParameters_MissingValuesAreNull()
+        {
+            AddTwoItems();
+
+            Assert.Null(_parameters["ABC"]);
+            Assert.Null(_parameters["XYZ"]);
+        }
+
+        [Test]
+        public void IndexParameters_NullKeyThrowsException()
+        {
+            Assert.That(() => _parameters[null], Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void GetParameters_ValuesAreCorrect()
+        {
+            AddTwoItems();
+
+            Assert.That(_parameters.Get("Parm1"), Is.EqualTo("5"));
+            Assert.That(_parameters.Get("Parm2"), Is.EqualTo("five"));
+        }
+
+        [Test]
+        public void GetParameters_MissingValuesAreNull()
+        {
+            AddTwoItems();
+
+            Assert.Null(_parameters.Get("ABC"));
+            Assert.Null(_parameters.Get("XYZ"));
+        }
+
+        [Test]
+        public void GetParameters_NullKeyThrowsException()
+        {
+            Assert.That(() => _parameters.Get(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void GetWithDefault_ValuesAreCorrect()
+        {
+            AddTwoItems();
+
+            Assert.That(_parameters.Get("Parm1", 99), Is.EqualTo(5));
+            Assert.That(_parameters.Get("Parm2", "JUNK"), Is.EqualTo("five"));
+        }
+
+        [Test]
+        public void GetWithDefault_MissingValuesUseDefault()
+        {
+            AddTwoItems();
+
+            Assert.That(_parameters.Get("ABC", 99), Is.EqualTo(99));
+            Assert.That(_parameters.Get("XYZ", "JUNK"), Is.EqualTo("JUNK"));
+        }
+
+        private void AddTwoItems()
+        {
+            _parameters.Add("Parm1", "5");
+            _parameters.Add("Parm2", "five");
+        }
+    }
+}

--- a/src/NUnitFramework/tests/TestParametersTests.cs
+++ b/src/NUnitFramework/tests/TestParametersTests.cs
@@ -13,17 +13,37 @@ namespace NUnit.Framework.Tests
         public void CreateTestParameters()
         {
             _parameters = new TestParameters();
-            _parameters.Add("IntParm", "5");
-            _parameters.Add("StringParm", "five");
         }
 
-        #region Add(string name, string value)
+        #region Initial Conditions
 
         [Test]
-        public void Add_CountIsCorrect()
+        public void Initially_CountIsZero()
         {
-            Assert.That(_parameters.Count, Is.EqualTo(2));
+            Assert.That(_parameters.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void Initially_ValuesAreNull()
+        {
+            Assert.Null(_parameters["ABC"]);
+        }
+
+        [Test]
+        public void Initially_ExistsIsFalse()
+        {
+            Assert.False(_parameters.Exists("ABC"));
+        }
+
+        [Test]
+        public void Initially_NamesAreEmpty()
+        {
+            Assert.That(_parameters.Names.Count, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region Add
 
         [Test]
         public void Add_NullKeyThrowsException()
@@ -31,46 +51,55 @@ namespace NUnit.Framework.Tests
             Assert.That(() => _parameters.Add((string)null, "X"), Throws.ArgumentNullException);
         }
 
+        [Test]
+        public void Add_IncrementsCount()
+        {
+            _parameters.Add("Parm1", "5");
+            _parameters.Add("Parm2", "five");
+            Assert.That(_parameters.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Add_AccumlatesNames()
+        {
+            _parameters.Add("Parm1", "5");
+            _parameters.Add("Parm2", "five");
+            Assert.That(_parameters.Names, Is.EquivalentTo(new[] { "Parm1", "Parm2" }));
+        }
+
+        [Test]
+        public void Add_ParameterExists()
+        {
+            _parameters.Add("SomeParm", "5");
+            Assert.That(_parameters.Exists("SomeParm"));
+        }
+
         #endregion
 
         #region this[string name]
 
         [Test]
-        public void Index_ValuesAreCorrect()
+        public void Indexer_ValueIsCorrect()
         {
-            Assert.That(_parameters["IntParm"], Is.EqualTo("5"));
-            Assert.That(_parameters["StringParm"], Is.EqualTo("five"));
+            _parameters.Add("SomeParm", "5");
+            Assert.That(_parameters["SomeParm"], Is.EqualTo("5"));
         }
 
         [Test]
-        public void Index_MissingValuesAreNull()
-        {
-            Assert.Null(_parameters["ABC"]);
-            Assert.Null(_parameters["XYZ"]);
-        }
-
-        [Test]
-        public void Index_NullKeyThrowsException()
+        public void Indexer_NullKeyThrowsException()
         {
             Assert.That(() => _parameters[null], Throws.ArgumentNullException);
         }
 
         #endregion
 
-        #region Get(string name)
+        #region Get
 
         [Test]
-        public void Get_ValuesAreCorrect()
+        public void Get_ValueIsCorrect()
         {
-            Assert.That(_parameters.Get("IntParm"), Is.EqualTo("5"));
-            Assert.That(_parameters.Get("StringParm"), Is.EqualTo("five"));
-        }
-
-        [Test]
-        public void Get_MissingValuesAreNull()
-        {
-            Assert.Null(_parameters.Get("ABC"));
-            Assert.Null(_parameters.Get("XYZ"));
+            _parameters.Add("SomeParm", "5");
+            Assert.That(_parameters.Get("SomeParm"), Is.EqualTo("5"));
         }
 
         [Test]
@@ -81,80 +110,195 @@ namespace NUnit.Framework.Tests
 
         #endregion
 
-        #region Get(string name, string defaultValue)
+        #region Get String
 
         [Test]
-        public void GetWithDefault_ValuesAreCorrect()
+        public void GetString_ValueIsCorrect()
         {
-            Assert.That(_parameters.Get("StringParm", "JUNK"), Is.EqualTo("five"));
+            _parameters.Add("SomeParm", "five");
+            Assert.That(_parameters.Get("SomeParm", "JUNK"), Is.EqualTo("five"));
         }
 
         [Test]
-        public void GetWithDefault_MissingValuesUseDefault()
+        public void GetString_MissingValue()
         {
             Assert.That(_parameters.Get("XYZ", "JUNK"), Is.EqualTo("JUNK"));
         }
 
         [Test]
-        public void GetWithDefault_NullKeyThrowsException()
+        public void GetString_NullKeyThrowsException()
         {
             Assert.That(() => _parameters.Get(null, "JUNK"), Throws.ArgumentNullException);
         }
 
         #endregion
 
-        #region GetInt(string name)
+        #region Get Int
 
         [Test]
-        public void GetInt_ValuesAreCorrect()
+        public void GetInt_ValueIsCorrect()
         {
-            Assert.That(_parameters.GetInt("IntParm"), Is.EqualTo(5));
+            _parameters.Add("SomeParm", "5");
+            Assert.That(_parameters.Get("SomeParm", 99), Is.EqualTo(5));
         }
 
         [Test]
-        public void GetInt_MissingValuesUseZero()
+        public void GetInt_MissingValue()
         {
-            Assert.That(_parameters.GetInt("ABC"), Is.EqualTo(0));
+            Assert.That(_parameters.Get("ABC", 99), Is.EqualTo(99));
         }
 
         [Test]
         public void GetInt_NullKeyThrowsException()
         {
-            Assert.That(() => _parameters.GetInt(null), Throws.ArgumentNullException);
+            Assert.That(() => _parameters.Get(null, 99), Throws.ArgumentNullException);
         }
 
         [Test]
-        public void GetInt_NonIntValueThrowsException()
+        public void GetInt_BadValueThrowsException()
         {
-            Assert.That(() => _parameters.GetInt("StringParm"), Throws.TypeOf<FormatException>());
+            _parameters.Add("SomeParm", "Not an int");
+            Assert.That(() => _parameters.Get("SomeParm", 99), Throws.TypeOf<FormatException>());
         }
 
         #endregion
 
-        #region GetInt(string name, int defaultValue)
+        #region Get Double
 
         [Test]
-        public void GetIntWithDefault_ValuesAreCorrect()
+        public void GetDouble_ValueIsCorrect()
         {
-            Assert.That(_parameters.GetInt("IntParm", 99), Is.EqualTo(5));
+            _parameters.Add("SomeParm", "5.2");
+            Assert.That(_parameters.Get("SomeParm", 99.9), Is.EqualTo(5.2));
         }
 
         [Test]
-        public void GetIntWithDefault_MissingValuesUseDefault()
+        public void GetDouble_MissingValue()
         {
-            Assert.That(_parameters.GetInt("ABC", 99), Is.EqualTo(99));
+            Assert.That(_parameters.Get("ABC", 99.9), Is.EqualTo(99.9));
         }
 
         [Test]
-        public void GetIntWithDefault_NullKeyThrowsException()
+        public void GetDouble_BadValueThrowsException()
         {
-            Assert.That(() => _parameters.GetInt(null, 99), Throws.ArgumentNullException);
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", 99.9), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region Get Decimal
+
+        [Test]
+        public void GetDecimal_ValueIsCorrect()
+        {
+            _parameters.Add("SomeParm", "1.234");
+            Assert.That(_parameters.Get("SomeParm", 99.9M), Is.EqualTo(1.234M));
         }
 
         [Test]
-        public void GetIntWithDefault_NonIntValueThrowsException()
+        public void GetDecimal_MissingValue()
         {
-            Assert.That(() => _parameters.GetInt("StringParm", 99), Throws.TypeOf<FormatException>());
+            Assert.That(_parameters.Get("ABC", 99.9M), Is.EqualTo(99.9M));
+        }
+
+        [Test]
+        public void GetDecimal_BadValueThrowsException()
+        {
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", 99.9M), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region Get Boolean
+
+        [Test]
+        public void GetBoolean_ValueIsCorrect()
+        {
+            _parameters.Add("SomeParm", "true");
+            Assert.That(_parameters.Get("SomeParm", false), Is.EqualTo(true));
+        }
+
+        [Test]
+        public void GetBoolean_MissingValue()
+        {
+            Assert.That(_parameters.Get("ABC", false), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void GetBoolean_BadValueThrowsException()
+        {
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", false), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region Get Char
+
+        [Test]
+        public void GetChar_ValueIsCorrect()
+        {
+            _parameters.Add("SomeParm", "Z");
+            Assert.That(_parameters.Get("SomeParm", 'A'), Is.EqualTo('Z'));
+        }
+
+        [Test]
+        public void GetChar_MissingValue()
+        {
+            Assert.That(_parameters.Get("ABC", 'A'), Is.EqualTo('A'));
+        }
+
+        [Test]
+        public void GetChar_BadValueThrowsException()
+        {
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", 'A'), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region Get DateTime
+
+        private static readonly DateTime DEFAULT_DATE_TIME = new DateTime(2000, 1, 1, 0, 0, 0);
+        [Test]
+        public void GetDateTime_ValueIsCorrect()
+        {
+            _parameters.Add("SomeParm", "1-January-2016");
+            Assert.That(_parameters.Get("SomeParm", DEFAULT_DATE_TIME), Is.EqualTo(new DateTime(2016,1,1,0,0,0)));
+        }
+
+        [Test]
+        public void GetDateTime_MissingValue()
+        {
+            Assert.That(_parameters.Get("ABC", DEFAULT_DATE_TIME), Is.EqualTo(DEFAULT_DATE_TIME));
+        }
+
+        [Test]
+        public void GetDateTime_BadValueThrowsException()
+        {
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", DEFAULT_DATE_TIME), Throws.TypeOf<FormatException>());
+        }
+
+        #endregion
+
+        #region Get Unsupported Type
+
+        [Test]
+        public void GetUnsupportedType_ThrowsException()
+        {
+            _parameters.Add("SomeParm", "five");
+            Assert.That(() => _parameters.Get("SomeParm", new UnsupportedDefaultType()), Throws.TypeOf<InvalidCastException>());
+        }
+
+        #endregion
+
+        #region
+
+        class UnsupportedDefaultType
+        {
         }
 
         #endregion

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Attributes\TestCaseSourceTests.cs" />
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="TestParametersTests.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestOfTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -274,6 +274,7 @@
     <Compile Include="Syntax\ThrowsTests.cs" />
     <Compile Include="Syntax\TypeConstraints.cs" />
     <Compile Include="TestContextTests.cs" />
+    <Compile Include="TestParametersTests.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectCollection.cs" />
     <Compile Include="TestUtilities\Collections\SimpleObjectList.cs" />
     <Compile Include="TestUtilities\Comparers\AlwaysEqualComparer.cs" />


### PR DESCRIPTION
Fixes #720

I implemented it in the simplest way possible. Everything is a string until you decide to fetch it as an int, at which time it gets converted.

The Mono 3.2.8 failure in travis seems to be an infrastructure problem. I confirmed that by rerunning a successful build of master from about five hours ago and getting the same failure.