### PR TITLE
Fix typos (".Net" => ".NET")

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Follow NUnit](https://img.shields.io/twitter/follow/nunit.svg?style=social)](https://twitter.com/nunit)
 
-NUnit is a unit-testing framework for all .Net languages. Initially ported from JUnit, the current production release, version 3.0, has been completely rewritten with many new features and support for a wide range of .NET platforms.
+NUnit is a unit-testing framework for all .NET languages. Initially ported from JUnit, the current production release, version 3.0, has been completely rewritten with many new features and support for a wide range of .NET platforms.
 
 ## License ##
 

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://nunit.org</projectUrl>
     <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
+    <summary>NUnit is a unit-testing framework for all .NET languages with a strong TDD focus.</summary>
     <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.
 
 This package includes the NUnit 3.0 framework assembly, which is referenced by your tests. You will need to install version 3.0 of the nunit3-console program or a third-party runner that supports NUnit 3.0 in order to execute tests. Runners intended for use with NUnit 2.x will not run 3.0 tests correctly.

--- a/nuget/framework/nunitCF.nuspec
+++ b/nuget/framework/nunitCF.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://nunit.org</projectUrl>
     <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
+    <summary>NUnit is a unit-testing framework for all .NET languages with a strong TDD focus.</summary>
     <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.&#10;&#13;This package includes the NUnit 3.0 framework assembly for .NET Compact Framework 3.5, which is referenced by your tests. You will need to install the NUnitLiteCF package in order to run the tests. Two separate packages are used because future versions will be supported by additional runners.</description>
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory plugin addin cf compact framework</tags>

--- a/nuget/framework/nunitSL.nuspec
+++ b/nuget/framework/nunitSL.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://nunit.org</projectUrl>
     <iconUrl>http://nunit.org/nuget/nunitv3_32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>NUnit is a unit-testing framework for .Net languages with a strong TDD focus.</summary>
+    <summary>NUnit is a unit-testing framework for .NET languages with a strong TDD focus.</summary>
     <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.&#10;&#13;This package includes the NUnit 3.0 framework assembly for SilverLight 5.0, which is referenced by your tests. You will need to install the NUnitLite.SL50 package in order to run the tests.</description>
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory</tags>


### PR DESCRIPTION
Reference: https://www.microsoft.com/net

Note that there were already other mentions of ".NET" (e.g. in `README.md`) which are now in sync.