### PR TITLE
Load user profile on test runners

### DIFF
--- a/src/Common/nunit/PackageSettings.cs
+++ b/src/Common/nunit/PackageSettings.cs
@@ -145,6 +145,10 @@ namespace NUnit.Common
         /// </summary>
         public const string ShadowCopyFiles = "ShadowCopyFiles";
 
+        /// <summary>
+        /// Bool flag indicating that user profile should be loaded on test runner processes
+        /// </summary>
+        public const string LoadUserProfile = "LoadUserProfile";
         #endregion
 
         #region Framework Settings - Passed through and used by the 3.0 Framework

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -56,6 +56,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("TeamCity", "teamcity")]
         [TestCase("DebugTests", "debug")]
         [TestCase("PauseBeforeRun", "pause")]
+        [TestCase("LoadUserProfile", "loaduserprofile")]
 #if DEBUG
         [TestCase("DebugAgent", "debug-agent")]
 #endif

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -131,7 +131,7 @@ namespace NUnit.Common
             this.Add("shadowcopy", "Shadow copy test files",
                 v => ShadowCopyFiles = v != null);
 
-            this.Add("loaduserprofile", "Load user profile on test runner processes",
+            this.Add("loaduserprofile", "Load user profile in test runner processes",
                 v => LoadUserProfile = v != null);
 
             this.Add("agents=", "Specify the maximum {NUMBER} of test assembly agents to run at one time. If not specified, there is no limit.",

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -65,6 +65,8 @@ namespace NUnit.Common
 
         public bool ShadowCopyFiles { get; private set; }
 
+        public bool LoadUserProfile { get; private set; }
+
         private int maxAgents = -1;
         public int MaxAgents { get { return maxAgents; } }
         public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
@@ -128,6 +130,9 @@ namespace NUnit.Common
 
             this.Add("shadowcopy", "Shadow copy test files",
                 v => ShadowCopyFiles = v != null);
+
+            this.Add("loaduserprofile", "Load user profile on test runner processes",
+                v => LoadUserProfile = v != null);
 
             this.Add("agents=", "Specify the maximum {NUMBER} of test assembly agents to run at one time. If not specified, there is no limit.",
                 v => maxAgents = RequiredInt(v, "--agents"));

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -335,6 +335,9 @@ namespace NUnit.ConsoleRunner
             if (options.ShadowCopyFiles)
                 package.AddSetting(PackageSettings.ShadowCopyFiles, true);
 
+            if (options.LoadUserProfile)
+                package.AddSetting(PackageSettings.LoadUserProfile, true);
+
             if (options.DefaultTimeout >= 0)
                 package.AddSetting(PackageSettings.DefaultTimeout, options.DefaultTimeout);
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -168,6 +168,7 @@ namespace NUnit.Engine.Services
             bool debugTests = package.GetSetting(PackageSettings.DebugTests, false);
             bool debugAgent = package.GetSetting(PackageSettings.DebugAgent, false);
             string traceLevel = package.GetSetting(PackageSettings.InternalTraceLevel, "Off");
+            bool loadUserProfile = package.GetSetting(PackageSettings.LoadUserProfile, false);
 
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
@@ -219,6 +220,7 @@ namespace NUnit.Engine.Services
                     string cpvOriginal = Environment.GetEnvironmentVariable("COMPLUS_Version");
                     p.StartInfo.EnvironmentVariables["TestAgency_COMPLUS_Version_Original"] = string.IsNullOrEmpty(cpvOriginal) ? "NULL" : cpvOriginal;
                     p.StartInfo.Arguments = arglist;
+                    p.StartInfo.LoadUserProfile = loadUserProfile;
                     break;
 
                 default:


### PR DESCRIPTION
## Problem
The product I am working on uses Microsoft SQL LocalDb for data storage. I have a number of tests verifying that data is stored and retreived correctly to/from the database. These tests works fine when run inside Visual Studio with NUnit 3 Test Adapter, but fails with 'SQL connection error' on the build server using nunit3-console.

## Cause
LocalDb requires the user profile (some registry keys under HKEY_CURRENT_USER) to be loaded on the process attempting to connect. The NUnit 3 Test Adapter runs in process of Visual Studio and the user profile is already loaded and my tests work. nunit3-console runs the tests in a separate test runner processes. These processes do not load the user profile and thus my tests fails.

## Solution
Added a '--loaduserprofile' switch to unit3-console. Setting this will load the user profile when starting the test runners.  As loading the user profile takes time this switch is default off.
[See [https://msdn.microsoft.com/en-us/library/system.diagnostics.processstartinfo.loaduserprofile(v=vs.110).aspx](url)]