### PR TITLE
Made ExactCount standalone and added Items no-op

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -198,9 +198,10 @@ namespace NUnit.Framework.Constraints
         /// the following constraint to all members of a collection,
         /// succeeding only if a specified number of them succeed.
         /// </summary>
-        public ConstraintExpression Exactly(int expectedCount)
+        public ItemsConstraintExpression Exactly(int expectedCount)
         {
-            return this.Append(new ExactCountOperator(expectedCount));
+            builder.Append(new ExactCountOperator(expectedCount));
+            return new ItemsConstraintExpression(builder);
         }
         
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ItemsConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ItemsConstraintExpression.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,50 +24,29 @@
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
-    /// Abstract base class used for prefixes
+    /// An extension of ResolvableConstraintExpression that adds a no-op Items property for readability.
     /// </summary>
-    public abstract class PrefixConstraint : Constraint
+    public sealed class ItemsConstraintExpression : ResolvableConstraintExpression
     {
         /// <summary>
-        /// The base constraint
+        /// Create a new instance of ItemsConstraintExpression
         /// </summary>
-        protected IConstraint BaseConstraint { get; set; }
+        public ItemsConstraintExpression() { }
 
         /// <summary>
-        /// Prefix used in forming the constraint description
+        /// Create a new instance of ResolvableConstraintExpression,
+        /// passing in a pre-populated ConstraintBuilder.
         /// </summary>
-        protected string DescriptionPrefix { get; set; }
+        /// <param name="builder"></param>
+        public ItemsConstraintExpression(ConstraintBuilder builder)
+            : base(builder) { }
 
         /// <summary>
-        /// Construct given a base constraint
+        /// No-op property for readability.
         /// </summary>
-        /// <param name="baseConstraint"></param>
-        protected PrefixConstraint(IResolveConstraint baseConstraint)
-            : base(baseConstraint)
+        public ResolvableConstraintExpression Items
         {
-            Guard.ArgumentNotNull(baseConstraint, "baseConstraint");
-
-            BaseConstraint = baseConstraint.Resolve();
-        }
-
-        /// <summary>
-        /// The Description of what this constraint tests, for
-        /// use in messages and in the ConstraintResult.
-        /// </summary>
-        public override string Description
-        {
-            get { return FormatDescription(DescriptionPrefix, BaseConstraint); }
-        }
-
-        /// <summary>
-        /// Formats a prefix constraint's description.
-        /// </summary>
-        internal static string FormatDescription(string descriptionPrefix, IConstraint baseConstraint)
-        {
-            return string.Format(
-                baseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}",
-                descriptionPrefix,
-                baseConstraint.Description);
+            get { return this; }
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
     /// Represents a constraint that succeeds if the specified 
     /// count of members of a collection match a base constraint.
     /// </summary>
-    public class ExactCountOperator : CollectionOperator
+    public class ExactCountOperator : SelfResolvingOperator
     {
         private int expectedCount;
 
@@ -39,17 +39,24 @@ namespace NUnit.Framework.Constraints
         /// <param name="expectedCount">The expected count</param>
         public ExactCountOperator(int expectedCount)
         {
+            // Collection Operators stack on everything
+            // and allow all other ops to stack on them
+            this.left_precedence = 1;
+            this.right_precedence = 10;
+
             this.expectedCount = expectedCount;
         }
 
+
         /// <summary>
-        /// Returns a constraint that will apply the argument
-        /// to the members of a collection, succeeding if
-        /// none of them succeed.
+        /// Reduce produces a constraint from the operator and 
+        /// any arguments. It takes the arguments from the constraint 
+        /// stack and pushes the resulting constraint on it.
         /// </summary>
-        public override IConstraint ApplyPrefix(IConstraint constraint)
+        /// <param name="stack"></param>
+        public override void Reduce(ConstraintBuilder.ConstraintStack stack)
         {
-            return new ExactCountConstraint(expectedCount, constraint);
+            stack.Push(stack.Empty ? new ExactCountConstraint(expectedCount) : new ExactCountConstraint(expectedCount, stack.Pop()));
         }
     }
 }

--- a/src/NUnitFramework/framework/Has.cs
+++ b/src/NUnitFramework/framework/Has.cs
@@ -95,7 +95,7 @@ namespace NUnit.Framework
         /// the following constraint to all members of a collection,
         /// succeeding only if a specified number of them succeed.
         /// </summary>
-        public static ConstraintExpression Exactly(int expectedCount)
+        public static ItemsConstraintExpression Exactly(int expectedCount)
         {
             return new ConstraintExpression().Exactly(expectedCount);
         }

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Constraints\FileExistsConstraint.cs" />
     <Compile Include="Constraints\FileOrDirectoryExistsConstraint.cs" />
     <Compile Include="Constraints\IConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\Operators\AllOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Constraints\FileExistsConstraint.cs" />
     <Compile Include="Constraints\FileOrDirectoryExistsConstraint.cs" />
     <Compile Include="Constraints\IConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\Operators\AllOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Constraints\InstanceOfTypeConstraint.cs" />
     <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\IResolveConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Constraints\InstanceOfTypeConstraint.cs" />
     <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\IResolveConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Constraints\InstanceOfTypeConstraint.cs" />
     <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\IResolveConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Constraints\IConstraint.cs" />
     <Compile Include="Constraints\InstanceOfTypeConstraint.cs" />
     <Compile Include="Constraints\IResolveConstraint.cs" />
+    <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -82,5 +82,34 @@ namespace NUnit.Framework.Constraints
             var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(2, Is.EqualTo("Fred"))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
+
+        [Test]
+        public void ExactlyFourItemsNoPredicate()
+        {
+            Assert.That(names, new ExactCountConstraint(4));
+            Assert.That(names, Has.Exactly(4));
+        }
+
+        [Test]
+        public void ExactlyFourItemsNoopNoPredicate()
+        {
+            Assert.That(names, Has.Exactly(4).Items);
+        }
+
+        [Test]
+        public void ExactlyOneItemNoPredicateFails()
+        {
+            var expectedMessage =
+                TextMessageWriter.Pfx_Expected + "exactly one item" + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + "< \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(1)));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void ExactlyTwoItemsNoopMatch()
+        {
+            Assert.That(names, Has.Exactly(2).Items.EqualTo("Charlie"));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Syntax/OperatorTests.cs
+++ b/src/NUnitFramework/tests/Syntax/OperatorTests.cs
@@ -122,6 +122,52 @@ namespace NUnit.Framework.Syntax
     }
     #endregion
 
+    #region Exactly
+    public class Exactly_WithoutConstraint : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = "<exactcount>";
+            staticSyntax = Has.Exactly(3).Items;
+            builderSyntax = Builder().Exactly(3).Items;
+        }
+    }
+
+    public class Exactly_WithConstraint : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = "<exactcount <lessthan 0>>";
+            staticSyntax = Has.Exactly(3).Items.LessThan(0);
+            builderSyntax = Builder().Exactly(3).Items.LessThan(0);
+        }
+    }
+
+    public class Exactly_WithConstraint_BeforeBinaryOperators : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = "<exactcount <or <lessthan 0> <and <greaterthan 10> <lessthan 20>>>>";
+            staticSyntax = Has.Exactly(3).Items.LessThan(0).Or.GreaterThan(10).And.LessThan(20);
+            builderSyntax = Builder().Exactly(3).Items.LessThan(0).Or.GreaterThan(10).And.LessThan(20);
+        }
+    }
+
+    public class Exactly_WithConstraint_BeforeAndAfterBinaryOperators : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = "<exactcount <or <lessthan 0> <and <greaterthan 10> <lessthan 20>>>>";
+            staticSyntax = Has.Exactly(3).Items.LessThan(0).And.Exactly(3).Items.GreaterThan(10);
+            builderSyntax = Builder().Exactly(3).Items.LessThan(0).Or.Exactly(3).Items.GreaterThan(10).And.Exactly(3).Items.LessThan(20);
+        }
+    }
+    #endregion
+
     #region And
     public class AndTest : SyntaxTest
     {


### PR DESCRIPTION
Fixes #1668.

I already solved the issue with self resolving before I read your post, so these are all supported:

``` c#
Assert.That(collection, Has.Exactly(3).EqualTo(val)); // Current syntax
Assert.That(collection, Has.Exactly(3).Items.EqualTo(val);
Assert.That(collection, Has.Exactly(3));
Assert.That(collection, Has.Exactly(3).Items);
```

I took into consideration that you aren't trying to preserve compatibility.
