### PR TITLE
Allow custom assembly builder by attribute

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -70,7 +70,11 @@ namespace NUnit.Framework.Api
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary settings)
         {
-            this.Builder = new DefaultTestAssemblyBuilder();
+#if !NETCF
+            this.Builder = new RuntimeAssemblyBuilder();
+#else
+            this.Builder = new DefaultTestAssemblyBuilder(); // TODO: Implement RuntimeAssemblyBuilder for .NET CF
+#endif
             this.Runner = new NUnitTestAssemblyRunner(this.Builder);
 
             Test.IdPrefix = idPrefix;
@@ -453,7 +457,7 @@ namespace NUnit.Framework.Api
 
         #region Nested Action Classes
 
-        #region TestContollerAction
+        #region TestControllerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions

--- a/src/NUnitFramework/framework/Api/RuntimeAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/RuntimeAssemblyBuilder.cs
@@ -1,0 +1,153 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework.Attributes;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Api 
+{
+    /// <summary>
+    /// Represents an <see cref="ITestAssemblyBuilder"/> which will instantiate the correct <see cref="ITestAssemblyBuilder"/> at runtime
+    /// </summary>
+    public sealed class RuntimeAssemblyBuilder : ITestAssemblyBuilder 
+    {
+        static Logger log = InternalTrace.GetLogger(typeof(RuntimeAssemblyBuilder));
+
+        /// <summary>
+        /// Build a suite of tests from a provided assembly
+        /// </summary>
+        /// <param name="assembly">The assembly from which tests are to be built</param>
+        /// <param name="options">A dictionary of options to use in building the suite</param>
+        /// <returns>A TestSuite containing the tests found in the assembly</returns>
+        public ITest Build(Assembly assembly, IDictionary<string, object> options) 
+        {
+#if PORTABLE
+            log.Debug("Loading {0}", assembly.FullName);
+#else
+            log.Debug("Loading {0} in AppDomain {1}", assembly.FullName, AppDomain.CurrentDomain.FriendlyName);
+#endif
+
+            return BuildUsingInnerBuilder(assembly, options);
+        }
+
+        /// <summary>
+        /// Build a suite of tests given the filename of an assembly
+        /// </summary>
+        /// <param name="assemblyName">The filename of the assembly from which tests are to be built</param>
+        /// <param name="options">A dictionary of options to use in building the suite</param>
+        /// <returns>A TestSuite containing the tests found in the assembly</returns>
+        public ITest Build(string assemblyName, IDictionary<string, object> options) 
+        {
+#if PORTABLE
+            log.Debug("Loading {0}", assemblyName);
+#else
+            log.Debug("Loading {0} in AppDomain {1}", assemblyName, AppDomain.CurrentDomain.FriendlyName);
+#endif
+
+            ITest test = null;
+
+            try 
+            {
+                var assembly = AssemblyHelper.Load(assemblyName);
+                test = BuildUsingInnerBuilder(assembly, assemblyName, options);
+            }
+            catch (Exception ex) 
+            {
+                var testAssembly = new TestAssembly(assemblyName);
+                testAssembly.RunState = RunState.NotRunnable;
+                testAssembly.Properties.Set(PropertyNames.SkipReason, ex.Message);
+
+                test = testAssembly;
+            }
+
+            return test;
+        }
+
+        private static ITest BuildUsingInnerBuilder(Assembly assembly, IDictionary<string, object> options)
+        {
+            ITestAssemblyBuilder testAssemblyBuilder;
+
+            try 
+            {
+                testAssemblyBuilder = ConstructTestAssemblyBuilder(assembly);
+            }
+            catch (Exception ex) 
+            {
+                var testAssembly = new TestAssembly(assembly, AssemblyHelper.GetAssemblyPath(assembly));
+                testAssembly.RunState = RunState.NotRunnable;
+                testAssembly.Properties.Set(PropertyNames.SkipReason, ex.Message);
+
+                return testAssembly;
+            }
+
+            return testAssemblyBuilder.Build(assembly, options);
+        }
+
+        private static ITest BuildUsingInnerBuilder(Assembly assembly, string assemblyName, IDictionary<string, object> options)
+        {
+            ITestAssemblyBuilder testAssemblyBuilder;
+
+            try 
+            {
+                testAssemblyBuilder = ConstructTestAssemblyBuilder(assembly);
+            }
+            catch (Exception ex) 
+            {
+                var testAssembly = new TestAssembly(assembly, assemblyName);
+                testAssembly.RunState = RunState.NotRunnable;
+                testAssembly.Properties.Set(PropertyNames.SkipReason, ex.Message);
+
+                return testAssembly;
+            }
+
+            return testAssemblyBuilder.Build(assemblyName, options);
+        }
+
+        private static ITestAssemblyBuilder ConstructTestAssemblyBuilder(Assembly assembly) 
+        {
+            log.Debug("Looking up ITestAssemblyBuilder for assembly");
+
+#if PORTABLE
+            var attributes = assembly.GetCustomAttributes<TestAssemblyBuilderAttribute>().ToArray();
+#else
+            var attributes = assembly.GetCustomAttributes(typeof(TestAssemblyBuilderAttribute), false /*unused*/);
+#endif
+
+            TestAssemblyBuilderAttribute testAssemblyBuilderAttribute;
+            if (attributes.Length == 1 && (testAssemblyBuilderAttribute = attributes[0] as TestAssemblyBuilderAttribute) != null) 
+            {
+                log.Debug("Constructing ITestAssemblyBuilder {0}", testAssemblyBuilderAttribute.AssemblyBuilderType);
+
+                return (ITestAssemblyBuilder) Reflect.Construct(testAssemblyBuilderAttribute.AssemblyBuilderType);
+            }
+
+            // Fallback to default implementation
+            return new DefaultTestAssemblyBuilder();
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Attributes/TestAssemblyBuilderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAssemblyBuilderAttribute.cs
@@ -1,0 +1,48 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.Framework.Attributes 
+{
+    /// <summary>
+    /// When declared on an assembly, specified which type should be used for discovery of tests within the assembly
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class TestAssemblyBuilderAttribute : Attribute 
+    {
+        /// <summary>
+        /// Gets the type that is used for discovery of tests in the assembly. The type specified must implement <see cref="NUnit.Framework.Api.ITestAssemblyBuilder"/>
+        /// </summary>
+        public Type AssemblyBuilderType { get; private set; }
+
+        /// <summary>
+        /// Constructs a TestAssemblyBuilderAttribute
+        /// </summary>
+        /// <param name="assemblyBuilderType"></param>
+        public TestAssemblyBuilderAttribute(Type assemblyBuilderType) 
+        {
+            this.AssemblyBuilderType = assemblyBuilderType;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -81,10 +81,12 @@
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\FrameworkController.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\OrderAttribute.cs" />
     <Compile Include="Attributes\RetryAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -81,10 +81,12 @@
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\FrameworkController.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\OrderAttribute.cs" />
     <Compile Include="Attributes\RetryAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Assert.Comparisons.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -113,6 +114,7 @@
     <Compile Include="Attributes\CombinatorialAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\OneTimeSetUpAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Assert.Comparisons.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -126,6 +127,7 @@
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\MaxTimeAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Assert.Comparisons.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -122,6 +123,7 @@
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\LevelOfParallelismAttribute.cs" />
     <Compile Include="Attributes\MaxTimeAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
+    <Compile Include="Api\RuntimeAssemblyBuilder.cs" />
     <Compile Include="Assert.Comparisons.cs">
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
@@ -164,6 +165,7 @@
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TearDownAttribute.cs" />
     <Compile Include="Attributes\TestActionAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyBuilderAttribute.cs" />
     <Compile Include="Attributes\TestAttribute.cs" />
     <Compile Include="Attributes\TestCaseAttribute.cs" />
     <Compile Include="Attributes\TestCaseSourceAttribute.cs" />

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -72,7 +72,11 @@ namespace NUnit.Framework.Api
         [Test]
         public void ConstructController()
         {
+#if !NETCF
+            Assert.That(_controller.Builder, Is.TypeOf<RuntimeAssemblyBuilder>());
+#else
             Assert.That(_controller.Builder, Is.TypeOf<DefaultTestAssemblyBuilder>());
+#endif
             Assert.That(_controller.Runner, Is.TypeOf<NUnitTestAssemblyRunner>());
 #if SILVERLIGHT || PORTABLE
             Assert.That(_controller.AssemblyNameOrPath, Is.EqualTo(MOCK_ASSEMBLY_NAME));


### PR DESCRIPTION
As shortly discussed in #345. 

In summary, the following changes have been made:
- Add attribute that is to be added to target test assembly, allowing a custom `ITestAssemblyBuilder` to be selected.
- The RuntimeAssemblyBuilder instantiates the correct `ITestAssembyBuilder` or uses the default implementation.
- No tests have been developed, not sure to proceed here or if it is useful here since there isn't much logic here.

If you open a wiki page I then I can write the documentation if you like.