### PR TITLE
Issue 1792 test case source too many arguments provided

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -139,6 +139,8 @@ namespace NUnit.Framework
         /// <returns></returns>
         private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
         {
+            var testName = method.TypeInfo.FullName + "." + method.Name;
+
             List<ITestCaseData> data = new List<ITestCaseData>();
 
             try
@@ -162,65 +164,55 @@ namespace NUnit.Framework
 
                         if (parms == null)
                         {
-                            // 3. An array was passed, it may be an object[]
-                            //    or possibly some other kind of array, which
-                            //    TestCaseSource can accept.
-                            var args = item as object[];
-                            if (args == null && item is Array)
-                            {
-                                Array array = item as Array;
-#if NETCF
-                                bool netcfOpenType = method.IsGenericMethodDefinition;
-#else
-                                bool netcfOpenType = false;
-#endif
-                                int numParameters = netcfOpenType ? array.Length : method.GetParameters().Length;
-                                if (array != null && array.Rank == 1 && array.Length == numParameters)
-                                {
-                                    // Array is something like int[] - convert it to
-                                    // an object[] for use as the argument array.
-                                    args = new object[array.Length];
-                                    for (int i = 0; i < array.Length; i++)
-                                        args[i] = array.GetValue(i);
-                                }
-                            }
+                            var args = new object[0];
 
-                            // Check again if we have an object[]
-                            if (args != null)
+                            var argsArray = item as Array;
+                            if (argsArray != null)
                             {
-#if NETCF
-                                if (method.IsGenericMethodDefinition)
-                                {
-                                    var mi = method.MakeGenericMethodEx(args);
-                                    if (mi == null)
-                                        throw new NotSupportedException("Cannot determine generic Type");
-                                    method = mi;
-                                }
-#endif
-
                                 var parameters = method.GetParameters();
-                                var argsNeeded = parameters.Length;
-                                var argsProvided = args.Length;
-               
-                                // If only one argument is needed, our array may actually
-                                // be the bare argument. If it is, we should wrap it in
-                                // an outer object[] representing the list of arguments.
-                                if (argsNeeded == 1)
+                                var numberOfParameters = 0;
+#if NETCF
+                                if(method.IsGenericMethodDefinition)
                                 {
-                                    var singleParmType = parameters[0].ParameterType;
-                                    
-                                    if (argsProvided == 0 || typeof(object[]).IsAssignableFrom(singleParmType))
+                                    numberOfParameters = argsArray.Length;
+                                    method = method.MakeGenericMethodEx(args);
+                                    if (method == null)
                                     {
-                                        if (argsProvided > 1 || singleParmType.IsAssignableFrom(args.GetType()))
-                                        {
-                                            args = new object[] { item };
-                                        }
+                                        throw new NotSupportedException("Cannot determine generic Type");
+                                    }
+                                }
+#else
+                                numberOfParameters = parameters.Length;
+#endif
+                                var argumentsProvidedForZeroArgumentMethod = numberOfParameters == 0 &&
+                                                                               argsArray.Length > 0;
+
+                                if (argumentsProvidedForZeroArgumentMethod)
+                                {
+                                    // Transpose the array anyway to force an error further downstream
+                                    args = TransposeArray(argsArray);
+                                }
+                                else if (numberOfParameters > 0)
+                                {
+                                    var isCollection = IsCollection(parameters);
+
+                                    if (numberOfParameters == 1 && argsArray.Length == 1 && isCollection)
+                                    {
+                                        args = new object[] { argsArray };
+                                    }
+                                    else if (argsArray.Rank == 1 && argsArray.Length == numberOfParameters)
+                                    {
+                                        args = TransposeArray(argsArray);
+                                    }
+                                    else
+                                    {
+                                        args = new object[] { argsArray };
                                     }
                                 }
                             }
-                            else // It may be a scalar or a multi-dimensioned array. Wrap it in object[]
+                            else
                             {
-                                args = new object[] { item };
+                                args = new object[] {item};
                             }
 
                             parms = new TestCaseParameters(args);
@@ -241,6 +233,16 @@ namespace NUnit.Framework
             }
 
             return data;
+        }
+
+        private static object[] TransposeArray(Array arguments)
+        {
+            var result = new object[arguments.Length];
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                result[i] = arguments.GetValue(i);
+            }
+            return result;
         }
 
         private IEnumerable GetTestCaseSource(IMethodInfo method)
@@ -304,6 +306,27 @@ namespace NUnit.Framework
         private const string NumberOfArgsDoesNotMatch = "You have given the wrong number of arguments to the method in the TestCaseSourceAttribute" +
                                                         ", please check the number of parameters passed in the object is correct in the 3rd parameter for the " +
                                                         "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.";
+
+        private static bool IsCollection(IParameterInfo[] parameters)
+        {
+            return IsColletionOfArrays(parameters) || 
+                   (IsCollectionOfEnumerables(parameters) && !IsCollectionOfStrings(parameters));
+        }
+
+        private static bool IsColletionOfArrays(IParameterInfo[] parameters)
+        {
+            return parameters[0].ParameterType.IsArray;
+        }
+
+        private static bool IsCollectionOfEnumerables(IParameterInfo[] parameters)
+        {
+            return typeof(IEnumerable).IsAssignableFrom(parameters[0].ParameterType);
+        }
+
+        private static bool IsCollectionOfStrings(IParameterInfo[] parameters)
+        {
+            return parameters[0].ParameterType == typeof(string);
+        }
 
 #endregion
     }

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -139,8 +139,6 @@ namespace NUnit.Framework
         /// <returns></returns>
         private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
         {
-            var testName = method.TypeInfo.FullName + "." + method.Name;
-
             List<ITestCaseData> data = new List<ITestCaseData>();
 
             try

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -397,25 +397,25 @@ namespace NUnit.Framework.Attributes
     {
         public static int[][] TestCaseData = { new[] { 1 } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(int int1)
         {
             Assert.That(new[] { int1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(int[] ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -427,25 +427,25 @@ namespace NUnit.Framework.Attributes
     {
         public static int[][] TestCaseData = { new[] { 1, 2, 3 } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(int int1, int int2, int int3)
         {
             Assert.That(new[] { int1, int2, int3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(int[] ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -457,25 +457,25 @@ namespace NUnit.Framework.Attributes
     {
         public static string[][] TestCaseData = { new[] { "1" } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(string string1)
         {
             Assert.That(new[] { string1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(string[] strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -487,25 +487,25 @@ namespace NUnit.Framework.Attributes
     {
         public static string[][] TestCaseData = { new[] { "1", "2", "3" } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(string string1, string string2, string string3)
         {
             Assert.That(new[] { string1, string2, string3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(string[] strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -388,6 +389,126 @@ namespace NUnit.Framework.Attributes
         protected static IEnumerable<bool> InheritedStaticProperty
         {
             get { yield return true; }
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayBoxingWithASingleValue
+    {
+        public static int[][] TestCaseData = { new[] { 1 } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(int int1)
+        {
+            Assert.That(new[] { int1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(int[] ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayBoxingWithMultipleValues
+    {
+        public static int[][] TestCaseData = { new[] { 1, 2, 3 } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(int int1, int int2, int int3)
+        {
+            Assert.That(new[] { int1, int2, int3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(int[] ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayCastingWithASingleValue
+    {
+        public static string[][] TestCaseData = { new[] { "1" } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(string string1)
+        {
+            Assert.That(new[] { string1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(string[] strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayCastingWithMultipleValues
+    {
+        public static string[][] TestCaseData = { new[] { "1", "2", "3" } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(string string1, string string2, string string3)
+        {
+            Assert.That(new[] { string1, string2, string3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(string[] strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -41,17 +41,17 @@ namespace NUnit.Framework.Constraints
         static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
 
         [Test]
-        [TestCaseSource( "IgnoreCaseData" )]
-        public void HonorsIgnoreCase( IEnumerable actual )
+        [TestCaseSource("IgnoreCaseData")]
+        public void HonorsIgnoreCase(IEnumerable actual)
         {
-            Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should be unique ignoring case", actual );
+            Assert.That(new UniqueItemsConstraint().IgnoreCase.ApplyTo(actual).IsSuccess, Is.False, "{0} should be unique ignoring case", actual);
         }
 
         private static readonly object[] IgnoreCaseData =
         {
-            new object[] {new SimpleObjectCollection("x", "y", "z", "Z")},
-            new object[] {new[] {'A', 'B', 'C', 'c'}},
-            new object[] {new[] {"a", "b", "c", "C"}}
+            new SimpleObjectCollection("x", "y", "z", "Z"),
+            new[] {'A', 'B', 'C', 'c'},
+            new[] {"a", "b", "c", "C"}
         };
     }
 }


### PR DESCRIPTION
Refactored logic to determine TestCase parameters from TestCaseeSourceAttributes. Logic now should support transposing arrays (vertical) into method parameters (horizontal) but still respect IEnumerable / Array parameters. The refactored logic treats strings as a special case as while these are technically IEnumerable existing functionality treats them as if they were not (which makes sense).

Also added a number of additional IEnumerable tests these each cover the current issue along with known regression risks.