### PR TITLE
Protect against RemotingException when stopping server

### DIFF
--- a/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
@@ -100,8 +100,16 @@ namespace NUnit.Engine.Internal
 
                 if ( this.channel != null )
                 {
-                    ChannelServices.UnregisterChannel( this.channel );
-                    this.channel = null;
+                    try
+                    {
+                        ChannelServices.UnregisterChannel(this.channel);
+                        this.channel = null;
+                    }
+                    catch (RemotingException)
+                    {
+                        // Mono 4.4 appears to unregister the channel itself
+                        // so don't do anything here.
+                    }
                 }
 
                 Monitor.PulseAll( theLock );


### PR DESCRIPTION
Fixes #1593 

Since this is an intermittent problem, we will have to see if it really fixes it, but it seems likely and there is no reason to report an exception in the particular case where the channel is already closed.