### PR TITLE
nunitlite implementation of the @filename option, as described in issue #890

### DIFF
--- a/src/NUnitFramework/TestFile.cs
+++ b/src/NUnitFramework/TestFile.cs
@@ -39,6 +39,11 @@ namespace NUnit.TestUtilities
         private long _fileLength;
 
         public TestFile(string fileName, string resourceName)
+            : this(fileName, resourceName, false)
+        {
+        }
+
+        public TestFile(string fileName, string contentSource, bool isContent)
         {
             if (Path.IsPathRooted(fileName))
                 _fileInfo = new FileInfo(fileName);
@@ -48,16 +53,28 @@ namespace NUnit.TestUtilities
                 _fileInfo = new FileInfo(Path.Combine(tempPath, fileName));
             }
 
+            if (isContent)
+            {
+                using (var fs = _fileInfo.CreateText())
+                {
+                    fs.Write(contentSource);
+                }
+
+                _fileLength = contentSource.Length;
+                return;
+            }
+
             // HACK! Only way I can figure out to avoid having two copies of TestFile
             _resourceName = GetType().Assembly.GetName().Name.Contains("nunitlite")
-                ? "NUnitLite.Tests." + resourceName
-                : "NUnit.Framework.Tests." + resourceName;
+                ? "NUnitLite.Tests." + contentSource
+                : "NUnit.Framework.Tests." + contentSource;
             _fileLength = 0L;
 
             Assembly a = typeof(TestFile).GetTypeInfo().Assembly;
             using (Stream s = a.GetManifestResourceStream(_resourceName))
             {
-                if (s == null) throw new Exception("Manifest Resource Stream " + _resourceName + " was not found.");
+                if (s == null)
+                    throw new Exception("Manifest Resource Stream " + _resourceName + " was not found.");
 
                 var buffer = new byte[1024];
                 using (FileStream fs = _fileInfo.Create())
@@ -65,7 +82,8 @@ namespace NUnit.TestUtilities
                     while (true)
                     {
                         int count = s.Read(buffer, 0, buffer.Length);
-                        if (count == 0) break;
+                        if (count == 0)
+                            break;
                         fs.Write(buffer, 0, count);
                         _fileLength += count;
                     }
@@ -80,10 +98,14 @@ namespace NUnit.TestUtilities
 
         public long OffsetOf(char target)
         {
+            if (_resourceName == null)
+                return -1L;
+
             Assembly a = typeof(TestFile).GetTypeInfo().Assembly;
             using (Stream s = a.GetManifestResourceStream(_resourceName))
             {
-                if (s == null) throw new Exception("Manifest Resource Stream " + _resourceName + " was not found.");
+                if (s == null)
+                    throw new Exception("Manifest Resource Stream " + _resourceName + " was not found.");
 
                 byte[] buffer = new byte[1024];
                 long offset = 0L;
@@ -91,7 +113,8 @@ namespace NUnit.TestUtilities
                 while (true)
                 {
                     int count = s.Read(buffer, 0, buffer.Length);
-                    if (count == 0) break;
+                    if (count == 0)
+                        break;
                     foreach (char c in buffer)
                         if (c == target)
                             return offset;
@@ -126,7 +149,7 @@ namespace NUnit.TestUtilities
             _disposedValue = true;
         }
 
-#region IDisposable Members
+        #region IDisposable Members
 
         public void Dispose()
         {
@@ -135,7 +158,7 @@ namespace NUnit.TestUtilities
             GC.SuppressFinalize(this);
         }
 
-#endregion
+        #endregion
     }
 }
 #endif

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -32,10 +32,56 @@ using NUnit.Framework;
 namespace NUnitLite.Tests
 {
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using NUnit.TestUtilities;
 
     [TestFixture]
     public class CommandLineTests
     {
+        #region @filename Tests
+
+#if !PORTABLE
+        [Test]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt", "--filearg1\r\n--filearg2", "--arg1 --filearg1 --filearg2 --arg2", "")]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt", "--filearg1 --filearg2", "--arg1 --filearg1 --filearg2 --arg2", "")]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt", "--filearg1 --filearg2\r\n--filearg3 --filearg4", "--arg1 --filearg1 --filearg2 --filearg3 --filearg4 --arg2", "")]
+        [TestCase("--arg1 @[,]file1.txt --arg2", "file1.txt", "--filearg1:filearg2\r\nfilearg3\r\nfilearg4", "--arg1 --filearg1:filearg2,filearg3,filearg4 --arg2", "")]
+        [TestCase("--arg1 @file1.txt --arg2", "", "", "--arg1 --arg2", "The file \"file1.txt\" was not found")]
+        [TestCase("--arg1 @ --arg2", "", "", "--arg1 --arg2", "The file name should not be empty")]
+        [TestCase("--arg1 @file1.txt --arg2 @file2.txt", "file1.txt|file2.txt", "--filearg1 --filearg2|--filearg3", "--arg1 --filearg1 --filearg2 --arg2 --filearg3", "")]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt", "", "--arg1 --arg2", "")]
+        [TestCase("--arg1 @file1.txt --arg2 @file2.txt", "file1.txt|file2.txt|file3.txt", "--filearg1 --filearg2|--filearg3 @file3.txt|--filearg4", "--arg1 --filearg1 --filearg2 --arg2 --filearg3 --filearg4", "")]
+        public void AtsignFilenameTests(string commandLine, string testFileNames, string testFileContents, string expectedArgs, string expectedErrors)
+        {
+            var ee = expectedErrors.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            var tfn = testFileNames.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            var tfc = testFileContents.Split(new[] { '|' });
+            var tfs = new TestFile[tfn.Length];
+
+            for (int ix = 0; ix < tfn.Length; ++ix)
+                tfs[ix] = new TestFile(Path.Combine(TestContext.CurrentContext.TestDirectory, tfn[ix]), tfc[ix], true);
+
+            var options = new NUnitLiteOptions();
+
+            string actualExpectedArgs;
+
+            try
+            {
+                actualExpectedArgs = String.Join(" ", options.PreParse(CommandLineOptions.GetArgs(commandLine)).ToArray());
+            }
+            finally
+            {
+                foreach (var tf in tfs)
+                    tf.Dispose();
+            }
+
+            Assert.AreEqual(expectedArgs, actualExpectedArgs);
+            Assert.AreEqual(options.ErrorMessages, ee);
+        }
+#endif
+        #endregion
+
         #region General Tests
 
         [Test]

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests-2.0.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests-2.0.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -82,6 +82,10 @@
     <Compile Include="TokenizerTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.System.Linq.0.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />

--- a/src/NUnitFramework/nunitlite.tests/packages.config
+++ b/src/NUnitFramework/nunitlite.tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.System.Linq" version="0.6.0" targetFramework="net20" />
+</packages>

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -124,17 +124,26 @@ namespace NUnit.Common
                     continue;
                 }
 
-#if NETCF
                 string contents;
-                using (var sr = new StreamReader (filename))
+                try
                     {
-                    contents = sr.ReadToEnd ();
-                    }
+#if NETCF
+                    using (var sr = new StreamReader (filename))
+                        {
+                        contents = sr.ReadToEnd ();
+                        }
 #else
-                var contents = File.ReadAllText(filename);
+                    contents = File.ReadAllText (filename);
 #endif
+                    }
+                catch (IOException ex)
+                    {
+                    ErrorMessages.Add("Error reading \"" + filename + "\": " + ex.Message);
+                    continue;
+                    }
+
                 var newArgs = GetArgs(contents.Replace("\r", "").Replace('\n', delim));
-                listArgs.AddRange(PreParse(newArgs));
+                    listArgs.AddRange(PreParse(newArgs));
             }
 
             --_nesting;

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -24,6 +24,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Options;
 
 namespace NUnit.Common
@@ -53,7 +55,7 @@ namespace NUnit.Common
         private bool noresult;
 #endif
 
-#region Constructor
+        #region Constructor
 
         internal CommandLineOptions(IDefaultOptionsProvider defaultOptionsProvider, params string[] args)
         {
@@ -64,18 +66,93 @@ namespace NUnit.Common
             
             ConfigureOptions();            
             if (args != null)
-                Parse(args);
+                Parse(PreParse(args));
         }
 
         public CommandLineOptions(params string[] args)
         {
             ConfigureOptions();
             if (args != null)
-                Parse(args);
+                Parse(PreParse(args));
         }
-        
+
+#if !PORTABLE
+        private int _nesting = 0;
+#endif
+
+        internal IEnumerable<string> PreParse(IEnumerable<string> args)
+        {
+#if PORTABLE
+            return args;
+#else
+            if (++_nesting > 3)
+            {
+                ErrorMessages.Add("@ nesting exceeds maximum depth of 3");
+                --_nesting;
+                return args;
+            }
+
+            var listArgs = new List<string>();
+            var delim = ' ';
+
+            foreach (var arg in args)
+            {
+                if (arg.Length == 0 || arg[0] != '@')
+                {
+                    listArgs.Add(arg);
+                    continue;
+                }
+
+                if (arg.Length == 1)
+                {
+                    ErrorMessages.Add("The file name should not be empty");
+                    continue;
+                }
+
+                var offset = 1;
+                if (arg.Length > 4 && arg[1] == '[' && arg[3] == ']')
+                {
+                    delim = arg[2];
+                    offset = 4;
+                }
+
+                var filename = arg.Substring(offset);
+
+                if (!File.Exists(filename))
+                {
+                    ErrorMessages.Add("The file \"" + filename + "\" was not found");
+                    continue;
+                }
+
+#if NETCF
+                string contents;
+                using (var sr = new StreamReader (filename))
+                    {
+                    contents = sr.ReadToEnd ();
+                    }
+#else
+                var contents = File.ReadAllText(filename);
+#endif
+                var newArgs = GetArgs(contents.Replace("\r", "").Replace('\n', delim));
+                listArgs.AddRange(PreParse(newArgs));
+            }
+
+            --_nesting;
+            return listArgs;
+#endif
+            }
+
+#if !PORTABLE
+        internal static IEnumerable<string> GetArgs(string commandLine)
+        {
+            const string re = @"\G(""((""""|[^""])+)""|(\S+)) *";
+            var ms = Regex.Matches(commandLine, re);
+            return ms.Cast<Match>().Select(m => Regex.Replace(m.Groups[2].Success ? m.Groups[2].Value : m.Groups[4].Value, @"""""", @""""));
+        }
+#endif
+
 #endregion
-        
+
 #region Properties
 
         // Action to Perform

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -143,7 +143,7 @@ namespace NUnit.Common
                     }
 
                 var newArgs = GetArgs(contents.Replace("\r", "").Replace('\n', delim));
-                    listArgs.AddRange(PreParse(newArgs));
+                listArgs.AddRange(PreParse(newArgs));
             }
 
             --_nesting;

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -149,7 +149,7 @@ namespace NUnit.Common
             --_nesting;
             return listArgs;
 #endif
-            }
+        }
 
 #if !PORTABLE
         internal static IEnumerable<string> GetArgs(string commandLine)

--- a/src/NUnitFramework/nunitlite/nunitlite-2.0.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite-2.0.csproj
@@ -39,6 +39,10 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\NUnit.System.Linq.0.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/src/NUnitFramework/nunitlite/packages.config
+++ b/src/NUnitFramework/nunitlite/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.System.Linq" version="0.6.0" targetFramework="net20" />
+</packages>


### PR DESCRIPTION
This is the nunitlite implementation of the @filename option, as described in issue #890.

It allows nesting (max 3) and an alternative delimiter for multi-line files.

Tests have been added for the various formats.