### PR TITLE
Support for param array argument in TestCaseSourceAttribute

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -160,16 +160,21 @@ namespace NUnit.Framework
                 {
                     foreach (object item in source)
                     {
+
+                        TestCaseParameters parms = null;
+
                         // First handle two easy cases:
                         // 1. Source is null. This is really an error but if we
                         //    throw an exception we simply get an invalid fixture
                         //    without good info as to what caused it. Passing a
                         //    single null argument will cause an error to be 
                         //    reported at the test level, in most cases.
+                        if (item == null)
+                            parms = new TestCaseParameters(new object[] { null });
+
                         // 2. User provided an ITestCaseData and we just use it.
-                        ITestCaseData parms = item == null
-                            ? new TestCaseParameters(new object[] { null })
-                            : item as ITestCaseData;
+                        if (item is ITestCaseData)
+                            parms = new TestCaseParameters(item as ITestCaseData);
 
                         if (parms == null)
                         {
@@ -240,6 +245,8 @@ namespace NUnit.Framework
                         if (this.Category != null)
                             foreach (string cat in this.Category.Split(new char[] { ',' }))
                                 parms.Properties.Add(PropertyNames.Category, cat);
+
+                     //   TestCaseAttribute.SpecialArgumentsHandling(parms, method.GetParameters());
 
                         data.Add(parms);
                     }

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -246,7 +246,7 @@ namespace NUnit.Framework
                             foreach (string cat in this.Category.Split(new char[] { ',' }))
                                 parms.Properties.Add(PropertyNames.Category, cat);
 
-                     //   TestCaseAttribute.SpecialArgumentsHandling(parms, method.GetParameters());
+                        TestCaseAttribute.SpecialArgumentsHandling(parms, method.GetParameters());
 
                         data.Add(parms);
                     }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -414,18 +414,18 @@ namespace NUnit.Framework.Attributes
 
         public static IEnumerable<TestCaseData> GetUrlCases()
         {
-            var yUrl = new Uri("https://www.yahoo.com/news");
-            var mUrl = new Uri("https://www.microsoft.com/linux");
-            var goUrl = new Uri("https://www.google.com/chromium");
-            var readUrl = new Uri("https://www.google.com/reader");
-            var emailUrl = new Uri("https://www.google.com/mail");
-            var docUrl = new Uri("https://www.google.com/doc");
+            var aUrl = new Uri("https://www.aaaa.com/news");
+            var bUrl = new Uri("https://www.bbbb.com/linux");
+            var goUrl = new Uri("https://www.cccc.com/chromium");
+            var readUrl = new Uri("https://www.cccc.com/reader");
+            var emailUrl = new Uri("https://www.cccc.com/mail");
+            var docUrl = new Uri("https://www.cccc.com/doc");
 
             yield return new TestCaseData(false);
-            yield return new TestCaseData(false, yUrl);
-            yield return new TestCaseData(false, yUrl, mUrl, goUrl);
+            yield return new TestCaseData(false, aUrl);
+            yield return new TestCaseData(false, aUrl, bUrl, goUrl);
             yield return new TestCaseData(true, goUrl, readUrl, emailUrl, docUrl);
-            yield return new TestCaseData(false, mUrl, goUrl, yUrl, emailUrl, docUrl);
+            yield return new TestCaseData(false, bUrl, goUrl, aUrl, emailUrl, docUrl);
         }
 
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.TestData.TestCaseSourceAttributeFixture;
 using NUnit.TestUtilities;
+using System;
 
 namespace NUnit.Framework.Attributes
 {
@@ -391,6 +392,43 @@ namespace NUnit.Framework.Attributes
                 throw new System.Exception("my message");
             }
         }
+        #endregion
+
+        #region Test Source for method with variable number of arguments
+
+        [TestCaseSource("GetUrlCases")]
+        public void HandlesParamsArrayAsLastArgument(bool mustBeTheSameDomain, /*Uri optionalUrl = null,*/ params Uri[] urls)
+        {
+            Assert.IsNotNull(urls);
+            if (urls.Length > 0)
+            {
+                var domain = urls[0].Host;
+
+                for (int i = 1; i < urls.Length; ++i)
+                    if (mustBeTheSameDomain)
+                        Assert.AreEqual(domain, urls[i].Host);
+                    else
+                        Assert.AreNotEqual(domain, urls[i].Host);
+            }
+        }
+
+        public static IEnumerable<TestCaseData> GetUrlCases()
+        {
+            var yUrl = new Uri("https://www.yahoo.com/news");
+            var mUrl = new Uri("https://www.microsoft.com/linux");
+            var goUrl = new Uri("https://www.google.com/chromium");
+            var readUrl = new Uri("https://www.google.com/reader");
+            var emailUrl = new Uri("https://www.google.com/mail");
+            var docUrl = new Uri("https://www.google.com/doc");
+
+            yield return new TestCaseData(false);
+            yield return new TestCaseData(false, yUrl);
+            yield return new TestCaseData(false, yUrl, mUrl, goUrl);
+            yield return new TestCaseData(true, goUrl, readUrl, emailUrl, docUrl);
+            yield return new TestCaseData(false, mUrl, goUrl, yUrl, emailUrl, docUrl);
+        }
+
+
         #endregion
     }
 


### PR DESCRIPTION
Hi, 

I noticed that TestCaseSourceAttribute does not implement support for params array argument as the TestCaseAttribute does. So I extracted the method that does that in the TestCaseAttribute and invoked it in the TestCaseSourceAttribute. 

I also included in the extracted method the code that handles the optional arguments, just to align the 2 attributes.

Br, 
Petru
