### PR TITLE
Fix hanging agent process at end of run

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Engine.Internal.Tests
         [TestCase("*/v2-tests/*.dll", 2)]
         [TestCase("add*/v?-*/*.dll", 2)]
         [TestCase("**/v2-tests/*.dll", 2)]
-        [TestCase("addins/**/*.dll", 18)]
+        [TestCase("addins/**/*.dll", 17)]
         [TestCase("addins/../net-*/nunit.framework.dll", 4)]
         public void GetFiles(string pattern, int count)
         {

--- a/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/DirectoryFinderTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Engine.Internal.Tests
         [TestCase("*/v2-tests/*.dll", 2)]
         [TestCase("add*/v?-*/*.dll", 2)]
         [TestCase("**/v2-tests/*.dll", 2)]
-        [TestCase("addins/**/*.dll", 17)]
+        [TestCase("addins/**/*.dll", 18)]
         [TestCase("addins/../net-*/nunit.framework.dll", 4)]
         public void GetFiles(string pattern, int count)
         {


### PR DESCRIPTION
Fixes #1628 

This first commit adds code to do a better job of killing the unloading thread if it hangs. This is only one hypothesis about the cause of the problem, so it would be helpful to have it tested before going further. @NikolayPianikov you seem to be able to reproduce this better than the rest of us, could you test?

Even if the first commit works, I think I'll go on to also kill the process if necessary, but it would be good to know the effect of the first change first.