### PR TITLE
Improve error message for invalid TestCase construction

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -214,7 +214,7 @@ namespace NUnit.Framework.Internal.Builders
                 return MarkAsNotRunnable(testMethod, "Method has non-void return value, but no result is expected");
 
             if (argsProvided > 0 && maxArgsNeeded == 0)
-                return MarkAsNotRunnable(testMethod, "Arguments provided for method not taking any");
+                return MarkAsNotRunnable(testMethod, "Arguments provided for method with no parameters");
 
             if (argsProvided == 0 && minArgsNeeded > 0)
                 return MarkAsNotRunnable(testMethod, "No arguments were provided");


### PR DESCRIPTION
Fixes #1805 

Looking at how the error is displayed in console, including the method name as I suggested on the issue would be daft, so instead have just reworded the error to be more explicit. 