### PR TITLE
Removed unused repository paths from repositories.config

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,18 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="../src/NUnitEngine/Addins/nunit.v2.driver.tests/packages.config" />
-  <repository path="../src/NUnitEngine/nunit.engine.tests/packages.config" />
-  <repository path="../src/NUnitEngine/nunit.engine/packages.config" />
   <repository path="../src/NUnitFramework/testdata/packages.config" />
   <repository path="../src/NUnitFramework/tests/packages.config" />
-  <repository path="..\src\NUnitEngine\Addins\nunit.v2.driver.tests\packages.config" />
-  <repository path="..\src\NUnitEngine\mock-v2-assembly\packages.config" />
-  <repository path="..\src\NUnitEngine\nunit.core.engine\packages.config" />
-  <repository path="..\src\NUnitEngine\nunit.engine.tests\packages.config" />
-  <repository path="..\src\NUnitEngine\nunit.engine\packages.config" />
-  <repository path="..\src\NUnitEngine\nunit.v2.driver.tests\packages.config" />
   <repository path="..\src\NUnitFramework\testdata\packages.config" />
   <repository path="..\src\NUnitFramework\tests\packages.config" />
-  <repository path="..\testdata\packages.config" />
-  <repository path="..\tests\packages.config" />
 </repositories>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="../src/NUnitFramework/testdata/packages.config" />
-  <repository path="../src/NUnitFramework/tests/packages.config" />
   <repository path="..\src\NUnitFramework\testdata\packages.config" />
   <repository path="..\src\NUnitFramework\tests\packages.config" />
 </repositories>


### PR DESCRIPTION
Fixes [#1827](https://github.com/nunit/nunit/issues/1827): removed all but NUnitFramework paths.