### PR TITLE
Fixups for DelayedConstraint tests

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -362,7 +362,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return string.Format("<after {0} {1}>", DelayInterval, BaseConstraint);
+            return string.Format("<after {0} {1}>", DelayInterval.AsTimeSpan.TotalMilliseconds, BaseConstraint);
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -319,7 +319,7 @@ namespace NUnit.Framework.Syntax
         {
             var constraint = EqualTo(10).After(1000);
             Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
-            Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <equal 10>>"));
+            Expect(constraint.ToString(), EqualTo("<after 1000 <equal 10>>"));
         }
 
         [Test]
@@ -327,7 +327,7 @@ namespace NUnit.Framework.Syntax
         {
             var constraint = Property("X").EqualTo(10).After(1000);
             Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
-            Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <property X <equal 10>>>"));
+            Expect(constraint.ToString(), EqualTo("<after 1000 <property X <equal 10>>>"));
         }
 
         [Test]
@@ -335,7 +335,7 @@ namespace NUnit.Framework.Syntax
         {
             var constraint = GreaterThan(0).And.LessThan(10).After(1000);
             Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
-            Expect(constraint.ToString(), EqualTo("<after 1000 milliseconds <and <greaterthan 0> <lessthan 10>>>"));
+            Expect(constraint.ToString(), EqualTo("<after 1000 <and <greaterthan 0> <lessthan 10>>>"));
         }
 #endif
 

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
         {
             theConstraint = new DelayedConstraint(new EqualConstraint(true), 500);
             expectedDescription = "True after 500 milliseconds delay";
-            stringRepresentation = "<after 500 milliseconds <equal True>>";
+            stringRepresentation = "<after 500 <equal True>>";
 
             boolValue = false;
             list = new List<int>();

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -34,6 +34,12 @@ namespace NUnit.Framework.Constraints
     [TestFixture, Parallelizable(ParallelScope.None)]
     public class DelayedConstraintTests : ConstraintTestBase
     {
+        // NOTE: This class tests the functioning of the DelayConstraint,
+        // not the After syntax. The AfterTests class tests our syntax,
+        // assuring that the proper constraint is generated. Here,we
+        // set up constraints in the simplest way possible, often by
+        // constructing the constraint class, and verify that they work.
+
         private const int DELAY = 100;
         private const int AFTER = 300;
         private const int POLLING = 50;
@@ -102,18 +108,6 @@ namespace NUnit.Framework.Constraints
             Assert.That(DelegateReturningValue, new DelayedConstraint(new EqualConstraint(true), AFTER, POLLING));
         }
 
-        [Test]
-        public void DifferentDelayTests()
-        {
-            SetValuesAfterDelay(60000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), 1)).Minutes);
-
-            SetValuesAfterDelay(5000);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), 5)).Seconds);
-
-            SetValuesAfterDelay(DELAY);
-            Assert.That(DelegateReturningValue, new DelayedConstraint.WithRawDelayInterval(new DelayedConstraint(new EqualConstraint(true), AFTER)).MilliSeconds);
-        }
 
         [Test]
         public void SimpleTestUsingBoolean()
@@ -250,102 +244,6 @@ namespace NUnit.Framework.Constraints
 
             watch.Stop();
             Assert.That(watch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(AFTER));
-        }
-
-        [Test]
-        public void PollEvery_WithoutSetting_TimeDimensions()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(DELAY);
-                return true;
-            }, Is.True.After(AFTER).PollEvery(POLLING));
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
-        }
-
-        [Test]
-        public void PollEvery_SetTo_MilliSeconds_ByDefault()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(DELAY);
-                return true;
-            }, Is.True.After(AFTER).PollEvery(POLLING));
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
-        }
-
-        [Test]
-        public void PollEvery_SetTo_MilliSeconds()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(DELAY);
-                return true;
-            }, Is.True.After(AFTER).PollEvery(POLLING).MilliSeconds);
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
-        }
-
-        [Test]
-        public void PollEvery_SetTo_Seconds()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(2000);
-                return true;
-            }, Is.True.After(5000).PollEvery(1).Seconds);
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(5000));
-        }
-
-        [Test]
-        public void PollEvery_SetTo_Minutes()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(50000);
-                return true;
-            }, Is.True.After(120000).PollEvery(1).Minutes);
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(120000));
-        }
-
-        [Test]
-        public void PollyEvery_SetOn_DimensionedDelay()
-        {
-            var watch = new Stopwatch();
-            watch.Start();
-
-            Assert.That(() =>
-            {
-                Delay(DELAY);
-                return true;
-            }, Is.True.After(AFTER).MilliSeconds.PollEvery(POLLING));
-
-            watch.Stop();
-            Assert.That(watch.ElapsedMilliseconds, Is.LessThan(AFTER));
         }
 
         private static int setValuesDelay;

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -28,12 +28,16 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Syntax
 {
+    // NOTE: The tests in this file ensure that the various
+    // syntactic elements work together to create a 
+    // DelayedConstraint object with the proper values.
+
     public class AfterTest_SimpleConstraint : SyntaxTest
     {
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 1000 milliseconds <equal 10>>";
+            parseTree = "<after 1000 <equal 10>>";
             staticSyntax = Is.EqualTo(10).After(1000);
             builderSyntax = Builder().EqualTo(10).After(1000);
         }
@@ -44,7 +48,7 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 1 minute <equal 10>>";
+            parseTree = "<after 60000 <equal 10>>";
             staticSyntax = Is.EqualTo(10).After(1).Minutes;
             builderSyntax = Builder().EqualTo(10).After(1).Minutes;
         }
@@ -55,7 +59,7 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 20 seconds <equal 10>>";
+            parseTree = "<after 20000 <equal 10>>";
             staticSyntax = Is.EqualTo(10).After(20).Seconds;
             builderSyntax = Builder().EqualTo(10).After(20).Seconds;
         }
@@ -66,7 +70,7 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 500 milliseconds <equal 10>>";
+            parseTree = "<after 500 <equal 10>>";
             staticSyntax = Is.EqualTo(10).After(500).MilliSeconds;
             builderSyntax = Builder().EqualTo(10).After(500).MilliSeconds;
         }
@@ -77,7 +81,7 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 1000 milliseconds <property X <equal 10>>>";
+            parseTree = "<after 1000 <property X <equal 10>>>";
             staticSyntax = Has.Property("X").EqualTo(10).After(1000);
             builderSyntax = Builder().Property("X").EqualTo(10).After(1000);
         }
@@ -88,7 +92,7 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void SetUp()
         {
-            parseTree = "<after 1000 milliseconds <and <greaterthan 0> <lessthan 10>>>";
+            parseTree = "<after 1000 <and <greaterthan 0> <lessthan 10>>>";
             staticSyntax = Is.GreaterThan(0).And.LessThan(10).After(1000);
             builderSyntax = Builder().GreaterThan(0).And.LessThan(10).After(1000);
         }


### PR DESCRIPTION
One of the new tests added with the recent syntax changes (Minutes, Seconds, PollEvery, etc.) keeps failing. It was requiring the test to succeed in too short a time frame. I intended to just adjust the delays, but discovered some other problems with the tests.

1. DelayedConstraintTests.cs had some rather long-running tests added in order to exercise the Seconds and Minutes options. Such tests don't really belong in that class. Normally, we test syntax separately (AfterTests in this case) from the actual execution tests of the constraint. I removed the long-running tests, including the one that was repeatedly failing.

2. AfterTests is set up to verify that the proper delay is set by the syntax. It does this by examining the string representation of the constraint. That string representation is not intended to be user-friendly, but is used for testing only. The string representation had been changed to include the time dimension (minutes, seconds, etc.) I changed it back to raw milliseconds. That way we test that `After(1).Minutes` causes a delay of 60000 milliseconds. This seems more certain than merely checking how the dimensioned interval displays itself.
