### PR TITLE
Fix: Escaping control chars in custom message #1575

### DIFF
--- a/nunit.sln
+++ b/nunit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NUnitFramework", "NUnitFramework", "{5D8A9D62-C11C-45B2-8965-43DE8160B558}"
 EndProject

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -374,6 +374,38 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Converts any null characters in a string 
+        /// to their escaped representation.
+        /// </summary>
+        /// <param name="s">The string to be converted</param>
+        /// <returns>The converted string</returns>
+        public static string EscapeNullCharacters(string s)
+        {
+            if(s != null)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                foreach(char c in s)
+                {
+                    switch(c)
+                    {
+                        case '\0':
+                            sb.Append("\\0");
+                            break;
+
+                        default:
+                            sb.Append(c);
+                            break;
+                    }
+                }
+
+                s = sb.ToString();               
+            }
+
+            return s;
+        }
+
+        /// <summary>
         /// Return the a string representation for a set of indices into an array
         /// </summary>
         /// <param name="indices">Array of indices for which a string is needed</param>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Internal
                 if (args != null && args.Length > 0)
                     message = string.Format(message, args);
 
-                WriteLine(MsgUtils.EscapeControlChars(message));
+                WriteLine(MsgUtils.EscapeNullCharacters(message));
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -173,7 +173,24 @@ namespace NUnit.Framework.Constraints
         }
 
         #endregion
+        #region EscapeNullChars
+        [TestCase("\n", "\n")]
+        [TestCase("\r", "\r")]
+        [TestCase("\r\n\r", "\r\n\r")]
+        [TestCase("\f", "\f")]
+        [TestCase("\b", "\b")]
+        public static void DoNotEscapeNonNullControlChars(string input, string expected)
+        {
+            Assert.That(MsgUtils.EscapeNullCharacters(input), Is.EqualTo(expected));
+        }
 
+        [Test]
+        public static void EscapesNullControlChars()
+        {
+            Assert.That(MsgUtils.EscapeNullCharacters("\0"), Is.EqualTo("\\0"));
+        }
+
+        #endregion
         #region ClipString
 
         private const string s52 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -96,6 +96,20 @@ namespace NUnit.Framework.Internal
             Assert.That(message, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void WriteMessageLine_EmbeddedNonNullControlChars()
+        {
+            string expected, message;
+
+            expected = message = "Here we have embedded control characters \b\f in the string!";
+
+            writer.WriteMessageLine(0, message, null);
+            message = writer.ToString();
+            expected = "  " + expected.Replace("\0", "\\0") + NL;
+
+            Assert.That(message, Is.EqualTo(expected));
+        }
+
         private string Q(string s)
         {
             return "\"" + s + "\"";


### PR DESCRIPTION
Adds EscapeNullCharacters to MsgUtils to specifically escape only null characters from a string.
Alters TextMessageWriter's WriteMessageLine to utilize new EscapeNullCharacters method instead of EscapeControlCharacters.