### PR TITLE
Feature Request: Allow TextMessageWriter.DEFAULT_LINE_LENGTH to be updated

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "type with attribute " + MsgUtils.FormatValue(expectedType); }
+            get { return "type with attribute " + MsgUtils.FormatValue(expectedType, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "type with attribute " + MsgUtils.FormatValue(expectedType, false); }
+            get { return "type with attribute " + MsgUtils.FormatValue(expectedType); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "collection containing " + MsgUtils.FormatValue(Expected); }
+            get { return "collection containing " + MsgUtils.FormatValue(Expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "collection containing " + MsgUtils.FormatValue(Expected, false); }
+            get { return "collection containing " + MsgUtils.FormatValue(Expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "equivalent to " + MsgUtils.FormatValue(_expected); }
+            get { return "equivalent to " + MsgUtils.FormatValue(_expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "equivalent to " + MsgUtils.FormatValue(_expected, false); }
+            get { return "equivalent to " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Constraints
             { 
                 string desc = propertyName == null
                     ? "collection ordered"
-                    : "collection ordered by "+ MsgUtils.FormatValue(propertyName);
+                    : "collection ordered by "+ MsgUtils.FormatValue(propertyName, false);
 
                 if (descending)
                     desc += ", descending";

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Constraints
             { 
                 string desc = propertyName == null
                     ? "collection ordered"
-                    : "collection ordered by "+ MsgUtils.FormatValue(propertyName, false);
+                    : "collection ordered by "+ MsgUtils.FormatValue(propertyName);
 
                 if (descending)
                     desc += ", descending";

--- a/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "subset of " + MsgUtils.FormatValue(_expected, false); }
+            get { return "subset of " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "subset of " + MsgUtils.FormatValue(_expected); }
+            get { return "subset of " + MsgUtils.FormatValue(_expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "superset of " + MsgUtils.FormatValue(_expected); }
+            get { return "superset of " + MsgUtils.FormatValue(_expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "superset of " + MsgUtils.FormatValue(_expected, false); }
+            get { return "superset of " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Constraints
             this.lessComparisonResult = lessComparisonResult;
             this.equalComparisonResult = equalComparisonResult;
             this.greaterComparisonResult = greaterComparisonResult;
-            this.Description = predicate + " " + MsgUtils.FormatValue(expected, false);
+            this.Description = predicate + " " + MsgUtils.FormatValue(expected);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Constraints
             this.lessComparisonResult = lessComparisonResult;
             this.equalComparisonResult = equalComparisonResult;
             this.greaterComparisonResult = greaterComparisonResult;
-            this.Description = predicate + " " + MsgUtils.FormatValue(expected);
+            this.Description = predicate + " " + MsgUtils.FormatValue(expected, false);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -109,7 +109,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to suppress string clipping 
         /// and return self.
         /// </summary>
-        public Constraint NoClip
+        public IConstraint NoClip
         {   
             get
             {

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -53,6 +53,7 @@ namespace NUnit.Framework.Constraints
         protected Constraint(params object[] args)
         {
             Arguments = args;
+            ClipStrings = true;
 
             _displayName = new Lazy<string>(() =>
             {
@@ -91,9 +92,31 @@ namespace NUnit.Framework.Constraints
         public object[] Arguments { get; private set; }
 
         /// <summary>
+        /// A value indicating whether or not to clip strings.
+        /// </summary>
+        public bool ClipStrings { get; private set; }
+
+        /// <summary>
         /// The ConstraintBuilder holding this constraint
         /// </summary>
         public ConstraintBuilder Builder { get; set; }
+
+        #endregion
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flag the constraint to suppress string clipping 
+        /// and return self.
+        /// </summary>
+        public Constraint NoClip
+        {   
+            get
+            {
+                ClipStrings = false;
+                return this;
+            }
+        }
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
@@ -143,7 +143,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The MessageWriter on which to display the message</param>
         public virtual void WriteMessageTo(MessageWriter writer)
         {
-            writer.DisplayDifferences(this);
+            writer.DisplayDifferences(this, _constraint.ClipStrings);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The writer on which the actual value is displayed</param>
         public virtual void WriteActualValueTo(MessageWriter writer)
         {
-            writer.WriteActualValue(ActualValue);
+            writer.WriteActualValue(ActualValue, _constraint.ClipStrings);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintResult.cs
@@ -68,6 +68,7 @@ namespace NUnit.Framework.Constraints
         {
             _constraint = constraint;
             ActualValue = actualValue;
+            ClipStrings = constraint.ClipStrings;
         }
 
         /// <summary>
@@ -109,6 +110,11 @@ namespace NUnit.Framework.Constraints
         public ConstraintStatus Status { get; set; }
 
         /// <summary>
+        /// Whether or not to clip strings when displaying this constraint result.
+        /// </summary>
+        public bool ClipStrings { get; private set; }
+
+        /// <summary>
         /// True if actual value meets the Constraint criteria otherwise false.
         /// </summary>
         public virtual bool IsSuccess
@@ -143,7 +149,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The MessageWriter on which to display the message</param>
         public virtual void WriteMessageTo(MessageWriter writer)
         {
-            writer.DisplayDifferences(this, _constraint.ClipStrings);
+            writer.DisplayDifferences(this);
         }
 
         /// <summary>
@@ -155,7 +161,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The writer on which the actual value is displayed</param>
         public virtual void WriteActualValueTo(MessageWriter writer)
         {
-            writer.WriteActualValue(ActualValue, _constraint.ClipStrings);
+            writer.WriteActualValue(ActualValue, ClipStrings);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         {
             get { return _realConstraint != null ? 
                     _realConstraint.Description : 
-                    "containing " + MsgUtils.FormatValue(_expected, false); }
+                    "containing " + MsgUtils.FormatValue(_expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         {
             get { return _realConstraint != null ? 
                     _realConstraint.Description : 
-                    "containing " + MsgUtils.FormatValue(_expected); }
+                    "containing " + MsgUtils.FormatValue(_expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "dictionary containing key " + MsgUtils.FormatValue(Expected); }
+            get { return "dictionary containing key " + MsgUtils.FormatValue(Expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "dictionary containing key " + MsgUtils.FormatValue(Expected, false); }
+            get { return "dictionary containing key " + MsgUtils.FormatValue(Expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "dictionary containing value " + MsgUtils.FormatValue(Expected, false); }
+            get { return "dictionary containing value " + MsgUtils.FormatValue(Expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "dictionary containing value " + MsgUtils.FormatValue(Expected); }
+            get { return "dictionary containing value " + MsgUtils.FormatValue(Expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -358,12 +358,12 @@ namespace NUnit.Framework.Constraints
         {
             get 
             { 
-                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected, false));
+                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected));
 
                 if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
                 {
                     sb.Append(" +/- ");
-                    sb.Append(MsgUtils.FormatValue(_tolerance.Value, false));
+                    sb.Append(MsgUtils.FormatValue(_tolerance.Value));
                     if (_tolerance.Mode != ToleranceMode.Linear)
                     {
                         sb.Append(" ");

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -61,7 +61,6 @@ namespace NUnit.Framework.Constraints
             AdjustArgumentIfNeeded(ref expected);
 
             _expected = expected;
-            ClipStrings = true;
         }
         #endregion
 
@@ -94,14 +93,6 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Gets a value indicating whether or not to clip strings.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if set to clip strings otherwise, <c>false</c>.
-        /// </value>
-        public bool ClipStrings { get; private set; }
-
-        /// <summary>
         /// Gets the failure points.
         /// </summary>
         /// <value>
@@ -123,19 +114,6 @@ namespace NUnit.Framework.Constraints
             get
             {
                 _comparer.IgnoreCase = true;
-                return this;
-            }
-        }
-
-        /// <summary>
-        /// Flag the constraint to suppress string clipping 
-        /// and return self.
-        /// </summary>
-        public EqualConstraint NoClip
-        {
-            get
-            {
-                ClipStrings = false;
                 return this;
             }
         }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -358,12 +358,12 @@ namespace NUnit.Framework.Constraints
         {
             get 
             { 
-                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected));
+                System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected, false));
 
                 if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
                 {
                     sb.Append(" +/- ");
-                    sb.Append(MsgUtils.FormatValue(_tolerance.Value));
+                    sb.Append(MsgUtils.FormatValue(_tolerance.Value, false));
                     if (_tolerance.Mode != ToleranceMode.Linear)
                     {
                         sb.Append(" ");

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -37,7 +37,6 @@ namespace NUnit.Framework.Constraints
         private object expectedValue;
         private Tolerance tolerance;
         private bool caseInsensitive;
-        private bool clipStrings;
         private IList<NUnitEqualityComparer.FailurePoint> failurePoints;
 
         #region Message Strings
@@ -68,7 +67,6 @@ namespace NUnit.Framework.Constraints
             this.expectedValue = constraint.Arguments[0];
             this.tolerance = constraint.Tolerance;
             this.caseInsensitive = constraint.CaseInsensitive;
-            this.clipStrings = constraint.ClipStrings;
             this.failurePoints = constraint.FailurePoints;
         }
 
@@ -108,7 +106,7 @@ namespace NUnit.Framework.Constraints
             else
                 writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatch);
 
-            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, clipStrings);
+            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, _constraint.ClipStrings);
         }
         #endregion
 
@@ -152,12 +150,12 @@ namespace NUnit.Framework.Constraints
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write("  Extra:    ");
-                    writer.WriteCollectionElements(actual, failurePoint.Position, 3);
+                    writer.WriteCollectionElements(actual, failurePoint.Position, _constraint.ClipStrings ? 3 : Int32.MaxValue);
                 }
                 else
                 {
                     writer.Write("  Missing:  ");
-                    writer.WriteCollectionElements(expected, failurePoint.Position, 3);
+                    writer.WriteCollectionElements(expected, failurePoint.Position, _constraint.ClipStrings ? 3: Int32.MaxValue);
                 }
             }
         }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
             else if (tolerance != null)
                 writer.DisplayDifferences(expected, actual, tolerance);
             else
-                writer.DisplayDifferences(expected, actual);
+                writer.DisplayDifferences(expected, actual, this.ClipStrings);
         }
 
         #region DisplayStringDifferences
@@ -106,7 +106,7 @@ namespace NUnit.Framework.Constraints
             else
                 writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatch);
 
-            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, _constraint.ClipStrings);
+            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, this.ClipStrings);
         }
         #endregion
 
@@ -150,12 +150,12 @@ namespace NUnit.Framework.Constraints
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write("  Extra:    ");
-                    writer.WriteCollectionElements(actual, failurePoint.Position, _constraint.ClipStrings ? 3 : Int32.MaxValue);
+                    writer.WriteCollectionElements(actual, failurePoint.Position, this.ClipStrings ? 3 : Int32.MaxValue);
                 }
                 else
                 {
                     writer.Write("  Missing:  ");
-                    writer.WriteCollectionElements(expected, failurePoint.Position, _constraint.ClipStrings ? 3: Int32.MaxValue);
+                    writer.WriteCollectionElements(expected, failurePoint.Position, this.ClipStrings ? 3: Int32.MaxValue);
                 }
             }
         }

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
                     }
                     else
                     {
-                        writer.WriteActualValue(ex);
+                        writer.WriteActualValue(ex, this.ClipStrings);
                     }
                 }
             }

--- a/src/NUnitFramework/framework/Constraints/IConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/IConstraint.cs
@@ -42,6 +42,11 @@ namespace NUnit.Framework.Constraints
         string Description { get; }
 
         /// <summary>
+        /// A value indicating whether or not to clip strings.
+        /// </summary>
+        bool ClipStrings { get; }
+
+        /// <summary>
         /// Arguments provided to this Constraint, for use in
         /// formatting the description.
         /// </summary>
@@ -51,6 +56,16 @@ namespace NUnit.Framework.Constraints
         /// The ConstraintBuilder holding this constraint
         /// </summary>
         ConstraintBuilder Builder { get; set; }
+
+        #endregion
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flag the constraint to suppress string clipping 
+        /// and return self.
+        /// </summary>
+        IConstraint NoClip { get; }
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/MessageWriter.cs
+++ b/src/NUnitFramework/framework/Constraints/MessageWriter.cs
@@ -83,7 +83,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value causing the failure</param>
-        public abstract void DisplayDifferences(object expected, object actual);
+        /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
+        public abstract void DisplayDifferences(object expected, object actual, bool clipping);
 
         /// <summary>
         /// Display Expected and Actual lines for given _values, including
@@ -110,13 +111,15 @@ namespace NUnit.Framework.Constraints
         /// Writes the text for an actual value.
         /// </summary>
         /// <param name="actual">The actual value.</param>
-        public abstract void WriteActualValue(object actual);
+        /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
+        public abstract void WriteActualValue(object actual, bool clipping);
 
         /// <summary>
         /// Writes the text for a generalized value.
         /// </summary>
         /// <param name="val">The value.</param>
-        public abstract void WriteValue(object val);
+        /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
+        public abstract void WriteValue(object val, bool clipping);
 
         /// <summary>
         /// Writes the text for a collection value,

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="val">The value</param>
 		/// <param name="clip">Whether or not to clip values when displaying them</param>
         /// <returns>The formatted text</returns>
-        public static string FormatValue(object val, bool clip)
+        public static string FormatValue(object val, bool clip = false)
         {
             if (val == null)
                 return Fmt_Null;
@@ -162,7 +162,7 @@ namespace NUnit.Framework.Constraints
                     if (++count > max)
                         break;
                     sb.Append(count == 1 ? "< " : ", ");
-                    sb.Append(FormatValue(obj, false));
+                    sb.Append(FormatValue(obj));
                 }
             }
 
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Constraints
                     if (startSegment) sb.Append("< ");
                 }
 
-                sb.Append(FormatValue(obj, false));
+                sb.Append(FormatValue(obj));
 
                 ++count;
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -33,6 +33,7 @@ namespace NUnit.Framework.Constraints
     /// Custom value formatter function
     /// </summary>
     /// <param name="val">The value</param>
+	/// <param name="clip">Whether or not to clip values when displaying them</param>
     /// <returns></returns>
     public delegate string ValueFormatter(object val, bool clip);
 
@@ -80,27 +81,27 @@ namespace NUnit.Framework.Constraints
             // Initialize formatter to default for values of indeterminate type.
             DefaultValueFormatter = (val, clip) => string.Format(Fmt_Default, val);
 
-            AddFormatter(next => (val, clip) => val is ValueType ? string.Format(Fmt_ValueType, val) : next(val));
+            AddFormatter(next => (val, clip) => val is ValueType ? string.Format(Fmt_ValueType, val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is DateTime ? FormatDateTime((DateTime)val) : next(val));
+            AddFormatter(next => (val, clip) => val is DateTime ? FormatDateTime((DateTime)val) : next(val, clip));
 
 #if !NETCF
-			AddFormatter(next => (val, clip) => val is DateTimeOffset ? FormatDateTimeOffset ((DateTimeOffset)val) : next (val));
+			AddFormatter(next => (val, clip) => val is DateTimeOffset ? FormatDateTimeOffset ((DateTimeOffset)val) : next (val, clip));
 #endif
 
-			AddFormatter(next => (val, clip) => val is decimal ? FormatDecimal((decimal)val) : next(val));
+			AddFormatter(next => (val, clip) => val is decimal ? FormatDecimal((decimal)val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is float ? FormatFloat((float)val) : next(val));
+            AddFormatter(next => (val, clip) => val is float ? FormatFloat((float)val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is double ? FormatDouble((double)val) : next(val));
+            AddFormatter(next => (val, clip) => val is double ? FormatDouble((double)val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is char ? string.Format(Fmt_Char, val) : next(val));
+            AddFormatter(next => (val, clip) => val is char ? string.Format(Fmt_Char, val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is IEnumerable ? FormatCollection((IEnumerable)val, 0, clip ? 10 : Int32.MaxValue) : next(val));
+            AddFormatter(next => (val, clip) => val is IEnumerable ? FormatCollection((IEnumerable)val, 0, clip ? 10 : Int32.MaxValue) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val is string ? FormatString(clip ? ClipString((string)val, 78, 0) : (string)val) : next(val));
+            AddFormatter(next => (val, clip) => val is string ? FormatString(clip ? ClipString((string)val, 78, 0) : (string)val) : next(val, clip));
 
-            AddFormatter(next => (val, clip) => val.GetType().IsArray ? FormatArray((Array)val) : next(val));
+            AddFormatter(next => (val, clip) => val.GetType().IsArray ? FormatArray((Array)val) : next(val, clip));
 
 #if NETCF
             AddFormatter(next => val =>
@@ -108,7 +109,7 @@ namespace NUnit.Framework.Constraints
                 var vi = val as System.Reflection.MethodInfo;
                 return (vi != null && vi.IsGenericMethodDefinition)
                         ? string.Format(Fmt_Default, vi.Name + "<>") 
-                        : next(val);
+                        : next(val, clip);
             });
 #endif
         }
@@ -126,6 +127,7 @@ namespace NUnit.Framework.Constraints
         /// Formats text to represent a generalized value.
         /// </summary>
         /// <param name="val">The value</param>
+		/// <param name="clip">Whether or not to clip values when displaying them</param>
         /// <returns>The formatted text</returns>
         public static string FormatValue(object val, bool clip)
         {
@@ -160,7 +162,7 @@ namespace NUnit.Framework.Constraints
                     if (++count > max)
                         break;
                     sb.Append(count == 1 ? "< " : ", ");
-                    sb.Append(FormatValue(obj));
+                    sb.Append(FormatValue(obj, false));
                 }
             }
 
@@ -200,7 +202,7 @@ namespace NUnit.Framework.Constraints
                     if (startSegment) sb.Append("< ");
                 }
 
-                sb.Append(FormatValue(obj));
+                sb.Append(FormatValue(obj, false));
 
                 ++count;
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -124,12 +124,22 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Formats text to represent a generalized value without clipping.
+        /// </summary>
+        /// <param name="val">The value</param>
+        /// <returns>The formatted text</returns>
+        public static string FormatValue(object val)
+        {
+            return FormatValue(val, false);
+        }
+
+        /// <summary>
         /// Formats text to represent a generalized value.
         /// </summary>
         /// <param name="val">The value</param>
-		/// <param name="clip">Whether or not to clip values when displaying them</param>
+        /// <param name="clip">Whether or not to clip values when displaying them</param>
         /// <returns>The formatted text</returns>
-        public static string FormatValue(object val, bool clip = false)
+        public static string FormatValue(object val, bool clip)
         {
             if (val == null)
                 return Fmt_Null;

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
             AddFormatter(next => (val, clip) => val.GetType().IsArray ? FormatArray((Array)val) : next(val, clip));
 
 #if NETCF
-            AddFormatter(next => val =>
+            AddFormatter(next => (val, clip) =>
             {
                 var vi = val as System.Reflection.MethodInfo;
                 return (vi != null && vi.IsGenericMethodDefinition)

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "same as " + MsgUtils.FormatValue(expected, false); }
+            get { return "same as " + MsgUtils.FormatValue(expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "same as " + MsgUtils.FormatValue(expected); }
+            get { return "same as " + MsgUtils.FormatValue(expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "Path matching " + MsgUtils.FormatValue(expected, false); }
+            get { return "Path matching " + MsgUtils.FormatValue(expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "Path matching " + MsgUtils.FormatValue(expected); }
+            get { return "Path matching " + MsgUtils.FormatValue(expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "Path under or matching " + MsgUtils.FormatValue(expected, false); }
+            get { return "Path under or matching " + MsgUtils.FormatValue(expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return "Path under or matching " + MsgUtils.FormatValue(expected); }
+            get { return "Path under or matching " + MsgUtils.FormatValue(expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/StringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StringConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         {
             get 
             { 
-                string desc = string.Format("{0} {1}", descriptionText, MsgUtils.FormatValue(expected));
+                string desc = string.Format("{0} {1}", descriptionText, MsgUtils.FormatValue(expected, false));
                 if (caseInsensitive)
                     desc += ", ignoring case";
                 return desc;

--- a/src/NUnitFramework/framework/Constraints/StringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StringConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         {
             get 
             { 
-                string desc = string.Format("{0} {1}", descriptionText, MsgUtils.FormatValue(expected, false));
+                string desc = string.Format("{0} {1}", descriptionText, MsgUtils.FormatValue(expected));
                 if (caseInsensitive)
                     desc += ", ignoring case";
                 return desc;

--- a/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return  "Subpath of " + MsgUtils.FormatValue(expected, false); }
+            get { return  "Subpath of " + MsgUtils.FormatValue(expected); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return  "Subpath of " + MsgUtils.FormatValue(expected); }
+            get { return  "Subpath of " + MsgUtils.FormatValue(expected, false); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
             : base(type)
         {
             this.expectedType = type;
-            this.Description = descriptionPrefix + MsgUtils.FormatValue(expectedType, false);
+            this.Description = descriptionPrefix + MsgUtils.FormatValue(expectedType);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
             : base(type)
         {
             this.expectedType = type;
-            this.Description = descriptionPrefix + MsgUtils.FormatValue(expectedType);
+            this.Description = descriptionPrefix + MsgUtils.FormatValue(expectedType, false);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal
     public class TextMessageWriter : MessageWriter
     {
         #region Message Formats and Constants
-        private static readonly int DEFAULT_LINE_LENGTH = 78;
+        private static readonly int Default_Line_Length = 78;
 
         // Prefixes used in all failure messages. All must be the same
         // length, which is held in the PrefixLength field. Should not
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Internal
         
         #endregion
 
-        private int maxLineLength = DEFAULT_LINE_LENGTH;
+        private int maxLineLength = Default_Line_Length;
 
         #region Constructors
         /// <summary>
@@ -79,6 +79,15 @@ namespace NUnit.Framework.Internal
         #endregion
 
         #region Properties
+        /// <summary>
+        /// Gets or sets the class-level default maximum line length for this writer
+        /// </summary>
+        public static int DefaultLineLength
+        {
+            get { return Default_Line_Length; }
+            set { Default_Line_length = value; }
+        }
+
         /// <summary>
         /// Gets or sets the maximum line length for this writer
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -208,7 +208,7 @@ namespace NUnit.Framework.Internal
         /// <param name="clipping">If true, clip the strings to fit the max line length</param>
         public override void WriteValue(object val, bool clipping)
         {
-            Write(MsgUtils.FormatValue(val, clip));
+            Write(MsgUtils.FormatValue(val, clipping));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal
     public class TextMessageWriter : MessageWriter
     {
         #region Message Formats and Constants
-        private static int Default_Line_Length = 78;
+        private static int _defaultLineLength = 78;
 
         // Prefixes used in all failure messages. All must be the same
         // length, which is held in the PrefixLength field. Should not
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Internal
         
         #endregion
 
-        private int maxLineLength = Default_Line_Length;
+        private int maxLineLength = _defaultLineLength;
 
         #region Constructors
         /// <summary>
@@ -84,8 +84,8 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static int DefaultLineLength
         {
-            get { return Default_Line_Length; }
-            set { Default_Line_Length = value; }
+            get { return _defaultLineLength; }
+            set { _defaultLineLength = value; }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         public override void DisplayDifferences(ConstraintResult result)
         {
             WriteExpectedLine(result);
-            WriteActualLine(result);
+            WriteActualLine(result, result.ClipStrings);
         }
 
         /// <summary>
@@ -131,10 +131,11 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value causing the failure</param>
-        public override void DisplayDifferences(object expected, object actual)
+        /// <param name="clipping">If true, clip the strings to fit the max line length</param>
+        public override void DisplayDifferences(object expected, object actual, bool clipping)
         {
             WriteExpectedLine(expected);
-            WriteActualLine(actual);
+            WriteActualLine(actual, clipping);
         }
 
         /// <summary>
@@ -147,7 +148,7 @@ namespace NUnit.Framework.Internal
         public override void DisplayDifferences(object expected, object actual, Tolerance tolerance)
         {
             WriteExpectedLine(expected, tolerance);
-            WriteActualLine(actual);
+            WriteActualLine(actual, false);
         }
 
         /// <summary>
@@ -177,7 +178,7 @@ namespace NUnit.Framework.Internal
             mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, ignoreCase);
 
             Write( Pfx_Expected );
-            Write( MsgUtils.FormatValue(expected) );
+            Write( MsgUtils.FormatValue(expected, clipping) );
             if ( ignoreCase )
                 Write( ", ignoring case" );
             WriteLine();
@@ -194,18 +195,20 @@ namespace NUnit.Framework.Internal
         /// Writes the text for an actual value.
         /// </summary>
         /// <param name="actual">The actual value.</param>
-        public override void WriteActualValue(object actual)
+        /// <param name="clipping">If true, clip the strings to fit the max line length</param>
+        public override void WriteActualValue(object actual, bool clipping)
         {
-            WriteValue(actual);
+            WriteValue(actual, clipping);
         }
 
         /// <summary>
         /// Writes the text for a generalized value.
         /// </summary>
         /// <param name="val">The value.</param>
-        public override void WriteValue(object val)
+        /// <param name="clipping">If true, clip the strings to fit the max line length</param>
+        public override void WriteValue(object val, bool clipping)
         {
-            Write(MsgUtils.FormatValue(val));
+            Write(MsgUtils.FormatValue(val, clip));
         }
 
         /// <summary>
@@ -251,12 +254,12 @@ namespace NUnit.Framework.Internal
         private void WriteExpectedLine(object expected, Tolerance tolerance)
         {
             Write(Pfx_Expected);
-            Write(MsgUtils.FormatValue(expected));
+            Write(MsgUtils.FormatValue(expected, false));
 
             if (tolerance != null && !tolerance.IsUnsetOrDefault)
             {
                 Write(" +/- ");
-                Write(MsgUtils.FormatValue(tolerance.Value));
+                Write(MsgUtils.FormatValue(tolerance.Value, false));
                 if (tolerance.Mode != ToleranceMode.Linear)
                     Write(" {0}", tolerance.Mode);
             }
@@ -280,10 +283,11 @@ namespace NUnit.Framework.Internal
         /// Write the generic 'Actual' line for a given value
         /// </summary>
         /// <param name="actual">The actual value causing a failure</param>
-        private void WriteActualLine(object actual)
+        /// <param name="clipping">If true, clip the strings to fit the max line length</param>
+        private void WriteActualLine(object actual, bool clipping)
         {
             Write(Pfx_Actual);
-            WriteActualValue(actual);
+            WriteActualValue(actual, clipping);
             WriteLine();
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -254,12 +254,12 @@ namespace NUnit.Framework.Internal
         private void WriteExpectedLine(object expected, Tolerance tolerance)
         {
             Write(Pfx_Expected);
-            Write(MsgUtils.FormatValue(expected, false));
+            Write(MsgUtils.FormatValue(expected));
 
             if (tolerance != null && !tolerance.IsUnsetOrDefault)
             {
                 Write(" +/- ");
-                Write(MsgUtils.FormatValue(tolerance.Value, false));
+                Write(MsgUtils.FormatValue(tolerance.Value));
                 if (tolerance.Mode != ToleranceMode.Linear)
                     Write(" {0}", tolerance.Mode);
             }

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal
     public class TextMessageWriter : MessageWriter
     {
         #region Message Formats and Constants
-        private static readonly int Default_Line_Length = 78;
+        private static int Default_Line_Length = 78;
 
         // Prefixes used in all failure messages. All must be the same
         // length, which is held in the PrefixLength field. Should not
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Internal
         public static int DefaultLineLength
         {
             get { return Default_Line_Length; }
-            set { Default_Line_length = value; }
+            set { Default_Line_Length = value; }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         public override void DisplayDifferences(ConstraintResult result)
         {
             WriteExpectedLine(result);
-            WriteActualLine(result, result.ClipStrings);
+            WriteActualLine(result);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal
     public class TextMessageWriter : MessageWriter
     {
         #region Message Formats and Constants
-        private static int _defaultLineLength = 78;
+        private static readonly int DEFAULT_LINE_LENGTH = 78;
 
         // Prefixes used in all failure messages. All must be the same
         // length, which is held in the PrefixLength field. Should not
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Internal
         
         #endregion
 
-        private int maxLineLength = _defaultLineLength;
+        private int maxLineLength = DEFAULT_LINE_LENGTH;
 
         #region Constructors
         /// <summary>
@@ -79,15 +79,6 @@ namespace NUnit.Framework.Internal
         #endregion
 
         #region Properties
-        /// <summary>
-        /// Gets or sets the class-level default maximum line length for this writer
-        /// </summary>
-        public static int DefaultLineLength
-        {
-            get { return _defaultLineLength; }
-            set { _defaultLineLength = value; }
-        }
-
         /// <summary>
         /// Gets or sets the maximum line length for this writer
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -182,7 +182,7 @@ namespace NUnit.Framework.Internal
             if ( ignoreCase )
                 Write( ", ignoring case" );
             WriteLine();
-            WriteActualLine( actual );
+            WriteActualLine(actual, clipping);
             //DisplayDifferences(expected, actual);
             if (mismatch >= 0)
                 WriteCaretLine(mismatch);

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Internal
             _currentPrincipal = Thread.CurrentPrincipal;
 #endif
 
-            CurrentValueFormatter = (val) => MsgUtils.DefaultValueFormatter(val);
+            CurrentValueFormatter = (val, bool) => MsgUtils.DefaultValueFormatter(val, bool);
             IsSingleThreaded = false;
         }
 

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Internal
             _currentPrincipal = Thread.CurrentPrincipal;
 #endif
 
-            CurrentValueFormatter = (val, bool) => MsgUtils.DefaultValueFormatter(val, bool);
+            CurrentValueFormatter = (val, clip) => MsgUtils.DefaultValueFormatter(val, clip);
             IsSingleThreaded = false;
         }
 

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -286,7 +286,7 @@ namespace NUnit.Framework
         /// <param name="formatter">The ValueFormatter delegate</param>
         public static void AddFormatter<TSUPPORTED>(ValueFormatter formatter)
         {
-            AddFormatter(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
+            AddFormatter(next => (val, clip) => (val is TSUPPORTED) ? formatter(val, clip) : next(val, clip));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Constraints
         {
             TestContext.AddFormatter(next => (val, clip) => (val is CustomFormattableType) ? "custom_formatted" : next(val, clip));
 
-            Assert.That(MsgUtils.FormatValue(new CustomFormattableType(), false), Is.EqualTo("custom_formatted"));
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
             // If this factory is actually called with null, it will throw
             TestContext.AddFormatter(next => (val, clip) => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val, clip));
 
-            Assert.That(MsgUtils.FormatValue(null, false), Is.EqualTo("null"));
+            Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
         }
 
         [Test]
@@ -56,19 +56,19 @@ namespace NUnit.Framework.Constraints
         {
             TestContext.AddFormatter<CustomFormattableType>((val, clip) => "custom_formatted_using_type");
 
-            Assert.That(MsgUtils.FormatValue(new CustomFormattableType(), false), Is.EqualTo("custom_formatted_using_type"));
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
         }
 
         [Test]
         public static void FormatValue_IntegerIsWrittenAsIs()
         {
-            Assert.That(MsgUtils.FormatValue(42, false), Is.EqualTo("42"));
+            Assert.That(MsgUtils.FormatValue(42), Is.EqualTo("42"));
         }
 
         [Test]
         public static void FormatValue_StringIsWrittenWithQuotes()
         {
-            Assert.That(MsgUtils.FormatValue("Hello", false), Is.EqualTo("\"Hello\""));
+            Assert.That(MsgUtils.FormatValue("Hello"), Is.EqualTo("\"Hello\""));
         }
 
         // This test currently fails because control character replacement is
@@ -84,13 +84,13 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_FloatIsWrittenWithTrailingF()
         {
-            Assert.That(MsgUtils.FormatValue(0.5f, false), Is.EqualTo("0.5f"));
+            Assert.That(MsgUtils.FormatValue(0.5f), Is.EqualTo("0.5f"));
         }
 
         [Test]
         public static void FormatValue_FloatIsWrittenToNineDigits()
         {
-            string s = MsgUtils.FormatValue(0.33333333333333f, false);
+            string s = MsgUtils.FormatValue(0.33333333333333f);
             int digits = s.Length - 3;   // 0.dddddddddf
             Assert.That(digits, Is.EqualTo(9));
         }
@@ -98,39 +98,39 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_DoubleIsWrittenWithTrailingD()
         {
-            Assert.That(MsgUtils.FormatValue(0.5d, false), Is.EqualTo("0.5d"));
+            Assert.That(MsgUtils.FormatValue(0.5d), Is.EqualTo("0.5d"));
         }
 
         [Test]
         public static void FormatValue_DoubleIsWrittenToSeventeenDigits()
         {
-            string s = MsgUtils.FormatValue(0.33333333333333333333333333333333333333333333d, false);
+            string s = MsgUtils.FormatValue(0.33333333333333333333333333333333333333333333d);
             Assert.That(s.Length, Is.EqualTo(20)); // add 3 for leading 0, decimal and trailing d
         }
 
         [Test]
         public static void FormatValue_DecimalIsWrittenWithTrailingM()
         {
-            Assert.That(MsgUtils.FormatValue(0.5m, false), Is.EqualTo("0.5m"));
+            Assert.That(MsgUtils.FormatValue(0.5m), Is.EqualTo("0.5m"));
         }
 
         [Test]
         public static void FormatValue_DecimalIsWrittenToTwentyNineDigits()
         {
-            Assert.That(MsgUtils.FormatValue(12345678901234567890123456789m, false), Is.EqualTo("12345678901234567890123456789m"));
+            Assert.That(MsgUtils.FormatValue(12345678901234567890123456789m), Is.EqualTo("12345678901234567890123456789m"));
         }
 
         [Test]
         public static void FormatValue_DateTimeTest()
         {
-            Assert.That(MsgUtils.FormatValue(new DateTime(2007, 7, 4, 9, 15, 30, 123), false), Is.EqualTo("2007-07-04 09:15:30.123"));
+            Assert.That(MsgUtils.FormatValue(new DateTime(2007, 7, 4, 9, 15, 30, 123)), Is.EqualTo("2007-07-04 09:15:30.123"));
         }
 
 #if !NETCF
 		[Test]
         public static void FormatValue_DateTimeOffsetTest()
         {
-            Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8)), false), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
+            Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8))), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
         }
 #endif
 

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -37,38 +37,38 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_ContextualCustomFormatterInvoked_FactoryArg()
         {
-            TestContext.AddFormatter(next => val => (val is CustomFormattableType) ? "custom_formatted" : next(val));
+            TestContext.AddFormatter(next => (val, clip) => (val is CustomFormattableType) ? "custom_formatted" : next(val, clip));
 
-            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted"));
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType(), false), Is.EqualTo("custom_formatted"));
         }
 
         [Test]
         public static void FormatValue_ContextualCustomFormatterNotInvokedForNull()
         {
             // If this factory is actually called with null, it will throw
-            TestContext.AddFormatter(next => val => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val));
+            TestContext.AddFormatter(next => (val, clip) => (val.GetType() == typeof(CustomFormattableType)) ? val.ToString() : next(val, clip));
 
-            Assert.That(MsgUtils.FormatValue(null), Is.EqualTo("null"));
+            Assert.That(MsgUtils.FormatValue(null, false), Is.EqualTo("null"));
         }
 
         [Test]
         public static void FormatValue_ContextualCustomFormatterInvoked_FormatterArg()
         {
-            TestContext.AddFormatter<CustomFormattableType>(val => "custom_formatted_using_type");
+            TestContext.AddFormatter<CustomFormattableType>((val, clip) => "custom_formatted_using_type");
 
-            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType(), false), Is.EqualTo("custom_formatted_using_type"));
         }
 
         [Test]
         public static void FormatValue_IntegerIsWrittenAsIs()
         {
-            Assert.That(MsgUtils.FormatValue(42), Is.EqualTo("42"));
+            Assert.That(MsgUtils.FormatValue(42, false), Is.EqualTo("42"));
         }
 
         [Test]
         public static void FormatValue_StringIsWrittenWithQuotes()
         {
-            Assert.That(MsgUtils.FormatValue("Hello"), Is.EqualTo("\"Hello\""));
+            Assert.That(MsgUtils.FormatValue("Hello", false), Is.EqualTo("\"Hello\""));
         }
 
         // This test currently fails because control character replacement is
@@ -84,13 +84,13 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_FloatIsWrittenWithTrailingF()
         {
-            Assert.That(MsgUtils.FormatValue(0.5f), Is.EqualTo("0.5f"));
+            Assert.That(MsgUtils.FormatValue(0.5f, false), Is.EqualTo("0.5f"));
         }
 
         [Test]
         public static void FormatValue_FloatIsWrittenToNineDigits()
         {
-            string s = MsgUtils.FormatValue(0.33333333333333f);
+            string s = MsgUtils.FormatValue(0.33333333333333f, false);
             int digits = s.Length - 3;   // 0.dddddddddf
             Assert.That(digits, Is.EqualTo(9));
         }
@@ -98,39 +98,39 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_DoubleIsWrittenWithTrailingD()
         {
-            Assert.That(MsgUtils.FormatValue(0.5d), Is.EqualTo("0.5d"));
+            Assert.That(MsgUtils.FormatValue(0.5d, false), Is.EqualTo("0.5d"));
         }
 
         [Test]
         public static void FormatValue_DoubleIsWrittenToSeventeenDigits()
         {
-            string s = MsgUtils.FormatValue(0.33333333333333333333333333333333333333333333d);
+            string s = MsgUtils.FormatValue(0.33333333333333333333333333333333333333333333d, false);
             Assert.That(s.Length, Is.EqualTo(20)); // add 3 for leading 0, decimal and trailing d
         }
 
         [Test]
         public static void FormatValue_DecimalIsWrittenWithTrailingM()
         {
-            Assert.That(MsgUtils.FormatValue(0.5m), Is.EqualTo("0.5m"));
+            Assert.That(MsgUtils.FormatValue(0.5m, false), Is.EqualTo("0.5m"));
         }
 
         [Test]
         public static void FormatValue_DecimalIsWrittenToTwentyNineDigits()
         {
-            Assert.That(MsgUtils.FormatValue(12345678901234567890123456789m), Is.EqualTo("12345678901234567890123456789m"));
+            Assert.That(MsgUtils.FormatValue(12345678901234567890123456789m, false), Is.EqualTo("12345678901234567890123456789m"));
         }
 
         [Test]
         public static void FormatValue_DateTimeTest()
         {
-            Assert.That(MsgUtils.FormatValue(new DateTime(2007, 7, 4, 9, 15, 30, 123)), Is.EqualTo("2007-07-04 09:15:30.123"));
+            Assert.That(MsgUtils.FormatValue(new DateTime(2007, 7, 4, 9, 15, 30, 123), false), Is.EqualTo("2007-07-04 09:15:30.123"));
         }
 
 #if !NETCF
 		[Test]
         public static void FormatValue_DateTimeOffsetTest()
         {
-            Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8))), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
+            Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8)), false), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
         }
 #endif
 

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -345,12 +345,12 @@ namespace NUnit.Framework.Internal
 
             try
             {
-                ValueFormatter f = val => "dummy";
+                ValueFormatter f = (val, clip) => "dummy";
                 context.AddFormatter(next => f);
                 Assert.That(context.CurrentValueFormatter, Is.EqualTo(f));
 
                 context.EstablishExecutionEnvironment();
-                Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("dummy"));
+                Assert.That(MsgUtils.FormatValue(123, false), Is.EqualTo("dummy"));
             }
             finally
             {
@@ -358,7 +358,7 @@ namespace NUnit.Framework.Internal
             }
 
             Assert.That(TestExecutionContext.CurrentContext.CurrentValueFormatter, Is.EqualTo(originalFormatter));
-            Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("123"));
+            Assert.That(MsgUtils.FormatValue(123, false), Is.EqualTo("123"));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -350,7 +350,7 @@ namespace NUnit.Framework.Internal
                 Assert.That(context.CurrentValueFormatter, Is.EqualTo(f));
 
                 context.EstablishExecutionEnvironment();
-                Assert.That(MsgUtils.FormatValue(123, false), Is.EqualTo("dummy"));
+                Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("dummy"));
             }
             finally
             {
@@ -358,7 +358,7 @@ namespace NUnit.Framework.Internal
             }
 
             Assert.That(TestExecutionContext.CurrentContext.CurrentValueFormatter, Is.EqualTo(originalFormatter));
-            Assert.That(MsgUtils.FormatValue(123, false), Is.EqualTo("123"));
+            Assert.That(MsgUtils.FormatValue(123), Is.EqualTo("123"));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -41,6 +41,23 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        public void TestMaLineLength()
+        {
+            Assert.That(78, Is.EqualTo(TextMessageWriter.DefaultLineLength));
+            TextMessageWriter w = new TextMessageWriter();
+            Assert.That(78, Is.EqualTo(w.MaxLineLength));
+            TextMessageWriter.DefaultLineLength = 120;
+            Assert.That(120, Is.EqualTo(TextMessageWriter.DefaultLineLength));
+            Assert.That(78, Is.EqualTo(w.MaxLineLength));
+            w.MaxLineLength = 42;
+            Assert.That(42, Is.EqualTo(w.MaxLineLength));
+            w = new TextMessageWriter();
+            Assert.That(120, Is.EqualTo(w.MaxLineLength));
+            TextMessageWriter.DefaultLineLength = 78;
+            Assert.That(78, Is.EqualTo(TextMessageWriter.DefaultLineLength));
+        }
+
+        [Test]
         public void DisplayStringDifferences()
         {
             string s72 = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -33,28 +33,46 @@ namespace NUnit.Framework.Internal
         private static readonly string NL = NUnit.Env.NewLine;
 
         private TextMessageWriter writer;
+        private int defaultLineLength;
 
         [SetUp]
         public void SetUp()
         {
             writer = new TextMessageWriter();
+            defaultLineLength = TextMessageWriter.DefaultLineLength;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TextMessageWriter.DefaultLineLength = defaultLineLength;
         }
 
         [Test]
-        public void TestMaLineLength()
+        public void TestSetDefaultMaxLineLength()
         {
-            Assert.That(78, Is.EqualTo(TextMessageWriter.DefaultLineLength));
-            TextMessageWriter w = new TextMessageWriter();
-            Assert.That(78, Is.EqualTo(w.MaxLineLength));
             TextMessageWriter.DefaultLineLength = 120;
             Assert.That(120, Is.EqualTo(TextMessageWriter.DefaultLineLength));
-            Assert.That(78, Is.EqualTo(w.MaxLineLength));
-            w.MaxLineLength = 42;
-            Assert.That(42, Is.EqualTo(w.MaxLineLength));
-            w = new TextMessageWriter();
+            TextMessageWriter w = new TextMessageWriter();
             Assert.That(120, Is.EqualTo(w.MaxLineLength));
-            TextMessageWriter.DefaultLineLength = 78;
-            Assert.That(78, Is.EqualTo(TextMessageWriter.DefaultLineLength));
+        }
+
+        [Test]
+        public void TestChangeDefaultMaxLineLengthAfterInstantiation()
+        {
+            TextMessageWriter.DefaultLineLength = 120;
+            TextMessageWriter w = new TextMessageWriter();
+            TextMessageWriter.DefaultLineLength = 43;
+            Assert.That(120, Is.EqualTo(w.MaxLineLength));
+        }
+
+        [Test]
+        public void TestMaxLineLength()
+        {
+            TextMessageWriter w = new TextMessageWriter();
+            Assert.That(TextMessageWriter.DefaultLineLength, Is.EqualTo(w.MaxLineLength));
+            w.MaxLineLength = 89;
+            Assert.That(89, Is.EqualTo(w.MaxLineLength));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -33,46 +33,11 @@ namespace NUnit.Framework.Internal
         private static readonly string NL = NUnit.Env.NewLine;
 
         private TextMessageWriter writer;
-        private int defaultLineLength;
 
         [SetUp]
         public void SetUp()
         {
             writer = new TextMessageWriter();
-            defaultLineLength = TextMessageWriter.DefaultLineLength;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            TextMessageWriter.DefaultLineLength = defaultLineLength;
-        }
-
-        [Test]
-        public void TestSetDefaultMaxLineLength()
-        {
-            TextMessageWriter.DefaultLineLength = 120;
-            Assert.That(120, Is.EqualTo(TextMessageWriter.DefaultLineLength));
-            TextMessageWriter w = new TextMessageWriter();
-            Assert.That(120, Is.EqualTo(w.MaxLineLength));
-        }
-
-        [Test]
-        public void TestChangeDefaultMaxLineLengthAfterInstantiation()
-        {
-            TextMessageWriter.DefaultLineLength = 120;
-            TextMessageWriter w = new TextMessageWriter();
-            TextMessageWriter.DefaultLineLength = 43;
-            Assert.That(120, Is.EqualTo(w.MaxLineLength));
-        }
-
-        [Test]
-        public void TestMaxLineLength()
-        {
-            TextMessageWriter w = new TextMessageWriter();
-            Assert.That(TextMessageWriter.DefaultLineLength, Is.EqualTo(w.MaxLineLength));
-            w.MaxLineLength = 89;
-            Assert.That(89, Is.EqualTo(w.MaxLineLength));
         }
 
         [Test]


### PR DESCRIPTION
Currently, TextMessageWriter.DEFAULT_LINE_LENGTH is a constant.  In this patch, I have changed it to  a class property.  This allows test classes (in the [SetUp] and [TearDown] methods) to change the default length length that will be used during the execution of a particular set of tests without the need to extend both the Assume and Assert classes.
