### PR TITLE
Clear retained reference to test objects

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -71,10 +71,6 @@ namespace NUnit.Framework.Internal.Commands
                 IDisposable disposable = context.TestObject as IDisposable;
                 if (disposable != null && Test is IDisposableFixture)
                     disposable.Dispose();
-
-                //Clear references to test objects to reduce memory usage
-                context.TestObject = null;
-                Test.Fixture = null;
             }
             catch (Exception ex)
             {

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -450,6 +450,10 @@ namespace NUnit.Framework.Internal.Execution
 
             if (Completed != null)
                 Completed(this, EventArgs.Empty);
+
+            //Clear references to test objects to reduce memory usage
+            Context.TestObject = null;
+            Test.Fixture = null;
         }
 
 #endregion


### PR DESCRIPTION
Fixes #1430.

Quick history, this was initially submitted as #1367. In that PR, we moved the reference clear from `WorkItem.WorkItemComplete` to `OneTimeTearDown`, to match up to the fields being initialised in `OneTimeSetUp`. When v3.2.1 was released this didn't work, I presume I missed checking the references were still released after making the change.

I've verified that moving the change back to `WorkItemComplete` solves the problem - what I haven't had time to do yet is dig in to why having it in `OneTimeTearDown` did not work - wonder if anyone has any ideas on this?

Submitting this now as it would be great for us if it can squeezed in to 3.4. :-) I'm fairly tight for time up till the end of this week, but will do what I can if any changes are required, although have done it on a branch so anyone else can modify as necessary!