### PR TITLE
Enable mono 3.2.8 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ mono:
   - latest
   - 3.2.8
 
-matrix:
-  allow_failures:
-    - mono: 3.2.8
-
 script: 
   - ./build.sh --target "Travis"
     


### PR DESCRIPTION
No longer allow failures of mono 3.2.8, thanks to travis-ci/travis-ci#6189 :-)