### PR TITLE
Fix #1866 More readable way to set polling interval in After constraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -294,13 +294,13 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a DelayedConstraint.WithRawDelayInterval with the specified delay time.
         /// </summary>
-        /// <param name="delayInMilliseconds">The delay in milliseconds.</param>
+        /// <param name="delay">The delay, which defaults to milliseconds.</param>
         /// <returns></returns>
-        public DelayedConstraint.WithRawDelayInterval After(int delayInMilliseconds)
+        public DelayedConstraint.WithRawDelayInterval After(int delay)
         {
             return new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(
                 Builder == null ? this : Builder.Resolve(),
-                delayInMilliseconds));
+                delay));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -296,9 +296,9 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="delayInMilliseconds">The delay in milliseconds.</param>
         /// <returns></returns>
-        public DelayedConstraint After(int delayInMilliseconds)
+        public DelayedConstraint.DelayedConstraint1 After(int delayInMilliseconds)
         {
-            return new DelayedConstraint(
+            return new DelayedConstraint.DelayedConstraint1(
                 Builder == null ? this : Builder.Resolve(),
                 delayInMilliseconds);
         }

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -292,15 +292,15 @@ namespace NUnit.Framework.Constraints
 
 #if !PORTABLE
         /// <summary>
-        /// Returns a DelayedConstraint with the specified delay time.
+        /// Returns a DelayedConstraint.WithRawDelayInterval with the specified delay time.
         /// </summary>
         /// <param name="delayInMilliseconds">The delay in milliseconds.</param>
         /// <returns></returns>
-        public DelayedConstraint.DelayedConstraint1 After(int delayInMilliseconds)
+        public DelayedConstraint.WithRawDelayInterval After(int delayInMilliseconds)
         {
-            return new DelayedConstraint.DelayedConstraint1(
+            return new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(
                 Builder == null ? this : Builder.Resolve(),
-                delayInMilliseconds);
+                delayInMilliseconds));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -25,7 +25,6 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -36,128 +35,158 @@ namespace NUnit.Framework.Constraints
     public class DelayedConstraint : PrefixConstraint
     {
         /// <summary>
-        /// 
+        /// Allows only changing the time dimension of the polling interval of a DelayedConstraint
         /// </summary>
-        public class DelayedConstraint3 : DelayedConstraint
+        public class WithRawPollingInterval : DelayedConstraint
         {
-            private DelayedConstraint1 _parent;
+            private readonly DelayedConstraint _parent;
 
             /// <summary>
-            /// 
+            /// Creates a new DelayedConstraint.WithRawPollingInterval
             /// </summary>
-            /// <param name="parent"></param>
-            public DelayedConstraint3(DelayedConstraint1 parent)
-                : base(parent.BaseConstraint, parent._delayInMilliseconds, parent._pollingInterval)
+            /// <param name="parent">Parent DelayedConstraint on which polling dimension is required to be set</param>
+            public WithRawPollingInterval(DelayedConstraint parent)
+                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
             {
-                _parent = parent; ;
+                _parent = parent;
             }
 
             /// <summary>
-            /// 
+            /// Changes polling interval dimension to minutes
             /// </summary>
-            public DelayedConstraint Minute
+            public DelayedConstraint Minutes
             {
                 get
                 {
+                    _parent._pollingInterval = _parent._pollingInterval.InMinutes;
+                    return _parent;
+                }
+            }
+
+            /// <summary>
+            /// Changes polling interval dimension to seconds
+            /// </summary>
+            public DelayedConstraint Seconds
+            {
+                get
+                {
+                    _parent._pollingInterval = _parent._pollingInterval.InSeconds;
+                    return _parent;
+                }
+            }
+
+            /// <summary>
+            /// Changes polling interval dimension to milliseconds
+            /// </summary>
+            public DelayedConstraint MilliSeconds
+            {
+                get
+                {
+                    _parent._pollingInterval = _parent._pollingInterval.InMilliseconds;
                     return _parent;
                 }
             }
         }
 
         /// <summary>
-        /// 
+        /// Allows only setting the polling interval of a DelayedConstraint
         /// </summary>
-        public class DelayedConstraint2 : DelayedConstraint
+        public class WithDimensionedDelayInterval : DelayedConstraint
         {
-            private readonly DelayedConstraint1 _parent;
+            private readonly DelayedConstraint _parent;
 
             /// <summary>
-            /// 
+            /// Creates a new DelayedConstraint.WithDimensionedDelayInterval
             /// </summary>
-            /// <param name="parent"></param>
-            /// <exception cref="NotImplementedException"></exception>
-            public DelayedConstraint2(DelayedConstraint1 parent)
-                : base(parent.BaseConstraint, parent._delayInMilliseconds, parent._pollingInterval)
+            /// <param name="parent">Parent DelayedConstraint on which polling interval is required to be set</param>
+            public WithDimensionedDelayInterval(DelayedConstraint parent)
+                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
             {
-                _parent = parent;
                 _delayInterval = parent._delayInterval;
+                _parent = parent;
             }
 
             /// <summary>
-            /// 
+            /// Set polling interval, in milliseconds
             /// </summary>
-            /// <param name="milliSeconds"></param>
+            /// <param name="milliSeconds">A time interval, in milliseconds</param>
             /// <returns></returns>
-            public DelayedConstraint3 PollEvery(int milliSeconds)
+            public WithRawPollingInterval PollEvery(int milliSeconds)
             {
-                _parent._pollingInterval = milliSeconds;
-                return new DelayedConstraint3(_parent);
+                _parent._pollingInterval = new Interval(milliSeconds).InMilliseconds;
+                return new WithRawPollingInterval(_parent);
             }
         }
 
         /// <summary>
-        /// 
+        /// Allows only changing the time dimension of delay interval and setting a polling interval of a DelayedConstraint 
         /// </summary>
-        public class DelayedConstraint1 : DelayedConstraint
+        public class WithRawDelayInterval : DelayedConstraint
         {
-            ///<summary>
-            /// Creates a new DelayedConstraint
-            ///</summary>
-            ///<param name="baseConstraint">The inner constraint to decorate</param>
-            ///<param name="delayInMilliseconds">The time interval after which the match is performed</param>
-            ///<exception cref="InvalidOperationException">If the value of <paramref name="delayInMilliseconds"/> is less than 0</exception>
-            public DelayedConstraint1(IConstraint baseConstraint, int delayInMilliseconds) : base(baseConstraint, delayInMilliseconds) { }
-
-            ///<summary>
-            /// Creates a new DelayedConstraint
-            ///</summary>
-            ///<param name="baseConstraint">The inner constraint to decorate</param>
-            ///<param name="delayInMilliseconds">The time interval after which the match is performed, in milliseconds</param>
-            ///<param name="pollingInterval">The time interval used for polling, in milliseconds</param>
-            ///<exception cref="InvalidOperationException">If the value of <paramref name="delayInMilliseconds"/> is less than 0</exception>
-            public DelayedConstraint1(IConstraint baseConstraint, int delayInMilliseconds, int pollingInterval) : base(baseConstraint, delayInMilliseconds, pollingInterval) { }
+            private readonly DelayedConstraint _parent;
 
             /// <summary>
-            /// 
+            /// Creates a new DelayedConstraint.WithRawDelayInterval
             /// </summary>
-            public DelayedConstraint2 Minutes
+            /// <param name="parent">Parent DelayedConstraint on which delay interval dimension is required to be set</param>
+            public WithRawDelayInterval(DelayedConstraint parent)
+                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
+            {
+                _delayInterval = parent._delayInterval;
+                _parent = parent;
+            }
+
+            /// <summary>
+            /// Changes delay interval dimension to minutes
+            /// </summary>
+            public WithDimensionedDelayInterval Minutes
             {
                 get
                 {
-                    _delayInterval = _delayInterval.InMinutes;
-                    return new DelayedConstraint2(this);
+                    _parent._delayInterval = _parent._delayInterval.InMinutes;
+                    return new WithDimensionedDelayInterval(_parent);
                 }
             }
 
             /// <summary>
-            /// 
+            /// Changes delay interval dimension to seconds
             /// </summary>
-            public DelayedConstraint2 Seconds
+            public WithDimensionedDelayInterval Seconds
             {
                 get
                 {
                     _delayInterval = _delayInterval.InSeconds;
-                    return new DelayedConstraint2(this);
+                    return new WithDimensionedDelayInterval(this);
                 }
             }
 
             /// <summary>
-            /// 
+            /// Changes delay interval dimension to milliseconds
             /// </summary>
             public DelayedConstraint MilliSeconds
             {
                 get
                 {
                     _delayInterval = _delayInterval.InMilliseconds;
-                    return new DelayedConstraint2(this);
+                    return new WithDimensionedDelayInterval(this);
                 }
+            }
+
+            /// <summary>
+            /// Set polling interval, in milliseconds
+            /// </summary>
+            /// <param name="milliSeconds">A time interval, in milliseconds</param>
+            /// <returns></returns>
+            public WithRawPollingInterval PollEvery(int milliSeconds)
+            {
+                _parent._pollingInterval = new Interval(milliSeconds).InMilliseconds;
+                return new WithRawPollingInterval(_parent);
             }
         }
 
         // TODO: Needs error message tests
         private Interval _delayInterval;
-        private int _delayInMilliseconds;
-        private int _pollingInterval;
+        private Interval _pollingInterval;
 
         ///<summary>
         /// Creates a new DelayedConstraint
@@ -173,16 +202,22 @@ namespace NUnit.Framework.Constraints
         ///</summary>
         ///<param name="baseConstraint">The inner constraint to decorate</param>
         ///<param name="delayInMilliseconds">The time interval after which the match is performed, in milliseconds</param>
-        ///<param name="pollingInterval">The time interval used for polling, in milliseconds</param>
+        ///<param name="pollingIntervalInMilliseconds">The time interval used for polling, in milliseconds</param>
         ///<exception cref="InvalidOperationException">If the value of <paramref name="delayInMilliseconds"/> is less than 0</exception>
-        public DelayedConstraint(IConstraint baseConstraint, int delayInMilliseconds, int pollingInterval)
+        public DelayedConstraint(IConstraint baseConstraint, int delayInMilliseconds, int pollingIntervalInMilliseconds)
             : base(baseConstraint)
         {
             if (delayInMilliseconds < 0)
                 throw new ArgumentException("Cannot check a condition in the past", "delayInMilliseconds");
 
             _delayInterval = new Interval(delayInMilliseconds).InMilliseconds;
-            _delayInMilliseconds = delayInMilliseconds;
+            _pollingInterval = new Interval(pollingIntervalInMilliseconds).InMilliseconds;
+        }
+
+        private DelayedConstraint(IConstraint baseConstraint, Interval delayInterval, Interval pollingInterval)
+            : base(baseConstraint)
+        {
+            _delayInterval = delayInterval;
             _pollingInterval = pollingInterval;
         }
 
@@ -204,14 +239,14 @@ namespace NUnit.Framework.Constraints
             long now = Stopwatch.GetTimestamp();
             long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
 
-            if (_pollingInterval > 0)
+            if (_pollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
 
                     ConstraintResult result = BaseConstraint.ApplyTo(actual);
                     if (result.IsSuccess)
@@ -235,14 +270,14 @@ namespace NUnit.Framework.Constraints
             long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
 
             object actual;
-            if (_pollingInterval > 0)
+            if (_pollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
 
                     actual = InvokeDelegate(del);
 
@@ -265,17 +300,6 @@ namespace NUnit.Framework.Constraints
             return new ConstraintResult(this, actual, BaseConstraint.ApplyTo(actual).IsSuccess);
         }
 
-        private static object InvokeDelegate<T>(ActualValueDelegate<T> del)
-        {
-#if NET_4_0 || NET_4_5
-            if (AsyncInvocationRegion.IsAsyncOperation(del))
-                using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(del))
-                    return region.WaitForPendingOperationsToComplete(del());
-#endif
-
-            return del();
-        }
-
         /// <summary>
         /// Test whether the constraint is satisfied by a given reference.
         /// Overridden to wait for the specified delay period before
@@ -288,14 +312,14 @@ namespace NUnit.Framework.Constraints
             long now = Stopwatch.GetTimestamp();
             long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
 
-            if (_pollingInterval > 0)
+            if (_pollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, TimeSpan.FromMilliseconds(_pollingInterval));
+                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
 
                     try
                     {
@@ -313,6 +337,17 @@ namespace NUnit.Framework.Constraints
                 Thread.Sleep((int)TimestampDiff(delayEnd, now).TotalMilliseconds);
 
             return new ConstraintResult(this, actual, BaseConstraint.ApplyTo(actual).IsSuccess);
+        }
+
+        private static object InvokeDelegate<T>(ActualValueDelegate<T> del)
+        {
+#if NET_4_0 || NET_4_5
+            if (AsyncInvocationRegion.IsAsyncOperation(del))
+                using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(del))
+                    return region.WaitForPendingOperationsToComplete(del());
+#endif
+
+            return del();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -35,9 +35,129 @@ namespace NUnit.Framework.Constraints
     ///</summary>
     public class DelayedConstraint : PrefixConstraint
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        public class DelayedConstraint3 : DelayedConstraint
+        {
+            private DelayedConstraint1 _parent;
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="parent"></param>
+            public DelayedConstraint3(DelayedConstraint1 parent)
+                : base(parent.BaseConstraint, parent._delayInMilliseconds, parent._pollingInterval)
+            {
+                _parent = parent; ;
+            }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public DelayedConstraint Minute
+            {
+                get
+                {
+                    return _parent;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public class DelayedConstraint2 : DelayedConstraint
+        {
+            private readonly DelayedConstraint1 _parent;
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="parent"></param>
+            /// <exception cref="NotImplementedException"></exception>
+            public DelayedConstraint2(DelayedConstraint1 parent)
+                : base(parent.BaseConstraint, parent._delayInMilliseconds, parent._pollingInterval)
+            {
+                _parent = parent;
+                _delayInterval = parent._delayInterval;
+            }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="milliSeconds"></param>
+            /// <returns></returns>
+            public DelayedConstraint3 PollEvery(int milliSeconds)
+            {
+                _parent._pollingInterval = milliSeconds;
+                return new DelayedConstraint3(_parent);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public class DelayedConstraint1 : DelayedConstraint
+        {
+            ///<summary>
+            /// Creates a new DelayedConstraint
+            ///</summary>
+            ///<param name="baseConstraint">The inner constraint to decorate</param>
+            ///<param name="delayInMilliseconds">The time interval after which the match is performed</param>
+            ///<exception cref="InvalidOperationException">If the value of <paramref name="delayInMilliseconds"/> is less than 0</exception>
+            public DelayedConstraint1(IConstraint baseConstraint, int delayInMilliseconds) : base(baseConstraint, delayInMilliseconds) { }
+
+            ///<summary>
+            /// Creates a new DelayedConstraint
+            ///</summary>
+            ///<param name="baseConstraint">The inner constraint to decorate</param>
+            ///<param name="delayInMilliseconds">The time interval after which the match is performed, in milliseconds</param>
+            ///<param name="pollingInterval">The time interval used for polling, in milliseconds</param>
+            ///<exception cref="InvalidOperationException">If the value of <paramref name="delayInMilliseconds"/> is less than 0</exception>
+            public DelayedConstraint1(IConstraint baseConstraint, int delayInMilliseconds, int pollingInterval) : base(baseConstraint, delayInMilliseconds, pollingInterval) { }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public DelayedConstraint2 Minutes
+            {
+                get
+                {
+                    _delayInterval = _delayInterval.InMinutes;
+                    return new DelayedConstraint2(this);
+                }
+            }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public DelayedConstraint2 Seconds
+            {
+                get
+                {
+                    _delayInterval = _delayInterval.InSeconds;
+                    return new DelayedConstraint2(this);
+                }
+            }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public DelayedConstraint MilliSeconds
+            {
+                get
+                {
+                    _delayInterval = _delayInterval.InMilliseconds;
+                    return new DelayedConstraint2(this);
+                }
+            }
+        }
+
         // TODO: Needs error message tests
         private Interval _delayInterval;
-        private readonly int _pollingInterval;
+        private int _delayInMilliseconds;
+        private int _pollingInterval;
 
         ///<summary>
         /// Creates a new DelayedConstraint
@@ -62,6 +182,7 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("Cannot check a condition in the past", "delayInMilliseconds");
 
             _delayInterval = new Interval(delayInMilliseconds).InMilliseconds;
+            _delayInMilliseconds = delayInMilliseconds;
             _pollingInterval = pollingInterval;
         }
 
@@ -71,43 +192,6 @@ namespace NUnit.Framework.Constraints
         public override string Description
         {
             get { return string.Format("{0} after {1} delay", BaseConstraint.Description, _delayInterval); }
-        }
-
-        /// <summary>
-        /// Converts the specified delay interval to minutes
-        /// </summary>
-        public DelayedConstraint Minutes
-        {
-            get
-            {
-                _delayInterval = _delayInterval.InMinutes;
-                return this;
-            }
-        }
-
-        /// <summary>
-        /// Converts the specified delay interval to seconds
-        /// </summary>
-        public DelayedConstraint Seconds
-        {
-            get
-            {
-                _delayInterval = _delayInterval.InSeconds;
-                return this;
-            }
-        }
-
-
-        /// <summary>
-        /// Converts the specified delay interval to milliseconds
-        /// </summary>
-        public DelayedConstraint MilliSeconds
-        {
-            get
-            {
-                _delayInterval = _delayInterval.InMilliseconds;
-                return this;
-            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -35,56 +35,68 @@ namespace NUnit.Framework.Constraints
     public class DelayedConstraint : PrefixConstraint
     {
         /// <summary>
-        /// Allows only changing the time dimension of the polling interval of a DelayedConstraint
+        /// Allows only changing the time dimension of delay interval and setting a polling interval of a DelayedConstraint 
         /// </summary>
-        public class WithRawPollingInterval : DelayedConstraint
+        public class WithRawDelayInterval : DelayedConstraint
         {
             private readonly DelayedConstraint _parent;
 
             /// <summary>
-            /// Creates a new DelayedConstraint.WithRawPollingInterval
+            /// Creates a new DelayedConstraint.WithRawDelayInterval
             /// </summary>
-            /// <param name="parent">Parent DelayedConstraint on which polling dimension is required to be set</param>
-            public WithRawPollingInterval(DelayedConstraint parent)
-                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
+            /// <param name="parent">Parent DelayedConstraint on which delay interval dimension is required to be set</param>
+            public WithRawDelayInterval(DelayedConstraint parent)
+                : base(parent.BaseConstraint, parent.DelayInterval, parent.PollingInterval)
             {
+                DelayInterval = parent.DelayInterval;
                 _parent = parent;
             }
 
             /// <summary>
-            /// Changes polling interval dimension to minutes
+            /// Changes delay interval dimension to minutes
             /// </summary>
-            public DelayedConstraint Minutes
+            public WithDimensionedDelayInterval Minutes
             {
                 get
                 {
-                    _parent._pollingInterval = _parent._pollingInterval.InMinutes;
-                    return _parent;
+                    _parent.DelayInterval = _parent.DelayInterval.InMinutes;
+                    return new WithDimensionedDelayInterval(_parent);
                 }
             }
 
             /// <summary>
-            /// Changes polling interval dimension to seconds
+            /// Changes delay interval dimension to seconds
             /// </summary>
-            public DelayedConstraint Seconds
+            public WithDimensionedDelayInterval Seconds
             {
                 get
                 {
-                    _parent._pollingInterval = _parent._pollingInterval.InSeconds;
-                    return _parent;
+                    DelayInterval = DelayInterval.InSeconds;
+                    return new WithDimensionedDelayInterval(_parent);
                 }
             }
 
             /// <summary>
-            /// Changes polling interval dimension to milliseconds
+            /// Changes delay interval dimension to milliseconds
             /// </summary>
-            public DelayedConstraint MilliSeconds
+            public WithDimensionedDelayInterval MilliSeconds
             {
                 get
                 {
-                    _parent._pollingInterval = _parent._pollingInterval.InMilliseconds;
-                    return _parent;
+                    DelayInterval = DelayInterval.InMilliseconds;
+                    return new WithDimensionedDelayInterval(_parent);
                 }
+            }
+
+            /// <summary>
+            /// Set polling interval, in milliseconds
+            /// </summary>
+            /// <param name="milliSeconds">A time interval, in milliseconds</param>
+            /// <returns></returns>
+            public WithRawPollingInterval PollEvery(int milliSeconds)
+            {
+                _parent.PollingInterval = new Interval(milliSeconds).InMilliseconds;
+                return new WithRawPollingInterval(_parent);
             }
         }
 
@@ -100,9 +112,9 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             /// <param name="parent">Parent DelayedConstraint on which polling interval is required to be set</param>
             public WithDimensionedDelayInterval(DelayedConstraint parent)
-                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
+                : base(parent.BaseConstraint, parent.DelayInterval, parent.PollingInterval)
             {
-                _delayInterval = parent._delayInterval;
+                DelayInterval = parent.DelayInterval;
                 _parent = parent;
             }
 
@@ -113,80 +125,75 @@ namespace NUnit.Framework.Constraints
             /// <returns></returns>
             public WithRawPollingInterval PollEvery(int milliSeconds)
             {
-                _parent._pollingInterval = new Interval(milliSeconds).InMilliseconds;
+                _parent.PollingInterval = new Interval(milliSeconds).InMilliseconds;
                 return new WithRawPollingInterval(_parent);
             }
         }
 
         /// <summary>
-        /// Allows only changing the time dimension of delay interval and setting a polling interval of a DelayedConstraint 
+        /// Allows only changing the time dimension of the polling interval of a DelayedConstraint
         /// </summary>
-        public class WithRawDelayInterval : DelayedConstraint
+        public class WithRawPollingInterval : DelayedConstraint
         {
             private readonly DelayedConstraint _parent;
 
             /// <summary>
-            /// Creates a new DelayedConstraint.WithRawDelayInterval
+            /// Creates a new DelayedConstraint.WithRawPollingInterval
             /// </summary>
-            /// <param name="parent">Parent DelayedConstraint on which delay interval dimension is required to be set</param>
-            public WithRawDelayInterval(DelayedConstraint parent)
-                : base(parent.BaseConstraint, parent._delayInterval, parent._pollingInterval)
+            /// <param name="parent">Parent DelayedConstraint on which polling dimension is required to be set</param>
+            public WithRawPollingInterval(DelayedConstraint parent)
+                : base(parent.BaseConstraint, parent.DelayInterval, parent.PollingInterval)
             {
-                _delayInterval = parent._delayInterval;
                 _parent = parent;
             }
 
             /// <summary>
-            /// Changes delay interval dimension to minutes
+            /// Changes polling interval dimension to minutes
             /// </summary>
-            public WithDimensionedDelayInterval Minutes
+            public DelayedConstraint Minutes
             {
                 get
                 {
-                    _parent._delayInterval = _parent._delayInterval.InMinutes;
-                    return new WithDimensionedDelayInterval(_parent);
+                    _parent.PollingInterval = _parent.PollingInterval.InMinutes;
+                    return _parent;
                 }
             }
 
             /// <summary>
-            /// Changes delay interval dimension to seconds
+            /// Changes polling interval dimension to seconds
             /// </summary>
-            public WithDimensionedDelayInterval Seconds
+            public DelayedConstraint Seconds
             {
                 get
                 {
-                    _delayInterval = _delayInterval.InSeconds;
-                    return new WithDimensionedDelayInterval(this);
+                    _parent.PollingInterval = _parent.PollingInterval.InSeconds;
+                    return _parent;
                 }
             }
 
             /// <summary>
-            /// Changes delay interval dimension to milliseconds
+            /// Changes polling interval dimension to milliseconds
             /// </summary>
-            public WithDimensionedDelayInterval MilliSeconds
+            public DelayedConstraint MilliSeconds
             {
                 get
                 {
-                    _delayInterval = _delayInterval.InMilliseconds;
-                    return new WithDimensionedDelayInterval(this);
+                    _parent.PollingInterval = _parent.PollingInterval.InMilliseconds;
+                    return _parent;
                 }
-            }
-
-            /// <summary>
-            /// Set polling interval, in milliseconds
-            /// </summary>
-            /// <param name="milliSeconds">A time interval, in milliseconds</param>
-            /// <returns></returns>
-            public WithRawPollingInterval PollEvery(int milliSeconds)
-            {
-                _parent._pollingInterval = new Interval(milliSeconds).InMilliseconds;
-                return new WithRawPollingInterval(_parent);
             }
         }
 
         // TODO: Needs error message tests
-        private Interval _delayInterval;
-        private Interval _pollingInterval;
+        /// <summary>
+        /// Delay value store as an Interval object
+        /// </summary>
+        protected Interval DelayInterval { get; set; }
+
+        /// <summary>
+        /// Polling value stored as an Interval object
+        /// </summary>
+        protected Interval PollingInterval { get; set; }
 
         ///<summary>
         /// Creates a new DelayedConstraint
@@ -210,15 +217,15 @@ namespace NUnit.Framework.Constraints
             if (delayInMilliseconds < 0)
                 throw new ArgumentException("Cannot check a condition in the past", "delayInMilliseconds");
 
-            _delayInterval = new Interval(delayInMilliseconds).InMilliseconds;
-            _pollingInterval = new Interval(pollingIntervalInMilliseconds).InMilliseconds;
+            DelayInterval = new Interval(delayInMilliseconds).InMilliseconds;
+            PollingInterval = new Interval(pollingIntervalInMilliseconds).InMilliseconds;
         }
 
         private DelayedConstraint(IConstraint baseConstraint, Interval delayInterval, Interval pollingInterval)
             : base(baseConstraint)
         {
-            _delayInterval = delayInterval;
-            _pollingInterval = pollingInterval;
+            DelayInterval = delayInterval;
+            PollingInterval = pollingInterval;
         }
 
         /// <summary>
@@ -226,7 +233,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get { return string.Format("{0} after {1} delay", BaseConstraint.Description, _delayInterval); }
+            get { return string.Format("{0} after {1} delay", BaseConstraint.Description, DelayInterval); }
         }
 
         /// <summary>
@@ -237,16 +244,16 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             long now = Stopwatch.GetTimestamp();
-            long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
+            long delayEnd = TimestampOffset(now, DelayInterval.AsTimeSpan);
 
-            if (_pollingInterval.IsNotZero)
+            if (PollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                long nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                    nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
 
                     ConstraintResult result = BaseConstraint.ApplyTo(actual);
                     if (result.IsSuccess)
@@ -267,17 +274,17 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
             long now = Stopwatch.GetTimestamp();
-            long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
+            long delayEnd = TimestampOffset(now, DelayInterval.AsTimeSpan);
 
             object actual;
-            if (_pollingInterval.IsNotZero)
+            if (PollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                long nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                    nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
 
                     actual = InvokeDelegate(del);
 
@@ -310,16 +317,16 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(ref TActual actual)
         {
             long now = Stopwatch.GetTimestamp();
-            long delayEnd = TimestampOffset(now, _delayInterval.AsTimeSpan);
+            long delayEnd = TimestampOffset(now, DelayInterval.AsTimeSpan);
 
-            if (_pollingInterval.IsNotZero)
+            if (PollingInterval.IsNotZero)
             {
-                long nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                long nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
                 while ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 {
                     if (nextPoll > now)
                         Thread.Sleep((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
-                    nextPoll = TimestampOffset(now, _pollingInterval.AsTimeSpan);
+                    nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
 
                     try
                     {
@@ -355,7 +362,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return string.Format("<after {0} {1}>", _delayInterval, BaseConstraint);
+            return string.Format("<after {0} {1}>", DelayInterval, BaseConstraint);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -163,7 +163,7 @@ namespace NUnit.Framework.Constraints
             /// <summary>
             /// Changes delay interval dimension to milliseconds
             /// </summary>
-            public DelayedConstraint MilliSeconds
+            public WithDimensionedDelayInterval MilliSeconds
             {
                 get
                 {

--- a/src/NUnitFramework/framework/Constraints/Interval.cs
+++ b/src/NUnitFramework/framework/Constraints/Interval.cs
@@ -6,19 +6,19 @@ namespace NUnit.Framework.Constraints
     /// Keeps track of an interval time which can be represented in
     /// Minutes, Seconds or Milliseconds
     /// </summary>
-    internal class Interval
+    public class Interval
     {
-        private readonly int _amount;
+        private readonly int _value;
         private IntervalUnit _mode;
 
         /// <summary>
-        /// Constructs a interval given an amount in milliseconds
+        /// Constructs a interval given an value in milliseconds
         /// </summary>
-        public Interval(int amount)
+        public Interval(int value)
         {
-            _amount = amount;
+            _value = value;
             _mode = IntervalUnit.Millisecond;
-            AsTimeSpan = TimeSpan.FromMilliseconds(amount);
+            AsTimeSpan = TimeSpan.FromMilliseconds(value);
         }
 
         /// <summary>
@@ -27,47 +27,50 @@ namespace NUnit.Framework.Constraints
         public TimeSpan AsTimeSpan { get; private set; }
 
         /// <summary>
-        /// Returns the interval with the current amount as a number of minutes.
+        /// Returns the interval with the current value as a number of minutes.
         /// </summary>
         public Interval InMinutes
         {
             get
             {
-                AsTimeSpan = TimeSpan.FromMinutes(_amount);
+                AsTimeSpan = TimeSpan.FromMinutes(_value);
                 _mode = IntervalUnit.Minute;
                 return this;
             }
         }
 
         /// <summary>
-        /// Returns the interval with the current amount as a number of seconds.
+        /// Returns the interval with the current value as a number of seconds.
         /// </summary>
         public Interval InSeconds
         {
             get
             {
-                AsTimeSpan = TimeSpan.FromSeconds(_amount);
+                AsTimeSpan = TimeSpan.FromSeconds(_value);
                 _mode = IntervalUnit.Second;
                 return this;
             }
         }
 
         /// <summary>
-        /// Returns the interval with the current amount as a number of milliseconds.
+        /// Returns the interval with the current value as a number of milliseconds.
         /// </summary>
         public Interval InMilliseconds
         {
             get
             {
-                AsTimeSpan = TimeSpan.FromMilliseconds(_amount);
+                AsTimeSpan = TimeSpan.FromMilliseconds(_value);
                 _mode = IntervalUnit.Millisecond;
                 return this;
             }
         }
 
+        /// <summary>
+        /// Is true for intervals created with a non zero value
+        /// </summary>
         public bool IsNotZero
         {
-            get { return _amount != 0; }
+            get { return _value != 0; }
         }
 
         /// <summary>
@@ -78,11 +81,11 @@ namespace NUnit.Framework.Constraints
         /// </returns>
         public override string ToString()
         {
-            return string.Format("{0} {1}{2}", _amount, _mode.ToString().ToLower(), _amount > 1 ? "s" : string.Empty);
+            return string.Format("{0} {1}{2}", _value, _mode.ToString().ToLower(), _value > 1 ? "s" : string.Empty);
         }
 
         /// <summary>
-        /// IntervalUnit provides the semantics to the amount stored in Interval class.
+        /// IntervalUnit provides the semantics to the value stored in Interval class.
         /// </summary>
         internal enum IntervalUnit
         {

--- a/src/NUnitFramework/framework/Constraints/Interval.cs
+++ b/src/NUnitFramework/framework/Constraints/Interval.cs
@@ -65,6 +65,11 @@ namespace NUnit.Framework.Constraints
             }
         }
 
+        public bool IsNotZero
+        {
+            get { return _amount != 0; }
+        }
+
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -318,7 +318,7 @@ namespace NUnit.Framework.Syntax
         public void After()
         {
             var constraint = EqualTo(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <equal 10>>"));
         }
 
@@ -326,7 +326,7 @@ namespace NUnit.Framework.Syntax
         public void After_Property()
         {
             var constraint = Property("X").EqualTo(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <property X <equal 10>>>"));
         }
 
@@ -334,7 +334,7 @@ namespace NUnit.Framework.Syntax
         public void After_And()
         {
             var constraint = GreaterThan(0).And.LessThan(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint>());
+            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <and <greaterthan 0> <lessthan 10>>>"));
         }
 #endif

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -318,7 +318,7 @@ namespace NUnit.Framework.Syntax
         public void After()
         {
             var constraint = EqualTo(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
+            Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <equal 10>>"));
         }
 
@@ -326,7 +326,7 @@ namespace NUnit.Framework.Syntax
         public void After_Property()
         {
             var constraint = Property("X").EqualTo(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
+            Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <property X <equal 10>>>"));
         }
 
@@ -334,7 +334,7 @@ namespace NUnit.Framework.Syntax
         public void After_And()
         {
             var constraint = GreaterThan(0).And.LessThan(10).After(1000);
-            Expect(constraint, TypeOf<DelayedConstraint.DelayedConstraint1>());
+            Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
             Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <and <greaterthan 0> <lessthan 10>>>"));
         }
 #endif

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -106,13 +106,13 @@ namespace NUnit.Framework.Constraints
         public void DifferentDelayTests()
         {
             SetValuesAfterDelay(60000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), 1).Minutes.Minutes);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), 1).Minutes);
 
             SetValuesAfterDelay(5000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), 5).Seconds);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), 5).Seconds);
 
             SetValuesAfterDelay(DELAY);
-            Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), AFTER).Seconds.MilliSeconds);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), AFTER).MilliSeconds);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -106,13 +106,13 @@ namespace NUnit.Framework.Constraints
         public void DifferentDelayTests()
         {
             SetValuesAfterDelay(60000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), 1).Minutes);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), 1)).Minutes);
 
             SetValuesAfterDelay(5000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), 5).Seconds);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), 5)).Seconds);
 
             SetValuesAfterDelay(DELAY);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.DelayedConstraint1(new EqualConstraint(true), AFTER).MilliSeconds);
+            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), AFTER)).MilliSeconds);
         }
 
         [Test]
@@ -185,8 +185,7 @@ namespace NUnit.Framework.Constraints
             }, Is.True.After(AFTER, POLLING));
 
             watch.Stop();
-            // TODO: This failed intermittently, esp. on .NET 4.0. Find another way to test or wait till we have warning errors.
-            //Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
+            Assert.That(watch.ElapsedMilliseconds, Is.InRange(DELAY, AFTER));
         }
 
         [Test]
@@ -251,6 +250,70 @@ namespace NUnit.Framework.Constraints
 
             watch.Stop();
             Assert.That(watch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(AFTER));
+        }
+
+        [Test]
+        public void PollEvery_WithoutSetting_TimeDimensions()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(DELAY);
+                return true;
+            }, Is.True.After(AFTER).PollEvery(POLLING));
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
+        }
+
+        [Test]
+        public void PollEvery_SetTo_MilliSeconds()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(100);
+                return true;
+            }, Is.True.After(200).PollEvery(10));
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(200));
+        }
+
+        [Test]
+        public void PollEvery_SetTo_Seconds()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(2000);
+                return true;
+            }, Is.True.After(5000).PollEvery(1).Seconds);
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(5000));
+        }
+
+        [Test]
+        public void PollEvery_SetTo_Minutes()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(50000);
+                return true;
+            }, Is.True.After(120000).PollEvery(1).Minutes);
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(120000));
         }
 
         private static int setValuesDelay;

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -269,6 +269,22 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void PollEvery_SetTo_MilliSeconds_ByDefault()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(DELAY);
+                return true;
+            }, Is.True.After(AFTER).PollEvery(POLLING));
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
+        }
+
+        [Test]
         public void PollEvery_SetTo_MilliSeconds()
         {
             var watch = new Stopwatch();
@@ -276,12 +292,12 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(() =>
             {
-                Delay(100);
+                Delay(DELAY);
                 return true;
-            }, Is.True.After(200).PollEvery(10));
+            }, Is.True.After(AFTER).PollEvery(POLLING).MilliSeconds);
 
             watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(200));
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
         }
 
         [Test]
@@ -314,6 +330,22 @@ namespace NUnit.Framework.Constraints
 
             watch.Stop();
             Assert.That(watch.ElapsedMilliseconds, Is.LessThan(120000));
+        }
+
+        [Test]
+        public void PollyEvery_SetOn_DimensionedDelay()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            Assert.That(() =>
+            {
+                Delay(DELAY);
+                return true;
+            }, Is.True.After(AFTER).MilliSeconds.PollEvery(POLLING));
+
+            watch.Stop();
+            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
         }
 
         private static int setValuesDelay;

--- a/src/NUnitFramework/tests/Constraints/IntervalTests.cs
+++ b/src/NUnitFramework/tests/Constraints/IntervalTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Tests.Constraints
+{
+    [TestFixture]
+    public class IntervalTests
+    {
+        [Test]
+        public void IsNonZeroInterval()
+        {
+            var interval = new Interval(1);
+            Assert.IsTrue(interval.IsNotZero);
+
+            interval =  new Interval(0);
+            Assert.IsFalse(interval.IsNotZero);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
+    <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />


### PR DESCRIPTION
Changes for #1866 

@CharliePoole I followed you suggestion for nested classes. This structure follows your idea as below,
- After(int,int) would give the base class, which would allow no further mods.
- After(int) would give nested class 1, allowing entry a dimension (minutes, etc.) or PollEvery
- Entering Minutes would give nested class 2, allowing only PollEvery
- PollEvery would give nested class 3, allowing only a polling dimension (minute, etc.)
- Minute would give the base class. Allowing no further modifiers.

I had to change the following to make this work,
1. Store delayInMilliseconds(int) apart from the delayInterval so that I could create nested class objects later when I needed.
2. Fix AssertionHelper tests for After(int) since it returns a nested type now.

There are many things missing (like tests and intervals for PollEvery) which I will add on later. Wanted to get the feedback if this is what you were looking for first.
