### PR TITLE
Allow mono 3.28 build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ mono:
   - latest
   - 3.2.8
 
+matrix:
+  allow_failures:
+    - mono: 3.2.8
+
 script: 
   - ./build.sh --target "Travis"
     


### PR DESCRIPTION
This change allows the travis-ci build to pass even if the mono 3.2.8 job fails.