### PR TITLE
Add Assert.Multiple to the framework

### DIFF
--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -244,11 +244,6 @@ namespace NUnit.Framework
                 Assert.That(actual, Is.EqualTo(expected).Within(delta), message, args);
         }
 
-        private static void IncrementAssertCount()
-        {
-            TestExecutionContext.CurrentContext.IncrementAssertCount();
-        }
-
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -142,11 +142,7 @@ namespace NUnit.Framework
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-            {
-                MessageWriter writer = new TextMessageWriter(message, args);
-                result.WriteMessageTo(writer);
-                throw new AssertionException(writer.ToString());
-            }
+                ReportFailure(result, message, args);
         }
 
 #if !NET_2_0
@@ -168,9 +164,7 @@ namespace NUnit.Framework
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-            {
-                throw new AssertionException(getExceptionMessage());
-            }
+                ReportFailure(result, getExceptionMessage());
         }
 #endif
 
@@ -250,11 +244,7 @@ namespace NUnit.Framework
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-            {
-                MessageWriter writer = new TextMessageWriter(message, args);
-                result.WriteMessageTo(writer);
-                throw new AssertionException(writer.ToString());
-            }
+                ReportFailure(result, message, args);
         }
 
 #if !NET_2_0
@@ -276,9 +266,7 @@ namespace NUnit.Framework
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-            {
-                throw new AssertionException(getExceptionMessage());
-            }
+                ReportFailure(result, getExceptionMessage());
         }
 #endif
 

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -25,6 +25,8 @@ using System;
 using System.Collections;
 using System.ComponentModel;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
@@ -270,15 +272,89 @@ namespace NUnit.Framework
 
         #region Multiple
 
-        ///// <summary>
-        ///// If an assert fails within this block, execution will continue and 
-        ///// the errors will be reported at the end of the block.
-        ///// </summary>
-        ///// <param name="del">The test delegate</param>
-        //public static void Multiple(TestDelegate del)
-        //{
-        //    del();
-        //}
+        /// <summary>
+        /// Wraps code containing a series of assertions, which should all
+        /// be executed, even if they fail. Failed results are saved and
+        /// reported at the end of the code block.
+        /// </summary>
+        /// <param name="testDelegate">A TestDelegate to be executed in Multiple Assertion mode.</param>
+        public static void Multiple(TestDelegate testDelegate)
+        {
+            TestExecutionContext context = TestExecutionContext.CurrentContext;
+            Guard.OperationValid(context != null, "Assert.Multiple called outside of a valid TestExecutionContext");
+
+            context.MultipleAssertLevel++;
+
+            try
+            {
+                testDelegate();
+            }
+            finally
+            {
+                context.MultipleAssertLevel--;
+            }
+
+            if (context.MultipleAssertLevel == 0)
+            {
+                int count = context.CurrentResult.AssertionResults.Count;
+
+                if (count > 0)
+                {
+                    var writer = new TextMessageWriter("Multiple Assert block had {0} failure(s).", count);
+                    writer.WriteLine();
+
+                    int counter = 0;
+                    foreach (var assertion in context.CurrentResult.AssertionResults)
+                    {
+                        writer.WriteLine(string.Format("  {0}) {1}", ++counter, assertion.Message));
+                        writer.WriteLine();
+                    }
+
+                    writer.Write(' '); // So the last newline doesn't get dropped
+
+                    throw new AssertionException(writer.ToString());
+                }
+            }
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static void ReportFailure(ConstraintResult result, string message)
+        {
+            ReportFailure(result, message, null);
+        }
+
+        private static void ReportFailure(ConstraintResult result, string message, params object[] args)
+        {
+            MessageWriter writer = new TextMessageWriter(message, args);
+            result.WriteMessageTo(writer);
+
+#if PORTABLE
+            try
+            {
+                // Throw to get stack trace
+                throw new AssertionException(message);
+            }
+            catch (AssertionException ex)
+            {
+                TestExecutionContext.CurrentContext.CurrentResult.RecordAssertion(
+                    AssertionStatus.Failed, message, ex.StackTrace);
+            }
+#else
+            TestExecutionContext.CurrentContext.CurrentResult.RecordAssertion(
+                AssertionStatus.Failed, writer.ToString(), Environment.StackTrace);
+#endif
+
+            if (TestExecutionContext.CurrentContext.MultipleAssertLevel == 0)
+                throw new AssertionException(writer.ToString());
+        }
+
+        private static void IncrementAssertCount()
+        {
+            TestExecutionContext.CurrentContext.IncrementAssertCount();
+        }
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -479,7 +479,6 @@ namespace NUnit.Framework.Internal
                 string message = ex.Message;
                 string stackTrace = StackFilter.Filter(ex.StackTrace);
 
-                //RecordAssertion(AssertionStatus.Failed, message, stackTrace);
                 SetResult(((ResultStateException)ex).ResultState, message, stackTrace);
             }
 #if !PORTABLE

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -479,7 +479,7 @@ namespace NUnit.Framework.Internal
                 string message = ex.Message;
                 string stackTrace = StackFilter.Filter(ex.StackTrace);
 
-                RecordAssertion(AssertionStatus.Failed, message, stackTrace);
+                //RecordAssertion(AssertionStatus.Failed, message, stackTrace);
                 SetResult(((ResultStateException)ex).ResultState, message, stackTrace);
             }
 #if !PORTABLE

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class StackFilter
     {
-        private static readonly Regex assertOrAssumeRegex = new Regex(
+        private static readonly Regex topOfStackRegex = new Regex(
             @" NUnit\.Framework\.Ass(ert|ume)\.");
 
         /// <summary>
@@ -52,8 +52,8 @@ namespace NUnit.Framework.Internal
             try
             {
                 string line;
-                // Skip past any Assert or Assume lines
-                while ((line = sr.ReadLine()) != null && assertOrAssumeRegex.IsMatch(line))
+                // First, skip past any Assert, Assume or MultipleAssertBlock lines
+                while ((line = sr.ReadLine()) != null && topOfStackRegex.IsMatch(line))
                     /*Skip*/
                     ;
 

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -388,6 +388,11 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// The current nesting level of multiple assert blocks
+        /// </summary>
+        internal int MultipleAssertLevel { get; set; }
+
+        /// <summary>
         /// Gets or sets the test case timeout value
         /// </summary>
         public int TestCaseTimeout { get; set; }

--- a/src/NUnitFramework/nunitlite.tests/TeamCityEventListenerTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TeamCityEventListenerTests.cs
@@ -37,7 +37,7 @@ namespace NUnitLite.Tests
         private TeamCityEventListener _teamCity;
         private StringBuilder _output;
 
-        private static readonly string NL = NUnit.Env.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         [SetUp]
         public void CreateListener()

--- a/src/NUnitFramework/nunitlite.tests/TextUITests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUITests.cs
@@ -36,7 +36,7 @@ namespace NUnitLite.Tests
 {
     public class TextUITests
     {
-        private static readonly string NL = NUnit.Env.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         private TextUI _textUI;
         private StringBuilder _reportBuilder;

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -217,7 +217,7 @@ namespace NUnitLite
 #endif
 
 #if !PORTABLE
-            Writer.WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? NUnit.Env.DefaultWorkDirectory);
+            Writer.WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? Environment.CurrentDirectory);
 #endif
 
             Writer.WriteLabelLine("    Internal Trace: ", _options.InternalTraceLevel ?? "Off");

--- a/src/NUnitFramework/testdata/AssertMultipleData.cs
+++ b/src/NUnitFramework/testdata/AssertMultipleData.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnit.TestData.AssertMultipleData
+{
+    public class AssertMultipleSuccessFixture
+    {
+        private static readonly ComplexNumber complex = new ComplexNumber(5.2, 3.9);
+
+        [Test]
+        public void EmptyBlock()
+        {
+            Assert.Multiple(() => { });
+        }
+
+        [Test]
+        public void SingleAssert()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(4));
+            });
+        }
+
+        [Test]
+        public void TwoAsserts()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(complex.RealPart, Is.EqualTo(5.2));
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+            });
+        }
+
+        [Test]
+        public void ThreeAsserts()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(4));
+                Assert.That(complex.RealPart, Is.EqualTo(5.2));
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+            });
+        }
+
+        [Test]
+        public void NestedBlock()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(4));
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                });
+            });
+        }
+
+        [Test]
+        public void TwoNestedBlocks()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(2 + 2, Is.EqualTo(4));
+                });
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                });
+            });
+        }
+
+        [Test]
+        public void NestedBlocksInMethodCalls()
+        {
+            SingleAssert();
+            TwoAsserts();
+        }
+    }
+
+    public class AssertMultipleFailureFixture
+    {
+        private static readonly ComplexNumber complex = new ComplexNumber(5.2, 3.9);
+
+        [Test]
+        public void TwoAsserts_FirstAssertFails()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+            });
+        }
+
+        [Test]
+        public void TwoAsserts_SecondAssertFails()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+            });
+        }
+
+        [Test]
+        public void TwoAsserts_BothAssertsFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+            });
+        }
+
+        [Test]
+        public void NestedBlock_FirstAssertFails()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+                });
+            });
+        }
+
+        [Test]
+        public void NestedBlock_TwoAssertsFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                });
+            });
+        }
+
+        [Test]
+        public void TwoNestedBlocks_FirstAssertFails()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(2 + 2, Is.EqualTo(5));
+                });
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+                });
+            });
+        }
+
+        [Test]
+        public void TwoNestedBlocks_TwoAssertsFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(2 + 2, Is.EqualTo(5));
+                });
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                });
+            });
+        }
+    }
+
+    class ComplexNumber
+    {
+        public ComplexNumber(double realPart, double imaginaryPart)
+        {
+            RealPart = realPart;
+            ImaginaryPart = imaginaryPart;
+        }
+
+        public double RealPart;
+        public double ImaginaryPart;
+    }
+}

--- a/src/NUnitFramework/testdata/AssertMultipleData.cs
+++ b/src/NUnitFramework/testdata/AssertMultipleData.cs
@@ -88,6 +88,10 @@ namespace NUnit.TestData.AssertMultipleData
 
     public class AssertMultipleFailureFixture
     {
+        // NOTE: Some of these methods were getting optimized out of
+        // existence in the .NET 2.0 AppVeyor build. For that reason,
+        // we turned optimization off for the testdata assembly.
+
         private static readonly ComplexNumber complex = new ComplexNumber(5.2, 3.9);
 
         [Test]

--- a/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-2.0\</OutputPath>
     <DefineConstants>TRACE;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
@@ -54,6 +54,7 @@
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="ActionAttributeFixture.cs" />
+    <Compile Include="AssertMultipleData.cs" />
     <Compile Include="AsyncDummyFixture.cs" />
     <Compile Include="AsyncRealFixture.cs" />
     <Compile Include="TextOutputFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-3.5\</OutputPath>
     <DefineConstants>TRACE;NET_3_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
     <DefineConstants>TRACE;NET_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
     <DefineConstants>TRACE;NET_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
     <DefineConstants>TRACE;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -1,0 +1,113 @@
+﻿// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.TestData.AssertMultipleData;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Assertions.Tests
+{
+    public class AssertMultipleTests
+    {
+        private static readonly ComplexNumber number = new ComplexNumber(5.2, 3.9);
+
+        [TestCase("EmptyBlock", 0)]
+        [TestCase("SingleAssert", 1)]
+        [TestCase("TwoAsserts", 2)]
+        [TestCase("ThreeAsserts", 3)]
+        [TestCase("NestedBlock", 3)]
+        [TestCase("TwoNestedBlocks", 3)]
+        [TestCase("NestedBlocksInMethodCalls", 3)]
+        public void AssertMultipleSucceeds(string methodName, int asserts)
+        {
+            var result = TestBuilder.RunTestCase(typeof(AssertMultipleSuccessFixture), methodName);
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+            Assert.That(result.AssertCount, Is.EqualTo(asserts));
+            Assert.IsEmpty(result.AssertionResults);
+        }
+
+        [TestCase("TwoAsserts_FirstAssertFails", 2, "RealPart")]
+        [TestCase("TwoAsserts_SecondAssertFails", 2, "ImaginaryPart")]
+        [TestCase("TwoAsserts_BothAssertsFail", 2, "RealPart", "ImaginaryPart")]
+        [TestCase("NestedBlock_FirstAssertFails", 3, "Expected: 5")]
+        [TestCase("NestedBlock_TwoAssertsFail", 3, "Expected: 5", "ImaginaryPart")]
+        [TestCase("TwoNestedBlocks_FirstAssertFails", 3, "Expected: 5")]
+        [TestCase("TwoNestedBlocks_TwoAssertsFail", 3, "Expected: 5", "ImaginaryPart")]
+        public void AssertMultipleFails(string methodName, int asserts, params string[] failureMessageRegex)
+        {
+            var result = TestBuilder.RunTestCase(typeof(AssertMultipleFailureFixture), methodName);
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+            Assert.That(result.AssertCount, Is.EqualTo(asserts), "AssertCount");
+
+            int expectedFailures = failureMessageRegex.Length;
+            int actualFailures = result.AssertionResults.Count;
+            Assert.That(actualFailures, Is.EqualTo(expectedFailures), "FailureCount");
+
+            if (actualFailures > 0)
+            {
+                Assert.That(result.Message, Contains.Substring(
+                    string.Format("Multiple Assert block had {0} failure(s)", actualFailures)));
+
+                int i = 0;
+                foreach (var failure in result.AssertionResults)
+                {
+                    // Since the order of argument evaluation is not guaranteed, we don't
+                    // want 'i' to appear more than once in the Assert statement.
+                    string errmsg = string.Format("AssertionResult {0}", i + 1);
+                    Assert.That(failure.Message, Does.Match(failureMessageRegex[i++]), errmsg);
+                    Assert.That(result.Message, Contains.Substring(failure.Message),
+                        "Failure message should contain AssertionResult message");
+
+                    Assert.That(failure.StackTrace, Is.Not.Null.And.Contains(methodName));
+                }
+
+                Assert.That(result.StackTrace, Is.Not.Null.And.Contains(methodName));
+            }
+        }
+
+        [Test, Explicit("Used to display error message for visual confirmation")]
+        public void MultipleAssertFailureDemo()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(number.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(number.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+            });
+        }
+
+        private class ComplexNumber
+        {
+            public ComplexNumber(double realPart, double imaginaryPart)
+            {
+                RealPart = realPart;
+                ImaginaryPart = imaginaryPart;
+            }
+
+            public double RealPart;
+            public double ImaginaryPart;
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -81,6 +81,9 @@ namespace NUnit.Framework.Assertions.Tests
                     Assert.That(result.Message, Contains.Substring(failure.Message),
                         "Failure message should contain AssertionResult message");
 
+                    // NOTE: This test expects the stack trace to contain the name of the method 
+                    // that actually caused the failure. To ensure it is not optimized away, we
+                    // compile the testdata assembly with optimizations disabled.
                     Assert.That(failure.StackTrace, Is.Not.Null.And.Contains(methodName));
                 }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
-using Env = NUnit.Env;
 
 namespace NUnit.Framework.Constraints
 {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -30,8 +30,7 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            var ex = Assert.Catch(() => { throw new InconclusiveException("because"); });
-            _testResult.RecordException(ex);
+            _testResult.SetResult(ResultState.Inconclusive, "because");
             _suiteResult.AddResult(_testResult);
         }
 
@@ -40,16 +39,6 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.AreEqual(ResultState.Inconclusive, _testResult.ResultState);
             Assert.AreEqual("because", _testResult.Message);
-        }
-
-        [Test]
-        public void TestResultRecordsFailingAssumption()
-        {
-            Assert.That(_testResult.AssertionResults.Count, Is.EqualTo(1));
-            var ar = _testResult.AssertionResults[0];
-            Assert.That(ar.Status, Is.EqualTo(AssertionStatus.Failed));
-            Assert.That(ar.Message, Is.EqualTo("because"));
-            Assert.That(ar.StackTrace, Is.EqualTo(_testResult.StackTrace));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
     <Compile Include="Assertions\AssertionHelperTests.cs" />
+    <Compile Include="Assertions\AssertMultipleTests.cs" />
     <Compile Include="Assertions\AssertPolarityTests.cs" />
     <Compile Include="Assertions\AssertZeroTests.cs" />
     <Compile Include="Assertions\AssumeEqualsTests.cs" />


### PR DESCRIPTION
Fixes issue #391 

This takes care of the syntactic part of Assert.Multiple. Note that we still may want to make format changes to the XML before our next release, but that can be done in a separate PR.

The original implementation used a MultipleAssertBlock class that lived in the TestExecutionContext and actually handled the reporting of errors. It seemed like a more object-oriented approach but introduced complications when the blocks were nested. I gradually weakened that class until it was doing nothing but counting entries into and exits from the blocks and ended up eliminating it entirely. Each TestExecutionContext now simply has a MultipleAssertLevel, which tracks nesting of blocks. We record the individual assertion failures in every case but only throw a final exception if the level is zero.

Writing tests that depended on finding the name of a particular method in the stack trace pointed out the need to disable optimization of the nunit.testdata assembly at least for certain platforms. It has been done now for all platforms just in case.

I have re-opened issue #1743 to allow us to have second thoughts - if necessary - on the XML format. The code in this PR is set up so that the actual elements we put out can be modified fairly simply if we decide to make a change.