### PR TITLE
Issue 1605

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -54,7 +54,6 @@ var PROJECT_DIR = Context.Environment.WorkingDirectory.FullPath + "/";
 var PACKAGE_DIR = PROJECT_DIR + "package/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
-var TOOLS_DIR = PROJECT_DIR + "tools/";
 
 var SOLUTION_FILE = IsRunningOnWindows()
 	? "./nunit.sln"
@@ -70,9 +69,6 @@ var PACKAGE_SOURCE = new string[]
 // Test Runners
 var NUNIT3_CONSOLE = BIN_DIR + "nunit3-console.exe";
 var NUNITLITE_RUNNER = "nunitlite-runner.exe";
-
-// NuGet.exe
-var NUGET_EXE = TOOLS_DIR + "nuget.exe";
 
 // Test Assemblies
 var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
@@ -882,8 +878,9 @@ void PackageRunnerWithExtensions(string package, string version, string tcVersio
 	var arguments = string.Format(
 		"pack {0} -Version {1} -Properties teamcityVersion={2} -BasePath {3} -OutputDirectory {4} -NoPackageAnalysis",
 		package, version, tcVersion, imageDir, packageDir);
+	var nugetPath = File("tools/nuget.exe");
 
-    StartProcess(NUGET_EXE, arguments);
+    StartProcess(nugetPath, arguments);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -630,24 +630,11 @@ Task("PackageNuGet")
             NoPackageAnalysis = true
         });
 
+        // NOTE: We can't use NuGetPack for these because our current version
+        // of Cake doesn't support the Properties option.
 		PackageRunnerWithExtensions("nuget/runners/nunit.console-runner-with-extensions.nuspec", packageVersion, teamcityVersion, currentImageDir, PACKAGE_DIR);
 
 		PackageRunnerWithExtensions("nuget/runners/nunit.runners.nuspec", packageVersion, teamcityVersion, currentImageDir, PACKAGE_DIR);
-
-        //NuGetPack("nuget/runners/nunit.console-runner-with-extensions.nuspec", new NuGetPackSettings()
-        //{
-        //    Version = packageVersion,
-        //    BasePath = currentImageDir,
-        //    OutputDirectory = PACKAGE_DIR,
-        //    NoPackageAnalysis = true
-        //});
-        //NuGetPack("nuget/runners/nunit.runners.nuspec", new NuGetPackSettings()
-        //{
-        //    Version = packageVersion,
-        //    BasePath = currentImageDir,
-        //    OutputDirectory = PACKAGE_DIR,
-        //    NoPackageAnalysis = true
-        //});
 
         // Package engine
         NuGetPack("nuget/engine/nunit.engine.nuspec", new NuGetPackSettings()

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -33,7 +33,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="[$version$]" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="[$version$]" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="[$version$]" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$version$]" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$teamcityVersion$]" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -27,7 +27,7 @@ Users may update their projects to use the NUnit.Console package directly if des
         <dependency id="NUnit.Extension.VSProjectLoader" version="[$version$]" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="[$version$]" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="[$version$]" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$version$]" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$teamcityVersion$]" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fixes #1605 

This PR essentially does two things...

1. Makes sure that the Appveyor builds of the teamcity event listener get the proper CI suffix.
2. Makes sure that the two runner packages that depend on the listener use the correct version.

Old event listener packages in the 3.3 range have been removed from MyGet. I can't figure out how to remove them from AppVeyor. From references, it may be necessary to remove the NUnit project from AppVeyor and re-add it, which will eliminate all builds. Not sure we want to do that.