### PR TITLE
Make nunitlite-runner Prefer32Bit option consistent across Debug/Release

### DIFF
--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-2.0.csproj
@@ -35,6 +35,7 @@
     <DefineConstants>TRACE;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-3.5.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-3.5.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.0.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.0.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
@@ -35,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-portable.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-portable.csproj
@@ -35,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
I have interfaces with native code that are designed to only run 64bit mode. The current nunitlite-runner build options cause my tests to run in Debug but not in Release.

This change makes the two environments consistent.