### PR TITLE
Attributes with description constructors

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -57,6 +57,26 @@ namespace NUnit.Framework
         private object _expectedResult;
         private readonly NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
 
+        #region Constructors
+
+        /// <summary>
+        /// Construct a test <see cref="Attribute"/>
+        /// </summary>
+        public TestAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Construct a test <see cref="Attribute"/>
+        /// </summary>
+        /// <param name="description">Descriptive text for this test</param>
+        public TestAttribute(string description)
+        {
+            Description = description;
+        }
+
+        #endregion
+
         /// <summary>
         /// Descriptive text for this test
         /// </summary>

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -40,10 +40,19 @@ namespace NUnit.Framework
         #region Constructors
 
         /// <summary>
+        /// Constructs a test fixture <see cref="Attribute"/>
+        /// </summary>
+        /// <param name="description">Descriptive text for this fixture</param>
+        public TestFixtureAttribute(string description) : this()
+        {
+            Description = description;
+        }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public TestFixtureAttribute() : this( new object[0] ) { }
-        
+
         /// <summary>
         /// Construct with a object[] representing a set of arguments. 
         /// In .NET 2.0, the arguments may later be separated into

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -40,15 +40,6 @@ namespace NUnit.Framework
         #region Constructors
 
         /// <summary>
-        /// Constructs a test fixture <see cref="Attribute"/>
-        /// </summary>
-        /// <param name="description">Descriptive text for this fixture</param>
-        public TestFixtureAttribute(string description) : this()
-        {
-            Description = description;
-        }
-
-        /// <summary>
         /// Default constructor
         /// </summary>
         public TestFixtureAttribute() : this( new object[0] ) { }

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -104,7 +104,7 @@ namespace NUnit.Tests
 #endif
         }
 
-        [TestFixture(Description="Fake Test Fixture")]
+        [TestFixture("Fake Test Fixture")]
         [Category("FixtureCategory")]
         public class MockTestFixture
         {
@@ -125,7 +125,7 @@ namespace NUnit.Tests
 
             public const int Inconclusive = 1;
 
-            [Test(Description="Mock Test #1")]
+            [Test("Mock Test #1")]
             [Category("MockCategory")]
             [Property("Severity", "Critical")]
             public void TestWithDescription() { }

--- a/src/NUnitFramework/testdata/DescriptionFixture.cs
+++ b/src/NUnitFramework/testdata/DescriptionFixture.cs
@@ -25,10 +25,10 @@ using NUnit.Framework;
 
 namespace NUnit.TestData
 {
-    [TestFixture(Description = "Fixture Description")]
+    [TestFixture("Fixture Description")]
     public class DescriptionFixture
     {
-        [Test(Description = "Test Description")]
+        [Test("Test Description")]
         public void Method()
         {}
 


### PR DESCRIPTION
It has annoyed me to no end that the `Description` on `TestFixtureAttribute` and `TestAttribute` don't have a corresponding constructor argument, meaning I always have to prefix descriptions for these two attributes with `Description = `. Seeing how the `DescriptionAttribute` and in some ways `CategoryAttribute` have the convenient constructors, I would love it if `TestAttribute` and `TestFixtureAttribute` could have them added as well.

It's not all sunshine and roses, though. Adding a `.ctor(string description)` to `TestFixtureAttribute` makes it collide with the `.ctor(params object[] arguments)` in cases where the latter is used with only one string parameter as such: `[TestFixture("First param argument")]`. I would still argue that having the constructor taking `description` is so useful that we should do something about it, and this PR provides what I hope are the grounds to discuss exactly **what** can be done.

@nunit/core-team Thoughts?