### PR TITLE
Add assertion overloads that delay evaluation of the message until needed

### DIFF
--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -35,31 +35,7 @@ namespace NUnit.Framework
     {
         #region Assert.That
 
-#region Boolean
-
-#if !NET_2_0
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
-        /// </summary> 
-        /// <param name="condition">The evaluated condition</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<ConstraintResult, string> getExceptionMessage)
-        {
-            Assert.That(condition, Is.True, getExceptionMessage);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
-        /// </summary> 
-        /// <param name="condition">The evaluated condition</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<string> getExceptionMessage)
-        {
-            Assert.That(condition, Is.True, getExceptionMessage);
-        }
-#endif
+        #region Boolean
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
@@ -83,34 +59,24 @@ namespace NUnit.Framework
             Assert.That(condition, Is.True, null, null);
         }
 
-#endregion
+#if !NET_2_0
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<string> getExceptionMessage)
+        {
+            Assert.That(condition, Is.True, getExceptionMessage);
+        }
+#endif
 
-#region Lambda returning Boolean
+        #endregion
+
+        #region Lambda returning Boolean
 
 #if !NET_2_0
-        
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
-        /// </summary> 
-        /// <param name="condition">A lambda that returns a Boolean</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<ConstraintResult, string> getExceptionMessage)
-        {
-            Assert.That(condition.Invoke(), Is.True, getExceptionMessage);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
-        /// </summary> 
-        /// <param name="condition">A lambda that returns a Boolean</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
-        {
-            Assert.That(condition.Invoke(), Is.True, getExceptionMessage);
-        }
-
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="AssertionException"/>.
@@ -133,10 +99,20 @@ namespace NUnit.Framework
             Assert.That(condition.Invoke(), Is.True, null, null);
         }
 
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
+        {
+            Assert.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
 #endif
-#endregion
+        #endregion
 
-#region ActualValueDelegate
+        #region ActualValueDelegate
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
@@ -196,29 +172,6 @@ namespace NUnit.Framework
                 throw new AssertionException(getExceptionMessage());
             }
         }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That<TActual>(
-            ActualValueDelegate<TActual> del,
-            IResolveConstraint expr,
-            Func<ConstraintResult, string> getExceptionMessage)
-        {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(del);
-            if (!result.IsSuccess)
-            {
-                throw new AssertionException(getExceptionMessage(result));
-            }
-        }
 #endif
 
         #endregion
@@ -261,25 +214,13 @@ namespace NUnit.Framework
         {
             Assert.That((object)code, constraint, getExceptionMessage);
         }
-
-        /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
-        /// </summary>
-        /// <param name="code">A TestDelegate to be executed</param>
-        /// <param name="constraint">A ThrowsConstraint used in the test</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, Func<ConstraintResult, string> getExceptionMessage)
-        {
-            Assert.That((object)code, constraint, getExceptionMessage);
-        }
 #endif
 
-#endregion
+        #endregion
 
-#endregion
+        #endregion
 
-#region Assert.That<TActual>
+        #region Assert.That<TActual>
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
@@ -339,34 +280,11 @@ namespace NUnit.Framework
                 throw new AssertionException(getExceptionMessage());
             }
         }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That<TActual>(
-            TActual actual,
-            IResolveConstraint expression,
-            Func<ConstraintResult, string> getExceptionMessage)
-        {
-            var constraint = expression.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-            if (!result.IsSuccess)
-            {
-                throw new AssertionException(getExceptionMessage(result));
-            }
-        }
 #endif
 
-#endregion
+        #endregion
 
-#region Assert.ByVal
+        #region Assert.ByVal
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
@@ -400,6 +318,6 @@ namespace NUnit.Framework
             Assert.That(actual, expression, message, args);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -27,11 +27,39 @@ using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
+    /// <summary>
+    /// The Assert class contains a collection of static methods that
+    /// implement the most common assertions used in NUnit.
+    /// </summary>
     public partial class Assert
     {
         #region Assert.That
 
-        #region Boolean
+#region Boolean
+
+#if !NET_2_0
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<ConstraintResult, string> getExceptionMessage)
+        {
+            Assert.That(condition, Is.True, getExceptionMessage);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<string> getExceptionMessage)
+        {
+            Assert.That(condition, Is.True, getExceptionMessage);
+        }
+#endif
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
@@ -40,7 +68,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That(bool condition, string message, params object[] args)
+        public static void That(bool condition, string message, params object[] args)
         {
             Assert.That(condition, Is.True, message, args);
         }
@@ -50,15 +78,39 @@ namespace NUnit.Framework
         /// an <see cref="AssertionException"/>.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        static public void That(bool condition)
+        public static void That(bool condition)
         {
             Assert.That(condition, Is.True, null, null);
         }
 
-        #endregion
+#endregion
 
-        #region Lambda returning Boolean
+#region Lambda returning Boolean
+
 #if !NET_2_0
+        
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<ConstraintResult, string> getExceptionMessage)
+        {
+            Assert.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="AssertionException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
+        {
+            Assert.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
+
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="AssertionException"/>.
@@ -66,7 +118,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That(Func<bool> condition, string message, params object[] args)
+        public static void That(Func<bool> condition, string message, params object[] args)
         {
             Assert.That(condition.Invoke(), Is.True, message, args);
         }
@@ -76,22 +128,24 @@ namespace NUnit.Framework
         /// an <see cref="AssertionException"/>.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        static public void That(Func<bool> condition)
+        public static void That(Func<bool> condition)
         {
             Assert.That(condition.Invoke(), Is.True, null, null);
         }
-#endif
-        #endregion
 
-        #region ActualValueDelegate
+#endif
+#endregion
+
+#region ActualValueDelegate
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an assertion exception on failure.
         /// </summary>
-        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        static public void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        /// <param name="expr">A Constraint expression to be applied</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
         {
             Assert.That(del, expr.Resolve(), null, null);
         }
@@ -100,14 +154,15 @@ namespace NUnit.Framework
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an assertion exception on failure.
         /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
         {
             var constraint = expr.Resolve();
-            
+
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
@@ -117,6 +172,54 @@ namespace NUnit.Framework
                 throw new AssertionException(writer.ToString());
             }
         }
+
+#if !NET_2_0
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an assertion exception on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            ActualValueDelegate<TActual> del,
+            IResolveConstraint expr,
+            Func<string> getExceptionMessage)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+            {
+                throw new AssertionException(getExceptionMessage());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an assertion exception on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            ActualValueDelegate<TActual> del,
+            IResolveConstraint expr,
+            Func<ConstraintResult, string> getExceptionMessage)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+            {
+                throw new AssertionException(getExceptionMessage(result));
+            }
+        }
+#endif
 
         #endregion
 
@@ -128,7 +231,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A ThrowsConstraint used in the test</param>
-        static public void That(TestDelegate code, IResolveConstraint constraint)
+        public static void That(TestDelegate code, IResolveConstraint constraint)
         {
             Assert.That(code, constraint, null, null);
         }
@@ -141,24 +244,51 @@ namespace NUnit.Framework
         /// <param name="constraint">A ThrowsConstraint used in the test</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That(TestDelegate code, IResolveConstraint constraint, string message, params string[] args)
+        public static void That(TestDelegate code, IResolveConstraint constraint, string message, params object[] args)
         {
             Assert.That((object)code, constraint, message, args);
         }
 
-        #endregion
+#if !NET_2_0
+        /// <summary>
+        /// Asserts that the code represented by a delegate throws an exception
+        /// that satisfies the constraint provided.
+        /// </summary>
+        /// <param name="code">A TestDelegate to be executed</param>
+        /// <param name="constraint">A ThrowsConstraint used in the test</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(TestDelegate code, IResolveConstraint constraint, Func<string> getExceptionMessage)
+        {
+            Assert.That((object)code, constraint, getExceptionMessage);
+        }
 
-        #endregion
+        /// <summary>
+        /// Asserts that the code represented by a delegate throws an exception
+        /// that satisfies the constraint provided.
+        /// </summary>
+        /// <param name="code">A TestDelegate to be executed</param>
+        /// <param name="constraint">A ThrowsConstraint used in the test</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(TestDelegate code, IResolveConstraint constraint, Func<ConstraintResult, string> getExceptionMessage)
+        {
+            Assert.That((object)code, constraint, getExceptionMessage);
+        }
+#endif
 
-        #region Assert.That<TActual>
+#endregion
+
+#endregion
+
+#region Assert.That<TActual>
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an assertion exception on failure.
         /// </summary>
-        /// <param name="expression">A Constraint to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
-        static public void That<TActual>(TActual actual, IResolveConstraint expression)
+        /// <param name="expression">A Constraint to be applied</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression)
         {
             Assert.That(actual, expression, null, null);
         }
@@ -167,11 +297,12 @@ namespace NUnit.Framework
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an assertion exception on failure.
         /// </summary>
-        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
         {
             var constraint = expression.Resolve();
 
@@ -185,9 +316,57 @@ namespace NUnit.Framework
             }
         }
 
-        #endregion
+#if !NET_2_0
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an assertion exception on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            TActual actual,
+            IResolveConstraint expression,
+            Func<string> getExceptionMessage)
+        {
+            var constraint = expression.Resolve();
 
-        #region Assert.ByVal
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                throw new AssertionException(getExceptionMessage());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an assertion exception on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            TActual actual,
+            IResolveConstraint expression,
+            Func<ConstraintResult, string> getExceptionMessage)
+        {
+            var constraint = expression.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                throw new AssertionException(getExceptionMessage(result));
+            }
+        }
+#endif
+
+#endregion
+
+#region Assert.ByVal
 
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
@@ -195,9 +374,9 @@ namespace NUnit.Framework
         /// Used as a synonym for That in rare cases where a private setter 
         /// causes a Visual Basic compilation error.
         /// </summary>
-        /// <param name="expression">A Constraint to be applied</param>
         /// <param name="actual">The actual value to test</param>
-        static public void ByVal(object actual, IResolveConstraint expression)
+        /// <param name="expression">A Constraint to be applied</param>
+        public static void ByVal(object actual, IResolveConstraint expression)
         {
             Assert.That(actual, expression, null, null);
         }
@@ -212,16 +391,15 @@ namespace NUnit.Framework
         /// This method is provided for use by VB developers needing to test
         /// the value of properties with private setters.
         /// </remarks>
-        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void ByVal(object actual, IResolveConstraint expression, string message, params object[] args)
+        public static void ByVal(object actual, IResolveConstraint expression, string message, params object[] args)
         {
             Assert.That(actual, expression, message, args);
         }
 
-        #endregion
-
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -103,6 +103,7 @@ namespace NUnit.Framework
             }
         }
 
+#if !NET_2_0
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
@@ -124,54 +125,11 @@ namespace NUnit.Framework
                 throw new InconclusiveException(getExceptionMessage());
             }
         }
+#endif
 
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an InconclusiveException on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That<TActual>(
-            ActualValueDelegate<TActual> del,
-            IResolveConstraint expr,
-            Func<ConstraintResult, string> getExceptionMessage)
-        {
-            var constraint = expr.Resolve();
-
-            var result = constraint.ApplyTo(del);
-            if (!result.IsSuccess)
-            {
-                throw new InconclusiveException(getExceptionMessage(result));
-            }
-        }
-
-        #endregion
+#endregion
 
         #region Boolean
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
-        /// <param name="condition">The evaluated condition</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<ConstraintResult, string> getExceptionMessage)
-        {
-            Assume.That(condition, Is.True, getExceptionMessage);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
-        /// <param name="condition">The evaluated condition</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<string> getExceptionMessage)
-        {
-            Assume.That(condition, Is.True, getExceptionMessage);
-        }
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
@@ -195,34 +153,24 @@ namespace NUnit.Framework
             Assume.That(condition, Is.True, null, null);
         }
 
+#if !NET_2_0
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<string> getExceptionMessage)
+        {
+            Assume.That(condition, Is.True, getExceptionMessage);
+        }
+#endif
+
         #endregion
 
         #region Lambda returning Boolean
 
 #if !NET_2_0
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
-        /// <param name="condition">A lambda that returns a Boolean</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<ConstraintResult, string> getExceptionMessage)
-        {
-            Assume.That(condition.Invoke(), Is.True, getExceptionMessage);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
-        /// <param name="condition">A lambda that returns a Boolean</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
-        {
-            Assume.That(condition.Invoke(), Is.True, getExceptionMessage);
-        }
-
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
@@ -245,6 +193,16 @@ namespace NUnit.Framework
             Assume.That(condition.Invoke(), Is.True, null, null);
         }
 
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
+        {
+            Assume.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
 #endif
 
         #endregion
@@ -262,9 +220,9 @@ namespace NUnit.Framework
             Assume.That((object)code, constraint);
         }
 
-        #endregion
+#endregion
 
-        #endregion
+#endregion
 
         #region Assume.That<TActual>
 
@@ -302,6 +260,7 @@ namespace NUnit.Framework
             }
         }
 
+#if !NET_2_0
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
@@ -323,28 +282,7 @@ namespace NUnit.Framework
                 throw new InconclusiveException(getExceptionMessage());
             }
         }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an InconclusiveException on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint to be applied</param>
-        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That<TActual>(
-            TActual actual,
-            IResolveConstraint expression,
-            Func<ConstraintResult, string> getExceptionMessage)
-        {
-            var constraint = expression.Resolve();
-
-            var result = constraint.ApplyTo(actual);
-            if (!result.IsSuccess)
-            {
-                throw new InconclusiveException(getExceptionMessage(result));
-            }
-        }
+#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -42,8 +42,9 @@ namespace NUnit.Framework
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
+        /// <param name="a">The left object.</param>
+        /// <param name="b">The right object.</param>
+        /// <returns>Not applicable</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
@@ -55,8 +56,8 @@ namespace NUnit.Framework
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
+        /// <param name="a">The left object.</param>
+        /// <param name="b">The right object.</param>
         public static new void ReferenceEquals(object a, object b)
         {
             throw new InvalidOperationException("Assume.ReferenceEquals should not be used for Assertions");
@@ -67,13 +68,15 @@ namespace NUnit.Framework
         #region Assume.That
 
         #region ActualValueDelegate
+
         /// <summary>
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
         /// </summary>
-        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        static public void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        /// <param name="expr">A Constraint expression to be applied</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
         {
             Assume.That(del, expr.Resolve(), null, null);
         }
@@ -82,11 +85,12 @@ namespace NUnit.Framework
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
         /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
         {
             var constraint = expr.Resolve();
 
@@ -98,9 +102,77 @@ namespace NUnit.Framework
                 throw new InconclusiveException(writer.ToString());
             }
         }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            ActualValueDelegate<TActual> del,
+            IResolveConstraint expr,
+            Func<string> getExceptionMessage)
+        {
+            var constraint = expr.Resolve();
+
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+            {
+                throw new InconclusiveException(getExceptionMessage());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            ActualValueDelegate<TActual> del,
+            IResolveConstraint expr,
+            Func<ConstraintResult, string> getExceptionMessage)
+        {
+            var constraint = expr.Resolve();
+
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+            {
+                throw new InconclusiveException(getExceptionMessage(result));
+            }
+        }
+
         #endregion
 
         #region Boolean
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<ConstraintResult, string> getExceptionMessage)
+        {
+            Assume.That(condition, Is.True, getExceptionMessage);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(bool condition, Func<string> getExceptionMessage)
+        {
+            Assume.That(condition, Is.True, getExceptionMessage);
+        }
+
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
@@ -108,7 +180,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That(bool condition, string message, params object[] args)
+        public static void That(bool condition, string message, params object[] args)
         {
             Assume.That(condition, Is.True, message, args);
         }
@@ -118,14 +190,39 @@ namespace NUnit.Framework
         /// method throws an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        static public void That(bool condition)
+        public static void That(bool condition)
         {
             Assume.That(condition, Is.True, null, null);
         }
+
         #endregion
 
         #region Lambda returning Boolean
+
 #if !NET_2_0
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<ConstraintResult, string> getExceptionMessage)
+        {
+            Assume.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary> 
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That(Func<bool> condition, Func<string> getExceptionMessage)
+        {
+            Assume.That(condition.Invoke(), Is.True, getExceptionMessage);
+        }
+
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
@@ -133,7 +230,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That(Func<bool> condition, string message, params object[] args)
+        public static void That(Func<bool> condition, string message, params object[] args)
         {
             Assume.That(condition.Invoke(), Is.True, message, args);
         }
@@ -143,11 +240,13 @@ namespace NUnit.Framework
         /// an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        static public void That(Func<bool> condition)
+        public static void That(Func<bool> condition)
         {
             Assume.That(condition.Invoke(), Is.True, null, null);
         }
+
 #endif
+
         #endregion
 
         #region TestDelegate
@@ -158,7 +257,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A ThrowsConstraint used in the test</param>
-        static public void That(TestDelegate code, IResolveConstraint constraint)
+        public static void That(TestDelegate code, IResolveConstraint constraint)
         {
             Assume.That((object)code, constraint);
         }
@@ -173,9 +272,10 @@ namespace NUnit.Framework
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
         /// </summary>
-        /// <param name="expression">A Constraint to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
-        static public void That<TActual>(TActual actual, IResolveConstraint expression)
+        /// <param name="expression">A Constraint to be applied</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression)
         {
             Assume.That(actual, expression, null, null);
         }
@@ -184,11 +284,12 @@ namespace NUnit.Framework
         /// Apply a constraint to an actual value, succeeding if the constraint
         /// is satisfied and throwing an InconclusiveException on failure.
         /// </summary>
-        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void That<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
         {
             var constraint = expression.Resolve();
 
@@ -198,6 +299,50 @@ namespace NUnit.Framework
                 MessageWriter writer = new TextMessageWriter(message, args);
                 result.WriteMessageTo(writer);
                 throw new InconclusiveException(writer.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            TActual actual,
+            IResolveConstraint expression,
+            Func<string> getExceptionMessage)
+        {
+            var constraint = expression.Resolve();
+
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                throw new InconclusiveException(getExceptionMessage());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint to be applied</param>
+        /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
+        public static void That<TActual>(
+            TActual actual,
+            IResolveConstraint expression,
+            Func<ConstraintResult, string> getExceptionMessage)
+        {
+            var constraint = expression.Resolve();
+
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                throw new InconclusiveException(getExceptionMessage(result));
             }
         }
 

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -68,13 +68,6 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
             Assert.That(2 + 2 == 4, getExceptionMessage);
         }
-
-        [Test]
-        public void AssertionPasses_BooleanWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assert.That(2 + 2 == 4, getExceptionMessage);
-        }
 #endif
 
         [Test]
@@ -104,13 +97,6 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void AssertionPasses_ActualAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assert.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
-        }
-
-        [Test]
         public void AssertionPasses_ActualLambdaAndConstraint()
         {
             Assert.That(() => 2 + 2, Is.EqualTo(4));
@@ -132,13 +118,6 @@ namespace NUnit.Framework.Assertions
         public void AssertionPasses_ActualLambdaAndConstraintWithMessageStringFunc()
         {
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
-            Assert.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
-        }
-
-        [Test]
-        public void AssertionPasses_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
             Assert.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
         }
 #endif
@@ -166,13 +145,6 @@ namespace NUnit.Framework.Assertions
         public void AssertionPasses_DelegateAndConstraintWithMessageStringFunc()
         {
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
-            Assert.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
-        }
-
-        [Test]
-        public void AssertionPasses_DelegateAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
             Assert.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
         }
 #endif
@@ -210,14 +182,6 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("Not Equal to 4"));
         }
-
-        [Test]
-        public void FailureThrowsAssertionException_BooleanWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Result was:"));
-        }
 #endif
 
         [Test]
@@ -250,14 +214,6 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void FailureThrowsAssertionException_ActualAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Result was:"));
-        }
-
-        [Test]
         public void FailureThrowsAssertionException_ActualLambdaAndConstraint()
         {
             Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5)));
@@ -283,14 +239,6 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => "error";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("error"));
-        }
-
-        [Test]
-        public void FailureThrowsAssertionException_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Result was:"));
         }
 #endif
 
@@ -321,14 +269,6 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => "error";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("error"));
-        }
-
-        [Test]
-        public void FailureThrowsAssertionException_DelegateAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Result was:"));
         }
 #endif
 
@@ -368,24 +308,6 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void PassingAssertion_DoesNotCallExceptionConstraintResultFunc()
-        {
-            // Arrange
-            var funcWasCalled = false;
-            Func<ConstraintResult, string> getExceptionMessage = result =>
-                {
-                    funcWasCalled = true;
-                    return "Func was called";
-                };
-
-            // Act
-            Assert.That(0 + 1 == 1, getExceptionMessage);
-
-            // Assert
-            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
-        }
-
-        [Test]
         public void FailingAssertion_CallsExceptionStringFunc()
         {
             // Arrange
@@ -399,25 +321,6 @@ namespace NUnit.Framework.Assertions
             // Act
             var ex = Assert.Throws<AssertionException>(() => Assert.That(1 + 1 == 1, getExceptionMessage));
             
-            // Assert
-            Assert.That(ex.Message, Does.Contain("Func was called"));
-            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
-        }
-
-        [Test]
-        public void FailingAssertion_CallsExceptionConstraintResultFunc()
-        {
-            // Arrange
-            var funcWasCalled = false;
-            Func<ConstraintResult, string> getExceptionMessage = result =>
-            {
-                funcWasCalled = true;
-                return "Func was called";
-            };
-
-            // Act
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(1 + 1 == 1, getExceptionMessage));
-
             // Assert
             Assert.That(ex.Message, Does.Contain("Func was called"));
             Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -38,6 +38,8 @@ using Task = System.Threading.Tasks.TaskEx;
 
 namespace NUnit.Framework.Assertions
 {
+    using System;
+
     [TestFixture]
     public class AssertThatTests
     {
@@ -59,6 +61,22 @@ namespace NUnit.Framework.Assertions
             Assert.That(2 + 2 == 4, "Not Equal to {0}", 4);
         }
 
+#if !NET_2_0
+        [Test]
+        public void AssertionPasses_BooleanWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assert.That(2 + 2 == 4, getExceptionMessage);
+        }
+
+        [Test]
+        public void AssertionPasses_BooleanWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assert.That(2 + 2 == 4, getExceptionMessage);
+        }
+#endif
+
         [Test]
         public void AssertionPasses_ActualAndConstraint()
         {
@@ -76,8 +94,22 @@ namespace NUnit.Framework.Assertions
         {
             Assert.That(2 + 2, Is.EqualTo(4), "Should be {0}", 4);
         }
-        
+
 #if !NET_2_0
+        [Test]
+        public void AssertionPasses_ActualAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assert.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssertionPasses_ActualAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assert.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
         [Test]
         public void AssertionPasses_ActualLambdaAndConstraint()
         {
@@ -94,6 +126,20 @@ namespace NUnit.Framework.Assertions
         public void AssertionPasses_ActualLambdaAndConstraintWithMessageAndArgs()
         {
             Assert.That(() => 2 + 2, Is.EqualTo(4), "Should be {0}", 4);
+        }
+
+        [Test]
+        public void AssertionPasses_ActualLambdaAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assert.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssertionPasses_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assert.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
         }
 #endif
 
@@ -114,6 +160,22 @@ namespace NUnit.Framework.Assertions
         {
             Assert.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), "Should be {0}", 4);
         }
+
+#if !NET_2_0
+        [Test]
+        public void AssertionPasses_DelegateAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assert.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssertionPasses_DelegateAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assert.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
+        }
+#endif
 
         private int ReturnsFour()
         {
@@ -140,6 +202,24 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
 
+#if !NET_2_0
+        [Test]
+        public void FailureThrowsAssertionException_BooleanWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Not Equal to 4"));
+        }
+
+        [Test]
+        public void FailureThrowsAssertionException_BooleanWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Result was:"));
+        }
+#endif
+
         [Test]
         public void FailureThrowsAssertionException_ActualAndConstraint()
         {
@@ -162,6 +242,22 @@ namespace NUnit.Framework.Assertions
 
 #if !NET_2_0
         [Test]
+        public void FailureThrowsAssertionException_ActualAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "error";
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("error"));
+        }
+
+        [Test]
+        public void FailureThrowsAssertionException_ActualAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Result was:"));
+        }
+
+        [Test]
         public void FailureThrowsAssertionException_ActualLambdaAndConstraint()
         {
             Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5)));
@@ -179,6 +275,22 @@ namespace NUnit.Framework.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), "Should be {0}", 5));
             Assert.That(ex.Message, Does.Contain("Should be 5"));
+        }
+
+        [Test]
+        public void FailureThrowsAssertionException_ActualLambdaAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "error";
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("error"));
+        }
+
+        [Test]
+        public void FailureThrowsAssertionException_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Result was:"));
         }
 #endif
 
@@ -202,6 +314,24 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 4"));
         }
 
+#if !NET_2_0
+        [Test]
+        public void FailureThrowsAssertionException_DelegateAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "error";
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("error"));
+        }
+
+        [Test]
+        public void FailureThrowsAssertionException_DelegateAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => string.Format("Result was: {0}", result.ToString());
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Result was:"));
+        }
+#endif
+
         [Test]
         public void AssertionsAreCountedCorrectly()
         {
@@ -217,6 +347,82 @@ namespace NUnit.Framework.Assertions
 
             Assert.That(result.AssertCount, Is.EqualTo(totalCount), "Fixture count is not correct");
         }
+
+#if !NET_2_0
+        [Test]
+        public void PassingAssertion_DoesNotCallExceptionStringFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<string> getExceptionMessage = () =>
+                {
+                    funcWasCalled = true;
+                    return "Func was called";
+                };
+
+            // Act
+            Assert.That(0 + 1 == 1, getExceptionMessage);
+
+            // Assert
+            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
+        }
+
+        [Test]
+        public void PassingAssertion_DoesNotCallExceptionConstraintResultFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<ConstraintResult, string> getExceptionMessage = result =>
+                {
+                    funcWasCalled = true;
+                    return "Func was called";
+                };
+
+            // Act
+            Assert.That(0 + 1 == 1, getExceptionMessage);
+
+            // Assert
+            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
+        }
+
+        [Test]
+        public void FailingAssertion_CallsExceptionStringFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<string> getExceptionMessage = () =>
+                {
+                    funcWasCalled = true;
+                    return "Func was called";
+                };
+
+            // Act
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(1 + 1 == 1, getExceptionMessage));
+            
+            // Assert
+            Assert.That(ex.Message, Does.Contain("Func was called"));
+            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
+        }
+
+        [Test]
+        public void FailingAssertion_CallsExceptionConstraintResultFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<ConstraintResult, string> getExceptionMessage = result =>
+            {
+                funcWasCalled = true;
+                return "Func was called";
+            };
+
+            // Act
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(1 + 1 == 1, getExceptionMessage));
+
+            // Assert
+            Assert.That(ex.Message, Does.Contain("Func was called"));
+            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
+        }
+#endif
 
         private int ReturnsFive()
         {

--- a/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
@@ -55,6 +55,7 @@ namespace NUnit.Framework.Assertions
             Assume.That(2 + 2 == 4, "Not Equal to {0}", 4);
         }
 
+#if !NET_2_0
         [Test]
         public void AssumptionPasses_BooleanWithMessageStringFunc()
         {
@@ -62,14 +63,6 @@ namespace NUnit.Framework.Assertions
             Assume.That(2 + 2 == 4, getExceptionMessage);
         }
 
-        [Test]
-        public void AssumptionPasses_BooleanWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assume.That(2 + 2 == 4, getExceptionMessage);
-        }
-
-#if !NET_2_0
         [Test]
         public void AssumptionPasses_BooleanLambda()
         {
@@ -94,13 +87,6 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
             Assume.That(() => 2 + 2 == 4, getExceptionMessage);
         }
-
-        [Test]
-        public void AssumptionPasses_BooleanLambdaWithWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assume.That(() => 2 + 2 == 4, getExceptionMessage);
-        }
 #endif
 
         [Test]
@@ -121,6 +107,7 @@ namespace NUnit.Framework.Assertions
             Assume.That(2 + 2, Is.EqualTo(4), "Should be {0}", 4);
         }
 
+#if !NET_2_0
         [Test]
         public void AssumptionPasses_ActualAndConstraintWithMessageStringFunc()
         {
@@ -128,14 +115,6 @@ namespace NUnit.Framework.Assertions
             Assume.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
         }
 
-        [Test]
-        public void AssumptionPasses_ActualAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assume.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
-        }
-
-#if !NET_2_0
         [Test]
         public void AssumptionPasses_ActualLambdaAndConstraint()
         {
@@ -160,13 +139,6 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
             Assume.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
         }
-
-        [Test]
-        public void AssumptionPasses_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assume.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
-        }
 #endif
 
         [Test]
@@ -187,19 +159,14 @@ namespace NUnit.Framework.Assertions
             Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), "Should be {0}", 4);
         }
 
+#if !NET_2_0
         [Test]
         public void AssumptionPasses_DelegateAndConstraintWithMessageStringFunc()
         {
             Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
             Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
         }
-
-        [Test]
-        public void AssumptionPasses_DelegateAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
-            Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
-        }
+#endif
 
         private int ReturnsFour()
         {
@@ -226,6 +193,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
 
+#if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_BooleanWithMessageStringFunc()
         {
@@ -234,15 +202,6 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
 
-        [Test]
-        public void FailureThrowsInconclusiveException_BooleanWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => "got 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("got 5"));
-        }
-
-#if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_BooleanLambda()
         {
@@ -270,14 +229,6 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
-
-        [Test]
-        public void FailureThrowsInconclusiveException_BooleanLambdaWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => "got 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("got 5"));
-        }
 #endif
 
         [Test]
@@ -300,6 +251,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 5"));
         }
 
+#if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_ActualAndConstraintWithMessageStringFunc()
         {
@@ -308,15 +260,6 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 5"));
         }
 
-        [Test]
-        public void FailureThrowsInconclusiveException_ActualAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Should be 5"));
-        }
-
-#if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_ActualLambdaAndConstraint()
         {
@@ -344,14 +287,6 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("Should be 5"));
         }
-
-        [Test]
-        public void FailureThrowsInconclusiveException_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Should be 5"));
-        }
 #endif
 
         [Test]
@@ -375,6 +310,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 4"));
         }
 
+#if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageStringFunc()
         {
@@ -385,43 +321,11 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageConstraintResultFunc()
-        {
-            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 4";
-            var ex = Assert.Throws<InconclusiveException>(
-                () => Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
-            Assert.That(ex.Message, Does.Contain("Should be 4"));
-        }
-
-        private int ReturnsFive()
-        {
-            return 5;
-        }
-
-        [Test]
         public void PassingAssertion_DoesNotCallExceptionStringFunc()
         {
             // Arrange
             var funcWasCalled = false;
             Func<string> getExceptionMessage = () =>
-            {
-                funcWasCalled = true;
-                return "Func was called";
-            };
-
-            // Act
-            Assume.That(0 + 1 == 1, getExceptionMessage);
-
-            // Assert
-            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
-        }
-
-        [Test]
-        public void PassingAssumption_DoesNotCallExceptionConstraintResultFunc()
-        {
-            // Arrange
-            var funcWasCalled = false;
-            Func<ConstraintResult, string> getExceptionMessage = result =>
             {
                 funcWasCalled = true;
                 return "Func was called";
@@ -452,26 +356,12 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Func was called"));
             Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
         }
+#endif
 
-        [Test]
-        public void FailingAssumption_CallsExceptionConstraintResultFunc()
+        private int ReturnsFive()
         {
-            // Arrange
-            var funcWasCalled = false;
-            Func<ConstraintResult, string> getExceptionMessage = result =>
-            {
-                funcWasCalled = true;
-                return "Func was called";
-            };
-
-            // Act
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(1 + 1 == 1, getExceptionMessage));
-
-            // Assert
-            Assert.That(ex.Message, Does.Contain("Func was called"));
-            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
+            return 5;
         }
-
 
 #if NET_4_0 || NET_4_5 || PORTABLE
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
@@ -54,7 +54,21 @@ namespace NUnit.Framework.Assertions
         {
             Assume.That(2 + 2 == 4, "Not Equal to {0}", 4);
         }
-        
+
+        [Test]
+        public void AssumptionPasses_BooleanWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assume.That(2 + 2 == 4, getExceptionMessage);
+        }
+
+        [Test]
+        public void AssumptionPasses_BooleanWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assume.That(2 + 2 == 4, getExceptionMessage);
+        }
+
 #if !NET_2_0
         [Test]
         public void AssumptionPasses_BooleanLambda()
@@ -72,6 +86,20 @@ namespace NUnit.Framework.Assertions
         public void AssumptionPasses_BooleanLambdaWithMessageAndArgs()
         {
             Assume.That(() => 2 + 2 == 4, "Not Equal to {0}", 4);
+        }
+
+        [Test]
+        public void AssumptionPasses_BooleanLambdaWithWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assume.That(() => 2 + 2 == 4, getExceptionMessage);
+        }
+
+        [Test]
+        public void AssumptionPasses_BooleanLambdaWithWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assume.That(() => 2 + 2 == 4, getExceptionMessage);
         }
 #endif
 
@@ -93,6 +121,20 @@ namespace NUnit.Framework.Assertions
             Assume.That(2 + 2, Is.EqualTo(4), "Should be {0}", 4);
         }
 
+        [Test]
+        public void AssumptionPasses_ActualAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assume.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssumptionPasses_ActualAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assume.That(2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
 #if !NET_2_0
         [Test]
         public void AssumptionPasses_ActualLambdaAndConstraint()
@@ -110,6 +152,20 @@ namespace NUnit.Framework.Assertions
         public void AssumptionPasses_ActualLambdaAndConstraintWithMessageAndArgs()
         {
             Assume.That(() => 2 + 2, Is.EqualTo(4), "Should be {0}", 4);
+        }
+
+        [Test]
+        public void AssumptionPasses_ActualLambdaAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assume.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssumptionPasses_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assume.That(() => 2 + 2, Is.EqualTo(4), getExceptionMessage);
         }
 #endif
 
@@ -129,6 +185,20 @@ namespace NUnit.Framework.Assertions
         public void AssumptionPasses_DelegateAndConstraintWithMessageAndArgs()
         {
             Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), "Should be {0}", 4);
+        }
+
+        [Test]
+        public void AssumptionPasses_DelegateAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => string.Format("Not Equal to {0}", 4);
+            Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
+        }
+
+        [Test]
+        public void AssumptionPasses_DelegateAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => result.ToString();
+            Assume.That(new ActualValueDelegate<int>(ReturnsFour), Is.EqualTo(4), getExceptionMessage);
         }
 
         private int ReturnsFour()
@@ -155,7 +225,23 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, "got {0}", 5));
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
-        
+
+        [Test]
+        public void FailureThrowsInconclusiveException_BooleanWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "got 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("got 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_BooleanWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => "got 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("got 5"));
+        }
+
 #if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_BooleanLambda()
@@ -174,6 +260,22 @@ namespace NUnit.Framework.Assertions
         public void FailureThrowsInconclusiveException_BooleanLambdaWithMessageAndArgs()
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, "got {0}", 5));
+            Assert.That(ex.Message, Does.Contain("got 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_BooleanLambdaWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "got 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("got 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_BooleanLambdaWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => "got 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("got 5"));
         }
 #endif
@@ -198,6 +300,22 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 5"));
         }
 
+        [Test]
+        public void FailureThrowsInconclusiveException_ActualAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "Should be 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Should be 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_ActualAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Should be 5"));
+        }
+
 #if !NET_2_0
         [Test]
         public void FailureThrowsInconclusiveException_ActualLambdaAndConstraint()
@@ -216,6 +334,22 @@ namespace NUnit.Framework.Assertions
         public void FailureThrowsInconclusiveException_ActualLambdaAndConstraintWithMessageAndArgs()
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), "Should be {0}", 5));
+            Assert.That(ex.Message, Does.Contain("Should be 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_ActualLambdaAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "Should be 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Should be 5"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_ActualLambdaAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 5";
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("Should be 5"));
         }
 #endif
@@ -241,10 +375,103 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain("Should be 4"));
         }
 
+        [Test]
+        public void FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageStringFunc()
+        {
+            Func<string> getExceptionMessage = () => "Should be 4";
+            var ex = Assert.Throws<InconclusiveException>(
+                () => Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Should be 4"));
+        }
+
+        [Test]
+        public void FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageConstraintResultFunc()
+        {
+            Func<ConstraintResult, string> getExceptionMessage = result => "Should be 4";
+            var ex = Assert.Throws<InconclusiveException>(
+                () => Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), getExceptionMessage));
+            Assert.That(ex.Message, Does.Contain("Should be 4"));
+        }
+
         private int ReturnsFive()
         {
             return 5;
         }
+
+        [Test]
+        public void PassingAssertion_DoesNotCallExceptionStringFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<string> getExceptionMessage = () =>
+            {
+                funcWasCalled = true;
+                return "Func was called";
+            };
+
+            // Act
+            Assume.That(0 + 1 == 1, getExceptionMessage);
+
+            // Assert
+            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
+        }
+
+        [Test]
+        public void PassingAssumption_DoesNotCallExceptionConstraintResultFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<ConstraintResult, string> getExceptionMessage = result =>
+            {
+                funcWasCalled = true;
+                return "Func was called";
+            };
+
+            // Act
+            Assume.That(0 + 1 == 1, getExceptionMessage);
+
+            // Assert
+            Assert.That(!funcWasCalled, "The getExceptionMessage function was called when it should not have been.");
+        }
+
+        [Test]
+        public void FailingAssumption_CallsExceptionStringFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<string> getExceptionMessage = () =>
+            {
+                funcWasCalled = true;
+                return "Func was called";
+            };
+
+            // Act
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(1 + 1 == 1, getExceptionMessage));
+
+            // Assert
+            Assert.That(ex.Message, Does.Contain("Func was called"));
+            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
+        }
+
+        [Test]
+        public void FailingAssumption_CallsExceptionConstraintResultFunc()
+        {
+            // Arrange
+            var funcWasCalled = false;
+            Func<ConstraintResult, string> getExceptionMessage = result =>
+            {
+                funcWasCalled = true;
+                return "Func was called";
+            };
+
+            // Act
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(1 + 1 == 1, getExceptionMessage));
+
+            // Assert
+            Assert.That(ex.Message, Does.Contain("Func was called"));
+            Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
+        }
+
 
 #if NET_4_0 || NET_4_5 || PORTABLE
         [Test]


### PR DESCRIPTION
This PR builds on PR #1783 contributed by @pflugs30, which got caught in the big split of framework, engine and console. See some discussion on the original PR as well as here.

Fixes #144