### PR TITLE
Avoid duplicate extensions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
     <add key="NUnit AppVeyor CI" value="https://ci.appveyor.com/nuget/nunit" />
     <add key="NUNit MyGet Feed" value="https://www.myget.org/F/nunit/api/v2" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />

--- a/build.cake
+++ b/build.cake
@@ -707,7 +707,8 @@ Task("PackageNuGet")
         });
         NuGetPack("nuget/extensions/teamcity-event-listener.nuspec", new NuGetPackSettings()
         {
-            Version = packageVersion,
+		    // The teamcity-event-listener extension uses its own versioning
+            Version = "1.0.0" + dbgSuffix,
             BasePath = currentImageDir,
             OutputDirectory = PACKAGE_DIR,
             NoPackageAnalysis = true

--- a/src/NUnitEngine/Addins/nunit-project-loader/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/nunit-project-loader/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6e520555-91a4-427d-8416-b0689e535cc9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
+++ b/src/NUnitEngine/Addins/nunit-project-loader/nunit-project-loader.csproj
@@ -38,6 +38,9 @@
     <Compile Include="..\..\..\Common\nunit\XmlHelper.cs">
       <Link>XmlHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\EngineVersion.cs">
+      <Link>Properties\EngineVersion.cs</Link>
+    </Compile>
     <Compile Include="StringHelper.cs" />
     <Compile Include="NUnitProject.cs" />
     <Compile Include="NUnitProjectLoader.cs" />

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("40b00727-cab1-46fc-85eb-9f62f32b93bb")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
+++ b/src/NUnitEngine/Addins/nunit-v2-result-writer/nunit-v2-result-writer.csproj
@@ -38,6 +38,9 @@
     <Compile Include="..\..\..\Common\nunit\XmlHelper.cs">
       <Link>XmlHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\EngineVersion.cs">
+      <Link>Properties\EngineVersion.cs</Link>
+    </Compile>
     <Compile Include="NUnit2ResultSummary.cs" />
     <Compile Include="NUnit2XmlResultWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NUnitEngine/Addins/nunit.v2.driver/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d9dde4fb-09c0-4a9a-924e-8691bf839092")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/nunit.v2.driver/nunit.v2.driver.csproj
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/nunit.v2.driver.csproj
@@ -41,6 +41,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\EngineVersion.cs">
+      <Link>Properties\EngineVersion.cs</Link>
+    </Compile>
     <Compile Include="TestEventAdapter.cs" />
     <Compile Include="XmlExtensions.cs" />
     <Compile Include="NUnit2FrameworkDriver.cs" />

--- a/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
@@ -30,6 +30,10 @@ using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Listeners
 {
+    // Note: Setting mimimum engine version in this case is
+    // purely documentary since engines prior to 3.6 do not
+    // check the EngineVersion property and will try to 
+    // load this extension anyway.
     [Extension(Enabled = false, EngineVersion = "3.6")]
     public class TeamCityEventListener : ITestEventListener
     {

--- a/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
@@ -30,7 +30,7 @@ using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Listeners
 {
-    [Extension(Enabled = false)]
+    [Extension(Enabled = false, EngineVersion = "3.6")]
     public class TeamCityEventListener : ITestEventListener
     {
         private readonly TextWriter _outWriter;

--- a/src/NUnitEngine/Addins/vs-project-loader/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/vs-project-loader/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("202d01de-2164-40a2-8dda-693d6c9b8395")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NUnitEngine/Addins/vs-project-loader/vs-project-loader.csproj
+++ b/src/NUnitEngine/Addins/vs-project-loader/vs-project-loader.csproj
@@ -35,6 +35,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\EngineVersion.cs">
+      <Link>Properties\EngineVersion.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisualStudioProjectLoader.cs" />
     <Compile Include="VSProject.cs" />

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/ExtensionAttribute.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/ExtensionAttribute.cs
@@ -57,5 +57,10 @@ namespace NUnit.Engine.Extensibility
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
         public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The minimum Engine version for which this extension is designed
+        /// </summary>
+        public string EngineVersion { get; set; }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionAssemblyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionAssemblyTests.cs
@@ -1,0 +1,117 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Services.Tests
+{
+    public class ExtensionAssemblyTests
+    {
+        private static readonly Assembly THIS_ASSEMBLY = Assembly.GetExecutingAssembly();
+        private static readonly string THIS_ASSEMBLY_PATH = THIS_ASSEMBLY.Location;
+        private static readonly string THIS_ASSEMBLY_NAME = THIS_ASSEMBLY.GetName().FullName;
+        private static readonly Assembly ENGINE_ASSEMBLY = Assembly.GetAssembly(typeof(ExtensionAssembly));
+        private static readonly string ENGINE_ASSEMBLY_PATH = ENGINE_ASSEMBLY.Location;
+
+        private ExtensionAssembly _ea;
+        private ExtensionAssembly _eaCopy;
+        private ExtensionAssembly _eaBetter;
+        private ExtensionAssembly _eaOther;
+
+        [SetUp]
+        public void CreateExtensionAssemblies()
+        {
+            _ea = new ExtensionAssembly(THIS_ASSEMBLY_PATH, false);
+            _eaCopy = new ExtensionAssembly(THIS_ASSEMBLY_PATH, false);
+            _eaBetter = new ExtensionAssembly(THIS_ASSEMBLY_PATH, false);
+            _eaBetter.Assembly.Name.Version = new Version(7, 0);
+            _eaOther = new ExtensionAssembly(ENGINE_ASSEMBLY_PATH, false);
+        }
+
+        [Test]
+        public void AssemblyDefinition()
+        {
+            Assert.That(_ea.Assembly.FullName, Is.EqualTo(THIS_ASSEMBLY_NAME));
+        }
+
+        [Test]
+        public void MainModule()
+        {
+            Assert.That(_ea.MainModule.Assembly.FullName, Is.EqualTo(THIS_ASSEMBLY_NAME));   
+        }
+
+        [Test]
+        public void AssemblyName()
+        {
+            Assert.That(_ea.AssemblyName.FullName, Is.EqualTo(THIS_ASSEMBLY_NAME));
+        }
+
+        [Test]
+        public void IsDuplicateOf_SameAssembly()
+        {
+            Assert.That(_ea.IsDuplicateOf(_eaCopy));
+            Assert.That(_eaCopy.IsDuplicateOf(_ea));
+        }
+
+        [Test]
+        public void IsDuplicateOf_DifferentAssembly()
+        {
+            Assert.False(_ea.IsDuplicateOf(_eaOther));
+            Assert.False(_eaOther.IsDuplicateOf(_ea));
+        }
+
+        [Test]
+        public void IsBetterVersionOf_DifferentVersions()
+        {
+            Assert.That(_eaBetter.IsBetterVersionOf(_ea));
+            Assert.False(_ea.IsBetterVersionOf(_eaBetter));
+        }
+
+        [Test]
+        public void IsBetterVersionOf_SameVersion()
+        {
+            Assert.False(_ea.IsBetterVersionOf(_eaCopy));
+            Assert.False(_eaCopy.IsBetterVersionOf(_ea));
+        }
+
+        [Test]
+        public void IsBetterVersionOf_SameVersion_OneWildCard()
+        {
+            var eaWild = new ExtensionAssembly(THIS_ASSEMBLY_PATH, true);
+            Assert.True(_ea.IsBetterVersionOf(eaWild));
+            Assert.False(eaWild.IsBetterVersionOf(_ea));
+        }
+
+#if DEBUG
+        [Test]
+        public void IsBetterVersionOf_ThrowsIfNotDuplicates()
+        {
+            Assert.That(() => { _ea.IsBetterVersionOf(_eaOther); }, Throws.TypeOf<NUnitEngineException>());
+        }
+#endif
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -70,7 +70,7 @@ namespace NUnit.Engine.Services.Tests
             _serviceClass.FindExtensionPoints(typeof(TestEngine).Assembly);
             _serviceClass.FindExtensionPoints(typeof(ITestEngine).Assembly);
 
-            _serviceClass.FindExtensionsInAssembly(GetType().Assembly.Location, true);
+            _serviceClass.FindExtensionsInAssembly(new ExtensionAssembly(GetType().Assembly.Location, true));
         }
 
         [TestCaseSource("KNOWN_EXTENSION_POINT_PATHS")]

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="ResultHelperTests.cs" />
     <Compile Include="Runners\ParallelTaskWorkerPoolTests.cs" />
     <Compile Include="RuntimeFrameworkTests.cs" />
+    <Compile Include="Services\ExtensionAssemblyTests.cs" />
     <Compile Include="Services\ExtensionServiceTests.cs" />
     <Compile Include="Services\Fakes\FakeRuntimeService.cs" />
     <Compile Include="Services\ServiceManagerTests.cs" />
@@ -153,7 +154,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Extensibility\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Extensibility
 
 
         /// <summary>
-        /// Construct an ExtensionNode
+        /// Construct an ExtensionNode supplying the assembly path and type name.
         /// </summary>
         /// <param name="assemblyPath">The path to the assembly where this extension is found.</param>
         /// <param name="typeName">The full name of the Type of the extension object.</param>

--- a/src/NUnitEngine/nunit.engine/Internal/CecilExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/CecilExtensions.cs
@@ -41,18 +41,8 @@ namespace NUnit.Engine.Internal
 
             foreach (CustomAttribute attr in type.CustomAttributes)
             {
-                var attrType = attr.AttributeType;
-                do
-                {
-                    if (attrType.FullName == fullName)
-                    {
-                        attributes.Add(attr);
-                        break;
-                    }
-
-                    attrType = attrType.Resolve().BaseType;
-                } 
-                while (attrType != null && attrType.FullName != "System.Object");
+                if (attr.AttributeType.FullName == fullName)
+                    attributes.Add(attr);
             }
 
             return attributes;
@@ -62,16 +52,8 @@ namespace NUnit.Engine.Internal
         {
             foreach (CustomAttribute attr in type.CustomAttributes)
             {
-                var attrType = attr.AttributeType;
-                while (true)
-                {
-                    if (attrType.FullName == fullName)
-                        return attr;
-
-                    attrType = attrType.Resolve().BaseType;
-                    if (attrType == null || attrType.FullName == "System.Object")
-                        break;
-                }
+                if (attr.AttributeType.FullName == fullName)
+                    return attr;
             }
 
             return null;

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionAssembly.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionAssembly.cs
@@ -99,27 +99,8 @@ namespace NUnit.Engine.Services
             if (version < otherVersion)
                 return false;
 
-            // Versions are equal, check for a nuget package version.
-            
-            // Override only if this one was specified exactly while the other wasn't
+            // Versions are equal, override only if this one was specified exactly while the other wasn't
             return !FromWildCard && other.FromWildCard;
         }
-
-        //private bool TryGetNugetPackageVersion(out version)
-        //{
-        //    var dir = new DirectoryInfo(Path.GetDirectoryName(FilePath));
-        //    if (dir.Name != "tools")
-        //        return false;
-
-        //    dir = dir.Parent;
-        //    if (dir == null)
-        //        return false;
-
-        //    var packages = dir.GetFiles("*.nupkg");
-        //    if (packages.Length != 1)
-        //        return false;
-
-        //    return packages[0].FullName;
-        //}
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionAssembly.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionAssembly.cs
@@ -1,0 +1,125 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.IO;
+using Mono.Cecil;
+
+namespace NUnit.Engine.Services
+{
+    public class ExtensionAssembly
+    {
+        public ExtensionAssembly(string filePath, bool fromWildCard)
+        {
+            FilePath = filePath;
+            FromWildCard = fromWildCard;
+        }
+
+        public string FilePath { get; private set; }
+        public bool FromWildCard { get; private set; }
+
+        private AssemblyDefinition _assemblyDefinition;
+        public AssemblyDefinition Assembly
+        {
+            get
+            {
+                if (_assemblyDefinition == null)
+                {
+                    var resolver = new DefaultAssemblyResolver();
+                    resolver.AddSearchDirectory(System.IO.Path.GetDirectoryName(FilePath));
+                    resolver.AddSearchDirectory(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
+                    var parameters = new ReaderParameters() { AssemblyResolver = resolver };
+
+                    _assemblyDefinition = AssemblyDefinition.ReadAssembly(FilePath);
+                }
+
+                return _assemblyDefinition;
+            }
+        }
+
+        public ModuleDefinition MainModule
+        {
+            get { return Assembly.MainModule; }
+        }
+
+        public AssemblyNameDefinition AssemblyName
+        {
+            get { return Assembly.Name; }
+        }
+
+        /// <summary>
+        /// IsDuplicateOf returns true if two assemblies have the same name.
+        /// </summary>
+        public bool IsDuplicateOf(ExtensionAssembly other)
+        {
+            return AssemblyName.Name == other.AssemblyName.Name;
+        }
+        
+        /// <summary>
+        /// IsBetterVersion determines whether another assembly is
+        /// a better (higher) version than the current assembly.
+        /// It is only intended to be called if IsDuplicateOf
+        /// has already returned true.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool IsBetterVersionOf(ExtensionAssembly other)
+        {
+#if DEBUG
+            if (!IsDuplicateOf(other))
+                throw new NUnitEngineException("IsBetterVersonOf should only be called on duplicate assemblies");
+#endif
+
+            var version = AssemblyName.Version;
+            var otherVersion = other.AssemblyName.Version;
+
+            if (version > otherVersion)
+                return true;
+
+            if (version < otherVersion)
+                return false;
+
+            // Versions are equal, check for a nuget package version.
+            
+            // Override only if this one was specified exactly while the other wasn't
+            return !FromWildCard && other.FromWildCard;
+        }
+
+        //private bool TryGetNugetPackageVersion(out version)
+        //{
+        //    var dir = new DirectoryInfo(Path.GetDirectoryName(FilePath));
+        //    if (dir.Name != "tools")
+        //        return false;
+
+        //    dir = dir.Parent;
+        //    if (dir == null)
+        //        return false;
+
+        //    var packages = dir.GetFiles("*.nupkg");
+        //    if (packages.Length != 1)
+        //        return false;
+
+        //    return packages[0].FullName;
+        //}
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -45,6 +45,7 @@ namespace NUnit.Engine.Services
         private Dictionary<string, ExtensionPoint> _pathIndex = new Dictionary<string, ExtensionPoint>();
 
         private List<ExtensionNode> _extensions = new List<ExtensionNode>();
+        private List<ExtensionAssembly> _assemblies = new List<ExtensionAssembly>();
 
         #region IExtensionService Members
 
@@ -175,7 +176,12 @@ namespace NUnit.Engine.Services
 
                 FindExtensionPoints(thisAssembly);
                 FindExtensionPoints(apiAssembly);
-                FindExtensionsInDirectory(startDir);
+
+                // Finding extensions is a two-stage process, which
+                // enables us to weed out duplicate assemblies
+                FindExtensionAssemblies(startDir, false);
+                foreach (var candidate in _assemblies)
+                    FindExtensionsInAssembly(candidate);
 
                 Status = ServiceStatus.Started;
             }
@@ -277,21 +283,21 @@ namespace NUnit.Engine.Services
         #region Helper Methods - Extensions
 
         /// <summary>
-        /// Scans a directory for addins. Note that assemblies in the directory
-        /// are only scanned if no file of type .addins is found. If such a file
-        /// is found, then those assemblies it references are scanned.
+        /// Scans a directory for candidate addin assemblies. Note that assemblies in 
+        /// the directory are only scanned if no file of type .addins is found. If such 
+        /// a file is found, then those assemblies it references are scanned.
         /// </summary>
-        private void FindExtensionsInDirectory(DirectoryInfo startDir)
+        private void FindExtensionAssemblies(DirectoryInfo startDir, bool fromWildCard)
         {
             log.Info("Scanning directory {0} for extensions", startDir.FullName);
 
             var addinsFiles = startDir.GetFiles("*.addins");
             if (addinsFiles.Length > 0)
                 foreach (var file in addinsFiles)
-                    ProcessAddinsFile(startDir, file.FullName);
+                    ProcessAddinsFile(startDir, file.FullName, fromWildCard);
             else
                 foreach (var file in startDir.GetFiles("*.dll"))
-                    FindExtensionsInAssembly(file.FullName, false);
+                    ProcessCandidateAssembly(file.FullName, true);
         }
 
         /// <summary>
@@ -300,7 +306,7 @@ namespace NUnit.Engine.Services
         /// path or a wildcard pattern used to find assemblies. Blank
         /// lines and comments started by # are ignored.
         /// </summary>
-        private void ProcessAddinsFile(DirectoryInfo baseDir, string fileName)
+        private void ProcessAddinsFile(DirectoryInfo baseDir, string fileName, bool fromWildCard)
         {
             log.Info("Processing file " + fileName);
 
@@ -320,13 +326,42 @@ namespace NUnit.Engine.Services
                     if (Path.DirectorySeparatorChar == '\\')
                         line = line.Replace(Path.DirectorySeparatorChar, '/');
 
+                    bool isWild = fromWildCard || line.Contains("*");
                     if (line.EndsWith("/"))
                         foreach (var dir in DirectoryFinder.GetDirectories(baseDir, line))
-                            FindExtensionsInDirectory(dir);
+                            FindExtensionAssemblies(dir, isWild);
                     else
                         foreach (var file in DirectoryFinder.GetFiles(baseDir, line))
-                            FindExtensionsInAssembly(file.FullName, true);
+                            ProcessCandidateAssembly(file.FullName, isWild);
                 }
+            }
+        }
+
+        private void ProcessCandidateAssembly(string filePath, bool fromWildCard)
+        {
+            try
+            {
+                var candidate = new ExtensionAssembly(filePath, fromWildCard);
+
+                for (int i = 0; i < _assemblies.Count; i++)
+                {
+                    var assembly = _assemblies[i];
+
+                    if (candidate.IsDuplicateOf(assembly))
+                    {
+                        if (candidate.IsBetterVersionOf(assembly))
+                            _assemblies[i] = candidate;
+                            
+                        return;
+                    }
+                }
+
+                _assemblies.Add(candidate);
+            }
+            catch(BadImageFormatException e)
+            {
+                if (!fromWildCard)
+                    throw new NUnitEngineException(String.Format("Specified extension {0} could not be read", filePath), e);
             }
         }
 
@@ -335,38 +370,20 @@ namespace NUnit.Engine.Services
         /// For each extension, create an ExtensionNode and link it to the
         /// correct ExtensionPoint. Public for testing.
         /// </summary>
-        public void FindExtensionsInAssembly(string assemblyName, bool specifiedInConfig)
+        public void FindExtensionsInAssembly(ExtensionAssembly assembly)
         {
-            log.Info("Scanning {0} assembly for Extensions", assemblyName);
+            log.Info("Scanning {0} assembly for Extensions", assembly.FilePath);
 
-            var resolver = new DefaultAssemblyResolver();
-            resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyName));
-            resolver.AddSearchDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-            var parameters = new ReaderParameters() { AssemblyResolver = resolver };
-
-            ModuleDefinition module;
-
-            try
-            {
-                module = AssemblyDefinition.ReadAssembly(assemblyName, parameters).MainModule;
-            }
-            //Thrown if assembly is unmanaged
-            catch (BadImageFormatException e)
-            {
-                if (specifiedInConfig)
-                    throw new NUnitEngineException(String.Format("Specified extension {0} could not be read", assemblyName), e);
-                else return;
-            }
-
-            foreach (var type in module.GetTypes())
+            foreach (var type in assembly.MainModule.GetTypes())
             {
                 CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");
 
                 if (extensionAttr != null)
                 {
-                    var node = new ExtensionNode(assemblyName, type.FullName);
+                    var node = new ExtensionNode(assembly.FilePath, type.FullName);
                     node.Path = extensionAttr.GetNamedArgument("Path") as string;
                     node.Description = extensionAttr.GetNamedArgument("Description") as string;
+
                     object enabledArg = extensionAttr.GetNamedArgument("Enabled");
                     node.Enabled = enabledArg != null
                        ? (bool)enabledArg : true;
@@ -420,6 +437,5 @@ namespace NUnit.Engine.Services
         }
 
         #endregion
-
     }
 }

--- a/src/NUnitEngine/nunit.engine/nunit.engine.addins
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.addins
@@ -3,3 +3,4 @@ addins/nunit-v2-result-writer.dll
 addins/nunit-project-loader.dll
 addins/vs-project-loader.dll
 addins/teamcity-event-listener.dll
+

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Runners\TestEventDispatcher.cs" />
     <Compile Include="Runners\TestExecutionTask.cs" />
     <Compile Include="RuntimeType.cs" />
+    <Compile Include="Services\ExtensionAssembly.cs" />
     <Compile Include="Services\ExtensionService.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />
     <Compile Include="Services\ResultWriters\TestCaseResultWriter.cs" />


### PR DESCRIPTION
Fixes #1427 

The initial commit solves the problem of duplicate extension assemlies in the full installation but not when using NuGet packages.

NOTE: We will need to decide on a versioning scheme for extensions. In the current build, extensions all remain as 1.0.0.0.