### PR TITLE
Issue 1683

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System/SerializableAttribute.cs
+++ b/src/NUnitFramework/framework/Compatibility/System/SerializableAttribute.cs
@@ -28,7 +28,7 @@ namespace System
     /// A shim of the .NET attribute for platforms that do not support it.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Delegate, Inherited = false)]
-    public sealed class SerializableAttribute : Attribute
+    internal sealed class SerializableAttribute : Attribute
     {
     }
 }

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -491,7 +491,7 @@ namespace Mono.Options
         }
     }
 
-#if !PORTABLE
+#if !SILVERLIGHT && !PORTABLE
     [Serializable]
 #endif
     public class OptionException : Exception

--- a/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Common
     /// TestSelectionParserException is thrown when an error 
     /// is found while parsing the selection expression.
     /// </summary>
-#if !PORTABLE
+#if !SILVERLIGHT && !PORTABLE
     [Serializable]
 #endif
     public class TestSelectionParserException : Exception


### PR DESCRIPTION
Mark `SerializableAttribute` as `internal` instead of `public` to prevent build error when consumers of NUnit them self has declared a `SerializableAttribute` shim in their project.