### PR TITLE
Issue 1792 test case source too many arguments provided

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -150,8 +150,6 @@ namespace NUnit.Framework
         /// <returns></returns>
         private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
         {
-            var testName = method.TypeInfo.FullName + "." + method.Name;
-
             List<ITestCaseData> data = new List<ITestCaseData>();
 
             try

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -178,21 +178,19 @@ namespace NUnit.Framework
                             var argsArray = item as Array;
                             if (argsArray != null)
                             {
-                                var parameters = method.GetParameters();
-                                var numberOfParameters = 0;
 #if NETCF
                                 if(method.IsGenericMethodDefinition)
                                 {
-                                    numberOfParameters = argsArray.Length;
-                                    method = method.MakeGenericMethodEx(args);
+                                    method = method.MakeGenericMethodEx((object[]) argsArray);
                                     if (method == null)
                                     {
                                         throw new NotSupportedException("Cannot determine generic Type");
                                     }
-                                }
-#else
-                                numberOfParameters = parameters.Length;
+                                }               
 #endif
+                                var parameters = method.GetParameters();
+                                var numberOfParameters = parameters.Length;
+
                                 var argumentsProvidedForZeroArgumentMethod = numberOfParameters == 0 &&
                                                                                argsArray.Length > 0;
 
@@ -221,7 +219,7 @@ namespace NUnit.Framework
                             }
                             else
                             {
-                                args = new object[] {item};
+                                args = new object[] { item };
                             }
 
                             parms = new TestCaseParameters(args);

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -399,6 +400,126 @@ namespace NUnit.Framework.Attributes
         protected static IEnumerable<bool> InheritedStaticProperty
         {
             get { yield return true; }
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayBoxingWithASingleValue
+    {
+        public static int[][] TestCaseData = { new[] { 1 } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(int int1)
+        {
+            Assert.That(new[] { int1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(int[] ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayBoxingWithMultipleValues
+    {
+        public static int[][] TestCaseData = { new[] { 1, 2, 3 } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(int int1, int int2, int int3)
+        {
+            Assert.That(new[] { int1, int2, int3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(int[] ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
+        {
+            Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayCastingWithASingleValue
+    {
+        public static string[][] TestCaseData = { new[] { "1" } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(string string1)
+        {
+            Assert.That(new[] { string1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(string[] strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+    }
+
+    [TestFixture]
+    public class TestCaseSourceArrayCastingWithMultipleValues
+    {
+        public static string[][] TestCaseData = { new[] { "1", "2", "3" } };
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBeTransposedToSeparateParameters(string string1, string string2, string string3)
+        {
+            Assert.That(new[] { string1, string2, string3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToArrayParameter(string[] strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
+        }
+
+        [TestCaseSource(nameof(TestCaseData))]
+        public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
+        {
+            Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -408,25 +408,25 @@ namespace NUnit.Framework.Attributes
     {
         public static int[][] TestCaseData = { new[] { 1 } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(int int1)
         {
             Assert.That(new[] { int1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(int[] ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -438,25 +438,25 @@ namespace NUnit.Framework.Attributes
     {
         public static int[][] TestCaseData = { new[] { 1, 2, 3 } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(int int1, int int2, int int3)
         {
             Assert.That(new[] { int1, int2, int3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(int[] ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<int> ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable ints)
         {
             Assert.That(ints, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -468,25 +468,25 @@ namespace NUnit.Framework.Attributes
     {
         public static string[][] TestCaseData = { new[] { "1" } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(string string1)
         {
             Assert.That(new[] { string1 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(string[] strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
@@ -498,25 +498,25 @@ namespace NUnit.Framework.Attributes
     {
         public static string[][] TestCaseData = { new[] { "1", "2", "3" } };
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBeTransposedToSeparateParameters(string string1, string string2, string string3)
         {
             Assert.That(new[] { string1, string2, string3 }, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToArrayParameter(string[] strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToTypedEnumerableParameter(IEnumerable<string> strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));
         }
 
-        [TestCaseSource(nameof(TestCaseData))]
+        [TestCaseSource("TestCaseData")]
         public void ArrayCanBePassedToUntypedEnumerableParameter(IEnumerable strings)
         {
             Assert.That(strings, Is.EqualTo(TestCaseData.ElementAt(0)));

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -41,17 +41,17 @@ namespace NUnit.Framework.Constraints
         static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
 
         [Test]
-        [TestCaseSource( "IgnoreCaseData" )]
-        public void HonorsIgnoreCase( IEnumerable actual )
+        [TestCaseSource("IgnoreCaseData")]
+        public void HonorsIgnoreCase(IEnumerable actual)
         {
-            Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should be unique ignoring case", actual );
+            Assert.That(new UniqueItemsConstraint().IgnoreCase.ApplyTo(actual).IsSuccess, Is.False, "{0} should be unique ignoring case", actual);
         }
 
         private static readonly object[] IgnoreCaseData =
         {
-            new object[] {new SimpleObjectCollection("x", "y", "z", "Z")},
-            new object[] {new[] {'A', 'B', 'C', 'c'}},
-            new object[] {new[] {"a", "b", "c", "C"}}
+            new SimpleObjectCollection("x", "y", "z", "Z"),
+            new[] {'A', 'B', 'C', 'c'},
+            new[] {"a", "b", "c", "C"}
         };
     }
 }


### PR DESCRIPTION
`TestCaseSourceAttribute` logic for determining test case arguments has been refactored to fix issue #1792.

The logic should now support both transposing arrays (mapping vertical array elements to horizontal method parameters) and passing single argument IEnumerable / Array parameters.

Strings are treated as a special case, as while these are IEnumerables we want to treat them as non-enumerable objects.
