### PR TITLE
Issue 1553

### DIFF
--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -35,61 +35,102 @@ namespace NUnit.Framework.Constraints
     {
         private readonly string NL = NUnit.Env.NewLine;
 
-        #region Simple Ordering
+        #region Ordering Tests
 
-        [Test]
-        public void IsOrdered_Strings()
+        [TestCaseSource("OrderedByData")]
+        public void IsOrderedBy(IEnumerable collection, Constraint constraint)
         {
-            Assert.That(new[] { "x", "y", "z" }, Is.Ordered);
+            Assert.That(collection, constraint);
         }
 
-        [Test]
-        public void IsOrdered_Ints()
+        static readonly object[] OrderedByData = new[]
         {
-            Assert.That(new[] { 1, 2, 3 }, Is.Ordered);
-        }
+            // Simple Ordering
+            new TestCaseData(
+                new[] { "x", "y", "z" },
+                Is.Ordered),
+            new TestCaseData(
+                new[] { 1, 2, 3 },
+                Is.Ordered),
+            new TestCaseData(
+                new[] { "x", "y", "z" },
+                Is.Ordered.Ascending),
+            new TestCaseData(
+                new[] { 1, 2, 3 },
+                Is.Ordered.Ascending),
+            new TestCaseData(
+                new[] { "z", "y", "x" },
+                Is.Ordered.Descending),
+            new TestCaseData(
+                new[] { 3, 2, 1 },
+                Is.Ordered.Descending),
+            new TestCaseData(
+                new[] { "x", "x", "z" },
+                Is.Ordered),
+            // Ordered By Single Property
+            new TestCaseData(
+                new[] { new TestClass1(1), new TestClass1(2), new TestClass1(3) },
+                Is.Ordered.By("Value") ),
+            new TestCaseData(
+                new[] { new TestClass1(1), new TestClass1(2), new TestClass1(3) },
+                Is.Ordered.By("Value").Ascending ),
+            new TestCaseData(
+                new[] { new TestClass1(1), new TestClass1(2), new TestClass1(3) },
+                Is.Ordered.Ascending.By("Value") ),
+            new TestCaseData(
+                new[] { new TestClass1(3), new TestClass1(2), new TestClass1(1) },
+                Is.Ordered.By("Value").Descending ),
+            new TestCaseData(
+                new[] { new TestClass1(3), new TestClass1(2), new TestClass1(1) },
+                Is.Ordered.Descending.By("Value") ),
+            new TestCaseData(
+                new[] { new TestClass1(1), new TestClass1(2), new TestClass1(3) },
+                Is.Ordered.By("Value").Using(ObjectComparer.Default) ),
+            new TestCaseData(
+                new object[] { new TestClass1(1), new TestClass2(2) },
+                Is.Ordered.By("Value") ),
+            // Ordered By Two Properties
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 1), new TestClass3("ABC", 42), new TestClass3("XYZ", 2) },
+                Is.Ordered.By("A").By("B") ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 1), new TestClass3("ABC", 42), new TestClass3("XYZ", 2) },
+                Is.Ordered.By("A").Then.By("B") ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 1), new TestClass3("ABC", 42), new TestClass3("XYZ", 2) },
+                Is.Ordered.Ascending.By("A").Then.Ascending.By("B") ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 1), new TestClass3("ABC", 42), new TestClass3("XYZ", 2) },
+                Is.Ordered.By("A").Ascending.Then.By("B").Ascending ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 42), new TestClass3("XYZ", 99), new TestClass3("XYZ", 2) },
+                Is.Not.Ordered.By("A").Then.By("B") ),
+            new TestCaseData(
+                new [] {  new TestClass3("XYZ", 2), new TestClass3("ABC", 1), new TestClass3("ABC", 42) },
+                Is.Ordered.By("A").Descending.Then.By("B") ),
+            new TestCaseData(
+                new [] {  new TestClass3("XYZ", 2), new TestClass3("ABC", 1), new TestClass3("ABC", 42) },
+                Is.Ordered.Descending.By("A").Then.By("B") ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 42), new TestClass3("ABC", 1), new TestClass3("XYZ", 2) },
+                Is.Ordered.By("A").Ascending.Then.By("B").Descending ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 42), new TestClass3("ABC", 1), new TestClass3("XYZ", 2) },
+                Is.Ordered.Ascending.By("A").Then.Descending.By("B") ),
+            new TestCaseData(
+                new [] { new TestClass3("ABC", 42), new TestClass3("ABC", 1), new TestClass3("XYZ", 2) },
+                Is.Not.Ordered.By("A").Then.By("B") ),
+            new TestCaseData(
+                new[] { new TestClass3("XYZ", 2), new TestClass3("ABC", 42), new TestClass3("ABC", 1) },
+                Is.Ordered.By("A").Descending.Then.By("B").Descending ),
+            new TestCaseData(
+                new[] { new TestClass3("XYZ", 2), new TestClass3("ABC", 42), new TestClass3("ABC", 1) },
+                Is.Ordered.Descending.By("A").Then.Descending.By("B") )
+        };
 
-        [Test]
-        public void IsOrderedAscending_Strings()
-        {
-            Assert.That(new[] { "x", "y", "z" }, Is.Ordered.Ascending);
-        }
+        #endregion
 
-        [Test]
-        public void IsOrderedAscending_Ints()
-        {
-            Assert.That(new[] { 1, 2, 3 }, Is.Ordered.Ascending);
-        }
-
-        [Test]
-        public void IsOrderedDescending_Strings()
-        {
-            Assert.That(new[] { "z", "y", "x" }, Is.Ordered.Descending);
-        }
-
-        [Test]
-        public void IsOrderedDescending_Ints()
-        {
-            Assert.That(new[] { 3, 2, 1 }, Is.Ordered.Descending);
-        }
-
-        [Test]
-        public void ExceptionThrownForRepeatedAscending()
-        {
-            Assert.That(() => Is.Ordered.Ascending.Ascending, Throws.TypeOf<InvalidOperationException>());
-        }
-
-        [Test]
-        public void ExceptionThrownForRepeatedDescending()
-        {
-            Assert.That(() => Is.Ordered.Descending.Descending, Throws.TypeOf<InvalidOperationException>());
-        }
-
-        [Test]
-        public void ExceptionThrownForAscendingPlusDescending()
-        {
-            Assert.That(() => Is.Ordered.Ascending.Descending, Throws.TypeOf<InvalidOperationException>());
-        }
+        #region Error Message Tests
 
         [Test]
         public void IsOrdered_Fails()
@@ -102,30 +143,9 @@ namespace NUnit.Framework.Constraints
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
-        [Test]
-        public void IsOrdered_AllowsAdjacentEqualValues()
-        {
-            Assert.That(new[] { "x", "x", "z" }, Is.Ordered);
-        }
+        #endregion
 
-        [Test]
-        public void IsOrdered_ThrowsOnNull()
-        {
-            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(new[] { "x", null, "z" }, Is.Ordered));
-            Assert.That(ex.Message, Does.Contain("index 1"));
-        }
-
-        [Test]
-        public void IsOrdered_TypesMustBeComparable()
-        {
-            Assert.Throws<ArgumentException>(() => Assert.That(new object[] { 1, "x" }, Is.Ordered));
-        }
-
-        [Test]
-        public void IsOrdered_AtLeastOneArgMustImplementIComparable()
-        {
-            Assert.Throws<ArgumentException>(() => Assert.That(new [] { new object(), new object() }, Is.Ordered));
-        }
+        #region Custom Comparer Tests
 
         [Test]
         public void IsOrdered_HandlesCustomComparison()
@@ -174,54 +194,49 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
-        #region Ordered By One Property
+        #region Exception Tests
 
         [Test]
-        public void IsOrderedBy()
+        public void ExceptionThrownForRepeatedAscending()
         {
-            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value"));
+            Assert.That(() => Is.Ordered.Ascending.Ascending, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]
-        public void IsOrderedByAscending()
+        public void ExceptionThrownForRepeatedDescending()
         {
-            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value").Ascending);
+            Assert.That(() => Is.Ordered.Descending.Descending, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]
-        public void IsOrderedAscendingBy()
+        public void ExceptionThrownForAscendingPlusDescending()
         {
-            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.Ascending.By("Value"));
+            Assert.That(() => Is.Ordered.Ascending.Descending, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]
-        public void IsOrderedByDescending()
-        {
-            Assert.That(new[] { new OrderedByTestClass(2), new OrderedByTestClass(1) }, Is.Ordered.By("Value").Descending);
-        }
-
-        [Test]
-        public void IsOrderedDescendingBy()
-        {
-            Assert.That(new[] { new OrderedByTestClass(2), new OrderedByTestClass(1) }, Is.Ordered.Descending.By("Value"));
-        }
-
-        [Test]
-        public void IsOrderedBy_Comparer()
-        {
-            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value").Using(ObjectComparer.Default));
-        }
-
-        [Test]
-        public void IsOrderedBy_HandlesHeterogeneousClassesIfPropertyIsOfSameType()
-        {
-            Assert.That(new object[] { new OrderedByTestClass(1), new OrderedByTestClass2(2) }, Is.Ordered.By("Value"));
-        }
-
-        [Test]
-        public void ExceptionThrownForAscendingPlusByPlusDescending()
+        public void ExceptionThrownForAscendingByDescending()
         {
             Assert.That(() => Is.Ordered.Ascending.By("A").Descending, Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void IsOrdered_ThrowsOnNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(new[] { "x", null, "z" }, Is.Ordered));
+            Assert.That(ex.Message, Does.Contain("index 1"));
+        }
+
+        [Test]
+        public void IsOrdered_TypesMustBeComparable()
+        {
+            Assert.Throws<ArgumentException>(() => Assert.That(new object[] { 1, "x" }, Is.Ordered));
+        }
+
+        [Test]
+        public void IsOrdered_AtLeastOneArgMustImplementIComparable()
+        {
+            Assert.Throws<ArgumentException>(() => Assert.That(new [] { new object(), new object() }, Is.Ordered));
         }
 
         #endregion
@@ -229,34 +244,50 @@ namespace NUnit.Framework.Constraints
         #region Test Classes
 
         // Public to avoid a MethodAccessException under CF 2.0
-        public class OrderedByTestClass
+        public class TestClass1
         {
-            private int myValue;
+            public int Value { get; private set; }
 
-            public int Value
-            {
-                get { return myValue; }
-                set { myValue = value; }
-            }
-
-            public OrderedByTestClass(int value)
+            public TestClass1(int value)
             {
                 Value = value;
+            }
+
+            public override string ToString()
+            {
+                return Value.ToString();
             }
         }
 
-        class OrderedByTestClass2
+        class TestClass2
         {
-            private int myValue;
-            public int Value
-            {
-                get { return myValue; }
-                set { myValue = value; }
-            }
+            public int Value { get; private set; }
 
-            public OrderedByTestClass2(int value)
+            public TestClass2(int value)
             {
                 Value = value;
+            }
+
+            public override string ToString()
+            {
+                return Value.ToString();
+            }
+        }
+
+        public class TestClass3
+        {
+            public string A { get; private set; }
+            public int B { get; private set; }
+
+            public TestClass3(string a, int b)
+            {
+                A = a;
+                B = b;
+            }
+
+            public override string ToString()
+            {
+                return A.ToString() + "," + B.ToString();
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -152,13 +152,29 @@ namespace NUnit.Framework.Constraints
         {
             AlwaysEqualComparer comparer = new AlwaysEqualComparer();
             Assert.That(new[] { new object(), new object() }, Is.Ordered.Using(comparer));
-            Assert.That(comparer.Called, "TestComparer was not called");
+            Assert.That(comparer.CallCount, Is.GreaterThan(0), "TestComparer was not called");
         }
 
         [Test]
-        public void ExceptionThrownForMultipleComparers()
+        public void ExceptionThrownForMultipleComparersInStep()
         {
             Assert.That(() => Is.Ordered.Using(new TestComparer()).Using(new AlwaysEqualComparer()), Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void MultipleComparersUsedInDifferentSteps()
+        {
+            var comparer1 = new TestComparer();
+            var comparer2 = new AlwaysEqualComparer();
+            var collection = new[] { new TestClass3("XYZ", 2), new TestClass3("ABC", 42), new TestClass3("ABC", 1) };
+
+            Assert.That(collection, Is.Ordered.By("A").Using(comparer1).Then.By("B").Using(comparer2));
+
+            // First comparer is called for every pair of items in the collection
+            Assert.That(comparer1.CallCount, Is.EqualTo(2), "First comparer should be called twice");
+
+            // Second comparer is only called where the first property matches
+            Assert.That(comparer2.CallCount, Is.EqualTo(1), "Second comparer should be called once");
         }
 
         [Test]
@@ -166,7 +182,7 @@ namespace NUnit.Framework.Constraints
         {
             TestComparer comparer = new TestComparer();
             Assert.That(new[] { 2, 1 }, Is.Ordered.Using(comparer));
-            Assert.That(comparer.Called, "TestComparer was not called");
+            Assert.That(comparer.CallCount, Is.GreaterThan(0), "TestComparer was not called");
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -35,197 +35,198 @@ namespace NUnit.Framework.Constraints
     {
         private readonly string NL = NUnit.Env.NewLine;
 
-        [Test]
-        public void IsOrdered()
-        {
-            var al = new List<string>();
-            al.Add("x");
-            al.Add("y");
-            al.Add("z");
+        #region Simple Ordering
 
-            Assert.That(al, Is.Ordered);
+        [Test]
+        public void IsOrdered_Strings()
+        {
+            Assert.That(new[] { "x", "y", "z" }, Is.Ordered);
         }
 
         [Test]
-        public void IsOrdered_2()
+        public void IsOrdered_Ints()
         {
-            var al = new List<int>();
-            al.Add(1);
-            al.Add(2);
-            al.Add(3);
-
-            Assert.That(al, Is.Ordered);
+            Assert.That(new[] { 1, 2, 3 }, Is.Ordered);
         }
 
         [Test]
-        public void IsOrderedDescending()
+        public void IsOrderedAscending_Strings()
         {
-            var al = new List<string>();
-            al.Add("z");
-            al.Add("y");
-            al.Add("x");
-
-            Assert.That(al, Is.Ordered.Descending);
+            Assert.That(new[] { "x", "y", "z" }, Is.Ordered.Ascending);
         }
 
         [Test]
-        public void IsOrderedDescending_2()
+        public void IsOrderedAscending_Ints()
         {
-            var al = new List<int>();
-            al.Add(3);
-            al.Add(2);
-            al.Add(1);
+            Assert.That(new[] { 1, 2, 3 }, Is.Ordered.Ascending);
+        }
 
-            Assert.That(al, Is.Ordered.Descending);
+        [Test]
+        public void IsOrderedDescending_Strings()
+        {
+            Assert.That(new[] { "z", "y", "x" }, Is.Ordered.Descending);
+        }
+
+        [Test]
+        public void IsOrderedDescending_Ints()
+        {
+            Assert.That(new[] { 3, 2, 1 }, Is.Ordered.Descending);
+        }
+
+        [Test]
+        public void ExceptionThrownForRepeatedAscending()
+        {
+            Assert.That(() => Is.Ordered.Ascending.Ascending, Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void ExceptionThrownForRepeatedDescending()
+        {
+            Assert.That(() => Is.Ordered.Descending.Descending, Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void ExceptionThrownForAscendingPlusDescending()
+        {
+            Assert.That(() => Is.Ordered.Ascending.Descending, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]
         public void IsOrdered_Fails()
         {
-            var al = new List<string>();
-            al.Add("x");
-            al.Add("z");
-            al.Add("y");
-
             var expectedMessage =
                 "  Expected: collection ordered" + NL +
                 "  But was:  < \"x\", \"z\", \"y\" >" + NL;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(al, Is.Ordered));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(new[] { "x", "z", "y" }, Is.Ordered));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
-        public void IsOrdered_Allows_adjacent_equal_values()
+        public void IsOrdered_AllowsAdjacentEqualValues()
         {
-            var al = new List<string>();
-            al.Add("x");
-            al.Add("x");
-            al.Add("z");
-
-            Assert.That(al, Is.Ordered);
+            Assert.That(new[] { "x", "x", "z" }, Is.Ordered);
         }
 
         [Test]
-        public void IsOrdered_Handles_null()
+        public void IsOrdered_ThrowsOnNull()
         {
-            var al = new List<object>();
-            al.Add("x");
-            al.Add(null);
-            al.Add("z");
-
-            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(al, Is.Ordered));
+            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(new[] { "x", null, "z" }, Is.Ordered));
             Assert.That(ex.Message, Does.Contain("index 1"));
         }
 
         [Test]
         public void IsOrdered_TypesMustBeComparable()
         {
-            var al = new List<object>();
-            al.Add(1);
-            al.Add("x");
-
-            Assert.Throws<ArgumentException>(() => Assert.That(al, Is.Ordered));
+            Assert.Throws<ArgumentException>(() => Assert.That(new object[] { 1, "x" }, Is.Ordered));
         }
 
         [Test]
         public void IsOrdered_AtLeastOneArgMustImplementIComparable()
         {
-            var al = new List<object>();
-            al.Add(new object());
-            al.Add(new object());
-
-            Assert.Throws<ArgumentException>(() => Assert.That(al, Is.Ordered));
+            Assert.Throws<ArgumentException>(() => Assert.That(new [] { new object(), new object() }, Is.Ordered));
         }
 
         [Test]
-        public void IsOrdered_Handles_custom_comparison()
+        public void IsOrdered_HandlesCustomComparison()
         {
-            var al = new List<object>();
-            al.Add(new object());
-            al.Add(new object());
-
             AlwaysEqualComparer comparer = new AlwaysEqualComparer();
-            Assert.That(al, Is.Ordered.Using(comparer));
+            Assert.That(new[] { new object(), new object() }, Is.Ordered.Using(comparer));
             Assert.That(comparer.Called, "TestComparer was not called");
         }
 
         [Test]
-        public void IsOrdered_Handles_custom_comparison2()
+        public void ExceptionThrownForMultipleComparers()
         {
-            var al = new List<int>();
-            al.Add(2);
-            al.Add(1);
+            Assert.That(() => Is.Ordered.Using(new TestComparer()).Using(new AlwaysEqualComparer()), Throws.TypeOf<InvalidOperationException>());
+        }
 
+        [Test]
+        public void IsOrdered_HandlesCustomComparison2()
+        {
             TestComparer comparer = new TestComparer();
-            Assert.That(al, Is.Ordered.Using(comparer));
+            Assert.That(new[] { 2, 1 }, Is.Ordered.Using(comparer));
             Assert.That(comparer.Called, "TestComparer was not called");
         }
 
         [Test]
         public void UsesProvidedGenericComparer()
         {
-            var al = new List<int>();
-            al.Add(1);
-            al.Add(2);
-
             var comparer = new GenericComparer<int>();
-            Assert.That(al, Is.Ordered.Using(comparer));
+            Assert.That(new[] { 1, 2 }, Is.Ordered.Using(comparer));
             Assert.That(comparer.WasCalled, "Comparer was not called");
         }
 
         [Test]
         public void UsesProvidedGenericComparison()
         {
-            var al = new List<int>();
-            al.Add(1);
-            al.Add(2);
-
             var comparer = new GenericComparison<int>();
-            Assert.That(al, Is.Ordered.Using(comparer.Delegate));
+            Assert.That(new[] { 1, 2 }, Is.Ordered.Using(comparer.Delegate));
             Assert.That(comparer.WasCalled, "Comparer was not called");
         }
 
         [Test]
         public void UsesProvidedLambda()
         {
-            var al = new List<int>();
-            al.Add(1);
-            al.Add(2);
-
             Comparison<int> comparer = (x, y) => x.CompareTo(y);
-            Assert.That(al, Is.Ordered.Using(comparer));
+            Assert.That(new[] { 1, 2 }, Is.Ordered.Using(comparer));
         }
+
+        #endregion
+
+        #region Ordered By One Property
 
         [Test]
         public void IsOrderedBy()
         {
-            var al = new List<OrderedByTestClass>();
-            al.Add(new OrderedByTestClass(1));
-            al.Add(new OrderedByTestClass(2));
+            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value"));
+        }
 
-            Assert.That(al, Is.Ordered.By("Value"));
+        [Test]
+        public void IsOrderedByAscending()
+        {
+            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value").Ascending);
+        }
+
+        [Test]
+        public void IsOrderedAscendingBy()
+        {
+            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.Ascending.By("Value"));
+        }
+
+        [Test]
+        public void IsOrderedByDescending()
+        {
+            Assert.That(new[] { new OrderedByTestClass(2), new OrderedByTestClass(1) }, Is.Ordered.By("Value").Descending);
+        }
+
+        [Test]
+        public void IsOrderedDescendingBy()
+        {
+            Assert.That(new[] { new OrderedByTestClass(2), new OrderedByTestClass(1) }, Is.Ordered.Descending.By("Value"));
         }
 
         [Test]
         public void IsOrderedBy_Comparer()
         {
-            var al = new List<OrderedByTestClass>();
-            al.Add(new OrderedByTestClass(1));
-            al.Add(new OrderedByTestClass(2));
-
-            Assert.That(al, Is.Ordered.By("Value").Using(ObjectComparer.Default));
+            Assert.That(new[] { new OrderedByTestClass(1), new OrderedByTestClass(2) }, Is.Ordered.By("Value").Using(ObjectComparer.Default));
         }
 
         [Test]
-        public void IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type()
+        public void IsOrderedBy_HandlesHeterogeneousClassesIfPropertyIsOfSameType()
         {
-            var al = new List<object>();
-            al.Add(new OrderedByTestClass(1));
-            al.Add(new OrderedByTestClass2(2));
-
-            Assert.That(al, Is.Ordered.By("Value"));
+            Assert.That(new object[] { new OrderedByTestClass(1), new OrderedByTestClass2(2) }, Is.Ordered.By("Value"));
         }
+
+        [Test]
+        public void ExceptionThrownForAscendingPlusByPlusDescending()
+        {
+            Assert.That(() => Is.Ordered.Ascending.By("A").Descending, Throws.TypeOf<InvalidOperationException>());
+        }
+
+        #endregion
+
+        #region Test Classes
 
         // Public to avoid a MethodAccessException under CF 2.0
         public class OrderedByTestClass
@@ -258,5 +259,7 @@ namespace NUnit.Framework.Constraints
                 Value = value;
             }
         }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/AlwaysEqualComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/AlwaysEqualComparer.cs
@@ -28,11 +28,11 @@ namespace NUnit.TestUtilities.Comparers
 {
     internal class AlwaysEqualComparer : IComparer
     {
-        public bool Called = false;
+        public int CallCount = 0;
 
         int IComparer.Compare(object x, object y)
         {
-            Called = true;
+            CallCount++;
 
             // This comparer ALWAYS returns zero (equal)!
             return 0;

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/TestComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/TestComparer.cs
@@ -24,16 +24,16 @@
 using System;
 using System.Collections;
 
-namespace NUnit.TestUtilities
+namespace NUnit.TestUtilities.Comparers
 {
     internal class TestComparer : IComparer
     {
-        public bool Called = false;
+        public int CallCount = 0;
 
         #region IComparer Members
         public int Compare(object x, object y)
         {
-            Called = true;
+            CallCount++;
 
             if (x == null && y == null)
                 return 0;

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -279,7 +279,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -276,9 +276,9 @@
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -273,9 +273,9 @@
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -277,9 +277,9 @@
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -286,9 +286,9 @@
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -263,9 +263,9 @@
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -306,9 +306,9 @@
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
-    <Compile Include="TestUtilities\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />
     <Compile Include="TestUtilities\TestFinder.cs" />


### PR DESCRIPTION
Fixes #1553 

This is my shot at #1553, based on #1564 by @jnsn.

This version...

 * Uses an enum for direction

 * Generalizes the algorithm into a series of steps, which will always be one step if there is no "By"

 * Adds test cases and reorganizes the tests

Still needed...

 * The Comparer should logically be part of each step, allowing such things as

   ```C#
   Is.Ordered.By("A").Using(myComparer).Then.By("B").Using(myOtherComparer)
   ```

 * This implementation still gives errors at runtime rather than compile time. I realized while working on it that this particular constraint is much more difficult than many others in this regard. I think it's possible, but would probably be better as a separate follow-on issue.

@jnsn Feel free to continue from this or combine it with your version. I don't plan to work further on it for a while.

