### PR TITLE
Changing misleading comment that implies that every ICollection<T> is a list

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -247,10 +247,10 @@ namespace NUnit.Framework
         #region Contains
 
         /// <summary>
-        /// Asserts that an object is contained in a list.
+        /// Asserts that an object is contained in a collection.
         /// </summary>
         /// <param name="expected">The expected object</param>
-        /// <param name="actual">The list to be examined</param>
+        /// <param name="actual">The collection to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void Contains(object expected, ICollection actual, string message, params object[] args)
@@ -259,10 +259,10 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an object is contained in a list.
+        /// Asserts that an object is contained in a collection.
         /// </summary>
         /// <param name="expected">The expected object</param>
-        /// <param name="actual">The list to be examined</param>
+        /// <param name="actual">The collection to be examined</param>
         public static void Contains(object expected, ICollection actual)
         {
             Assert.That(actual, new CollectionContainsConstraint(expected) ,null, null);


### PR DESCRIPTION
Misleading because of `List<T>` from .NET Framework.
**Collection** is a broader term than **list** for anything that implements `ICollection<T>` (including for ex. `HashSet<T>`, `SortedSet<T>` etc.).