### PR TITLE
Remove Guard.cs from Common

### DIFF
--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -74,9 +74,6 @@
     <Compile Include="..\..\Common\nunit\ExtendedTextWriter.cs">
       <Link>ExtendedTextWriter.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Utilities\Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\IDefaultOptionsProvider.cs">
       <Link>IDefaultOptionsProvider.cs</Link>
     </Compile>

--- a/src/NUnitEngine/nunit.engine/Guard.cs
+++ b/src/NUnitEngine/nunit.engine/Guard.cs
@@ -1,0 +1,93 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// Class used to guard against unexpected argument values
+    /// or operations by throwing an appropriate exception.
+    /// </summary>
+    internal static class Guard
+    {
+        /// <summary>
+        /// Throws an exception if an argument is null
+        /// </summary>
+        /// <param name="value">The value to be tested</param>
+        /// <param name="name">The name of the argument</param>
+        public static void ArgumentNotNull(object value, string name)
+        {
+            if (value == null)
+                throw new ArgumentNullException("Argument " + name + " must not be null", name);
+        }
+
+        /// <summary>
+        /// Throws an exception if a string argument is null or empty
+        /// </summary>
+        /// <param name="value">The value to be tested</param>
+        /// <param name="name">The name of the argument</param>
+        public static void ArgumentNotNullOrEmpty(string value, string name)
+        {
+            ArgumentNotNull(value, name);
+
+            if (value == string.Empty)
+                throw new ArgumentException("Argument " + name +" must not be the empty string", name);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentOutOfRangeException if the specified condition is not met.
+        /// </summary>
+        /// <param name="condition">The condition that must be met</param>
+        /// <param name="message">The exception message to be used</param>
+        /// <param name="paramName">The name of the argument</param>
+        public static void ArgumentInRange(bool condition, string message, string paramName)
+        {
+            if (!condition)
+                throw new ArgumentOutOfRangeException(paramName, message);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException if the specified condition is not met.
+        /// </summary>
+        /// <param name="condition">The condition that must be met</param>
+        /// <param name="message">The exception message to be used</param>
+        /// <param name="paramName">The name of the argument</param>
+        public static void ArgumentValid(bool condition, string message, string paramName)
+        {
+            if (!condition)
+                throw new ArgumentException(message, paramName);
+        }
+
+        /// <summary>
+        /// Throws an InvalidOperationException if the specified condition is not met.
+        /// </summary>
+        /// <param name="condition">The condition that must be met</param>
+        /// <param name="message">The exception message to be used</param>
+        public static void OperationValid(bool condition, string message)
+        {
+            if (!condition)
+                throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Common;
 
 // Missing XML Docs
 #pragma warning disable 1591

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -59,9 +59,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\InternalTrace.cs">
       <Link>Internal\InternalTrace.cs</Link>
     </Compile>
@@ -94,6 +91,7 @@
     <Compile Include="Extensibility\ExtensionPoint.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Guard.cs" />
     <Compile Include="IDriverService.cs" />
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />

--- a/src/NUnitFramework/framework/Guard.cs
+++ b/src/NUnitFramework/framework/Guard.cs
@@ -23,13 +23,13 @@
 
 using System;
 
-namespace NUnit
+namespace NUnit.Framework
 {
     /// <summary>
     /// Class used to guard against unexpected argument values
     /// or operations by throwing an appropriate exception.
     /// </summary>
-    static class Guard
+    internal static class Guard
     {
         /// <summary>
         /// Throws an exception if an argument is null

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -140,6 +137,7 @@
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Env.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -139,6 +136,7 @@
       <DependentUpon>Assert.cs</DependentUpon>
     </Compile>
     <Compile Include="Env.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Interfaces\IDisposableFixture.cs" />
     <Compile Include="Interfaces\IMethodInfo.cs" />
     <Compile Include="Interfaces\IParameterInfo.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -53,9 +53,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -272,6 +269,7 @@
     <Compile Include="Exceptions\InconclusiveException.cs" />
     <Compile Include="Exceptions\ResultStateException.cs" />
     <Compile Include="Exceptions\SuccessException.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -57,9 +57,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -278,6 +275,7 @@
     <Compile Include="Exceptions\SuccessException.cs" />
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -69,9 +69,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -93,6 +90,7 @@
     <Compile Include="..\FrameworkVersion.cs">
       <Link>FrameworkVersion.cs</Link>
     </Compile>
+    <Compile Include="Guard.cs" />
     <Compile Include="ActionTargets.cs" />
     <Compile Include="Api\DefaultTestAssemblyBuilder.cs" />
     <Compile Include="Api\FrameworkController.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -281,6 +278,7 @@
     <Compile Include="Exceptions\SuccessException.cs" />
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -71,9 +71,6 @@
     <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
       <Link>Internal\AssemblyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\Guard.cs">
-      <Link>Guard.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -296,6 +293,7 @@
     <Compile Include="Exceptions\SuccessException.cs" />
     <Compile Include="FileAssert.cs" />
     <Compile Include="GlobalSettings.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="Interfaces\IApplyToContext.cs" />
     <Compile Include="Interfaces\IApplyToTest.cs" />

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -27,7 +27,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Common;
 using NUnit.Framework;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -8,7 +8,6 @@
 #if !SILVERLIGHT && !PORTABLE
 using System.Collections;
 using System.Collections.Generic;
-using NUnit.Common;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -25,7 +25,6 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Globalization;
-using NUnit.Common;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal.Execution;


### PR DESCRIPTION
Another step towards #1596.

Only point worth a mention - the class was included in the console runner but never used, hence why it's just been removed.