### PR TITLE
Eliminate error write in netcf

### DIFF
--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -136,7 +136,7 @@ namespace NUnit.Tests
             [Test]
             public void FailingTest()
             {
-#if !PORTABLE && !SILVERLIGHT
+#if !PORTABLE && !SILVERLIGHT && !NETCF
                 Console.Error.WriteLine("Immediate Error Message");
 #endif
                 Assert.Fail("Intentional failure");


### PR DESCRIPTION
Fixes #1615.

Error write in the netcf tests was not causing the appearance of a cake error in the CI build.