### PR TITLE
Report unloading errors

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -169,7 +169,8 @@ namespace NUnit.ConsoleRunner
                 ? _options.DisplayTestLabels.ToUpperInvariant()
                 : "ON";
 
-            XmlNode result;
+            XmlNode result = null;
+            NUnitEngineException engineException = null;
 
             try
             {
@@ -178,10 +179,14 @@ namespace NUnit.ConsoleRunner
                 using (ITestRunner runner = _engine.GetRunner(package))
                 using (var output = CreateOutputWriter())
                 {
-                    var eventHandler = new TestEventHandler(output, labels); 
+                    var eventHandler = new TestEventHandler(output, labels);
 
                     result = runner.Run(eventHandler, filter);
                 }
+            }
+            catch (NUnitEngineException ex)
+            {
+                engineException = ex;
             }
             finally
             {
@@ -189,26 +194,39 @@ namespace NUnit.ConsoleRunner
             }
 
             var writer = new ColorConsoleWriter(!_options.NoColor);
-            var reporter = new ResultReporter(result, writer, _options);
-            reporter.ReportResults();
 
-            foreach (var spec in _options.ResultOutputSpecifications)
+            if (result != null)
             {
-                var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
-                GetResultWriter(spec).WriteResultFile(result, outputPath);
-                _outWriter.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
-            }
+                var reporter = new ResultReporter(result, writer, _options);
+                reporter.ReportResults();
 
-            if (reporter.Summary.UnexpectedError)
-                return ConsoleRunner.UNEXPECTED_ERROR;
+                foreach (var spec in _options.ResultOutputSpecifications)
+                {
+                    var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
+                    GetResultWriter(spec).WriteResultFile(result, outputPath);
+                    _outWriter.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
+                }
 
-            if (reporter.Summary.InvalidAssemblies > 0)
-                return ConsoleRunner.INVALID_ASSEMBLY;
+                // Since we got a result, we display any engine exception as a warning
+                if (engineException != null)
+                    writer.WriteLine(ColorStyle.Warning, Environment.NewLine + engineException.Message);
 
-            return reporter.Summary.InvalidTestFixtures > 0
+                if (reporter.Summary.UnexpectedError)
+                    return ConsoleRunner.UNEXPECTED_ERROR;
+
+                if (reporter.Summary.InvalidAssemblies > 0)
+                    return ConsoleRunner.INVALID_ASSEMBLY;
+
+                return reporter.Summary.InvalidTestFixtures > 0
                     ? ConsoleRunner.INVALID_TEST_FIXTURE
                     : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;
+            }
 
+            // If we got here, it's because we had an exception, but check anyway
+            if (engineException != null)
+                writer.WriteLine(ColorStyle.Error, engineException.Message);
+
+            return ConsoleRunner.UNEXPECTED_ERROR;
         }
 
         private void DisplayRuntimeEnvironment(ExtendedTextWriter OutWriter)

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -120,11 +120,6 @@ namespace NUnit.ConsoleRunner
                     {
                         return new ConsoleRunner(engine, Options, OutWriter).Execute();
                     }
-                    catch (NUnitEngineException ex)
-                    {
-                        OutWriter.WriteLine(ColorStyle.Error, ex.Message);
-                        return ConsoleRunner.INVALID_ARG;
-                    }
                     catch (TestSelectionParserException ex)
                     {
                         OutWriter.WriteLine(ColorStyle.Error, ex.Message);

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -100,11 +100,12 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
-        public void UnloadingTwiceDoesNoHarm()
+        public void UnloadingTwiceThrowsNUnitEngineException()
         {
             var domain = _domainManager.CreateDomain(_package);
             _domainManager.Unload(domain);
-            _domainManager.Unload(domain);
+
+            Assert.That(() => _domainManager.Unload(domain), Throws.TypeOf<NUnitEngineException>());
 
             CheckDomainIsUnloaded(domain);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -131,6 +131,7 @@ namespace NUnit.Engine.Runners
             {
                 log.Warning("Failed to unload the remote runner. {0}", e.Message);
                 _remoteRunner = null;
+                throw;
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -181,7 +181,7 @@ namespace NUnit.Engine.Services
                     domainName = _domain.FriendlyName;
 
                     // Uncomment to simulate an error in unloading
-                    //throw new Exception("Testing");
+                    //throw new Exception("Testing: simulated unload error");
 
                     // Uncomment to simulate a timeout while unloading
                     //while (true) ;

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -29,7 +29,6 @@ using NUnit.TestData.TestCaseAttributeFixture;
 using NUnit.TestUtilities;
 
 #if NET_4_0 || NET_4_5 || PORTABLE
-using System;
 using System.Threading.Tasks;
 #endif
 


### PR DESCRIPTION
This will fix #329 but should not be merged until we agree on what it is doing!!!

As discussed in #329, I'm doing two things here:

1. I fixed it so that we get an error in the console runner when the AppDomain unload throws one. I think we need to discuss if we really want this.

2. I eliminated all use of a private shadow cache directory. We no longer create it or try to clean it up. The user or the OS will have to clean out any leftover files periodically. I think this part is good to go.

With the unload errors showing up, our console run now fails if we have any problem unloading. Even though the tests have run to completion, we don't get any output from them, just a message saying that we failed to unload the AppDomain. For me, this kind of reinforces the original V2 decision to allow these errors to go unnoticed.

What we could do next...

1. Leave it as it is... for the reasons already stated, I don't think this is a good idea.
2. Go back to ignoring the exceptions
3. Catch the exception but report it as some kind of warning - not 100% sure how to do this, we might need a new exception or a Severity property on NUnitEngineException.
4. We could possibly handle actual errors differently from timeouts.
5. Whatever we do in the engine, we need a way to avoid the error showing up in TFS runs using the VS adapter - for that reason, we would need to distinguish it from other exceptions.
6. We could pass a package setting to the engine to indicate whether we want such exceptions depending on which runner is doing the running.