### PR TITLE
Revise approach to locating extensions

### DIFF
--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -28,6 +28,5 @@
     <file src="bin\nunit-agent.exe.config" target="lib" />
     <file src="bin\nunit-agent-x86.exe" target="lib" />
     <file src="bin\nunit-agent-x86.exe.config" target="lib" />
-    <file src="..\..\nuget\engine\nunit.nuget.addins" target="lib"/>
   </files>
 </package>

--- a/nuget/engine/nunit.engine.tool.nuspec
+++ b/nuget/engine/nunit.engine.tool.nuspec
@@ -29,6 +29,5 @@
     <file src="bin\nunit-agent.exe.config" target="tools" />
     <file src="bin\nunit-agent-x86.exe" target="tools" />
     <file src="bin\nunit-agent-x86.exe.config" target="tools" />
-    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
   </files>
 </package>

--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,2 +1,0 @@
-../../NUnit.Extension.*/tools/
-../../../NUnit.Extension.*/**/tools/

--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,1 +1,2 @@
 ../../NUnit.Extension.*/tools/
+../../../NUnit.Extension.*/**/tools/

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -35,6 +35,5 @@
     <file src="bin/nunit.engine.api.xml" target="tools" />
     <file src="bin/nunit.engine.dll" target="tools" />
     <file src="bin/Mono.Cecil.dll" target="tools" />
-    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
   </files>
 </package>

--- a/nunit.sln
+++ b/nunit.sln
@@ -163,8 +163,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "engine", "engine", "{43A219
 	ProjectSection(SolutionItems) = preProject
 		nuget\engine\nunit.engine.nuspec = nuget\engine\nunit.engine.nuspec
 		nuget\engine\nunit.engine.tool.nuspec = nuget\engine\nunit.engine.tool.nuspec
-		nuget\engine\nunit.nuget.addins = nuget\engine\nunit.nuget.addins
-		nuget\engine\nunit.portable.agent.nuspec = nuget\engine\nunit.portable.agent.nuspec
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "framework", "framework", "{BC87F477-1A7A-45D0-9AC1-9F7315264732}"

--- a/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
@@ -37,12 +37,15 @@ namespace NUnit.Engine.Internal.Tests
             _baseDir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
         }
 
+        // TODO: These tests are fragile because they rely on the directory structure
+        // of the project itself - we should find a better way to test.
+
         [TestCase("net-4.0", 1)]
         [TestCase("net-*", 4)]
         [TestCase("*/v2-tests", 1)]
         [TestCase("add*/v?-*", 1)]
         [TestCase("**/v2-tests", 1)]
-        [TestCase("addins/**", 2)]
+        [TestCase("addins/**", 3)]
         [TestCase("addins/../net-*", 4)]
         [TestCase("addins/v2-tests/", 1)]
         [TestCase("addins//v2-tests/", 1)]
@@ -59,12 +62,23 @@ namespace NUnit.Engine.Internal.Tests
         [TestCase("*/v2-tests/*.dll", 2)]
         [TestCase("add*/v?-*/*.dll", 2)]
         [TestCase("**/v2-tests/*.dll", 2)]
-        [TestCase("addins/**/*.dll", 9)]
+        [TestCase("addins/**/*.dll", 17)]
         [TestCase("addins/../net-*/nunit.framework.dll", 4)]
         public void GetFiles(string pattern, int count)
         {
             var files = DirectoryFinder.GetFiles(_baseDir, pattern);
             Assert.That(files.Count, Is.EqualTo(count));
+        }
+
+        [Test]
+        public void GetPackageDirectory()
+        {
+            // Test only makes sense if run as part of the NUnit solution
+            string solutionDir = _baseDir.Parent.Parent.FullName;
+            Assume.That(File.Exists(Path.Combine(solutionDir, "nunit.sln")));
+
+            string expected = Path.Combine(solutionDir, "packages");
+            Assert.That(DirectoryFinder.GetPackageDirectory(_baseDir).FullName, Is.EqualTo(expected));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
@@ -119,7 +119,10 @@ namespace NUnit.Engine.Internal
                 if (pattern == "." || pattern == "")
                     newList.Add(dir);
                 else if (pattern == "..")
-                    newList.Add(dir.Parent);
+                {
+                    if (dir.Parent != null)
+                        newList.Add(dir.Parent);
+                }
                 else if (pattern == "**")
                 {
                     var subDirs = dir.GetDirectories("*", SearchOption.AllDirectories);

--- a/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
@@ -106,6 +106,22 @@ namespace NUnit.Engine.Internal
             return fileList;
         }
 
+        public static DirectoryInfo GetPackageDirectory(DirectoryInfo startDir)
+        {
+            var dir = new DirectoryInfo(startDir.FullName).Parent;
+
+            while (dir != null)
+            {
+                string tryPath = Path.Combine(dir.FullName, "packages");
+                if (Directory.Exists(tryPath))
+                    return new DirectoryInfo(tryPath);
+
+                dir = dir.Parent;
+            }
+
+            return null;
+        }
+
         #endregion
 
         #region Helper Methods
@@ -125,6 +141,9 @@ namespace NUnit.Engine.Internal
                 }
                 else if (pattern == "**")
                 {
+                    // ** means zero or more intervening directories, so we
+                    // add the directory itself to start out.
+                    newList.Add(dir);
                     var subDirs = dir.GetDirectories("*", SearchOption.AllDirectories);
                     if (subDirs.Length > 0) newList.AddRange(subDirs);
                 }

--- a/src/NUnitEngine/nunit.engine/nunit.engine.addins
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.addins
@@ -3,4 +3,3 @@ addins/nunit-v2-result-writer.dll
 addins/nunit-project-loader.dll
 addins/vs-project-loader.dll
 addins/teamcity-event-listener.dll
-


### PR DESCRIPTION
PR #1613 will take care of issue #1607 as written. This PR aims to make improvements to that fix but it does so by making a number of changes to how NUnit finds extensions. If we can verify it today, it would be a good addition to the 3.4 release but we shouldn't put it in without testing the packages thoroughly.

Changes included:

* Use of `/**/` in a `.addins` file now means 0 or more subdirectories rather than 1 or more. This allows the use of `**/tools` for both nuget v2 and v3.

* The initial directory used for starting the search for addins does not have all its assemblies examined. This eliminates the need for an empty `.addins` file in the directory.

* The search for extensions in the packages directory is now done programmatically, without the need for wildcard entries in the addins file to locate them. Consequently, nunit.nuget.addins has been removed.

I'll go ahead and install this in a project using the NUnit.Console nuget package. I should be able to copy over all the addin tests and run them in that project.