### PR TITLE
OS X CI build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ mono:
 os:
   - linux
   - osx
+matrix:
+  exclude:
+    - os: osx
+      mono: 3.2.8
 script:
   - ./build.sh --target "Travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 mono:
   - latest
   - 3.2.8
-
-script: 
+os:
+  - linux
+  - osx
+script:
   - ./build.sh --target "Travis"
-    


### PR DESCRIPTION
This PR adds `osx` for `mono: latest` to the Travis CI build.

Fixes #1641.