### PR TITLE
Allow specifying partial list of optional params

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -318,7 +318,8 @@ namespace NUnit.Framework
                     object[] newArgList = new object[parameters.Length];
                     Array.Copy(parms.Arguments, newArgList, parms.Arguments.Length);
 
-                    for (var i = 0; i < parameters.Length; i++)
+                    //Fill with Type.Missing for remaining required parameters where optional
+                    for (var i = parms.Arguments.Length; i < parameters.Length; i++)
                     {
                         if (parameters[i].IsOptional)
                             newArgList[i] = Type.Missing;

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -201,20 +201,20 @@ namespace NUnit.Framework.Attributes
         }
 
 #if !NETCF
-        [TestCase("a")]
-        [TestCase("a", "b")]
-        public void HandlesOptionalArguments(string s1, string s2 = "b")
+        [TestCase("x", ExpectedResult = new []{"x", "b", "c"})]
+        [TestCase("x", "y", ExpectedResult = new[] { "x", "y", "c" })]
+        [TestCase("x", "y", "z", ExpectedResult = new[] { "x", "y", "z" })]
+        public string[] HandlesOptionalArguments(string s1, string s2 = "b", string s3 = "c")
         {
-            Assert.AreEqual("a", s1);
-            Assert.AreEqual("b", s2);
+            return new[] {s1, s2, s3};
         }
 
-        [TestCase]
-        [TestCase("a", "b")]
-        public void HandlesAllOptionalArguments(string s1 = "a", string s2 = "b")
+        [TestCase(ExpectedResult = new []{"a", "b"})]
+        [TestCase("x", ExpectedResult = new[] { "x", "b" })]
+        [TestCase("x", "y", ExpectedResult = new[] { "x", "y" })]
+        public string[] HandlesAllOptionalArguments(string s1 = "a", string s2 = "b")
         {
-            Assert.AreEqual("a", s1);
-            Assert.AreEqual("b", s2);
+            return new[] {s1, s2};
         }
 #endif
 


### PR DESCRIPTION
Fixes #1640.

Two problems - the first that my implementation would overwrite any specified optional parameters with `Type.Missing`. 

The second issue being that by passing in the default value in the `TestCaseAttribute` tests - you counldn't tell if you're getting the passed in value, or the default. Whoops!