### PR TITLE
Remove AssemblyHelper from Common

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/AssemblyHelperTests.cs
@@ -1,0 +1,75 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Internal.Tests
+{
+    [TestFixture]
+    public class AssemblyHelperTests
+    {
+        private static readonly string THIS_ASSEMBLY_PATH = "nunit.engine.tests.dll";
+
+        [Test]
+        public void GetPathForAssembly()
+        {
+            string path = AssemblyHelper.GetAssemblyPath(this.GetType().Assembly);
+            Assert.That(Path.GetFileName(path), Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
+            Assert.That(File.Exists(path));
+        }
+
+        // The following tests are only useful to the extent that the test cases
+        // match what will actually be provided to the method in production.
+        // As currently used, NUnit's codebase can only use the file: schema,
+        // since we don't load assemblies from anything but files. The uri's
+        // provided can be absolute file paths or UNC paths.
+
+        // Local paths - Windows Drive
+        [TestCase(@"file:///C:/path/to/assembly.dll", @"C:\path\to\assembly.dll")]
+        [TestCase(@"file:///C:/my path/to my/assembly.dll", @"C:/my path/to my/assembly.dll")]
+        [TestCase(@"file:///C:/dev/C#/assembly.dll", @"C:\dev\C#\assembly.dll")]
+        [TestCase(@"file:///C:/dev/funnychars?:=/assembly.dll", @"C:\dev\funnychars?:=\assembly.dll")]
+        // Local paths - Linux or Windows absolute without a drive
+        [TestCase(@"file:///path/to/assembly.dll", @"/path/to/assembly.dll")]
+        [TestCase(@"file:///my path/to my/assembly.dll", @"/my path/to my/assembly.dll")]
+        [TestCase(@"file:///dev/C#/assembly.dll", @"/dev/C#/assembly.dll")]
+        [TestCase(@"file:///dev/funnychars?:=/assembly.dll", @"/dev/funnychars?:=/assembly.dll")]
+        // Windows drive specified as if it were a server - odd case, sometimes seen
+        [TestCase(@"file://C:/path/to/assembly.dll", @"C:\path\to\assembly.dll")]
+        [TestCase(@"file://C:/my path/to my/assembly.dll", @"C:\my path\to my\assembly.dll")]
+        [TestCase(@"file://C:/dev/C#/assembly.dll", @"C:\dev\C#\assembly.dll")]
+        [TestCase(@"file://C:/dev/funnychars?:=/assembly.dll", @"C:\dev\funnychars?:=\assembly.dll")]
+        // UNC format with server and path
+        [TestCase(@"file://server/path/to/assembly.dll", @"//server/path/to/assembly.dll")]
+        [TestCase(@"file://server/my path/to my/assembly.dll", @"//server/my path/to my/assembly.dll")]
+        [TestCase(@"file://server/dev/C#/assembly.dll", @"//server/dev/C#/assembly.dll")]
+        [TestCase(@"file://server/dev/funnychars?:=/assembly.dll", @"//server/dev/funnychars?:=/assembly.dll")]
+        // [TestCase(@"http://server/path/to/assembly.dll", "//server/path/to/assembly.dll")]
+        public void GetAssemblyPathFromCodeBase(string uri, string expectedPath)
+        {
+            string localPath = AssemblyHelper.GetAssemblyPathFromCodeBase(uri);
+            Assert.That(localPath, Is.SamePath(expectedPath));
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -53,9 +53,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\tests\TestSelectionParserTests.cs">
       <Link>Services\TestSelectionParserTests.cs</Link>
     </Compile>
@@ -71,6 +68,7 @@
     <Compile Include="AsyncTestEngineResultTests.cs" />
     <Compile Include="Drivers\NUnit3FrameworkDriverTests.cs" />
     <Compile Include="DummyExtensions.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\DirectoryFinderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Drivers\NotRunnableFrameworkDriverTests.cs" />

--- a/src/NUnitEngine/nunit.engine/Internal/AssemblyHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/AssemblyHelper.cs
@@ -1,0 +1,106 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.IO;
+using System.Reflection;
+namespace NUnit.Engine.Internal
+{
+    /// <summary>
+    /// AssemblyHelper provides static methods for working
+    /// with assemblies.
+    /// </summary>
+    public static class AssemblyHelper
+    {
+        #region GetDirectoryName
+
+        /// <summary>
+        /// Gets the path to the directory from which an assembly was loaded.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <returns>The path.</returns>
+        public static string GetDirectoryName(Assembly assembly)
+        {
+            return Path.GetDirectoryName(GetAssemblyPath(assembly));
+        }
+
+        #endregion
+
+        #region GetAssemblyPath
+
+        /// <summary>
+        /// Gets the path from which an assembly was loaded.
+        /// For builds where this is not possible, returns
+        /// the name of the assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <returns>The path.</returns>
+        public static string GetAssemblyPath(Assembly assembly)
+        {
+            string codeBase = assembly.CodeBase;
+
+            if (IsFileUri(codeBase))
+                return GetAssemblyPathFromCodeBase(codeBase);
+
+            return assembly.Location;
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static bool IsFileUri(string uri)
+        {
+            return uri.ToLower().StartsWith(Uri.UriSchemeFile);
+        }
+
+        /// <summary>
+        /// Gets the assembly path from code base.
+        /// </summary>
+        /// <remarks>Public for testing purposes</remarks>
+        /// <param name="codeBase">The code base.</param>
+        /// <returns></returns>
+        public static string GetAssemblyPathFromCodeBase(string codeBase)
+        {
+            // Skip over the file:// part
+            int start = Uri.UriSchemeFile.Length + Uri.SchemeDelimiter.Length;
+
+            if (codeBase[start] == '/') // third slash means a local path
+            {
+                // Handle Windows Drive specifications
+                if (codeBase[start + 2] == ':')
+                    ++start;
+                // else leave the last slash so path is absolute
+            }
+            else // It's either a Windows Drive spec or a share
+            {
+                if (codeBase[start + 1] != ':')
+                    start -= 2; // Back up to include two slashes
+            }
+
+            return codeBase.Substring(start);
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -56,9 +56,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\InternalTrace.cs">
       <Link>Internal\InternalTrace.cs</Link>
     </Compile>
@@ -92,6 +89,7 @@
     <Compile Include="Guard.cs" />
     <Compile Include="IDriverService.cs" />
     <Compile Include="InternalEnginePackageSettings.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
     <Compile Include="Internal\ProvidedPathsAssemblyResolver.cs" />

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -25,35 +25,15 @@ using System;
 using System.IO;
 using System.Reflection;
 
-#if NUNIT_ENGINE
-namespace NUnit.Engine.Internal
-#elif NUNIT_FRAMEWORK
 namespace NUnit.Framework.Internal
-#else
-namespace NUnit.Common
-#endif
 {
     /// <summary>
     /// AssemblyHelper provides static methods for working
     /// with assemblies.
     /// </summary>
-    public class AssemblyHelper
+    public static class AssemblyHelper
     {
         #region GetAssemblyPath
-
-        /// <summary>
-        /// Gets the path from which the assembly defining a type was loaded.
-        /// </summary>
-        /// <param name="type">The Type.</param>
-        /// <returns>The path.</returns>
-        public static string GetAssemblyPath(Type type)
-        {
-#if PORTABLE
-            return GetAssemblyPath(type.GetTypeInfo().Assembly);
-#else
-            return GetAssemblyPath(type.Assembly);
-#endif
-        }
 
         /// <summary>
         /// Gets the path from which an assembly was loaded.
@@ -78,9 +58,9 @@ namespace NUnit.Common
 #endif
         }
 
-#endregion
+        #endregion
 
-#region GetDirectoryName
+        #region GetDirectoryName
 
 #if !SILVERLIGHT && !PORTABLE
         /// <summary>
@@ -94,9 +74,9 @@ namespace NUnit.Common
         }
 #endif
 
-#endregion
+        #endregion
 
-#region GetAssemblyName
+        #region GetAssemblyName
 
         /// <summary>
         /// Gets the AssemblyName of an assembly.
@@ -161,7 +141,7 @@ namespace NUnit.Common
 
         #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
 #if !NETCF && !SILVERLIGHT && !PORTABLE
         private static bool IsFileUri(string uri)
@@ -197,6 +177,6 @@ namespace NUnit.Common
         }
 #endif
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -51,9 +51,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -141,6 +138,7 @@
     <Compile Include="Interfaces\IParameterInfo.cs" />
     <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
     <Compile Include="Interfaces\TestOutput.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -51,9 +51,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -141,6 +138,7 @@
     <Compile Include="Interfaces\IReflectionInfo.cs" />
     <Compile Include="Interfaces\ITypeInfo.cs" />
     <Compile Include="Interfaces\TestOutput.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\Builders\ParameterDataProvider.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -50,9 +50,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -303,6 +300,7 @@
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\AsyncInvocationRegion.cs" />
     <Compile Include="Internal\Builders\CombinatorialStrategy.cs" />
     <Compile Include="Internal\Builders\DatapointProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -306,6 +303,7 @@
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\Builders\CombinatorialStrategy.cs" />
     <Compile Include="Interfaces\ICombiningStrategy.cs" />
     <Compile Include="Internal\Builders\DatapointProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netcf-3.5.csproj
@@ -66,9 +66,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -328,6 +325,7 @@
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\AsyncInvocationRegion.cs" />
     <Compile Include="Internal\Builders\CombinatorialStrategy.cs" />
     <Compile Include="Internal\Builders\DatapointProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -51,9 +51,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -310,6 +307,7 @@
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\AsyncInvocationRegion.cs" />
     <Compile Include="Internal\Builders\CombinatorialStrategy.cs" />
     <Compile Include="Internal\Builders\DatapointProvider.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-sl-5.0.csproj
@@ -68,9 +68,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\nunit\AssemblyHelper.cs">
-      <Link>Internal\AssemblyHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\nunit\Logging\ILogger.cs">
       <Link>Internal\ILogger.cs</Link>
     </Compile>
@@ -325,6 +322,7 @@
     <Compile Include="Interfaces\TestStatus.cs" />
     <Compile Include="Interfaces\TNode.cs" />
     <Compile Include="Internal\ActionsHelper.cs" />
+    <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\AsyncInvocationRegion.cs" />
     <Compile Include="Internal\Builders\CombinatorialStrategy.cs" />
     <Compile Include="Internal\Builders\DatapointProvider.cs" />

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Tests
         // different runtimes, so we now look only at the relative position
         // of before and after actions with respect to the test.
 
-        private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(ActionAttributeFixture));
+        private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(ActionAttributeFixture).Assembly);
         private static readonly string ASSEMBLY_NAME = System.IO.Path.GetFileName(ASSEMBLY_PATH);
 
         private ITestResult _result = null;

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2012 Charlie Poole
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,60 +21,42 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !SILVERLIGHT && !PORTABLE
-using System;
+#if !PORTABLE
 using System.IO;
-using System.Reflection;
-using NUnit.Framework;
 
-#if NUNIT_ENGINE
-namespace NUnit.Engine.Internal.Tests
-#elif NUNIT_FRAMEWORK
 namespace NUnit.Framework.Internal.Tests
-#else
-namespace NUnit.Common.Tests
-#endif
 {
     [TestFixture]
     public class AssemblyHelperTests
     {
-#if NUNIT_ENGINE
-        private static readonly string THIS_ASSEMBLY_PATH = "nunit.engine.tests.dll";
-        private static readonly string THIS_ASSEMBLY_NAME = "nunit.engine.tests";
-#else
 #if NETCF
         private static readonly string THIS_ASSEMBLY_PATH = "nunit.framework.tests.exe";
+#elif SILVERLIGHT
+        private static readonly string THIS_ASSEMBLY_PATH = "nunit.framework.tests";
 #else
         private static readonly string THIS_ASSEMBLY_PATH = "nunit.framework.tests.dll";
 #endif
         private static readonly string THIS_ASSEMBLY_NAME = "nunit.framework.tests";
-#endif
 
+        [Test]
         public void GetNameForAssembly()
         {
             var assemblyName = AssemblyHelper.GetAssemblyName(this.GetType().Assembly);
             Assert.That(assemblyName.Name, Is.EqualTo(THIS_ASSEMBLY_NAME).IgnoreCase);
-            Assert.That(assemblyName.FullName, Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
         }
 
-#if !SILVERLIGHT && !PORTABLE
         [Test]
         public void GetPathForAssembly()
         {
             string path = AssemblyHelper.GetAssemblyPath(this.GetType().Assembly);
             Assert.That(Path.GetFileName(path), Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
+
+#if !NETCF && !SILVERLIGHT
             Assert.That(File.Exists(path));
+#endif
         }
 
-        [Test]
-        public void GetPathForType()
-        {
-            string path = AssemblyHelper.GetAssemblyPath(this.GetType());
-            Assert.That(Path.GetFileName(path), Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
-            Assert.That(File.Exists(path));
-        }
-
-#if !NETCF
+#if !NETCF && !SILVERLIGHT
         // The following tests are only useful to the extent that the test cases
         // match what will actually be provided to the method in production.
         // As currently used, NUnit's codebase can only use the file: schema,
@@ -108,7 +90,7 @@ namespace NUnit.Common.Tests
             Assert.That(localPath, Is.SamePath(expectedPath));
         }
 #endif
-#endif
+
     }
 }
 #endif

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class SetUpFixtureTests
     {
-        private static readonly string testAssembly = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture));
+        private static readonly string testAssembly = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).Assembly);
 
         ITestAssemblyBuilder builder;
         ITestAssemblyRunner runner;

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -86,6 +83,7 @@
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -86,6 +83,7 @@
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -54,9 +54,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -132,6 +129,7 @@
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -56,9 +56,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -200,6 +197,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netcf-3.5.csproj
@@ -61,9 +61,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -225,6 +222,7 @@
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs">
       <SubType>Code</SubType>

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -45,9 +45,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\AssemblyHelperTests.cs">
-      <Link>Internal\AssemblyHelperTests.cs</Link>
-    </Compile>
     <Compile Include="..\Fakes.cs">
       <Link>TestUtilities\Fakes.cs</Link>
     </Compile>
@@ -187,6 +184,7 @@
     <Compile Include="Constraints\ToStringTests.cs" />
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-sl-5.0.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Compatibility\StopwatchTests.cs" />
+    <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />
     <Compile Include="Attributes\TestFixtureSourceTests.cs" />


### PR DESCRIPTION
More on #1596.

This one was a bit more gnarly, so I'll detail what's changed.

The engine change was simple - it maintains the original namespace, and lots of unused methods were removed.

The framework Assembly helper just tidies, and removes a the `GetAssemblyPath(Type type)` method, which was only used in tests - and even then, inconsistently. (Many places already used `AssemblyHelper.GetAssemblyPath(typeof(MyType).Assembly))` - I just updated the remaining two to do the same, and removed the overload.)

The framework tests were more messy:

1. `GetNameForAssembly()` was missing a `[Test]` attribute so wasn't being run. Once I'd added this, I then removed the line testing for FullName, as a) it required version number/public key etc and b) seemed to be more a test of `System.Reflection.AssemblyName` than any NUnit code.

2. The tests were excluded for both SL and Portable. As the methods were used in both builds, I adapted it to run as much as possible for SL. I left stuff excluded for portable based on #1661


Finally - I'd have ideally made these classes internal, but they currently need to be public for the tests. Should we use `[InternalsVisisbleTo]` instead? I didn't do that here as it's really a separate discussion.