### PR TITLE
TestAgency modifies the COMPLUS_Version env var for its child agent p…

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -89,6 +89,22 @@ namespace NUnit.Agent
                 Environment.Version,
                 RuntimeFramework.CurrentFramework.DisplayName);
 
+            // Restore the COMPLUS_Version env variable if it's been overridden by TestAgency::LaunchAgentProcess
+            try
+            {
+              string cpvOriginal = Environment.GetEnvironmentVariable("TestAgency_COMPLUS_Version_Original");
+              if(!string.IsNullOrEmpty(cpvOriginal))
+              {
+                log.Debug("Agent process has the COMPLUS_Version environment variable value \"{0}\" overridden with \"{1}\", restoring the original value.", cpvOriginal, Environment.GetEnvironmentVariable("COMPLUS_Version"));
+                Environment.SetEnvironmentVariable("TestAgency_COMPLUS_Version_Original", null, EnvironmentVariableTarget.Process); // Erase marker
+                Environment.SetEnvironmentVariable("COMPLUS_Version", (cpvOriginal == "NULL" ? null : cpvOriginal), EnvironmentVariableTarget.Process); // Restore original (which might be n/a)
+              }
+            }
+            catch(Exception ex)
+            {
+              log.Warning("Failed to restore the COMPLUS_Version variable. " + ex.Message); // Proceed with running tests anyway
+            }
+
             // Create TestEngine - this program is
             // conceptually part of  the engine and
             // can access it's internals as needed.

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -212,8 +212,12 @@ namespace NUnit.Engine.Services
 
                 case RuntimeType.Net:
                     p.StartInfo.FileName = agentExePath;
+                    // Override the COMPLUS_Version env variable, this would cause CLR meta host to run a CLR of the specific version
                     string envVar = "v" + targetRuntime.ClrVersion.ToString(3);
                     p.StartInfo.EnvironmentVariables["COMPLUS_Version"] = envVar;
+                    // Leave a marker that we have changed this variable, so that the agent could restore it for any code or child processes running within the agent
+                    string cpvOriginal = Environment.GetEnvironmentVariable("COMPLUS_Version");
+                    p.StartInfo.EnvironmentVariables["TestAgency_COMPLUS_Version_Original"] = string.IsNullOrEmpty(cpvOriginal) ? "NULL" : cpvOriginal;
                     p.StartInfo.Arguments = arglist;
                     break;
 


### PR DESCRIPTION
…rocess to run in the specific CLR, and the agent process now restores it to the original value for test code to run in the original env. (gh-1579)