### PR TITLE
A test proving that issue #1897 is not an issue

### DIFF
--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -532,6 +532,7 @@ namespace NUnit.Framework.Constraints
                 Assert.That(comparer.WasCalled, "Comparer was not called");
             }
 
+#if !PORTABLE
             [Test]
             public void CanCompareUncomparableTypes()
             {
@@ -539,6 +540,7 @@ namespace NUnit.Framework.Constraints
                 var comparer = new ConvertibleComparer();
                 Assert.That(2 + 2, Is.EqualTo("4").Using(comparer));
             }
+#endif
 
             [Test]
             public void UsesProvidedEqualityComparer()
@@ -763,6 +765,7 @@ namespace NUnit.Framework.Constraints
     }
     #endregion
 
+#if !PORTABLE
     /// <summary>
     /// ConvertibleComparer is used in testing to ensure that objects
     /// of different types can be compared when appropriate.
@@ -779,4 +782,6 @@ namespace NUnit.Framework.Constraints
             return string.Compare(str1, str2, StringComparison.Ordinal);
         }
     }
+#endif
+
 }

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Comparers;
 
@@ -532,6 +533,14 @@ namespace NUnit.Framework.Constraints
             }
 
             [Test]
+            public void CanCompareUncomparableTypes()
+            {
+                Assert.That(2 + 2, Is.Not.EqualTo("4"));
+                var comparer = new ConvertibleComparer();
+                Assert.That(2 + 2, Is.EqualTo("4").Using(comparer));
+            }
+
+            [Test]
             public void UsesProvidedEqualityComparer()
             {
                 var comparer = new ObjectEqualityComparer();
@@ -753,4 +762,21 @@ namespace NUnit.Framework.Constraints
         }
     }
     #endregion
+
+    /// <summary>
+    /// ConvertibleComparer is used in testing to ensure that objects
+    /// of different types can be compared when appropriate.
+    /// </summary>
+    /// <remark>Introduced when testing issue 1897.
+    /// https://github.com/nunit/nunit/issues/1897
+    /// </remark>
+    public class ConvertibleComparer : IComparer<IConvertible>
+    {
+        public int Compare(IConvertible x, IConvertible y)
+        {
+            var str1 = Convert.ToString(x, CultureInfo.InvariantCulture);
+            var str2 = Convert.ToString(y, CultureInfo.InvariantCulture);
+            return string.Compare(str1, str2, StringComparison.Ordinal);
+        }
+    }
 }


### PR DESCRIPTION
A test that proves that `CanCompare` in `EqualityAdapter` is not used when a
generic comparer is provided. It is equivalent to `UsesProvidedGenericEqualityComparer`
but illustrates that otherwise-uncomparable values (in this case, int and IEnumerable)
can be compared when you provide and specify the correct comparer.
