### PR TITLE
Remove PackageSettings.cs from Common

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using NUnit.Common;
@@ -30,6 +29,7 @@ using NUnit.ConsoleRunner.Utilities;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 namespace NUnit.ConsoleRunner
 {
@@ -354,61 +354,61 @@ namespace NUnit.ConsoleRunner
             TestPackage package = new TestPackage(options.InputFiles);
 
             if (options.ProcessModelSpecified)
-                package.AddSetting(PackageSettings.ProcessModel, options.ProcessModel);
+                package.AddSetting(EnginePackageSettings.ProcessModel, options.ProcessModel);
 
             if (options.DomainUsageSpecified)
-                package.AddSetting(PackageSettings.DomainUsage, options.DomainUsage);
+                package.AddSetting(EnginePackageSettings.DomainUsage, options.DomainUsage);
 
             if (options.FrameworkSpecified)
-                package.AddSetting(PackageSettings.RuntimeFramework, options.Framework);
+                package.AddSetting(EnginePackageSettings.RuntimeFramework, options.Framework);
 
             if (options.RunAsX86)
-                package.AddSetting(PackageSettings.RunAsX86, true);
+                package.AddSetting(EnginePackageSettings.RunAsX86, true);
 
             if (options.DisposeRunners)
-                package.AddSetting(PackageSettings.DisposeRunners, true);
+                package.AddSetting(EnginePackageSettings.DisposeRunners, true);
 
             if (options.ShadowCopyFiles)
-                package.AddSetting(PackageSettings.ShadowCopyFiles, true);
+                package.AddSetting(EnginePackageSettings.ShadowCopyFiles, true);
 
             if (options.LoadUserProfile)
-                package.AddSetting(PackageSettings.LoadUserProfile, true);
+                package.AddSetting(EnginePackageSettings.LoadUserProfile, true);
 
             if (options.DefaultTimeout >= 0)
-                package.AddSetting(PackageSettings.DefaultTimeout, options.DefaultTimeout);
+                package.AddSetting(FrameworkPackageSettings.DefaultTimeout, options.DefaultTimeout);
 
             if (options.InternalTraceLevelSpecified)
-                package.AddSetting(PackageSettings.InternalTraceLevel, options.InternalTraceLevel);
+                package.AddSetting(FrameworkPackageSettings.InternalTraceLevel, options.InternalTraceLevel);
 
             if (options.ActiveConfigSpecified)
-                package.AddSetting(PackageSettings.ActiveConfig, options.ActiveConfig);
+                package.AddSetting(EnginePackageSettings.ActiveConfig, options.ActiveConfig);
 
             // Always add work directory, in case current directory is changed
             var workDirectory = options.WorkDirectory ?? Environment.CurrentDirectory;
-            package.AddSetting(PackageSettings.WorkDirectory, workDirectory);
+            package.AddSetting(FrameworkPackageSettings.WorkDirectory, workDirectory);
 
             if (options.StopOnError)
-                package.AddSetting(PackageSettings.StopOnError, true);
+                package.AddSetting(FrameworkPackageSettings.StopOnError, true);
 
             if (options.MaxAgentsSpecified)
-                package.AddSetting(PackageSettings.MaxAgents, options.MaxAgents);
+                package.AddSetting(EnginePackageSettings.MaxAgents, options.MaxAgents);
 
             if (options.NumberOfTestWorkersSpecified)
-                package.AddSetting(PackageSettings.NumberOfTestWorkers, options.NumberOfTestWorkers);
+                package.AddSetting(FrameworkPackageSettings.NumberOfTestWorkers, options.NumberOfTestWorkers);
 
             if (options.RandomSeedSpecified)
-                package.AddSetting(PackageSettings.RandomSeed, options.RandomSeed);
+                package.AddSetting(FrameworkPackageSettings.RandomSeed, options.RandomSeed);
 
             if (options.DebugTests)
             {
-                package.AddSetting(PackageSettings.DebugTests, true);
+                package.AddSetting(FrameworkPackageSettings.DebugTests, true);
 
                 if (!options.NumberOfTestWorkersSpecified)
-                    package.AddSetting(PackageSettings.NumberOfTestWorkers, 0);
+                    package.AddSetting(FrameworkPackageSettings.NumberOfTestWorkers, 0);
             }
 
             if (options.PauseBeforeRun)
-                package.AddSetting(PackageSettings.PauseBeforeRun, true);
+                package.AddSetting(FrameworkPackageSettings.PauseBeforeRun, true);
 
 #if DEBUG
             if (options.DebugAgent)
@@ -420,10 +420,10 @@ namespace NUnit.ConsoleRunner
 #endif
 
             if (options.DefaultTestNamePattern != null)
-                package.AddSetting(PackageSettings.DefaultTestNamePattern, options.DefaultTestNamePattern);
+                package.AddSetting(FrameworkPackageSettings.DefaultTestNamePattern, options.DefaultTestNamePattern);
 
             if (options.TestParameters != null)
-                package.AddSetting(PackageSettings.TestParameters, options.TestParameters);
+                package.AddSetting(FrameworkPackageSettings.TestParameters, options.TestParameters);
 
             return package;
         }

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -29,7 +29,6 @@ using NUnit.ConsoleRunner.Utilities;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
 namespace NUnit.ConsoleRunner
 {
@@ -412,7 +411,7 @@ namespace NUnit.ConsoleRunner
 
 #if DEBUG
             if (options.DebugAgent)
-                package.AddSetting(PackageSettings.DebugAgent, true);
+                package.AddSetting(EnginePackageSettings.DebugAgent, true);
 
             //foreach (KeyValuePair<string, object> entry in package.Settings)
             //    if (!(entry.Value is string || entry.Value is int || entry.Value is bool))

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace NUnit
 {
     /// <summary>
     /// EngineSettings contains constant values that

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,43 +21,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Common
+namespace NUnit.Engine
 {
     /// <summary>
-    /// PackageSettings is a static class containing constant values that
-    /// are used as keys in setting up a TestPackage. These values are used in
-    /// the engine and framework. Setting values may be a string, int or bool.
+    /// EngineSettings contains constant values that
+    /// are used as keys in setting up a TestPackage. 
+    /// Values here are used in the engine, and set by the runner.
+    /// Setting values may be a string, int or bool.
     /// </summary>
-    public static class PackageSettings
+    public static class EnginePackageSettings
     {
-        #region Common Settings - Used by both the Engine and the 3.0 Framework
-
-        /// <summary>
-        /// Flag (bool) indicating whether tests are being debugged.
-        /// </summary>
-        public const string DebugTests = "DebugTests";
-
-        /// <summary>
-        /// Flag (bool) indicating whether to pause execution of tests to allow
-        /// the user to attache a debugger.
-        /// </summary>
-        public const string PauseBeforeRun = "PauseBeforeRun";
-
-        /// <summary>
-        /// The InternalTraceLevel for this run. Values are: "Default",
-        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
-        /// Default is "Off". "Debug" and "Verbose" are synonyms.
-        /// </summary>
-        public const string InternalTraceLevel = "InternalTraceLevel";
-
-        /// <summary>
-        /// Full path of the directory to be used for work and result files.
-        /// This path is provided to tests by the frameowrk TestContext.
-        /// </summary>
-        public const string WorkDirectory = "WorkDirectory";
-
-        #endregion
-
         #region Engine Settings - Used by the Engine itself
 
         /// <summary>
@@ -85,6 +58,11 @@ namespace NUnit.Common
         /// Path to the config file to use in running the tests. 
         /// </summary>
         public const string ConfigurationFile = "ConfigurationFile";
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
 
         /// <summary>
         /// Bool flag indicating whether a debugger should be launched at agent 
@@ -149,91 +127,19 @@ namespace NUnit.Common
         /// Bool flag indicating that user profile should be loaded on test runner processes
         /// </summary>
         public const string LoadUserProfile = "LoadUserProfile";
-        #endregion
-
-        #region Framework Settings - Passed through and used by the 3.0 Framework
 
         /// <summary>
-        /// Integer value in milliseconds for the default timeout value
-        /// for test cases. If not specified, there is no timeout except
-        /// as specified by attributes on the tests themselves.
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attache a debugger.
         /// </summary>
-        public const string DefaultTimeout = "DefaultTimeout";
+        public const string PauseBeforeRun = "PauseBeforeRun";
 
         /// <summary>
-        /// A TextWriter to which the internal trace will be sent.
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
         /// </summary>
-        public const string InternalTraceWriter = "InternalTraceWriter";
-
-        /// <summary>
-        /// A list of tests to be loaded. 
-        /// </summary>
-        // TODO: Remove?
-        public const string LOAD = "LOAD";
-
-        /// <summary>
-        /// The number of test threads to run for the assembly. If set to
-        /// 1, a single queue is used. If set to 0, tests are executed
-        /// directly, without queuing.
-        /// </summary>
-        public const string NumberOfTestWorkers = "NumberOfTestWorkers";
-
-        /// <summary>
-        /// The random seed to be used for this assembly. If specified
-        /// as the value reported from a prior run, the framework should
-        /// generate identical random values for tests as were used for
-        /// that run, provided that no change has been made to the test
-        /// assembly. Default is a random value itself.
-        /// </summary>
-        public const string RandomSeed = "RandomSeed";
-
-        /// <summary>
-        /// If true, execution stops after the first error or failure.
-        /// </summary>
-        public const string StopOnError = "StopOnError";
-
-        /// <summary>
-        /// If true, use of the event queue is suppressed and test events are synchronous.
-        /// </summary>
-        public const string SynchronousEvents = "SynchronousEvents";
-
-        /// <summary>
-        /// The default naming pattern used in generating test names
-        /// </summary>
-        public const string DefaultTestNamePattern = "DefaultTestNamePattern";
-
-        /// <summary>
-        /// Parameters to be passed on to the test
-        /// </summary>
-        public const string TestParameters = "TestParameters";
-
-        #endregion
-
-        #region Internal Settings - Used only within the engine
-
-        /// <summary>
-        /// If the package represents an assembly, then this is the CLR version
-        /// stored in the assembly image. If it represents a project or other
-        /// group of assemblies, it is the maximum version for all the assemblies.
-        /// </summary>
-        public const string ImageRuntimeVersion = "ImageRuntimeVersion";
-
-        /// <summary>
-        /// True if any assembly in the package requires running as a 32-bit
-        /// process when on a 64-bit system.
-        /// </summary>
-        public const string ImageRequiresX86 = "ImageRequiresX86";
-
-        /// <summary>
-        /// True if any assembly in the package requires a special assembly resolution hook
-        /// in the default AppDomain in order to find dependent assemblies.
-        /// </summary>
-        public const string ImageRequiresDefaultAppDomainAssemblyResolver = "ImageRequiresDefaultAppDomainAssemblyResolver";
-
-        /// <summary>
-        /// The FrameworkName specified on a TargetFrameworkAttribute for the assembly
-        /// </summary>
-        public const string ImageTargetFrameworkName = "ImageTargetFrameworkName";
+        public const string InternalTraceLevel = "InternalTraceLevel";
 
         #endregion
     }

--- a/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Framework
+namespace NUnit
 {
     /// <summary>
     /// FrameworkPackageSettings is a static class containing constant values that

--- a/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
@@ -1,0 +1,115 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// FrameworkPackageSettings is a static class containing constant values that
+    /// are used as keys in setting up a TestPackage. These values are used in
+    /// the framework, and set in the runner. Setting values may be a string, int or bool.
+    /// </summary>
+    public static class FrameworkPackageSettings
+    {
+        #region Settings u
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attache a debugger.
+        /// </summary>
+        public const string PauseBeforeRun = "PauseBeforeRun";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        /// <summary>
+        /// Full path of the directory to be used for work and result files.
+        /// This path is provided to tests by the frameowrk TestContext.
+        /// </summary>
+        public const string WorkDirectory = "WorkDirectory";
+
+        /// <summary>
+        /// Integer value in milliseconds for the default timeout value
+        /// for test cases. If not specified, there is no timeout except
+        /// as specified by attributes on the tests themselves.
+        /// </summary>
+        public const string DefaultTimeout = "DefaultTimeout";
+
+        /// <summary>
+        /// A TextWriter to which the internal trace will be sent.
+        /// </summary>
+        public const string InternalTraceWriter = "InternalTraceWriter";
+
+        /// <summary>
+        /// A list of tests to be loaded. 
+        /// </summary>
+        // TODO: Remove?
+        public const string LOAD = "LOAD";
+
+        /// <summary>
+        /// The number of test threads to run for the assembly. If set to
+        /// 1, a single queue is used. If set to 0, tests are executed
+        /// directly, without queuing.
+        /// </summary>
+        public const string NumberOfTestWorkers = "NumberOfTestWorkers";
+
+        /// <summary>
+        /// The random seed to be used for this assembly. If specified
+        /// as the value reported from a prior run, the framework should
+        /// generate identical random values for tests as were used for
+        /// that run, provided that no change has been made to the test
+        /// assembly. Default is a random value itself.
+        /// </summary>
+        public const string RandomSeed = "RandomSeed";
+
+        /// <summary>
+        /// If true, execution stops after the first error or failure.
+        /// </summary>
+        public const string StopOnError = "StopOnError";
+
+        /// <summary>
+        /// If true, use of the event queue is suppressed and test events are synchronous.
+        /// </summary>
+        public const string SynchronousEvents = "SynchronousEvents";
+
+        /// <summary>
+        /// The default naming pattern used in generating test names
+        /// </summary>
+        public const string DefaultTestNamePattern = "DefaultTestNamePattern";
+
+        /// <summary>
+        /// Parameters to be passed on to the test
+        /// </summary>
+        public const string TestParameters = "TestParameters";
+
+        #endregion
+    }
+}

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -83,9 +83,6 @@
     <Compile Include="..\..\Common\nunit\OutputSpecification.cs">
       <Link>Utilities\OutputSpecification.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\TestNameParser.cs">
       <Link>Utilities\TestNameParser.cs</Link>
     </Compile>
@@ -94,6 +91,8 @@
     </Compile>
     <Compile Include="ConsoleOptions.cs" />
     <Compile Include="ConsoleRunner.cs" />
+    <Compile Include="EnginePackageSettings.cs" />
+    <Compile Include="FrameworkPackageSettings.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ResultSummary.cs" />
     <Compile Include="SafeAttributeAccess.cs" />

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -1,0 +1,146 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// EngineSettings contains constant values that
+    /// are used as keys in setting up a TestPackage. 
+    /// Values here are used in the engine, and set by the runner.
+    /// Setting values may be a string, int or bool.
+    /// </summary>
+    public static class EnginePackageSettings
+    {
+        #region Engine Settings - Used by the Engine itself
+
+        /// <summary>
+        /// The name of the config to use in loading a project.
+        /// If not specified, the first config found is used.
+        /// </summary>
+        public const string ActiveConfig = "ActiveConfig";
+
+        /// <summary>
+        /// Bool indicating whether the engine should determine the private
+        /// bin path by examining the paths to all the tests. Defaults to
+        /// true unless PrivateBinPath is specified.
+        /// </summary>
+        public const string AutoBinPath = "AutoBinPath";
+
+        /// <summary>
+        /// The ApplicationBase to use in loading the tests. If not 
+        /// specified, and each assembly has its own process, then the
+        /// location of the assembly is used. For multiple  assemblies
+        /// in a single process, the closest common root directory is used.
+        /// </summary>
+        public const string BasePath = "BasePath";
+
+        /// <summary>
+        /// Path to the config file to use in running the tests. 
+        /// </summary>
+        public const string ConfigurationFile = "ConfigurationFile";
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// startup. Used only for debugging NUnit itself.
+        /// </summary>
+        public const string DebugAgent = "DebugAgent";
+
+        /// <summary>
+        /// Indicates how to load tests across AppDomains. Values are:
+        /// "Default", "None", "Single", "Multiple". Default is "Multiple"
+        /// if more than one assembly is loaded in a process. Otherwise,
+        /// it is "Single".
+        /// </summary>
+        public const string DomainUsage = "DomainUsage";
+
+        /// <summary>
+        /// The private binpath used to locate assemblies. Directory paths
+        /// is separated by a semicolon. It's an error to specify this and
+        /// also set AutoBinPath to true.
+        /// </summary>
+        public const string PrivateBinPath = "PrivateBinPath";
+
+        /// <summary>
+        /// The maximum number of test agents permitted to run simultneously. 
+        /// Ignored if the ProcessModel is not set or defaulted to Multiple.
+        /// </summary>
+        public const string MaxAgents = "MaxAgents";
+
+        /// <summary>
+        /// Indicates how to allocate assemblies to processes. Values are:
+        /// "Default", "Single", "Separate", "Multiple". Default is "Multiple"
+        /// for more than one assembly, "Separate" for a single assembly.
+        /// </summary>
+        public const string ProcessModel = "ProcessModel";
+
+        /// <summary>
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
+        /// </summary>
+        public const string RuntimeFramework = "RuntimeFramework";
+
+        /// <summary>
+        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
+        /// a 64-bit system. Ignored if set on a 32-bit system.
+        /// </summary>
+        public const string RunAsX86 = "RunAsX86";
+
+        /// <summary>
+        /// Indicates that test runners should be disposed after the tests are executed
+        /// </summary>
+        public const string DisposeRunners = "DisposeRunners";
+
+        /// <summary>
+        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Defaults to false.
+        /// </summary>
+        public const string ShadowCopyFiles = "ShadowCopyFiles";
+
+        /// <summary>
+        /// Bool flag indicating that user profile should be loaded on test runner processes
+        /// </summary>
+        public const string LoadUserProfile = "LoadUserProfile";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attach a debugger.
+        /// </summary>
+        public const string PauseBeforeRun = "PauseBeforeRun";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        #endregion
+    }
+}

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace NUnit
 {
     /// <summary>
     /// EngineSettings contains constant values that

--- a/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine
     /// Values here are set/used internally within the engine. 
     /// Setting values may be a string, int or bool.
     /// </summary>
-    internal static class InternalEngineSettings
+    internal static class InternalEnginePackageSettings
     {
         #region Internal Settings - Used only within the engine
 

--- a/src/NUnitEngine/nunit.engine/InternalEngineSettings.cs
+++ b/src/NUnitEngine/nunit.engine/InternalEngineSettings.cs
@@ -1,0 +1,62 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// InternalEngineSettings contains constant values that
+    /// are used as keys in setting up a TestPackage. 
+    /// Values here are set/used internally within the engine. 
+    /// Setting values may be a string, int or bool.
+    /// </summary>
+    internal static class InternalEngineSettings
+    {
+        #region Internal Settings - Used only within the engine
+
+        /// <summary>
+        /// If the package represents an assembly, then this is the CLR version
+        /// stored in the assembly image. If it represents a project or other
+        /// group of assemblies, it is the maximum version for all the assemblies.
+        /// </summary>
+        public const string ImageRuntimeVersion = "ImageRuntimeVersion";
+
+        /// <summary>
+        /// True if any assembly in the package requires running as a 32-bit
+        /// process when on a 64-bit system.
+        /// </summary>
+        public const string ImageRequiresX86 = "ImageRequiresX86";
+
+        /// <summary>
+        /// True if any assembly in the package requires a special assembly resolution hook
+        /// in the default AppDomain in order to find dependent assemblies.
+        /// </summary>
+        public const string ImageRequiresDefaultAppDomainAssemblyResolver = "ImageRequiresDefaultAppDomainAssemblyResolver";
+
+        /// <summary>
+        /// The FrameworkName specified on a TargetFrameworkAttribute for the assembly
+        /// </summary>
+        public const string ImageTargetFrameworkName = "ImageTargetFrameworkName";
+
+        #endregion
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -21,9 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections.Generic;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Runners
@@ -117,7 +115,7 @@ namespace NUnit.Engine.Runners
         {
             var results = new List<TestEngineResult>();
 
-            bool disposeRunners = TestPackage.GetSetting(PackageSettings.DisposeRunners, false);
+            bool disposeRunners = TestPackage.GetSetting(EnginePackageSettings.DisposeRunners, false);
 
             int levelOfParallelism = GetLevelOfParallelism();
 

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -99,14 +99,14 @@ namespace NUnit.Engine.Runners
                 var testFile = subPackage.FullName;
 
                 if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()
-                    && subPackage.GetSetting(PackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
+                    && subPackage.GetSetting(InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
                 {
                     // It's OK to do this in the loop because the Add method 
                     // checks to see if the path is already present.
                     _assemblyResolver.AddPathFromFile(testFile);
                 }
 
-                var targetFramework = subPackage.GetSetting(PackageSettings.ImageTargetFrameworkName, (string)null);
+                var targetFramework = subPackage.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, (string)null);
 
                 IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework);
                 driver.ID = TestPackage.ID;

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Common;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Internal;
 
@@ -99,14 +98,14 @@ namespace NUnit.Engine.Runners
                 var testFile = subPackage.FullName;
 
                 if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()
-                    && subPackage.GetSetting(InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
+                    && subPackage.GetSetting(InternalEnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
                 {
                     // It's OK to do this in the loop because the Add method 
                     // checks to see if the path is already present.
                     _assemblyResolver.AddPathFromFile(testFile);
                 }
 
-                var targetFramework = subPackage.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, (string)null);
+                var targetFramework = subPackage.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, (string)null);
 
                 IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework);
                 driver.ID = TestPackage.ID;

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -28,7 +28,6 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xml;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 
@@ -88,8 +87,8 @@ namespace NUnit.Engine.Runners
             _runtimeService.SelectRuntimeFramework(TestPackage);
 
             if (IntPtr.Size == 8 &&
-                TestPackage.GetSetting(PackageSettings.ProcessModel, "") == "InProcess" &&
-                TestPackage.GetSetting(PackageSettings.RunAsX86, false))
+                TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "") == "InProcess" &&
+                TestPackage.GetSetting(EnginePackageSettings.RunAsX86, false))
             {
                 throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");
             }
@@ -270,7 +269,7 @@ namespace NUnit.Engine.Runners
         // runner is putting invalid values into the package.
         private void ValidatePackageSettings()
         {
-            var frameworkSetting = TestPackage.GetSetting(PackageSettings.RuntimeFramework, "");
+            var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RuntimeFramework, "");
             if (frameworkSetting.Length > 0)
             {
                 // Check requested framework is actually available
@@ -279,7 +278,7 @@ namespace NUnit.Engine.Runners
                     throw new NUnitEngineException(string.Format("The requested framework {0} is unknown or not available.", frameworkSetting));
 
                 // If running in process, check requested framework is compatible
-                var processModel = TestPackage.GetSetting(PackageSettings.ProcessModel, "Default");
+                var processModel = TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "Default");
                 if (processModel.ToLower() == "single")
                 {
                     var currentFramework = RuntimeFramework.CurrentFramework;

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -21,9 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using NUnit.Common;
-
 namespace NUnit.Engine.Runners
 {
     /// <summary>
@@ -48,7 +45,7 @@ namespace NUnit.Engine.Runners
 
         protected override int GetLevelOfParallelism()
         {
-            return TestPackage.GetSetting(PackageSettings.MaxAgents, int.MaxValue);
+            return TestPackage.GetSetting(EnginePackageSettings.MaxAgents, int.MaxValue);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -22,8 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Xml;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 
@@ -89,8 +87,8 @@ namespace NUnit.Engine.Runners
                 if (_agent == null)
                 {
                     // Increase the timeout to give time to attach a debugger
-                    bool debug = TestPackage.GetSetting(PackageSettings.DebugAgent, false) ||
-                                 TestPackage.GetSetting(PackageSettings.PauseBeforeRun, false);
+                    bool debug = TestPackage.GetSetting(EnginePackageSettings.DebugAgent, false) ||
+                                 TestPackage.GetSetting(EnginePackageSettings.PauseBeforeRun, false);
 
                     _agent = _agency.GetAgent(TestPackage, debug ? DEBUG_TIMEOUT : NORMAL_TIMEOUT);
 

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Runners;
 
@@ -138,7 +136,7 @@ namespace NUnit.Engine.Services
         {
             return (ProcessModel)System.Enum.Parse(
                 typeof(ProcessModel),
-                package.GetSetting(PackageSettings.ProcessModel, "Default"));
+                package.GetSetting(EnginePackageSettings.ProcessModel, "Default"));
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -114,7 +114,7 @@ namespace NUnit.Engine.Services
                 // If property is null, .NET 4.5+ is not installed, so there is no need
                 if (TargetFrameworkNameProperty != null)
                 {
-                    var frameworkName = package.GetSetting(PackageSettings.ImageTargetFrameworkName, "");
+                    var frameworkName = package.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, "");
                     if (frameworkName != "")
                         TargetFrameworkNameProperty.SetValue(setup, frameworkName, null);
                 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -120,7 +120,7 @@ namespace NUnit.Engine.Services
                 }
             }
 
-            if (package.GetSetting("ShadowCopyFiles", false))
+            if (package.GetSetting(PackageSettings.ShadowCopyFiles, false))
             {
                 setup.ShadowCopyFiles = "true";
                 setup.ShadowCopyDirectories = setup.ApplicationBase;

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -31,7 +31,6 @@ using System.Diagnostics;
 using System.Security;
 using System.Security.Policy;
 using System.Security.Principal;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
@@ -114,13 +113,13 @@ namespace NUnit.Engine.Services
                 // If property is null, .NET 4.5+ is not installed, so there is no need
                 if (TargetFrameworkNameProperty != null)
                 {
-                    var frameworkName = package.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, "");
+                    var frameworkName = package.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, "");
                     if (frameworkName != "")
                         TargetFrameworkNameProperty.SetValue(setup, frameworkName, null);
                 }
             }
 
-            if (package.GetSetting(PackageSettings.ShadowCopyFiles, false))
+            if (package.GetSetting(EnginePackageSettings.ShadowCopyFiles, false))
             {
                 setup.ShadowCopyFiles = "true";
                 setup.ShadowCopyDirectories = setup.ApplicationBase;
@@ -212,7 +211,7 @@ namespace NUnit.Engine.Services
         {
             Guard.ArgumentNotNull(package, "package");
 
-            var appBase = package.GetSetting(PackageSettings.BasePath, string.Empty);
+            var appBase = package.GetSetting(EnginePackageSettings.BasePath, string.Empty);
 
             if (string.IsNullOrEmpty(appBase))
                 appBase = string.IsNullOrEmpty(package.FullName)
@@ -235,7 +234,7 @@ namespace NUnit.Engine.Services
             Guard.ArgumentNotNull(package, "package");
 
             // Use provided setting if available
-            string configFile = package.GetSetting(PackageSettings.ConfigurationFile, string.Empty);
+            string configFile = package.GetSetting(EnginePackageSettings.ConfigurationFile, string.Empty);
             if (configFile != string.Empty)
                 return Path.Combine(appBase, configFile);
         
@@ -299,9 +298,9 @@ namespace NUnit.Engine.Services
 
         public static string GetPrivateBinPath(string appBase, TestPackage package)
         {
-            var binPath = package.GetSetting(PackageSettings.PrivateBinPath, string.Empty);
+            var binPath = package.GetSetting(EnginePackageSettings.PrivateBinPath, string.Empty);
 
-            if (package.GetSetting(PackageSettings.AutoBinPath, binPath == string.Empty))
+            if (package.GetSetting(EnginePackageSettings.AutoBinPath, binPath == string.Empty))
                 binPath = package.SubPackages.Count > 0
                     ? GetPrivateBinPath(appBase, package.SubPackages)
                     : package.FullName != null

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -20,9 +20,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-
-using System;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Runners;
 
@@ -49,7 +46,7 @@ namespace NUnit.Engine.Services
         {
             DomainUsage domainUsage = (DomainUsage)System.Enum.Parse(
                 typeof(DomainUsage),
-                package.GetSetting(PackageSettings.DomainUsage, "Default"));
+                package.GetSetting(EnginePackageSettings.DomainUsage, "Default"));
 
             switch (domainUsage)
             {

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -21,10 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Common;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services
@@ -70,7 +68,7 @@ namespace NUnit.Engine.Services
             IProject project = LoadFrom(path);
             Guard.ArgumentValid(project != null, "Unable to load project " + path, "package");
 
-            string configName = package.GetSetting(PackageSettings.ActiveConfig, (string)null); // Need RunnerSetting
+            string configName = package.GetSetting(EnginePackageSettings.ActiveConfig, (string)null); // Need RunnerSetting
             TestPackage tempPackage = project.GetTestPackage(configName);
 
             // The original package held overrides, so don't change them, but
@@ -85,11 +83,11 @@ namespace NUnit.Engine.Services
             // If no config is specified (by user or by the proejct loader) check
             // to see if one exists in same directory as the package. If so, we
             // use it. If not, each assembly will use it's own config, if present.
-            if (!package.Settings.ContainsKey(PackageSettings.ConfigurationFile))
+            if (!package.Settings.ContainsKey(EnginePackageSettings.ConfigurationFile))
             {
                 var packageConfig = Path.ChangeExtension(path, ".config");
                 if (File.Exists(packageConfig))
-                    package.Settings[PackageSettings.ConfigurationFile] = packageConfig;
+                    package.Settings[EnginePackageSettings.ConfigurationFile] = packageConfig;
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
@@ -94,7 +93,7 @@ namespace NUnit.Engine.Services
         {
             // Start by examining the provided settings
             RuntimeFramework currentFramework = RuntimeFramework.CurrentFramework;
-            string frameworkSetting = package.GetSetting(PackageSettings.RuntimeFramework, "");
+            string frameworkSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
             RuntimeFramework requestedFramework = frameworkSetting.Length > 0
                 ? RuntimeFramework.Parse(frameworkSetting)
                 : new RuntimeFramework(RuntimeType.Any, RuntimeFramework.DefaultVersion);
@@ -115,7 +114,7 @@ namespace NUnit.Engine.Services
             ApplyImageData(package);
 
             // Modify settings if necessary
-            targetVersion = package.GetSetting(InternalEngineSettings.ImageRuntimeVersion, targetVersion);
+            targetVersion = package.GetSetting(InternalEnginePackageSettings.ImageRuntimeVersion, targetVersion);
             RuntimeFramework checkFramework = new RuntimeFramework(targetRuntime, targetVersion);
             if (!checkFramework.IsAvailable)
             {
@@ -125,7 +124,7 @@ namespace NUnit.Engine.Services
             }
 
             RuntimeFramework targetFramework = new RuntimeFramework(targetRuntime, targetVersion);
-            package.Settings[PackageSettings.RuntimeFramework] = targetFramework.ToString();
+            package.Settings[EnginePackageSettings.RuntimeFramework] = targetFramework.ToString();
 
             log.Debug("Test will use {0} framework", targetFramework);
 
@@ -161,12 +160,12 @@ namespace NUnit.Engine.Services
                     ApplyImageData(subPackage);
 
                     // Collect the highest version required
-                    Version v = subPackage.GetSetting(InternalEngineSettings.ImageRuntimeVersion, new Version(0, 0));
+                    Version v = subPackage.GetSetting(InternalEnginePackageSettings.ImageRuntimeVersion, new Version(0, 0));
                     if (v > targetVersion) targetVersion = v;
 
                     // Collect highest framework name 
                     // TODO: This assumes lexical ordering is valid - check it
-                    string fn = subPackage.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, "");
+                    string fn = subPackage.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, "");
                     if (fn != "")
                     {
                         if (frameworkName == null || fn.CompareTo(frameworkName) < 0)
@@ -174,10 +173,10 @@ namespace NUnit.Engine.Services
                     }
 
                     // If any assembly requires X86, then the aggregate package requires it
-                    if (subPackage.GetSetting(InternalEngineSettings.ImageRequiresX86, false))
+                    if (subPackage.GetSetting(InternalEnginePackageSettings.ImageRequiresX86, false))
                         requiresX86 = true;
 
-                    if (subPackage.GetSetting(InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
+                    if (subPackage.GetSetting(InternalEnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
                         requiresAssemblyResolver = true;
                 }
             }
@@ -228,16 +227,16 @@ namespace NUnit.Engine.Services
             }
 
             if (targetVersion.Major > 0)
-                package.Settings[InternalEngineSettings.ImageRuntimeVersion] = targetVersion;
+                package.Settings[InternalEnginePackageSettings.ImageRuntimeVersion] = targetVersion;
 
             if (!string.IsNullOrEmpty(frameworkName))
-                package.Settings[InternalEngineSettings.ImageTargetFrameworkName] = frameworkName;
+                package.Settings[InternalEnginePackageSettings.ImageTargetFrameworkName] = frameworkName;
 
-            package.Settings[InternalEngineSettings.ImageRequiresX86] = requiresX86;
+            package.Settings[InternalEnginePackageSettings.ImageRequiresX86] = requiresX86;
             if (requiresX86)
-                package.Settings[PackageSettings.RunAsX86] = true;
+                package.Settings[EnginePackageSettings.RunAsX86] = true;
 
-            package.Settings[InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
+            package.Settings[InternalEnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -115,7 +115,7 @@ namespace NUnit.Engine.Services
             ApplyImageData(package);
 
             // Modify settings if necessary
-            targetVersion = package.GetSetting(PackageSettings.ImageRuntimeVersion, targetVersion);
+            targetVersion = package.GetSetting(InternalEngineSettings.ImageRuntimeVersion, targetVersion);
             RuntimeFramework checkFramework = new RuntimeFramework(targetRuntime, targetVersion);
             if (!checkFramework.IsAvailable)
             {
@@ -161,12 +161,12 @@ namespace NUnit.Engine.Services
                     ApplyImageData(subPackage);
 
                     // Collect the highest version required
-                    Version v = subPackage.GetSetting(PackageSettings.ImageRuntimeVersion, new Version(0, 0));
+                    Version v = subPackage.GetSetting(InternalEngineSettings.ImageRuntimeVersion, new Version(0, 0));
                     if (v > targetVersion) targetVersion = v;
 
                     // Collect highest framework name 
                     // TODO: This assumes lexical ordering is valid - check it
-                    string fn = subPackage.GetSetting(PackageSettings.ImageTargetFrameworkName, "");
+                    string fn = subPackage.GetSetting(InternalEngineSettings.ImageTargetFrameworkName, "");
                     if (fn != "")
                     {
                         if (frameworkName == null || fn.CompareTo(frameworkName) < 0)
@@ -174,10 +174,10 @@ namespace NUnit.Engine.Services
                     }
 
                     // If any assembly requires X86, then the aggregate package requires it
-                    if (subPackage.GetSetting(PackageSettings.ImageRequiresX86, false))
+                    if (subPackage.GetSetting(InternalEngineSettings.ImageRequiresX86, false))
                         requiresX86 = true;
 
-                    if (subPackage.GetSetting(PackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
+                    if (subPackage.GetSetting(InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
                         requiresAssemblyResolver = true;
                 }
             }
@@ -228,16 +228,16 @@ namespace NUnit.Engine.Services
             }
 
             if (targetVersion.Major > 0)
-                package.Settings[PackageSettings.ImageRuntimeVersion] = targetVersion;
+                package.Settings[InternalEngineSettings.ImageRuntimeVersion] = targetVersion;
 
             if (!string.IsNullOrEmpty(frameworkName))
-                package.Settings[PackageSettings.ImageTargetFrameworkName] = frameworkName;
+                package.Settings[InternalEngineSettings.ImageTargetFrameworkName] = frameworkName;
 
-            package.Settings[PackageSettings.ImageRequiresX86] = requiresX86;
+            package.Settings[InternalEngineSettings.ImageRequiresX86] = requiresX86;
             if (requiresX86)
                 package.Settings[PackageSettings.RunAsX86] = true;
 
-            package.Settings[PackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
+            package.Settings[InternalEngineSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -26,8 +26,6 @@ using System.IO;
 using System.Threading;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Reflection;
-using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
@@ -157,18 +155,18 @@ namespace NUnit.Engine.Services
         private Guid LaunchAgentProcess(TestPackage package)
         {
             RuntimeFramework targetRuntime = RuntimeFramework.CurrentFramework;
-            string runtimeSetting = package.GetSetting(PackageSettings.RuntimeFramework, "");
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
             if (runtimeSetting != "")
                 targetRuntime = RuntimeFramework.Parse(runtimeSetting);
 
             if (targetRuntime.Runtime == RuntimeType.Any)
                 targetRuntime = new RuntimeFramework(RuntimeFramework.CurrentFramework.Runtime, targetRuntime.ClrVersion);
 
-            bool useX86Agent = package.GetSetting(PackageSettings.RunAsX86, false);
-            bool debugTests = package.GetSetting(PackageSettings.DebugTests, false);
-            bool debugAgent = package.GetSetting(PackageSettings.DebugAgent, false);
-            string traceLevel = package.GetSetting(PackageSettings.InternalTraceLevel, "Off");
-            bool loadUserProfile = package.GetSetting(PackageSettings.LoadUserProfile, false);
+            bool useX86Agent = package.GetSetting(EnginePackageSettings.RunAsX86, false);
+            bool debugTests = package.GetSetting(EnginePackageSettings.DebugTests, false);
+            bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
+            string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
+            bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
 
             // Set options that need to be in effect before the package
             // is loaded by using the command line.

--- a/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -93,6 +93,7 @@
     </Compile>
     <Compile Include="Guard.cs" />
     <Compile Include="IDriverService.cs" />
+    <Compile Include="InternalEngineSettings.cs" />
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
     <Compile Include="Internal\ProvidedPathsAssemblyResolver.cs" />

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -68,9 +68,6 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\TestSelectionParser.cs">
       <Link>Services\TestSelectionParser.cs</Link>
     </Compile>
@@ -87,13 +84,14 @@
     <Compile Include="Drivers\NUnit3DriverFactory.cs" />
     <Compile Include="Drivers\NUnit3FrameworkDriver.cs" />
     <Compile Include="EngineExtensionPoints.cs" />
+    <Compile Include="EnginePackageSettings.cs" />
     <Compile Include="Extensibility\ExtensionNode.cs" />
     <Compile Include="Extensibility\ExtensionPoint.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Guard.cs" />
     <Compile Include="IDriverService.cs" />
-    <Compile Include="InternalEngineSettings.cs" />
+    <Compile Include="InternalEnginePackageSettings.cs" />
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
     <Compile Include="Internal\ProvidedPathsAssemblyResolver.cs" />

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using NUnit.Common;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -130,12 +129,12 @@ namespace NUnit.Framework.Api
 
             try
             {
-                if (options.ContainsKey(PackageSettings.DefaultTestNamePattern))
-                    TestNameGenerator.DefaultTestNamePattern = options[PackageSettings.DefaultTestNamePattern] as string;
+                if (options.ContainsKey(FrameworkPackageSettings.DefaultTestNamePattern))
+                    TestNameGenerator.DefaultTestNamePattern = options[FrameworkPackageSettings.DefaultTestNamePattern] as string;
 
-                if (options.ContainsKey(PackageSettings.TestParameters))
+                if (options.ContainsKey(FrameworkPackageSettings.TestParameters))
                 {
-                    string parameters = options[PackageSettings.TestParameters] as string;
+                    string parameters = options[FrameworkPackageSettings.TestParameters] as string;
                     if (!string.IsNullOrEmpty(parameters))
                         foreach (string param in parameters.Split(new[] { ';' }))
                         {
@@ -152,8 +151,8 @@ namespace NUnit.Framework.Api
                 }
 
                 IList fixtureNames = null;
-                if (options.ContainsKey (PackageSettings.LOAD))
-                    fixtureNames = options[PackageSettings.LOAD] as IList;
+                if (options.ContainsKey (FrameworkPackageSettings.LOAD))
+                    fixtureNames = options[FrameworkPackageSettings.LOAD] as IList;
                 var fixtures = GetFixtures(assembly, fixtureNames);
 
                 testAssembly = BuildTestAssembly(assembly, assemblyPath, fixtures);

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -30,7 +30,6 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Web.UI;
-using NUnit.Common;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -131,16 +130,16 @@ namespace NUnit.Framework.Api
             var newSettings = settings as IDictionary<string, object>;
             Settings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
 
-            if (Settings.ContainsKey(PackageSettings.InternalTraceLevel))
+            if (Settings.ContainsKey(FrameworkPackageSettings.InternalTraceLevel))
             {
-                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)Settings[PackageSettings.InternalTraceLevel], true);
+                var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), (string)Settings[FrameworkPackageSettings.InternalTraceLevel], true);
 
-                if (Settings.ContainsKey(PackageSettings.InternalTraceWriter))
-                    InternalTrace.Initialize((TextWriter)Settings[PackageSettings.InternalTraceWriter], traceLevel);
+                if (Settings.ContainsKey(FrameworkPackageSettings.InternalTraceWriter))
+                    InternalTrace.Initialize((TextWriter)Settings[FrameworkPackageSettings.InternalTraceWriter], traceLevel);
 #if !PORTABLE && !SILVERLIGHT
                 else
                 {
-                    var workDirectory = Settings.ContainsKey(PackageSettings.WorkDirectory) ? (string)Settings[PackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
+                    var workDirectory = Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory) ? (string)Settings[FrameworkPackageSettings.WorkDirectory] : Env.DefaultWorkDirectory;
                     var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
@@ -433,8 +432,8 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // Add default values for display
-            if (!settings.ContainsKey(PackageSettings.NumberOfTestWorkers))
-                AddSetting(settingsNode, PackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
+            if (!settings.ContainsKey(FrameworkPackageSettings.NumberOfTestWorkers))
+                AddSetting(settingsNode, FrameworkPackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 #endif
 
                 return settingsNode;

--- a/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Framework
+namespace NUnit
 {
     /// <summary>
     /// FrameworkPackageSettings is a static class containing constant values that

--- a/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
@@ -1,0 +1,115 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// FrameworkPackageSettings is a static class containing constant values that
+    /// are used as keys in setting up a TestPackage. These values are used in
+    /// the framework, and set in the runner. Setting values may be a string, int or bool.
+    /// </summary>
+    public static class FrameworkPackageSettings
+    {
+        #region Settings used in Framework
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attache a debugger.
+        /// </summary>
+        public const string PauseBeforeRun = "PauseBeforeRun";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        /// <summary>
+        /// Full path of the directory to be used for work and result files.
+        /// This path is provided to tests by the frameowrk TestContext.
+        /// </summary>
+        public const string WorkDirectory = "WorkDirectory";
+
+        /// <summary>
+        /// Integer value in milliseconds for the default timeout value
+        /// for test cases. If not specified, there is no timeout except
+        /// as specified by attributes on the tests themselves.
+        /// </summary>
+        public const string DefaultTimeout = "DefaultTimeout";
+
+        /// <summary>
+        /// A TextWriter to which the internal trace will be sent.
+        /// </summary>
+        public const string InternalTraceWriter = "InternalTraceWriter";
+
+        /// <summary>
+        /// A list of tests to be loaded. 
+        /// </summary>
+        // TODO: Remove?
+        public const string LOAD = "LOAD";
+
+        /// <summary>
+        /// The number of test threads to run for the assembly. If set to
+        /// 1, a single queue is used. If set to 0, tests are executed
+        /// directly, without queuing.
+        /// </summary>
+        public const string NumberOfTestWorkers = "NumberOfTestWorkers";
+
+        /// <summary>
+        /// The random seed to be used for this assembly. If specified
+        /// as the value reported from a prior run, the framework should
+        /// generate identical random values for tests as were used for
+        /// that run, provided that no change has been made to the test
+        /// assembly. Default is a random value itself.
+        /// </summary>
+        public const string RandomSeed = "RandomSeed";
+
+        /// <summary>
+        /// If true, execution stops after the first error or failure.
+        /// </summary>
+        public const string StopOnError = "StopOnError";
+
+        /// <summary>
+        /// If true, use of the event queue is suppressed and test events are synchronous.
+        /// </summary>
+        public const string SynchronousEvents = "SynchronousEvents";
+
+        /// <summary>
+        /// The default naming pattern used in generating test names
+        /// </summary>
+        public const string DefaultTestNamePattern = "DefaultTestNamePattern";
+
+        /// <summary>
+        /// Parameters to be passed on to the test
+        /// </summary>
+        public const string TestParameters = "TestParameters";
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -22,16 +22,13 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
-using System.IO;
 using System.Reflection;
 using System.Threading;
-using NUnit.Common;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using System.Collections.Generic;
-
+using System.IO;
 #if !SILVERLIGHT && !NETCF && !PORTABLE
 using System.Diagnostics;
 using System.Windows.Forms;
@@ -155,8 +152,8 @@ namespace NUnit.Framework.Api
         {
             Settings = settings;
 
-            if (settings.ContainsKey(PackageSettings.RandomSeed))
-                Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
+            if (settings.ContainsKey(FrameworkPackageSettings.RandomSeed))
+                Randomizer.InitialSeed = (int)settings[FrameworkPackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assemblyName, settings);
 
@@ -172,8 +169,8 @@ namespace NUnit.Framework.Api
         {
             Settings = settings;
 
-            if (settings.ContainsKey(PackageSettings.RandomSeed))
-                Randomizer.InitialSeed = (int)settings[PackageSettings.RandomSeed];
+            if (settings.ContainsKey(FrameworkPackageSettings.RandomSeed))
+                Randomizer.InitialSeed = (int)settings[FrameworkPackageSettings.RandomSeed];
 
             return LoadedTest = _builder.Build(assembly, settings);
         }
@@ -281,7 +278,7 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // Queue and pump events, unless settings have SynchronousEvents == false
-            if (!Settings.ContainsKey(PackageSettings.SynchronousEvents) || !(bool)Settings[PackageSettings.SynchronousEvents])
+            if (!Settings.ContainsKey(FrameworkPackageSettings.SynchronousEvents) || !(bool)Settings[FrameworkPackageSettings.SynchronousEvents])
             {
                 QueuingEventListener queue = new QueuingEventListener();
                 Context.Listener = queue;
@@ -293,13 +290,13 @@ namespace NUnit.Framework.Api
 
 #if !NETCF
             if (!System.Diagnostics.Debugger.IsAttached &&
-                Settings.ContainsKey(PackageSettings.DebugTests) &&
-                (bool)Settings[PackageSettings.DebugTests])
+                Settings.ContainsKey(FrameworkPackageSettings.DebugTests) &&
+                (bool)Settings[FrameworkPackageSettings.DebugTests])
                 System.Diagnostics.Debugger.Launch();
 
 #if !SILVERLIGHT && !PORTABLE
-            if (Settings.ContainsKey(PackageSettings.PauseBeforeRun) &&
-                (bool)Settings[PackageSettings.PauseBeforeRun])
+            if (Settings.ContainsKey(FrameworkPackageSettings.PauseBeforeRun) &&
+                (bool)Settings[FrameworkPackageSettings.PauseBeforeRun])
                 PauseBeforeRun();
 
 #endif
@@ -317,13 +314,13 @@ namespace NUnit.Framework.Api
             Context = new TestExecutionContext();
 
             // Apply package settings to the context
-            if (Settings.ContainsKey(PackageSettings.DefaultTimeout))
-                Context.TestCaseTimeout = (int)Settings[PackageSettings.DefaultTimeout];
-            if (Settings.ContainsKey(PackageSettings.StopOnError))
-                Context.StopOnError = (bool)Settings[PackageSettings.StopOnError];
+            if (Settings.ContainsKey(FrameworkPackageSettings.DefaultTimeout))
+                Context.TestCaseTimeout = (int)Settings[FrameworkPackageSettings.DefaultTimeout];
+            if (Settings.ContainsKey(FrameworkPackageSettings.StopOnError))
+                Context.StopOnError = (bool)Settings[FrameworkPackageSettings.StopOnError];
 
-            if (Settings.ContainsKey(PackageSettings.WorkDirectory))
-                Context.WorkDirectory = (string)Settings[PackageSettings.WorkDirectory];
+            if (Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory))
+                Context.WorkDirectory = (string)Settings[FrameworkPackageSettings.WorkDirectory];
             else
                 Context.WorkDirectory = Env.DefaultWorkDirectory;
 
@@ -378,8 +375,8 @@ namespace NUnit.Framework.Api
 #if PARALLEL
         private int GetLevelOfParallelism()
         {
-            return Settings.ContainsKey(PackageSettings.NumberOfTestWorkers)
-                ? (int)Settings[PackageSettings.NumberOfTestWorkers]
+            return Settings.ContainsKey(FrameworkPackageSettings.NumberOfTestWorkers)
+                ? (int)Settings[FrameworkPackageSettings.NumberOfTestWorkers]
                 : (LoadedTest.Properties.ContainsKey(PropertyNames.LevelOfParallelism)
                    ? (int)LoadedTest.Properties.Get(PropertyNames.LevelOfParallelism)
                    : NUnitTestAssemblyRunner.DefaultLevelOfParallelism);

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -69,14 +69,12 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -69,14 +69,12 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -68,15 +68,13 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -72,15 +72,13 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -84,9 +84,6 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>FrameworkVersion.cs</Link>
     </Compile>
@@ -94,6 +91,7 @@
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs">

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -69,15 +69,13 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -86,15 +86,13 @@
     <Compile Include="..\..\Common\nunit\Logging\Logger.cs">
       <Link>Internal\Logger.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\PackageSettings.cs">
-      <Link>Api\PackageSettings.cs</Link>
-    </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />
+    <Compile Include="Api\FrameworkPackageSettings.cs" />
     <Compile Include="Api\ITestAssemblyBuilder.cs" />
     <Compile Include="Api\ITestAssemblyRunner.cs" />
     <Compile Include="Api\NUnitTestAssemblyRunner.cs" />

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -22,13 +22,12 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using NUnit.Common;
+using NUnit.Framework;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -343,20 +342,20 @@ namespace NUnitLite
             var runSettings = new Dictionary<string, object>();
 
             if (options.RandomSeed >= 0)
-                runSettings[PackageSettings.RandomSeed] = options.RandomSeed;
+                runSettings[FrameworkPackageSettings.RandomSeed] = options.RandomSeed;
 
 #if !PORTABLE
             if (options.WorkDirectory != null)
-                runSettings[PackageSettings.WorkDirectory] = Path.GetFullPath(options.WorkDirectory);
+                runSettings[FrameworkPackageSettings.WorkDirectory] = Path.GetFullPath(options.WorkDirectory);
 #endif
             if (options.DefaultTimeout >= 0)
-                runSettings[PackageSettings.DefaultTimeout] = options.DefaultTimeout;
+                runSettings[FrameworkPackageSettings.DefaultTimeout] = options.DefaultTimeout;
 
             if (options.StopOnError)
-                runSettings[PackageSettings.StopOnError] = true;
+                runSettings[FrameworkPackageSettings.StopOnError] = true;
 
             if (options.DefaultTestNamePattern != null)
-                runSettings[PackageSettings.DefaultTestNamePattern] = options.DefaultTestNamePattern;
+                runSettings[FrameworkPackageSettings.DefaultTestNamePattern] = options.DefaultTestNamePattern;
 
             return runSettings;
         }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -27,7 +27,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using NUnit.Common;
-using NUnit.Framework;
+using NUnit;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -24,7 +24,6 @@
 // TODO: Test uses features not available in Silverlight
 #if !SILVERLIGHT && !PORTABLE
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -6,7 +6,6 @@
 
 // TODO: Figure out how to make test work in SILVERLIGHT, since they support SetUpFixture
 #if !SILVERLIGHT && !PORTABLE
-using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -28,8 +28,6 @@ using System.Globalization;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal.Execution;
-using NUnit.TestData.TestContextData;
-using NUnit.TestUtilities;
 
 #if !NETCF
 using System.Security.Principal;


### PR DESCRIPTION
Another step towards #1596.

This duplicates Package Settings for the console, framework and engine. In each case, everything that was unused was removed.



