### PR TITLE
Revise approach to locating extensions

### DIFF
--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -28,5 +28,6 @@
     <file src="bin\nunit-agent.exe.config" target="lib" />
     <file src="bin\nunit-agent-x86.exe" target="lib" />
     <file src="bin\nunit-agent-x86.exe.config" target="lib" />
+    <file src="..\..\nuget\engine\nunit.nuget.addins" target="lib"/>
   </files>
 </package>

--- a/nuget/engine/nunit.engine.tool.nuspec
+++ b/nuget/engine/nunit.engine.tool.nuspec
@@ -29,5 +29,6 @@
     <file src="bin\nunit-agent.exe.config" target="tools" />
     <file src="bin\nunit-agent-x86.exe" target="tools" />
     <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>  
   </files>
 </package>

--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,0 +1,2 @@
+../../NUnit.Extension.*/**/tools/     # nuget v2 layout
+../../../NUnit.Extension.*/**/tools/  # nuget v3 layout

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -35,5 +35,6 @@
     <file src="bin/nunit.engine.api.xml" target="tools" />
     <file src="bin/nunit.engine.dll" target="tools" />
     <file src="bin/Mono.Cecil.dll" target="tools" />
+    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
   </files>
 </package>

--- a/nunit.sln
+++ b/nunit.sln
@@ -163,6 +163,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "engine", "engine", "{43A219
 	ProjectSection(SolutionItems) = preProject
 		nuget\engine\nunit.engine.nuspec = nuget\engine\nunit.engine.nuspec
 		nuget\engine\nunit.engine.tool.nuspec = nuget\engine\nunit.engine.tool.nuspec
+		nuget\engine\nunit.nuget.addins = nuget\engine\nunit.nuget.addins
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "framework", "framework", "{BC87F477-1A7A-45D0-9AC1-9F7315264732}"

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -75,6 +75,8 @@ namespace NUnit.Common
 
         public bool DebugAgent { get; private set; }
 
+        public bool ListExtensions { get; private set; }
+
         public bool PauseBeforeRun { get; private set; }
 
         #endregion
@@ -142,6 +144,9 @@ namespace NUnit.Common
 
             this.Add("pause", "Pause before running to allow attaching a debugger.",
                 v => PauseBeforeRun = v != null);
+
+            this.Add("list-extensions", "List all extension points and the extensions for each.",
+                v => ListExtensions = v != null);
 
 #if DEBUG
             this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -103,6 +103,17 @@ namespace NUnit.ConsoleRunner
 
             DisplayRuntimeEnvironment(_outWriter);
 
+            if (_options.ListExtensions)
+                DisplayExtensionList();
+
+            if (_options.InputFiles.Count == 0)
+            {
+                if (!_options.ListExtensions)
+                    using (new ColorConsole(ColorStyle.Error))
+                        Console.Error.WriteLine("Error: no inputs specified");
+                return ConsoleRunner.OK;
+            }
+
             DisplayTestFiles();
 
             TestPackage package = MakeTestPackage(_options);
@@ -259,6 +270,31 @@ namespace NUnit.ConsoleRunner
 
         [DllImport("libc")]
         static extern int uname(IntPtr buf);
+
+        private void DisplayExtensionList()
+        {
+            _outWriter.WriteLine(ColorStyle.SectionHeader, "Installed Extensions");
+
+            foreach (var ep in _extensionService.ExtensionPoints)
+            {
+                _outWriter.WriteLabelLine("  Extension Point: ", ep.Path);
+                foreach (var node in ep.Extensions)
+                {
+                    _outWriter.Write("    Extension: ");
+                    _outWriter.Write(ColorStyle.Value, node.TypeName);
+                    _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
+                    foreach (var prop in node.PropertyNames)
+                    {
+                        _outWriter.Write("      " + prop + ":");
+                        foreach (var val in node.GetValues(prop))
+                            _outWriter.Write(ColorStyle.Value, " " + val);
+                        _outWriter.WriteLine();
+                    }
+                }
+            }
+
+            _outWriter.WriteLine();
+        }
 
         private void DisplayTestFilters()
         {

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -101,13 +101,6 @@ namespace NUnit.ConsoleRunner
                     return ConsoleRunner.INVALID_ARG;
                 }
 
-                if (Options.InputFiles.Count == 0)
-                {
-                    using (new ColorConsole(ColorStyle.Error))
-                        Console.Error.WriteLine("Error: no inputs specified");
-                    return ConsoleRunner.OK;
-                }
-
                 using (ITestEngine engine = TestEngineActivator.CreateInstance(false))
                 {
                     if (Options.WorkDirectory != null)


### PR DESCRIPTION
Fixes #1626 Fixes #1635 
Changes:

* Returned to use of nunit.nuget.addins file in our nuget packages. The file now has a line for nuget V2 format installs and another for V3, which incorporates an extra directory level. Will find extensions for the NUnit.ConsoleRunner package provided the common parent of all packages is either two or three directories up.

* Eliminated programmatic scan for `packages` dir, since the name is not guaranteed.

* Re-defined `**` in the addins file to mean zero or more directory components rather than one or more.

* Tracks assemblies that have already been seen so they are not processed twice.

* Adds an option to the console runner to allow displaying all extensions that are in use.

I originally planned to add the option of another addins file in the TestDirectory. Since addins are initialized before any tests are loaded, this would require too much work to do right now.

