### PR TITLE
Support NUnit assertions in partial trust code.

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -241,7 +241,11 @@ namespace NUnit.Framework.Api
         }
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
-        [SecuritySafeCritical]
+        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of 
+        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the 
+        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
+        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
+        [SecuritySafeCritical]  
 #endif
         private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList<Test> fixtures)
         {

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -240,7 +240,9 @@ namespace NUnit.Framework.Api
             return result;
         }
 
+#if !SILVERLIGHT && !NETCF && !PORTABLE
         [SecuritySafeCritical]
+#endif
         private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList<Test> fixtures)
         {
             TestSuite testAssembly = new TestAssembly(assembly, assemblyName);

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Security;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -239,6 +240,7 @@ namespace NUnit.Framework.Api
             return result;
         }
 
+        [SecuritySafeCritical]
         private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList<Test> fixtures)
         {
             TestSuite testAssembly = new TestAssembly(assembly, assemblyName);

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -29,6 +29,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Security;
 using System.Web.UI;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -123,6 +124,7 @@ namespace NUnit.Framework.Api
             _testAssembly = assembly;
         }
 
+        [SecuritySafeCritical]
         private void Initialize(string assemblyPath, IDictionary settings)
         {
             AssemblyNameOrPath = assemblyPath;

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -125,6 +125,10 @@ namespace NUnit.Framework.Api
         }
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
+        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of 
+        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the 
+        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
+        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
         [SecuritySafeCritical]
 #endif   
         private void Initialize(string assemblyPath, IDictionary settings)

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -124,7 +124,9 @@ namespace NUnit.Framework.Api
             _testAssembly = assembly;
         }
 
+#if !SILVERLIGHT && !NETCF && !PORTABLE
         [SecuritySafeCritical]
+#endif   
         private void Initialize(string assemblyPath, IDictionary settings)
         {
             AssemblyNameOrPath = assemblyPath;

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.IO;
 #if !SILVERLIGHT && !NETCF && !PORTABLE
 using System.Diagnostics;
+using System.Security;
 using System.Windows.Forms;
 #endif
 
@@ -384,6 +385,7 @@ namespace NUnit.Framework.Api
 #endif
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
+        [SecuritySafeCritical]
         private static void PauseBeforeRun()
         {
             var process = Process.GetCurrentProcess();

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -385,6 +385,10 @@ namespace NUnit.Framework.Api
 #endif
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
+        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of 
+        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the 
+        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
+        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
         [SecuritySafeCritical]
         private static void PauseBeforeRun()
         {

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Security;
 
 namespace NUnit.Compatibility
 {
@@ -38,6 +39,7 @@ namespace NUnit.Compatibility
         /// <summary>
         /// Obtains a lifetime service object to control the lifetime policy for this instance.
         /// </summary>
+        [SecurityCritical]
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -39,7 +39,7 @@ namespace NUnit.Compatibility
         /// <summary>
         /// Obtains a lifetime service object to control the lifetime policy for this instance.
         /// </summary>
-        [SecurityCritical]
+        [SecurityCritical]  // Override of security critical method must be security critical itself
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -25,12 +25,14 @@
 using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace NUnit.Framework.Internal
 {
     /// <summary>
     /// OSPlatform represents a particular operating system platform
     /// </summary>
+    [SecuritySafeCritical]
     public class OSPlatform
     {
         readonly PlatformID _platform;

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -33,6 +33,9 @@ namespace NUnit.Framework.Internal
     /// OSPlatform represents a particular operating system platform
     /// </summary>
 #if !SILVERLIGHT && !NETCF
+    // This class invokes security critical P/Invoke and 'System.Runtime.InteropServices.Marshall' methods. 
+    // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute' 
+    // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
     [SecuritySafeCritical]
 #endif
     public class OSPlatform

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -32,7 +32,9 @@ namespace NUnit.Framework.Internal
     /// <summary>
     /// OSPlatform represents a particular operating system platform
     /// </summary>
+#if !SILVERLIGHT && !NETCF
     [SecuritySafeCritical]
+#endif
     public class OSPlatform
     {
         readonly PlatformID _platform;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -242,6 +242,9 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestExecutionContext CurrentContext
         {
+            // This getter invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class. 
+            // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute' 
+            // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
             [SecuritySafeCritical]
             get
             {
@@ -254,6 +257,9 @@ namespace NUnit.Framework.Internal
 
                 return context;
             }
+            // This setter invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class. 
+            // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute' 
+            // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
             [SecuritySafeCritical]
             private set
             {
@@ -267,6 +273,10 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Get the current context or return null if none is found.
         /// </summary>
+        /// <remarks></remarks>
+        // This setter invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class. 
+        // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute' 
+        // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
         [SecuritySafeCritical]
         public static TestExecutionContext GetTestExecutionContext()
         {
@@ -554,7 +564,7 @@ namespace NUnit.Framework.Internal
         /// Obtain lifetime service object
         /// </summary>
         /// <returns></returns>
-        [SecurityCritical]
+        [SecurityCritical]  // Override of security critical method must be security critical itself
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -33,6 +33,7 @@ using NUnit.Framework.Internal.Execution;
 
 #if !SILVERLIGHT && !NETCF && !PORTABLE
 using System.Runtime.Remoting.Messaging;
+using System.Security;
 using System.Security.Principal;
 using NUnit.Compatibility;
 #endif
@@ -241,6 +242,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestExecutionContext CurrentContext
         {
+            [SecuritySafeCritical]
             get
             {
                 var context = GetTestExecutionContext();
@@ -252,6 +254,7 @@ namespace NUnit.Framework.Internal
 
                 return context;
             }
+            [SecuritySafeCritical]
             private set
             {
                 if (value == null)
@@ -264,6 +267,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Get the current context or return null if none is found.
         /// </summary>
+        [SecuritySafeCritical]
         public static TestExecutionContext GetTestExecutionContext()
         {
             return CallContext.GetData(CONTEXT_KEY) as TestExecutionContext;
@@ -550,6 +554,7 @@ namespace NUnit.Framework.Internal
         /// Obtain lifetime service object
         /// </summary>
         /// <returns></returns>
+        [SecurityCritical]
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Security;
 
 [assembly: InternalsVisibleTo("nunit.framework.tests, PublicKey=002400000480000094" +
                               "000000060200000024000052534131000400000100010031eea" +
@@ -52,3 +53,5 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(true)]
+
+[assembly: AllowPartiallyTrustedCallers]

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -54,4 +54,6 @@ using System.Security;
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(true)]
 
+#if !SILVERLIGHT && !NETCF && !PORTABLE
 [assembly: AllowPartiallyTrustedCallers]
+#endif

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Assertions
             var permissions = new PermissionSet(PermissionState.None);
             permissions.AddPermission(new SecurityPermission(
                 SecurityPermissionFlag.Execution |                  // Required to execute test code
-                SecurityPermissionFlag.SerializationFormatter));    // Required to support test result formatting by NUnit TestContext
+                SecurityPermissionFlag.SerializationFormatter));    // Required to support cross-appdomain test result formatting by NUnit TestContext
             permissions.AddPermission(new ReflectionPermission(
                 ReflectionPermissionFlag.MemberAccess));            // Required to instantiate classes that contain test code and to get cross-appdomain communication to work.
             return permissions;
@@ -178,7 +178,7 @@ namespace NUnit.Framework.Assertions
         }
         public object Run(MethodInfo method, params object[] parameters)
         {
-            if (method == null) throw new ArgumentNullException(nameof(method));
+            if (method == null) throw new ArgumentNullException("method");
             if (_appDomain == null) throw new ObjectDisposedException(null);
 
             var methodRunnerType = typeof(MethodRunner);

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -1,0 +1,246 @@
+// ***********************************************************************
+// Copyright (c) 2004 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
+using System.Security.Policy;
+
+namespace NUnit.Framework.Assertions
+{
+    [TestFixture]
+    public class LowTrustFixture
+    {
+        private TestSandBox _sandBox;
+
+        [OneTimeSetUp]
+        public void CreateSandBox()
+        {
+            _sandBox = new TestSandBox();
+        }
+
+        [OneTimeTearDown]
+        public void DisposeSandBox()
+        {
+            if (_sandBox != null)
+            {
+                _sandBox.Dispose();
+                _sandBox = null;
+            }
+        }
+
+        [Test]
+        public void AssertEqualityInLowTrustSandBox()
+        {
+            _sandBox.Run(() =>
+            {
+                Assert.That(1, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void AssertThrowsInLowTrustSandBox()
+        {
+            _sandBox.Run(() =>
+            {
+                Assert.Throws<SecurityException>(() => new SecurityPermission(SecurityPermissionFlag.Infrastructure).Demand());
+            });
+        }
+    }
+
+    /// <summary>
+    /// A facade for an <see cref="AppDomain"/> with partial trust privileges.
+    /// </summary>
+    public class TestSandBox : IDisposable
+    {
+        private const string PARTIAL_TRUST_APP_DOMAIN_NAME = "Partial Trust AppDomain";
+
+        private AppDomain _appDomain;
+
+        #region Constructor(s)
+
+        /// <summary>
+        /// Creates a low trust <see cref="TestSandBox"/> instance.
+        /// </summary>
+        /// <param name="fullTrustAssemblies">Strong named assemblies that will have full trust in the sandbox.</param>
+        public TestSandBox(params Assembly[] fullTrustAssemblies)
+            : this(null, fullTrustAssemblies)
+        { }
+
+        /// <summary>
+        /// Creates a partial trust <see cref="TestSandBox"/> instance with a given set of permissions.
+        /// </summary>
+        /// <param name="permissions">Optional <see cref="TestSandBox"/> permission set. By default a minimal trust
+        /// permission set is used.</param>
+        /// <param name="fullTrustAssemblies">Strong named assemblies that will have full trust in the sandbox.</param>
+        public TestSandBox(PermissionSet permissions, params Assembly[] fullTrustAssemblies)
+        {
+            var setup = new AppDomainSetup { ApplicationBase = AppDomain.CurrentDomain.BaseDirectory };
+
+            var strongNames = new HashSet<StrongName>();
+
+            // Grant full trust to NUnit.Framework assembly to enable use of NUnit assertions in sandboxed test code. 
+            strongNames.Add(GetStrongName(typeof(TestAttribute).Assembly));
+            if (fullTrustAssemblies != null)
+            {
+                foreach (var assembly in fullTrustAssemblies)
+                {
+                    strongNames.Add(GetStrongName(assembly));
+                }
+            }
+
+            _appDomain = AppDomain.CreateDomain(
+                PARTIAL_TRUST_APP_DOMAIN_NAME + ": " + DateTime.Now.Ticks, null, setup,
+                permissions ?? GetLowTrustPermissionSet(),
+                strongNames.ToArray());
+        }
+
+        #endregion
+
+        #region Finalizer and Dispose methods
+
+        /// <summary>
+        /// The <see cref="TestSandBox"/> finalizer.
+        /// </summary>
+        ~TestSandBox()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Unloads the <see cref="AppDomain"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Unloads the <see cref="AppDomain"/>.
+        /// </summary>
+        /// <param name="disposing">Indicates whether this method is called from <see cref="Dispose()"/>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_appDomain != null)
+            {
+                AppDomain.Unload(_appDomain);
+                _appDomain = null;
+            }
+        }
+
+        #endregion
+
+        #region PermissionSet factory methods
+        public static PermissionSet GetLowTrustPermissionSet()
+        {
+            var permissions = new PermissionSet(PermissionState.None);
+            permissions.AddPermission(new SecurityPermission(
+                SecurityPermissionFlag.Execution |                  // Required to execute test code
+                SecurityPermissionFlag.SerializationFormatter));    // Required to support test result formatting by NUnit TestContext
+            permissions.AddPermission(new ReflectionPermission(
+                ReflectionPermissionFlag.MemberAccess));            // Required to instantiate classes that contain test code and to get cross-appdomain communication to work.
+            return permissions;
+        }
+
+        #endregion
+
+        #region Run methods
+
+        public T Run<T>(Func<T> func)
+        {
+            return (T)Run(func.Method);
+        }
+
+        public void Run(Action action)
+        {
+            Run(action.Method);
+        }
+        public object Run(MethodInfo method, params object[] parameters)
+        {
+            if (method == null) throw new ArgumentNullException(nameof(method));
+            if (_appDomain == null) throw new ObjectDisposedException(null);
+
+            var methodRunnerType = typeof(MethodRunner);
+            var methodRunnerProxy = (MethodRunner)_appDomain.CreateInstanceAndUnwrap(
+                methodRunnerType.Assembly.FullName, methodRunnerType.FullName);
+
+            try
+            {
+                return methodRunnerProxy.Run(method, parameters);
+            }
+            catch (Exception e)
+            {
+                throw e is TargetInvocationException
+                    ? e.InnerException
+                    : e;
+            }
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static StrongName GetStrongName(Assembly assembly)
+        {
+            AssemblyName assemblyName = assembly.GetName();
+
+            byte[] publicKey = assembly.GetName().GetPublicKey();
+            if (publicKey == null || publicKey.Length == 0)
+            {
+                throw new InvalidOperationException("Assembly is not strongly named");
+            }
+
+            return new StrongName(new StrongNamePublicKeyBlob(publicKey), assemblyName.Name, assemblyName.Version);
+        }
+
+        #endregion
+
+        #region Inner classes
+
+        [Serializable]
+        internal class MethodRunner : MarshalByRefObject
+        {
+            public object Run(MethodInfo method, params object[] parameters)
+            {
+                var instance = method.IsStatic
+                    ? null
+                    : Activator.CreateInstance(method.ReflectedType);
+                try
+                {
+                    return method.Invoke(instance, parameters);
+                }
+                catch (TargetInvocationException e)
+                {
+                    if (e.InnerException == null) throw;
+                    throw e.InnerException;
+                }
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Assertions
             });
         }
 
-        [Test]
+        [Test, Platform(Exclude="Mono,MonoTouch", Reason= "Mono does not implement Code Access Security")]
         public void AssertThrowsInLowTrustSandBox()
         {
             _sandBox.Run(() =>
@@ -76,8 +76,6 @@ namespace NUnit.Framework.Assertions
     /// </summary>
     public class TestSandBox : IDisposable
     {
-        private const string PARTIAL_TRUST_APP_DOMAIN_NAME = "Partial Trust AppDomain";
-
         private AppDomain _appDomain;
 
         #region Constructor(s)
@@ -113,7 +111,7 @@ namespace NUnit.Framework.Assertions
             }
 
             _appDomain = AppDomain.CreateDomain(
-                PARTIAL_TRUST_APP_DOMAIN_NAME + ": " + DateTime.Now.Ticks, null, setup,
+                "TestSandBox" + DateTime.Now.Ticks, null, setup,
                 permissions ?? GetLowTrustPermissionSet(),
                 strongNames.ToArray());
         }

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Assertions\AssertZeroTests.cs" />
     <Compile Include="Assertions\AssumeEqualsTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\LowTrustFixture.cs" />
     <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\RetryAttributeTests.cs" />
     <Compile Include="Attributes\RandomAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Assertions\AssertZeroTests.cs" />
     <Compile Include="Assertions\AssumeEqualsTests.cs" />
     <Compile Include="Assertions\AsyncThrowsTests.cs" />
+    <Compile Include="Assertions\LowTrustFixture.cs" />
     <Compile Include="Attributes\CommandWrapperTests.cs" />
     <Compile Include="Attributes\RetryAttributeTests.cs" />
     <Compile Include="Attributes\RandomAttributeTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
+    <Compile Include="Assertions\LowTrustFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\NullableTypesTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
+    <Compile Include="Assertions\LowTrustFixture.cs" />
     <Compile Include="Assertions\NotEqualFixture.cs" />
     <Compile Include="Assertions\NotSameFixture.cs" />
     <Compile Include="Assertions\NullableTypesTests.cs" />


### PR DESCRIPTION
NUnit 2 supported running test code with NUnit assertions in partial-trust. The same test fail however on NUnit 3. I have added a test fixture to the test projects for the .NET 2, 3.5, 4.0 and 4.5 platforms and security assertions to the NUnit.Framework assemblies to get the tests to run.