### PR TITLE
Allow delayed assert to be set in minutes

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Constraints
     {
         // TODO: Needs error message tests
 
-        private readonly int delayInMilliseconds;
+        private int delayInMilliseconds;
         private readonly int pollingInterval;
 
         ///<summary>
@@ -72,6 +72,18 @@ namespace NUnit.Framework.Constraints
         public override string Description
         {
             get { return string.Format("{0} after {1} millisecond delay", BaseConstraint.Description, delayInMilliseconds); }
+        }
+
+        /// <summary>
+        /// Converts delayInMilliseconds input from minutes to milliseconds
+        /// </summary>
+        public DelayedConstraint Minutes
+        {
+            get
+            {
+                delayInMilliseconds = (int)TimeSpan.FromMinutes(delayInMilliseconds).TotalMilliseconds;
+                return this;
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -103,6 +103,13 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void SimpleMinutesTest()
+        {
+            SetValuesAfterDelay(60000);
+            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), 1).Minutes);
+        }
+
+        [Test]
         public void SimpleTestUsingBoolean()
         {
             SetValuesAfterDelay(DELAY);


### PR DESCRIPTION
Fixes #1837 

This was a simple change indeed. If you think this makes sense I could continue doing something similar for polling interval. I'll also cleanup the magic numbers in the tests along the way.