### PR TITLE
Fix required minimum engine version for teamcity extension

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ var version = "3.4.0";
 var modifier = "";
 
 //For now, set teamcity extension verson and modifier separately
-var tcVersion = "1.0.0";
+var tcVersion = "1.0.1";
 var tcModifier = "";
 
 var isCompactFrameworkInstalled = FileExists(Environment.GetEnvironmentVariable("windir") + "\\Microsoft.NET\\Framework\\v3.5\\Microsoft.CompactFramework.CSharp.targets");

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -28,12 +28,12 @@
     <copyright>Copyright (c) 2016 Charlie Poole</copyright>
     <dependencies>
       <group>
-        <dependency id="NUnit.ConsoleRunner" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitProjectLoader" version="[$version$]" />
-        <dependency id="NUnit.Extension.VSProjectLoader" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitV2Driver" version="[$version$]" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$teamcityVersion$]" />
+        <dependency id="NUnit.ConsoleRunner" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitProjectLoader" version="$version$" />
+        <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="$teamcityVersion$" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -22,12 +22,12 @@ Users may update their projects to use the NUnit.Console package directly if des
     <copyright>Copyright (c) 2016 Charlie Poole</copyright>
     <dependencies>
       <group>
-        <dependency id="NUnit.ConsoleRunner" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitProjectLoader" version="[$version$]" />
-        <dependency id="NUnit.Extension.VSProjectLoader" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="[$version$]" />
-        <dependency id="NUnit.Extension.NUnitV2Driver" version="[$version$]" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[$teamcityVersion$]" />
+        <dependency id="NUnit.ConsoleRunner" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitProjectLoader" version="$version$" />
+        <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
+        <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="$teamcityVersion$" />
       </group>
     </dependencies>
   </metadata>

--- a/src/NUnitEngine/Addins/addin-tests/NUnit2XmlResultWriterTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnit2XmlResultWriterTests.cs
@@ -1,0 +1,50 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Engine.Extensibility;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Addins
+{
+    public class NUnit2XmlResultWriterTests
+    {
+        [Test]
+        public void CheckExtensionAttribute()
+        {
+            Assert.That(typeof(NUnit2XmlResultWriter),
+                Has.Attribute<ExtensionAttribute>());
+        }
+
+        [Test]
+        public void CheckExtensionPropertyAttribute()
+        {
+            Assert.That(typeof(NUnit2XmlResultWriter),
+                Has.Attribute<ExtensionPropertyAttribute>()
+                    .With.Property("Name").EqualTo("Format")
+                    .And.Property("Value").EqualTo("nunit2"));
+        }
+    }
+}

--- a/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/NUnitProjectLoaderTests.cs
@@ -42,6 +42,22 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
         }
 
         [Test]
+        public void CheckExtensionAttribute()
+        {
+            Assert.That(typeof(NUnitProjectLoader),
+                Has.Attribute<ExtensionAttribute>());
+        }
+
+        [Test]
+        public void CheckExtensionPropertyAttribute()
+        {
+            Assert.That(typeof(NUnitProjectLoader),
+                Has.Attribute<ExtensionPropertyAttribute>()
+                    .With.Property("Name").EqualTo("FileExtension")
+                    .And.Property("Value").EqualTo(".nunit"));
+        }
+
+        [Test]
         public void CheckExtension()
         {
             Assert.That(_loader.CanLoadFrom("dummy.nunit"));

--- a/src/NUnitEngine/Addins/addin-tests/TeamCityEventListenerTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/TeamCityEventListenerTests.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using NUnit.Framework;
+using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Listeners
 {
@@ -48,6 +49,15 @@ namespace NUnit.Engine.Listeners
         public void TearDown()
         {
             _outputWriter.Dispose();
+        }
+
+        [Test]
+        public void CheckExtensionAttribute()
+        {
+            Assert.That(typeof(TeamCityEventListener),
+                Has.Attribute<ExtensionAttribute>()
+                    .With.Property("EngineVersion").EqualTo("3.4")
+                    .And.Property("Enabled").EqualTo(false));
         }
 
         [Test]

--- a/src/NUnitEngine/Addins/addin-tests/VisualStudioProjectLoaderTests.cs
+++ b/src/NUnitEngine/Addins/addin-tests/VisualStudioProjectLoaderTests.cs
@@ -56,6 +56,45 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
         }
 
         [Test]
+        public void CheckExtensionAttribute()
+        {
+            Assert.That(typeof(VisualStudioProjectLoader),
+                Has.Attribute<ExtensionAttribute>());
+        }
+
+        // Note for review:
+        // The following test doesn't pass because AttributeConstraint always uses the
+        // first attribute it finds. Should we fix the syntax or just document it?
+        //[TestCase(".sln")]
+        //[TestCase(".csproj")]
+        //[TestCase(".vbproj")]
+        //[TestCase(".vjsproj")]
+        //[TestCase(".vcproj")]
+        //[TestCase(".fsproj")]
+        //public void CheckExtensionPropertyAttributes(string ext)
+        //{
+        //    Assert.That(typeof(VisualStudioProjectLoader),
+        //        Has.Attribute<ExtensionPropertyAttribute>()
+        //            .With.Property("Name").EqualTo("FileExtension").And.Property("Value").EqualTo(ext));
+        //}
+
+        [TestCase(".sln")]
+        [TestCase(".csproj")]
+        [TestCase(".vbproj")]
+        [TestCase(".vjsproj")]
+        [TestCase(".vcproj")]
+        [TestCase(".fsproj")]
+        public void CheckExtensionPropertyAttributes(string ext)
+        {
+            var attrs = typeof(VisualStudioProjectLoader).GetCustomAttributes(typeof(ExtensionPropertyAttribute), false);
+
+            Assert.That(attrs, 
+                Has.Exactly(1)
+                    .With.Property("Name").EqualTo("FileExtension")
+                    .And.Property("Value").EqualTo(ext));
+        }
+
+        [Test]
         public void CannotLoadWebProject()
         {
             Assert.IsFalse(_loader.CanLoadFrom(@"http://localhost/web.csproj"));

--- a/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
+++ b/src/NUnitEngine/Addins/addin-tests/addin-tests.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NUnit2XmlResultWriterTests.cs" />
     <Compile Include="NUnitProjectLoaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="resources\TestResource.cs" />
@@ -55,6 +56,10 @@
     <ProjectReference Include="..\nunit-project-loader\nunit-project-loader.csproj">
       <Project>{E71A76CA-0089-4E1A-A7FB-210429DBED6E}</Project>
       <Name>nunit-project-loader</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\nunit-v2-result-writer\nunit-v2-result-writer.csproj">
+      <Project>{aecfa3fb-e55a-4151-9dea-f715fbb972ba}</Project>
+      <Name>nunit-v2-result-writer</Name>
     </ProjectReference>
     <ProjectReference Include="..\teamcity-event-listener\teamcity-event-listener.csproj">
       <Project>{a867079b-a172-4dae-9549-63b331092a23}</Project>

--- a/src/NUnitEngine/Addins/teamcity-event-listener/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
+++ b/src/NUnitEngine/Addins/teamcity-event-listener/TeamCityEventListener.cs
@@ -31,10 +31,10 @@ using NUnit.Engine.Extensibility;
 namespace NUnit.Engine.Listeners
 {
     // Note: Setting mimimum engine version in this case is
-    // purely documentary since engines prior to 3.6 do not
+    // purely documentary since engines prior to 3.4 do not
     // check the EngineVersion property and will try to 
     // load this extension anyway.
-    [Extension(Enabled = false, EngineVersion = "3.6")]
+    [Extension(Enabled = false, EngineVersion = "3.4")]
     public class TeamCityEventListener : ITestEventListener
     {
         private readonly TextWriter _outWriter;

--- a/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Engine.Internal.Tests
         [TestCase("*/v2-tests/*.dll", 2)]
         [TestCase("add*/v?-*/*.dll", 2)]
         [TestCase("**/v2-tests/*.dll", 2)]
-        [TestCase("addins/**/*.dll", 17)]
+        [TestCase("addins/**/*.dll", 18)]
         [TestCase("addins/../net-*/nunit.framework.dll", 4)]
         public void GetFiles(string pattern, int count)
         {


### PR DESCRIPTION
This fixes #1623 

Contents...

* Change required engine version for extension to 3.4
* Advance extension version to 1.0.1
* Update runner packages to use 1.0.1 
* Add minimal tests to check attributes on each extension

The last point is only slightly helpful but at least it means we have to make the same mistake in two places for the tests to pass.

We'll need to do more around the issue of integration testing after the 3.4.1 release.