### PR TITLE
Remove Cake target 'TestAll'

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,7 +55,6 @@ important top-level tasks to use are listed here:
  * Build               Builds everything. This is the default if no target is given.
  * Rebuild             Cleans the output directory and builds everything
  * Test                Runs all tests. Dependent on Build.
- * TestAll             Runs all tests. Dependent on Build.
  * TestAllFrameworks   Runs all framework tests. Dependent on Build.
  * Test45              Tests the 4.5 framework without building first.
  * Test40              Tests the 4.0 framework without building first.
@@ -76,7 +75,4 @@ important top-level tasks to use are listed here:
  2. If the compact framework or Silverlight SDK are not installed on a machine, the relevant 
     building and testing tasks are skipped and a warning is issued.
 
- 3. The Test and TestAll targets currently do the same thing. Both are retained for backwards
-    compatibility and the semantics of at least one of them may change in the future.
-
- 4. For additional targets, refer to the build.cake script itself.
+ 3. For additional targets, refer to the build.cake script itself.

--- a/build.cake
+++ b/build.cake
@@ -955,14 +955,6 @@ Task("BuildFramework")
     .IsDependentOn("BuildSL")
     .IsDependentOn("BuildCF");
 
-Task("TestAll")
-    .IsDependentOn("TestFramework")
-    .IsDependentOn("TestEngine")
-    .IsDependentOn("TestAddins")
-    .IsDependentOn("TestV2Driver")
-    .IsDependentOn("TestConsole");
-
-// NOTE: Test has been changed to now be a synonym of TestAll
 Task("Test")
     .IsDependentOn("TestFramework")
     .IsDependentOn("TestEngine")
@@ -993,12 +985,12 @@ Task("Package")
 
 Task("Appveyor")
     .IsDependentOn("Build")
-    .IsDependentOn("TestAll")
+    .IsDependentOn("Test")
     .IsDependentOn("Package");
 
 Task("Travis")
     .IsDependentOn("Build")
-    .IsDependentOn("TestAll");
+    .IsDependentOn("Test");
 
 Task("Default")
     .IsDependentOn("Build"); // Rebuild?


### PR DESCRIPTION
Removing the Cake target 'TestAll' since it is identical to the target 'Test'. This ambiguity might be confusing for new contributors, thus it is removed.

Fixes #1723