### PR TITLE
Ensure test gets loaded for all runners by moving code to the base class

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -167,6 +167,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         public TestEngineResult Explore(TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return ExploreTests(filter);
         }
 
@@ -209,6 +210,7 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases.</returns>
         public int CountTestCases(TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return CountTests(filter);
         }
 
@@ -221,6 +223,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         public TestEngineResult Run(ITestEventListener listener, TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return RunTests(listener, filter);
         }
 
@@ -233,6 +236,7 @@ namespace NUnit.Engine.Runners
         /// <returns>An <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
         public AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return RunTestsAsync(listener, filter);
         }
         

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -126,8 +126,6 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases.</returns>
         public int CountTestCases(TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return _engineRunner.CountTestCases(filter);
         }
 
@@ -173,8 +171,6 @@ namespace NUnit.Engine.Runners
         /// <returns>An XmlNode representing the tests found.</returns>
         public XmlNode Explore(TestFilter filter)
         {
-            EnsurePackageIsLoaded(); // Needed?
-
             return _engineRunner.Explore(filter)
                 .Aggregate(TEST_RUN_ELEMENT, TestPackage.Name, TestPackage.FullName).Xml;
         }
@@ -208,12 +204,6 @@ namespace NUnit.Engine.Runners
         #endregion
 
         #region Helper Methods
-
-        private void EnsurePackageIsLoaded()
-        {
-            if (!IsPackageLoaded)
-                LoadPackage();
-        }
 
         /// <summary>
         /// Load a TestPackage for possible execution,

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -64,7 +64,6 @@ namespace NUnit.Engine.Runners
         {
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.Explore(filter);
             }
             catch (Exception e)
@@ -144,7 +143,6 @@ namespace NUnit.Engine.Runners
         {
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.CountTestCases(filter);
             }
             catch (Exception e)
@@ -166,8 +164,6 @@ namespace NUnit.Engine.Runners
 
             try
             {
-                EnsurePackageIsLoaded();
-
                 var result = _remoteRunner.Run(listener, filter);
                 log.Info("Done running " + TestPackage.Name);
                 return result;
@@ -193,7 +189,6 @@ namespace NUnit.Engine.Runners
 
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.RunAsync(listener, filter);
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #1732 

I've run a bunch of manual tests using various combinations of settings this time, so I believe this fixes any latent problems. We should talk about whether we want a 3.4.2 release or to simply accelerate 3.5. Alternatively, people would have to be told to run all tests using the default process and domain settings.