### PR TITLE
Include method and class name in XML for V2 tests when it is available

### DIFF
--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -101,6 +101,10 @@ namespace NUnit.Engine.Drivers
             thisNode.AddAttribute("id", string.Format("{0}-{1}", tn.RunnerID, tn.TestID));
             thisNode.AddAttribute("name", tn.Name);
             thisNode.AddAttribute("fullname", tn.FullName);
+            if (!string.IsNullOrEmpty(test.MethodName))
+                thisNode.AddAttribute("methodname", test.MethodName);
+            if (!string.IsNullOrEmpty(test.ClassName))
+                thisNode.AddAttribute("classname", test.ClassName);
             thisNode.AddAttribute("runstate", test.RunState.ToString());
 
             if (test.IsSuite)


### PR DESCRIPTION
**Do Not Merge Yet** Being tested with the adapter.

This fixes #1727. As explained there, the fix is needed in order for the NUnit 3 VS adapter to be able to find the source info for NUnit 2 tests. My current implementation doesn't find it at all since these fields are never available.