### PR TITLE
Fix extensions path for nuget 3 and handle path errors

### DIFF
--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,1 +1,2 @@
 ../../NUnit.Extension.*/tools/
+../../../NUnit.Extension.*/**/tools/

--- a/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
@@ -119,7 +119,10 @@ namespace NUnit.Engine.Internal
                 if (pattern == "." || pattern == "")
                     newList.Add(dir);
                 else if (pattern == "..")
-                    newList.Add(dir.Parent);
+                {
+                    if (dir.Parent != null)
+                        newList.Add(dir.Parent);
+                }
                 else if (pattern == "**")
                 {
                     var subDirs = dir.GetDirectories("*", SearchOption.AllDirectories);

--- a/src/NUnitEngine/nunit.engine/nunit.engine.addins
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.addins
@@ -3,4 +3,3 @@ addins/nunit-v2-result-writer.dll
 addins/nunit-project-loader.dll
 addins/vs-project-loader.dll
 addins/teamcity-event-listener.dll
-


### PR DESCRIPTION
This fixes #1607 and fixes #1551 

In the case of #1607, this is a quick fix, simply adding another entry in the addins file. I'm working on a better fix and it's possible I'll have it before Saturday but I think this little one should be merged anyway.