### PR TITLE
Make NUnitLite use AssertionResult info in it's reporting

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -301,16 +301,10 @@ namespace NUnit.Framework
                 if (count > 0)
                 {
                     var writer = new TextMessageWriter("Multiple Assert block had {0} failure(s).", count);
-                    writer.WriteLine();
 
                     int counter = 0;
                     foreach (var assertion in context.CurrentResult.AssertionResults)
-                    {
                         writer.WriteLine(string.Format("  {0}) {1}", ++counter, assertion.Message));
-                        writer.WriteLine();
-                    }
-
-                    writer.Write(' '); // So the last newline doesn't get dropped
 
                     throw new AssertionException(writer.ToString());
                 }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -310,7 +310,7 @@ namespace NUnit.Framework.Internal.Execution
 
         private void SkipFixture(ResultState resultState, string message, string stackTrace)
         {
-            Result.SetResult(resultState.WithSite(FailureSite.SetUp), message, StackFilter.Filter(stackTrace));
+            Result.SetResult(resultState.WithSite(FailureSite.SetUp), message, StackFilter.DefaultFilter.Filter(stackTrace));
             SkipChildren(_suite, resultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + message);
         }
 

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -477,7 +477,7 @@ namespace NUnit.Framework.Internal
             if (ex is ResultStateException)
             {
                 string message = ex.Message;
-                string stackTrace = StackFilter.Filter(ex.StackTrace);
+                string stackTrace = StackFilter.DefaultFilter.Filter(ex.StackTrace);
 
                 SetResult(((ResultStateException)ex).ResultState, message, stackTrace);
             }
@@ -506,7 +506,7 @@ namespace NUnit.Framework.Internal
             if (ex is ResultStateException)
                 SetResult(((ResultStateException)ex).ResultState.WithSite(site),
                     ex.Message,
-                    StackFilter.Filter(ex.StackTrace));
+                    StackFilter.DefaultFilter.Filter(ex.StackTrace));
 #if !PORTABLE
             else if (ex is System.Threading.ThreadAbortException)
                 SetResult(ResultState.Cancelled.WithSite(site),

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -32,17 +32,51 @@ namespace NUnit.Framework.Internal
     /// entries from a stack trace so that the resulting
     /// trace provides better information about the test.
     /// </summary>
-    public static class StackFilter
+    public class StackFilter
     {
-        private static readonly Regex topOfStackRegex = new Regex(
-            @" NUnit\.Framework\.Ass(ert|ume)\.");
+        private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.Ass(ert|ume)\.";
+        private const string DEFAULT_BOTTOM_OF_STACK_PATTERN = @" System\.R(eflection|untimeMethodHandle)\.";
+
+        /// <summary>
+        /// Single instance of our default filter
+        /// </summary>
+        public static StackFilter DefaultFilter = new StackFilter();
+
+        private Regex _topOfStackRegex;
+        private Regex _bottomOfStackRegex;
+
+        /// <summary>
+        /// Construct a stack filter instance
+        /// </summary>
+        /// <param name="topOfStackPattern">Regex pattern used to delete lines from the top of the stack</param>
+        /// <param name="bottomOfStackPattern">Regex pattern used to delete lines from the bottom of the stack</param>
+        public StackFilter(string topOfStackPattern, string bottomOfStackPattern)
+        {
+            if (topOfStackPattern != null)
+                _topOfStackRegex = new Regex(topOfStackPattern);
+            if (bottomOfStackPattern != null)
+                _bottomOfStackRegex = new Regex(bottomOfStackPattern);
+        }
+
+        /// <summary>
+        /// Construct a stack filter instance
+        /// </summary>
+        /// <param name="topOfStackPattern">Regex pattern used to delete lines from the top of the stack</param>
+        public StackFilter(string topOfStackPattern)
+            : this(topOfStackPattern, DEFAULT_BOTTOM_OF_STACK_PATTERN) { }
+
+        /// <summary>
+        /// Construct a stack filter instance
+        /// </summary>
+        public StackFilter()
+            : this(DEFAULT_TOP_OF_STACK_PATTERN, DEFAULT_BOTTOM_OF_STACK_PATTERN) { }
 
         /// <summary>
         /// Filters a raw stack trace and returns the result.
         /// </summary>
         /// <param name="rawTrace">The original stack trace</param>
         /// <returns>A filtered stack trace</returns>
-        public static string Filter(string rawTrace)
+        public string Filter(string rawTrace)
         {
             if (rawTrace == null) return null;
 
@@ -51,18 +85,22 @@ namespace NUnit.Framework.Internal
 
             try
             {
-                string line;
-                // First, skip past any Assert, Assume or MultipleAssertBlock lines
-                while ((line = sr.ReadLine()) != null && topOfStackRegex.IsMatch(line))
-                    /*Skip*/
-                    ;
+                string line = sr.ReadLine();
+
+                if (_topOfStackRegex != null)
+                    // First, skip past any Assert, Assume or MultipleAssertBlock lines
+                    while (line != null && _topOfStackRegex.IsMatch(line))
+                        line = sr.ReadLine();
 
                 // Copy lines down to the line that invoked the failing method.
                 // This is actually only needed for the compact framework, but 
                 // we do it on all platforms for simplicity. Desktop platforms
                 // won't have any System.Reflection lines.
-                while (line != null && line.IndexOf(" System.Reflection.") < 0)
+                while (line != null)
                 {
+                    if (_bottomOfStackRegex != null && _bottomOfStackRegex.IsMatch(line))
+                        break;
+
                     sw.WriteLine(line.Trim());
                     line = sr.ReadLine();
                 }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -482,19 +482,33 @@ namespace NUnitLite
 
         private void DisplayTestResult(ITestResult result)
         {
-            string status = result.ResultState.Label;
+            ResultState resultState = result.ResultState;
+            string fullName = result.FullName;
+            string message = result.Message;
+            string stackTrace = result.StackTrace;
+
+            if (result.AssertionResults.Count > 0)
+                foreach (var assertion in result.AssertionResults)
+                    DisplayTestResult(resultState, fullName, assertion.Message, assertion.StackTrace);
+            else
+                DisplayTestResult(resultState, fullName, message, stackTrace);
+        }
+
+        private void DisplayTestResult(ResultState resultState, string fullName, string message, string stackTrace)
+        {
+            string status = resultState.Label;
             if (string.IsNullOrEmpty(status))
-                status = result.ResultState.Status.ToString();
+                status = resultState.Status.ToString();
 
             if (status == "Failed" || status == "Error")
             {
-                var site = result.ResultState.Site.ToString();
+                var site = resultState.Site.ToString();
                 if (site == "SetUp" || site == "TearDown")
                     status = site + " " + status;
             }
 
             ColorStyle style = ColorStyle.Output;
-            switch (result.ResultState.Status)
+            switch (resultState.Status)
             {
                 case TestStatus.Failed:
                     style = ColorStyle.Failure;
@@ -509,13 +523,13 @@ namespace NUnitLite
 
             Writer.WriteLine();
             Writer.WriteLine(
-                style, string.Format("{0}) {1} : {2}", ++_reportIndex, status, result.FullName));
+                style, string.Format("{0}) {1} : {2}", ++_reportIndex, status, fullName));
 
-            if (!string.IsNullOrEmpty(result.Message))
-                Writer.WriteLine(style, result.Message.TrimEnd(TRIM_CHARS));
+            if (!string.IsNullOrEmpty(message))
+                Writer.WriteLine(style, message.TrimEnd(TRIM_CHARS));
 
-            if (!string.IsNullOrEmpty(result.StackTrace))
-                Writer.WriteLine(style, result.StackTrace.TrimEnd(TRIM_CHARS));
+            if (!string.IsNullOrEmpty(stackTrace))
+                Writer.WriteLine(style, stackTrace.TrimEnd(TRIM_CHARS));
         }
 
 #if FULL

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -488,16 +488,16 @@ namespace NUnitLite
             string stackTrace = result.StackTrace;
             string reportID = (++_reportIndex).ToString();
 
-            //if (result.AssertionResults.Count > 0)
-            //{
-            //    int assertionCounter = 0;
-            //    foreach (var assertion in result.AssertionResults)
-            //    {
-            //        string assertID = string.Format("{0}-{1}", reportID, ++assertionCounter);
-            //        DisplayTestResult(assertID, resultState, fullName, assertion.Message, assertion.StackTrace);
-            //    }
-            //}
-            //else
+            if (result.AssertionResults.Count > 0)
+            {
+                int assertionCounter = 0;
+                foreach (var assertion in result.AssertionResults)
+                {
+                    string assertID = string.Format("{0}-{1}", reportID, ++assertionCounter);
+                    DisplayTestResult(assertID, resultState, fullName, assertion.Message, assertion.StackTrace);
+                }
+            }
+            else
                 DisplayTestResult(reportID, resultState, fullName, message, stackTrace);
         }
 

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -486,15 +486,22 @@ namespace NUnitLite
             string fullName = result.FullName;
             string message = result.Message;
             string stackTrace = result.StackTrace;
+            string reportID = (++_reportIndex).ToString();
 
-            if (result.AssertionResults.Count > 0)
-                foreach (var assertion in result.AssertionResults)
-                    DisplayTestResult(resultState, fullName, assertion.Message, assertion.StackTrace);
-            else
-                DisplayTestResult(resultState, fullName, message, stackTrace);
+            //if (result.AssertionResults.Count > 0)
+            //{
+            //    int assertionCounter = 0;
+            //    foreach (var assertion in result.AssertionResults)
+            //    {
+            //        string assertID = string.Format("{0}-{1}", reportID, ++assertionCounter);
+            //        DisplayTestResult(assertID, resultState, fullName, assertion.Message, assertion.StackTrace);
+            //    }
+            //}
+            //else
+                DisplayTestResult(reportID, resultState, fullName, message, stackTrace);
         }
 
-        private void DisplayTestResult(ResultState resultState, string fullName, string message, string stackTrace)
+        private void DisplayTestResult(string prefix, ResultState resultState, string fullName, string message, string stackTrace)
         {
             string status = resultState.Label;
             if (string.IsNullOrEmpty(status))
@@ -523,7 +530,7 @@ namespace NUnitLite
 
             Writer.WriteLine();
             Writer.WriteLine(
-                style, string.Format("{0}) {1} : {2}", ++_reportIndex, status, fullName));
+                style, string.Format("{0}) {1} : {2}", prefix, status, fullName));
 
             if (!string.IsNullOrEmpty(message))
                 Writer.WriteLine(style, message.TrimEnd(TRIM_CHARS));

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -487,13 +487,16 @@ namespace NUnitLite
             string message = result.Message;
             string stackTrace = result.StackTrace;
             string reportID = (++_reportIndex).ToString();
+            int numAsserts = result.AssertionResults.Count;
 
-            if (result.AssertionResults.Count > 0)
+            if (numAsserts > 0)
             {
                 int assertionCounter = 0;
+                string assertID = reportID;
                 foreach (var assertion in result.AssertionResults)
                 {
-                    string assertID = string.Format("{0}-{1}", reportID, ++assertionCounter);
+                    if (numAsserts > 1)
+                        assertID = string.Format("{0}-{1}", reportID, ++assertionCounter);
                     DisplayTestResult(assertID, resultState, fullName, assertion.Message, assertion.StackTrace);
                 }
             }

--- a/src/NUnitFramework/tests/Internal/StackFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/StackFilterTests.cs
@@ -85,19 +85,19 @@ namespace NUnit.Framework.Internal.Tests
         [Test]
         public void FilterShortTraceWithAssert()
         {
-            Assert.That(StackFilter.Filter(shortTrace_Assert), Is.EqualTo(shortTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(shortTrace_Assert), Is.EqualTo(shortTrace_Result));
         }
 
         [Test]
         public void FilterShortTraceWithAssume_Trace1()
         {
-            Assert.That(StackFilter.Filter(shortTrace_Assume), Is.EqualTo(shortTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(shortTrace_Assume), Is.EqualTo(shortTrace_Result));
         }
 
         [Test]
         public void FilterLongTrace()
         {
-            Assert.That(StackFilter.Filter(longTrace), Is.EqualTo(longTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(longTrace), Is.EqualTo(longTrace_Result));
         }
     }
 }


### PR DESCRIPTION
Fixes #1889 

The first commit is an initial pass at using AssertionResult for our reporting. Before merging, let's use this as an opportunity to do a final review on the formatting of our reports.

In order to make this change I did some refactoring of StackFilter so it could be reused for different kinds of filtering.