### PR TITLE
Improve appdomain unload error message

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -166,7 +166,9 @@ namespace NUnit.Engine.Services
                 }
 
                 if (_unloadException != null)
-                    throw new NUnitEngineException("Exception encountered unloading AppDomain", _unloadException);
+                {
+                    throw new NUnitEngineException($"Exception encountered unloading AppDomain {_domain.FriendlyName}: {_unloadException.Message}", _unloadException);
+                }
             }
 
             private void UnloadOnThread()

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -167,7 +167,8 @@ namespace NUnit.Engine.Services
 
                 if (_unloadException != null)
                 {
-                    throw new NUnitEngineException($"Exception encountered unloading AppDomain {_domain.FriendlyName}: {_unloadException.Message}", _unloadException);
+                    var msg = string.Format("Exception encountered unloading AppDomain '{0}': {1}", _domain.FriendlyName, _unloadException.Message);
+                    throw new NUnitEngineException(msg, _unloadException);
                 }
             }
 


### PR DESCRIPTION
Related to my comment on nunit/nunit#1572. By adding a little bit more info in the runner, it is immediately clear which test assembly is the culprit.

The test output becomes:
`Exception encountered unloading AppDomain test-domain-common.tests.dll: Error while unloading appdomain. (Exception from HRESULT: 0x80131015)`