### PR TITLE
Fix for #1870 Fine tune for the DateTime and DateTimeOffset format

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -62,9 +62,9 @@ namespace NUnit.Framework.Constraints
         private static readonly string Fmt_EmptyCollection = "<empty>";
         private static readonly string Fmt_String = "\"{0}\"";
         private static readonly string Fmt_Char = "'{0}'";
-        private static readonly string Fmt_DateTime = "yyyy-MM-dd HH:mm:ss.fff";
-		private static readonly string Fmt_DateTimeOffset = "yyyy-MM-dd HH:mm:ss.fffzzz";
-		private static readonly string Fmt_ValueType = "{0}";
+        private static readonly string Fmt_DateTime = "yyyy-MM-dd HH:mm:ss.FFFFFFF";
+        private static readonly string Fmt_DateTimeOffset = "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz";
+        private static readonly string Fmt_ValueType = "{0}";
         private static readonly string Fmt_Default = "<{0}>";
 
         /// <summary>
@@ -81,9 +81,9 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val is DateTime ? FormatDateTime((DateTime)val) : next(val));
 
-			AddFormatter(next => val => val is DateTimeOffset ? FormatDateTimeOffset ((DateTimeOffset)val) : next (val));
+            AddFormatter(next => val => val is DateTimeOffset ? FormatDateTimeOffset ((DateTimeOffset)val) : next (val));
 
-			AddFormatter(next => val => val is decimal ? FormatDecimal((decimal)val) : next(val));
+            AddFormatter(next => val => val is decimal ? FormatDecimal((decimal)val) : next(val));
 
             AddFormatter(next => val => val is float ? FormatFloat((float)val) : next(val));
 
@@ -248,19 +248,19 @@ namespace NUnit.Framework.Constraints
             return dt.ToString(Fmt_DateTime, CultureInfo.InvariantCulture);
         }
 
-		private static string FormatDateTimeOffset(DateTimeOffset dto)
+        private static string FormatDateTimeOffset(DateTimeOffset dto)
         {
             return dto.ToString(Fmt_DateTimeOffset, CultureInfo.InvariantCulture);
         }
 
-		/// <summary>
-		/// Returns the representation of a type as used in NUnitLite.
-		/// This is the same as Type.ToString() except for arrays,
-		/// which are displayed with their declared sizes.
-		/// </summary>
-		/// <param name="obj"></param>
-		/// <returns></returns>
-		public static string GetTypeRepresentation(object obj)
+        /// <summary>
+        /// Returns the representation of a type as used in NUnitLite.
+        /// This is the same as Type.ToString() except for arrays,
+        /// which are displayed with their declared sizes.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static string GetTypeRepresentation(object obj)
         {
             Array array = obj as Array;
             if (array == null)

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -21,14 +21,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Globalization;
-using System.IO;
 using NUnit.TestUtilities;
+using System;
+using System.IO;
 
 namespace NUnit.Framework.Assertions
 {
-    [TestFixture]
+	[TestFixture]
     public class AssertEqualsTests
     {
         [Test]
@@ -399,13 +398,25 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void DateTimeNotEqual()
+        public void DateTimeNotEqual_DifferenceInHours()
         {
             DateTime dt1 = new DateTime( 2005, 6, 1, 7, 0, 0 );
             DateTime dt2 = new DateTime( 2005, 6, 1, 0, 0, 0 );
             var expectedMessage =
-                "  Expected: 2005-06-01 07:00:00.000" + Env.NewLine +
-                "  But was:  2005-06-01 00:00:00.000" + Env.NewLine;
+                "  Expected: 2005-06-01 07:00:00" + Env.NewLine +
+                "  But was:  2005-06-01 00:00:00" + Env.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(dt1, dt2));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+        [Test]
+        public void DateTimeNotEqual_DifferenceInTicks()
+        {
+            DateTime dt1 = new DateTime(1914, 06, 28, 12, 00, 00);
+            DateTime dt2 = dt1.AddTicks(666);
+            var expectedMessage =
+                "  Expected: 1914-06-28 12:00:00" + Env.NewLine +
+                "  But was:  1914-06-28 12:00:00.0000666" + Env.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(dt1, dt2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));


### PR DESCRIPTION
Fine tuned the DateTime and DateTimeOffset format, so that ticks are also shown in a assertion message if required. Added unit test too.

Fixes #1870