### PR TITLE
Enable Path, File and Directory Assert/Constraints in the .NET Standard Build

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -27,6 +27,13 @@ Supported platforms:
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory plugin addin</tags>
     <copyright>Copyright (c) 2016 Charlie Poole</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.6">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
+        <dependency id="System.Runtime.Loader" version="4.0.0" />
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -30,6 +30,10 @@ How to use this package:
       <group>
         <dependency id="NUnit" version="[$version$]" />
       </group>
+      <group targetFramework="netstandard1.6">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -170,7 +170,7 @@ namespace NUnit.TestUtilities
             // TODO: Replace with an event - but not while method is static
             while (work.State != WorkItemState.Complete)
             {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
                 System.Threading.Tasks.Task.Delay(1);
 #else
                 Thread.Sleep(1);

--- a/src/NUnitFramework/TestFile.cs
+++ b/src/NUnitFramework/TestFile.cs
@@ -65,7 +65,7 @@ namespace NUnit.TestUtilities
             }
 
             // HACK! Only way I can figure out to avoid having two copies of TestFile
-            _resourceName = GetType().Assembly.GetName().Name.Contains("nunitlite")
+            _resourceName = GetType().GetTypeInfo().Assembly.GetName().Name.Contains("nunitlite")
                 ? "NUnitLite.Tests." + contentSource
                 : "NUnit.Framework.Tests." + contentSource;
             _fileLength = 0L;

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Api
         /// </returns>
         public ITest Build(Assembly assembly, IDictionary<string, object> options)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             log.Debug("Loading {0}", assembly.FullName);
 #else
             log.Debug("Loading {0} in AppDomain {1}", assembly.FullName, AppDomain.CurrentDomain.FriendlyName);
@@ -99,7 +99,7 @@ namespace NUnit.Framework.Api
         /// </returns>
         public ITest Build(string assemblyName, IDictionary<string, object> options)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             log.Debug("Loading {0}", assemblyName);
 #else
             log.Debug("Loading {0} in AppDomain {1}", assemblyName, AppDomain.CurrentDomain.FriendlyName);
@@ -264,7 +264,7 @@ namespace NUnit.Framework.Api
 
             testAssembly.ApplyAttributesToTest(assembly);
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             testAssembly.Properties.Set(PropertyNames.ProcessID, System.Diagnostics.Process.GetCurrentProcess().Id);
             testAssembly.Properties.Set(PropertyNames.AppDomain, AppDomain.CurrentDomain.FriendlyName);
 #endif

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -151,8 +151,8 @@ namespace NUnit.Framework.Api
 #if !PORTABLE
                 else
                 {
-                    var workDirectory = Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory) 
-                        ? (string)Settings[FrameworkPackageSettings.WorkDirectory] 
+                    var workDirectory = Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory)
+                        ? (string)Settings[FrameworkPackageSettings.WorkDirectory]
                         : Directory.GetCurrentDirectory();
 #if NETSTANDARD1_6
                     var id = DateTime.Now.ToString("o");
@@ -274,7 +274,7 @@ namespace NUnit.Framework.Api
 
             public void RaiseCallbackEvent(string report)
             {
-                if(_callback != null)
+                if (_callback != null)
                     _callback.Invoke(report);
             }
         }
@@ -473,7 +473,7 @@ namespace NUnit.Framework.Api
                 AddSetting(settingsNode, FrameworkPackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 #endif
 
-                return settingsNode;
+            return settingsNode;
         }
 
         private static void AddSetting(TNode settingsNode, string name, object value)
@@ -485,11 +485,11 @@ namespace NUnit.Framework.Api
             settingsNode.ChildNodes.Add(setting);
         }
 
-#endregion
+        #endregion
 
-#region Nested Action Classes
+        #region Nested Action Classes
 
-#region TestContollerAction
+        #region TestContollerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions
@@ -499,9 +499,9 @@ namespace NUnit.Framework.Api
         {
         }
 
-#endregion
+        #endregion
 
-#region LoadTestsAction
+        #region LoadTestsAction
 
         /// <summary>
         /// LoadTestsAction loads a test into the FrameworkController
@@ -519,9 +519,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        #endregion
 
-#region ExploreTestsAction
+        #region ExploreTestsAction
 
         /// <summary>
         /// ExploreTestsAction returns info about the tests in an assembly
@@ -540,9 +540,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        #endregion
 
-#region CountTestsAction
+        #region CountTestsAction
 
         /// <summary>
         /// CountTestsAction counts the number of test cases in the loaded TestSuite
@@ -556,15 +556,15 @@ namespace NUnit.Framework.Api
             /// <param name="controller">A FrameworkController holding the TestSuite whose cases are to be counted</param>
             /// <param name="filter">A string containing the XML representation of the filter to use</param>
             /// <param name="handler">A callback handler used to report results</param>
-            public CountTestsAction(FrameworkController controller, string filter, object handler) 
+            public CountTestsAction(FrameworkController controller, string filter, object handler)
             {
                 controller.CountTests((ICallbackEventHandler)handler, filter);
             }
         }
 
-#endregion
+        #endregion
 
-#region RunTestsAction
+        #region RunTestsAction
 
         /// <summary>
         /// RunTestsAction runs the loaded TestSuite held by the FrameworkController.
@@ -577,15 +577,15 @@ namespace NUnit.Framework.Api
             /// <param name="controller">A FrameworkController holding the TestSuite to run</param>
             /// <param name="filter">A string containing the XML representation of the filter to use</param>
             /// <param name="handler">A callback handler used to report results</param>
-            public RunTestsAction(FrameworkController controller, string filter, object handler) 
+            public RunTestsAction(FrameworkController controller, string filter, object handler)
             {
                 controller.RunTests((ICallbackEventHandler)handler, filter);
             }
         }
 
-#endregion
+        #endregion
 
-#region RunAsyncAction
+        #region RunAsyncAction
 
         /// <summary>
         /// RunAsyncAction initiates an asynchronous test run, returning immediately
@@ -598,15 +598,15 @@ namespace NUnit.Framework.Api
             /// <param name="controller">A FrameworkController holding the TestSuite to run</param>
             /// <param name="filter">A string containing the XML representation of the filter to use</param>
             /// <param name="handler">A callback handler used to report results</param>
-            public RunAsyncAction(FrameworkController controller, string filter, object handler) 
+            public RunAsyncAction(FrameworkController controller, string filter, object handler)
             {
                 controller.RunAsync((ICallbackEventHandler)handler, filter);
             }
         }
 
-#endregion
+        #endregion
 
-#region StopRunAction
+        #region StopRunAction
 
         /// <summary>
         /// StopRunAction stops an ongoing run.
@@ -627,8 +627,8 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        #endregion
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -153,8 +153,13 @@ namespace NUnit.Framework.Api
                 {
                     var workDirectory = Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory) 
                         ? (string)Settings[FrameworkPackageSettings.WorkDirectory] 
-                        : Environment.CurrentDirectory;
-                    var logName = string.Format(LOG_FILE_FORMAT, Process.GetCurrentProcess().Id, Path.GetFileName(assemblyPath));
+                        : Directory.GetCurrentDirectory();
+#if NETSTANDARD1_6
+                    var id = DateTime.Now.ToString("o");
+#else      
+                    var id = Process.GetCurrentProcess().Id;
+#endif
+                    var logName = string.Format(LOG_FILE_FORMAT, id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
 #endif
@@ -396,7 +401,7 @@ namespace NUnit.Framework.Api
             handler.RaiseCallbackEvent(CountTests(filter).ToString());
         }
 
-#if !PORTABLE || NETSTANDARD1_6
+#if !PORTABLE
         /// <summary>
         /// Inserts environment element
         /// </summary>

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -34,6 +34,9 @@ using System.Web.UI;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+#if NETSTANDARD1_6
+using System.Runtime.InteropServices;
+#endif
 
 namespace NUnit.Framework.Api
 {
@@ -393,12 +396,31 @@ namespace NUnit.Framework.Api
             handler.RaiseCallbackEvent(CountTests(filter).ToString());
         }
 
-#if !PORTABLE
+#if !PORTABLE || NETSTANDARD1_6
         /// <summary>
         /// Inserts environment element
         /// </summary>
         /// <param name="targetNode">Target node</param>
         /// <returns>The new node</returns>
+#if NETSTANDARD1_6
+        public static TNode InsertEnvironmentElement(TNode targetNode)
+        {
+            TNode env = new TNode("environment");
+            targetNode.ChildNodes.Insert(0, env);
+
+            var assemblyName = AssemblyHelper.GetAssemblyName(typeof(FrameworkController).GetTypeInfo().Assembly);
+            env.AddAttribute("framework-version", assemblyName.Version.ToString());
+            env.AddAttribute("clr-version", RuntimeInformation.FrameworkDescription);
+            env.AddAttribute("os-version", RuntimeInformation.OSDescription);
+            env.AddAttribute("cwd", Directory.GetCurrentDirectory());
+            env.AddAttribute("machine-name", Environment.MachineName);
+            env.AddAttribute("culture", CultureInfo.CurrentCulture.ToString());
+            env.AddAttribute("uiculture", CultureInfo.CurrentUICulture.ToString());
+            env.AddAttribute("os-architecture", RuntimeInformation.ProcessArchitecture.ToString());
+
+            return env;
+        }
+#else
         public static TNode InsertEnvironmentElement(TNode targetNode)
         {
             TNode env = new TNode("environment");
@@ -423,6 +445,7 @@ namespace NUnit.Framework.Api
         {
             return IntPtr.Size == 8 ? "x64" : "x86";
         }
+#endif
 #endif
 
         /// <summary>
@@ -457,11 +480,11 @@ namespace NUnit.Framework.Api
             settingsNode.ChildNodes.Add(setting);
         }
 
-        #endregion
+#endregion
 
-        #region Nested Action Classes
+#region Nested Action Classes
 
-        #region TestContollerAction
+#region TestContollerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions
@@ -471,9 +494,9 @@ namespace NUnit.Framework.Api
         {
         }
 
-        #endregion
+#endregion
 
-        #region LoadTestsAction
+#region LoadTestsAction
 
         /// <summary>
         /// LoadTestsAction loads a test into the FrameworkController
@@ -491,9 +514,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region ExploreTestsAction
+#region ExploreTestsAction
 
         /// <summary>
         /// ExploreTestsAction returns info about the tests in an assembly
@@ -512,9 +535,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region CountTestsAction
+#region CountTestsAction
 
         /// <summary>
         /// CountTestsAction counts the number of test cases in the loaded TestSuite
@@ -534,9 +557,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region RunTestsAction
+#region RunTestsAction
 
         /// <summary>
         /// RunTestsAction runs the loaded TestSuite held by the FrameworkController.
@@ -555,9 +578,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region RunAsyncAction
+#region RunAsyncAction
 
         /// <summary>
         /// RunAsyncAction initiates an asynchronous test run, returning immediately
@@ -576,9 +599,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region StopRunAction
+#region StopRunAction
 
         /// <summary>
         /// StopRunAction stops an ongoing run.
@@ -599,8 +622,8 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using System.Collections.Generic;
 using System.IO;
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System.Diagnostics;
 using System.Security;
 using System.Windows.Forms;
@@ -232,7 +232,7 @@ namespace NUnit.Framework.Api
         /// <returns>True if the run completed, otherwise false</returns>
         public bool WaitForCompletion(int timeout)
         {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             return _runComplete.WaitOne(timeout, false);
 #else
             return _runComplete.WaitOne(timeout);
@@ -290,7 +290,7 @@ namespace NUnit.Framework.Api
                 (bool)Settings[FrameworkPackageSettings.DebugTests])
                 System.Diagnostics.Debugger.Launch();
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             if (Settings.ContainsKey(FrameworkPackageSettings.PauseBeforeRun) &&
                 (bool)Settings[FrameworkPackageSettings.PauseBeforeRun])
                 PauseBeforeRun();
@@ -320,7 +320,7 @@ namespace NUnit.Framework.Api
 #if PORTABLE
                 Context.WorkDirectory = @"\My Documents";
 #else
-                Context.WorkDirectory = Environment.CurrentDirectory;
+                Context.WorkDirectory = Directory.GetCurrentDirectory();
 #endif
 
             // Apply attributes to the context
@@ -382,7 +382,7 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of 
         // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the 
         // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
@@ -396,6 +396,6 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
 using System;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
 using System;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         {
             Exception caughtException = null;
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (AsyncInvocationRegion.IsAsyncOperation(code))
             {
                 using (var region = AsyncInvocationRegion.Create(code))

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         {
             Exception caughtException = null;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (AsyncInvocationRegion.IsAsyncOperation(code))
             {
                 using (var region = AsyncInvocationRegion.Create(code))

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework
     /// </summary>
     public delegate void TestDelegate();
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
     /// <summary>
     /// Delegate used by tests that execute async code and
     /// capture any thrown exception.

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework
     /// </summary>
     public delegate void TestDelegate();
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
     /// <summary>
     /// Delegate used by tests that execute async code and
     /// capture any thrown exception.

--- a/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/RequiresMTAAtribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresMTAAtribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/RequiresSTAAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresSTAAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -41,6 +41,7 @@ namespace NUnit.Framework
         public RequiresThreadAttribute()
             : base(true) { }
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Construct a RequiresThreadAttribute, specifying the apartment
         /// </summary>
@@ -49,6 +50,7 @@ namespace NUnit.Framework
         {
             this.Properties.Add(PropertyNames.ApartmentState, apartment);
         }
+#endif
 
         void IApplyToTest.ApplyToTest(Test test)
         {

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using NUnit.Framework.Interfaces;
@@ -41,7 +41,6 @@ namespace NUnit.Framework
         public RequiresThreadAttribute()
             : base(true) { }
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// Construct a RequiresThreadAttribute, specifying the apartment
         /// </summary>
@@ -50,7 +49,6 @@ namespace NUnit.Framework
         {
             this.Properties.Add(PropertyNames.ApartmentState, apartment);
         }
-#endif
 
         void IApplyToTest.ApplyToTest(Test test)
         {

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -378,7 +378,7 @@ namespace NUnit.Framework
 
                 if (targetType.IsAssignableFrom(arg.GetType()))
                     continue;
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (arg is DBNull)
                 {
                     arglist[i] = null;
@@ -429,8 +429,8 @@ namespace NUnit.Framework
         public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
-            
-#if !PORTABLE
+
+#if !PORTABLE && !NETSTANDARD1_6
             if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)
             {

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -224,8 +224,8 @@ namespace NUnit.Framework
                 Reason = value;
             }
         }
-        
-#if !PORTABLE
+
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Comma-delimited list of platforms to run the test for
         /// </summary>

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -132,7 +132,7 @@ namespace NUnit.Framework
                 if (targetType.GetTypeInfo().IsAssignableFrom(arg.GetType().GetTypeInfo()))
                     continue;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (arg is DBNull)
                 {
                     data[i] = null;

--- a/src/NUnitFramework/framework/Compatibility/BindingFlags.cs
+++ b/src/NUnitFramework/framework/Compatibility/BindingFlags.cs
@@ -1,4 +1,4 @@
-﻿#if PORTABLE && !NETSTANDARD1_6
+﻿#if PORTABLE
 using System;
 
 namespace NUnit.Compatibility

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -29,7 +29,7 @@ namespace NUnit.Compatibility
     /// <summary>
     /// A MarshalByRefObject that lives forever
     /// </summary>
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
     public class LongLivedMarshalByRefObject
     {
     }

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 namespace NUnit.Compatibility
 {
-#if !NET_4_5 && !PORTABLE
+#if !NET_4_5 && !PORTABLE && !NETSTANDARD1_6
     /// <summary>
     /// Provides NUnit specific extensions to aid in Reflection
     /// across multiple frameworks
@@ -71,7 +71,7 @@ namespace NUnit.Compatibility
         }
     }
 
-#elif PORTABLE
+#elif PORTABLE || NETSTANDARD1_6
 
     /// <summary>
     /// Provides NUnit specific extensions to aid in Reflection

--- a/src/NUnitFramework/framework/Compatibility/System.Web.UI/ICallbackEventHandler.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Web.UI/ICallbackEventHandler.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 namespace System.Web.UI
 {
     /// <summary>

--- a/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Runtime.Serialization;

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         public virtual ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (AsyncInvocationRegion.IsAsyncOperation(del))
                 using (var region = AsyncInvocationRegion.Create(del))
                     return ApplyTo(region.WaitForPendingOperationsToComplete(del()));

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         public virtual ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (AsyncInvocationRegion.IsAsyncOperation(del))
                 using (var region = AsyncInvocationRegion.Create(del))
                     return ApplyTo(region.WaitForPendingOperationsToComplete(del()));

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -290,7 +290,7 @@ namespace NUnit.Framework.Constraints
 
         #region After Modifier
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a DelayedConstraint.WithRawDelayInterval with the specified delay time.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -438,7 +438,7 @@ namespace NUnit.Framework.Constraints
 
         #region BinarySerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in binary format.
         /// </summary>
@@ -452,7 +452,7 @@ namespace NUnit.Framework.Constraints
 
         #region XmlSerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in xml format.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintFactory.cs
@@ -309,7 +309,7 @@ namespace NUnit.Framework.Constraints
 
         #region BinarySerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in binary format.
         /// </summary>
@@ -323,7 +323,7 @@ namespace NUnit.Framework.Constraints
 
         #region XmlSerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in xml format.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
                 var name = predicate.GetMethodInfo().Name;
 #else
                 var name = predicate.Method.Name;

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Constraints
             {
                 var invocationDescriptor = GetInvocationDescriptor(invocation);
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
                 if (AsyncInvocationRegion.IsAsyncOperation(invocationDescriptor.Delegate))
                 {
                     using (var region = AsyncInvocationRegion.Create(invocationDescriptor.Delegate))
@@ -201,7 +201,7 @@ namespace NUnit.Framework.Constraints
                         invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
                     }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
                     else
                     {
                         var asyncTestDelegate = actual as AsyncTestDelegate;

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Constraints
             {
                 var invocationDescriptor = GetInvocationDescriptor(invocation);
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
                 if (AsyncInvocationRegion.IsAsyncOperation(invocationDescriptor.Delegate))
                 {
                     using (var region = AsyncInvocationRegion.Create(invocationDescriptor.Delegate))
@@ -201,7 +201,7 @@ namespace NUnit.Framework.Constraints
                         invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
                     }
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
                     else
                     {
                         var asyncTestDelegate = actual as AsyncTestDelegate;

--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Constraints
                     caughtException = ex;
                 }
             }
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             AsyncTestDelegate asyncCode = actual as AsyncTestDelegate;
             if (asyncCode != null)
             {

--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Constraints
                     caughtException = ex;
                 }
             }
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             AsyncTestDelegate asyncCode = actual as AsyncTestDelegate;
             if (asyncCode != null)
             {

--- a/src/NUnitFramework/framework/Constraints/XmlSerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/XmlSerializableConstraint.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Xml.Serialization;

--- a/src/NUnitFramework/framework/Exceptions/AssertionException.cs
+++ b/src/NUnitFramework/framework/Exceptions/AssertionException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Thrown when an assertion failed.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class AssertionException : ResultStateException
@@ -48,7 +48,7 @@ namespace NUnit.Framework
             base(message, inner) 
         {}
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
+++ b/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Thrown when an assertion failed.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class IgnoreException : ResultStateException
@@ -47,7 +47,7 @@ namespace NUnit.Framework
             base(message, inner) 
         {}
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
+++ b/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Thrown when a test executes inconclusively.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class InconclusiveException : ResultStateException
@@ -50,7 +50,7 @@ namespace NUnit.Framework
             base(message, inner)
         { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
+++ b/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Abstract base for Exceptions that terminate a test and provide a ResultState.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public abstract class ResultStateException : Exception
@@ -48,7 +48,7 @@ namespace NUnit.Framework
             base(message, inner) 
         {}
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Exceptions/SuccessException.cs
+++ b/src/NUnitFramework/framework/Exceptions/SuccessException.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Thrown when an assertion failed.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class SuccessException : ResultStateException
@@ -48,7 +48,7 @@ namespace NUnit.Framework
             base(message, inner)
         { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -25,7 +25,7 @@ using System;
 using System.Text.RegularExpressions;
 using System.Xml;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Xml.Linq;
 #endif
 
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Interfaces
         /// <returns>A TNode</returns>
         public static TNode FromXml(string xmlText)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return FromXml(XElement.Parse(xmlText));
 #else
             var doc = new XmlDocument();
@@ -258,7 +258,7 @@ namespace NUnit.Framework.Interfaces
 
         #region Helper Methods
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         private static TNode FromXml(XElement xElement)
         {
             TNode tNode = new TNode(xElement.Name.ToString(), xElement.Value);

--- a/src/NUnitFramework/framework/Internal/ActionsHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ActionsHelper.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -60,8 +60,8 @@ namespace NUnit.Framework.Internal
                     action.AfterTest(test);
             }
         }
-        
-#if PORTABLE
+
+#if PORTABLE || NETSTANDARD1_6
         public static ITestAction[] GetActionsFromAttributeProvider(Assembly attributeProvider)
         {
             if (attributeProvider == null)

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -33,6 +33,14 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class AssemblyHelper
     {
+#if PORTABLE || NETSTANDARD1_6
+        const string UriSchemeFile = "file";
+        const string SchemeDelimiter = "://";
+#else
+        const string UriSchemeFile = Uri.UriSchemeFile;
+        const string SchemeDelimiter = Uri.SchemeDelimiter;
+#endif
+
         #region GetAssemblyPath
 
         /// <summary>
@@ -44,7 +52,7 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
             return assembly.ManifestModule.FullyQualifiedName;
 #else
             string codeBase = assembly.CodeBase;
@@ -94,7 +102,7 @@ namespace NUnit.Framework.Internal
 
         #region Load
 
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
         /// <summary>
         /// Loads an assembly given a string, which is the AssemblyName
         /// </summary>
@@ -135,10 +143,9 @@ namespace NUnit.Framework.Internal
 
         #region Helper Methods
 
-#if !PORTABLE && !NETSTANDARD1_6
         private static bool IsFileUri(string uri)
         {
-            return uri.ToLower().StartsWith(Uri.UriSchemeFile);
+            return uri.ToLower().StartsWith(UriSchemeFile);
         }
 
         /// <summary>
@@ -150,7 +157,7 @@ namespace NUnit.Framework.Internal
         public static string GetAssemblyPathFromCodeBase(string codeBase)
         {
             // Skip over the file:// part
-            int start = Uri.UriSchemeFile.Length + Uri.SchemeDelimiter.Length;
+            int start = UriSchemeFile.Length + SchemeDelimiter.Length;
 
             if (codeBase[start] == '/') // third slash means a local path
             {
@@ -167,7 +174,6 @@ namespace NUnit.Framework.Internal
 
             return codeBase.Substring(start);
         }
-#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return assembly.ManifestModule.FullyQualifiedName;
 #else
             string codeBase = assembly.CodeBase;
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal
 
         #region Load
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         /// <summary>
         /// Loads an assembly given a string, which is the AssemblyName
         /// </summary>
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Internal
 
         #region Helper Methods
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private static bool IsFileUri(string uri)
         {
             return uri.ToLower().StartsWith(Uri.UriSchemeFile);

--- a/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +29,7 @@ using System.Reflection;
 using System.Threading;
 using NUnit.Compatibility;
 
-#if NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if !NET_4_0
 using System.Runtime.ExceptionServices;
 #endif
 

--- a/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncInvocationRegion.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +29,7 @@ using System.Reflection;
 using System.Threading;
 using NUnit.Compatibility;
 
-#if NET_4_5 || PORTABLE
+#if NET_4_5 || PORTABLE || NETSTANDARD1_6
 using System.Runtime.ExceptionServices;
 #endif
 
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
 
         public static AsyncInvocationRegion Create(Delegate @delegate)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return Create(@delegate.GetMethodInfo());
 #else
             return Create(@delegate.Method);
@@ -75,7 +75,7 @@ at wrapping a non-async method invocation in an async region was done");
 
         public static bool IsAsyncOperation(Delegate @delegate)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return IsAsyncOperation(@delegate.GetMethodInfo());
 #else
             return IsAsyncOperation(@delegate.Method);

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Internal.Builders
 
             ITypeInfo returnType = testMethod.Method.ReturnType;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
             {
                 if (returnType.IsType(typeof(void)))

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Internal.Builders
 
             ITypeInfo returnType = testMethod.Method.ReturnType;
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
             {
                 if (returnType.IsType(typeof(void)))

--- a/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/ApplyChangesToContextCommand.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Internal.Commands
             }
             catch (Exception ex)
             {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (ex is ThreadAbortException)
                     Thread.ResetAbort();
 #endif

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Internal.Commands
             }
             catch (Exception ex)
             {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (ex is ThreadAbortException)
                     Thread.ResetAbort();
 #endif

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal.Commands
 
         private void RunSetUpOrTearDownMethod(TestExecutionContext context, MethodInfo method)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (AsyncInvocationRegion.IsAsyncOperation(method))
                 RunAsyncMethod(method, context);
             else
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal.Commands
                 RunNonAsyncMethod(method, context);
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
         private void RunAsyncMethod(MethodInfo method, TestExecutionContext context)
         {
             using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(method))

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal.Commands
 
         private void RunSetUpOrTearDownMethod(TestExecutionContext context, MethodInfo method)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (AsyncInvocationRegion.IsAsyncOperation(method))
                 RunAsyncMethod(method, context);
             else
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal.Commands
                 RunNonAsyncMethod(method, context);
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
         private void RunAsyncMethod(MethodInfo method, TestExecutionContext context)
         {
             using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(method))

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
@@ -82,7 +82,7 @@ namespace NUnit.Framework.Internal.Commands
             }
             catch (Exception ex)
             {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (ex is ThreadAbortException)
                     Thread.ResetAbort();
 #endif

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Internal.Commands
 
         private object RunTestMethod(TestExecutionContext context)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
                 return RunAsyncTestMethod(context);
             else
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal.Commands
                 return RunNonAsyncTestMethod(context);
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
         private object RunAsyncTestMethod(TestExecutionContext context)
         {
             using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(testMethod.Method.MethodInfo))

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Internal.Commands
 
         private object RunTestMethod(TestExecutionContext context)
         {
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (AsyncInvocationRegion.IsAsyncOperation(testMethod.Method.MethodInfo))
                 return RunAsyncTestMethod(context);
             else
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal.Commands
                 return RunNonAsyncTestMethod(context);
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
         private object RunAsyncTestMethod(TestExecutionContext context)
         {
             using (AsyncInvocationRegion region = AsyncInvocationRegion.Create(testMethod.Method.MethodInfo))

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class ExceptionHelper
     {
-#if !NET_4_5 && !PORTABLE
+#if !NET_4_5 && !PORTABLE && !NETSTANDARD1_6
         private static readonly Action<Exception> PreserveStackTrace;
 
         static ExceptionHelper()
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal
         /// <param name="exception">The exception to rethrow</param>
         public static void Rethrow(Exception exception)
         {
-#if NET_4_5 || PORTABLE
+#if NET_4_5 || PORTABLE || NETSTANDARD1_6
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
 #else
             PreserveStackTrace(exception);

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -132,7 +132,7 @@ namespace NUnit.Framework.Internal
         {
             var result = new List<Exception>();
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
             if (exception is AggregateException)
             {
                 var aggregateException = (exception as AggregateException);

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -132,7 +132,7 @@ namespace NUnit.Framework.Internal
         {
             var result = new List<Exception>();
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
             if (exception is AggregateException)
             {
                 var aggregateException = (exception as AggregateException);

--- a/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal.Execution
             {
                 var testAssembly = suite as TestAssembly;
                 if (testAssembly != null)
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
                     changes = new List<IApplyToContext>(testAssembly.Assembly.GetAttributes<IApplyToContext>());
 #else
                     changes = (IApplyToContext[])testAssembly.Assembly.GetCustomAttributes(typeof(IApplyToContext), true);

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Internal.Execution
                     var child = WorkItem.CreateWorkItem(test, _childFilter);
                     child.WorkerId = this.WorkerId;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                     if (child.TargetApartment == ApartmentState.Unknown && TargetApartment != ApartmentState.Unknown)
                         child.TargetApartment = TargetApartment;
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -83,8 +83,12 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         override public System.Text.Encoding Encoding
 		{
-			get { return Encoding.Default; }
-		}
+#if NETSTANDARD1_6
+            get { return Encoding.UTF8; }
+#else
+            get { return Encoding.Default; }
+#endif
+        }
 
         private bool TrySendToListener(string text)
         {

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class SimpleWorkItemDispatcher : IWorkItemDispatcher
     {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         // The first WorkItem to be dispatched, assumed to be top-level item
         private WorkItem _topLevelWorkItem;
 
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="work">The item to dispatch</param>
         public void Dispatch(WorkItem work)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             if (work != null)
                 work.Execute();
 #else
@@ -74,14 +74,14 @@ namespace NUnit.Framework.Internal.Execution
 #endif
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private void RunnerThreadProc()
         {
             _topLevelWorkItem.Execute();
         }
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private object cancelLock = new object();
 #endif
 
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="force">true if the run should be aborted, false if it should allow its currently running test to complete</param>
         public void CancelRun(bool force)
         {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             lock (cancelLock)
             {
                 if (_topLevelWorkItem != null)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Internal.Execution
             Result = test.MakeTestResult();
             State = WorkItemState.Ready;
             Actions = new List<ITestAction>();
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             TargetApartment = Test.Properties.ContainsKey(PropertyNames.ApartmentState)
                 ? (ApartmentState)Test.Properties.Get(PropertyNames.ApartmentState)
                 : ApartmentState.Unknown;
@@ -188,7 +188,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public TestResult Result { get; protected set; }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         internal ApartmentState TargetApartment { get; set; }
         private ApartmentState CurrentApartment { get; set; }
 #endif
@@ -251,9 +251,11 @@ namespace NUnit.Framework.Internal.Execution
                 ownThreadReason |= OwnThreadReason.RequiresThread;
             if (timeout > 0 && Test is TestMethod)
                 ownThreadReason |= OwnThreadReason.Timeout;
+#if !NETSTANDARD1_6
             CurrentApartment = Thread.CurrentThread.GetApartmentState();
             if (CurrentApartment != TargetApartment && TargetApartment != ApartmentState.Unknown)
                 ownThreadReason |= OwnThreadReason.DifferentApartment;
+#endif
 #endif
 
             if (ownThreadReason == OwnThreadReason.NotNeeded)
@@ -268,7 +270,7 @@ namespace NUnit.Framework.Internal.Execution
             else
             {
                 log.Debug("Running test on own thread. " + ownThreadReason);
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 var apartment = (ownThreadReason | OwnThreadReason.DifferentApartment) != 0
                     ? TargetApartment
                     : CurrentApartment;
@@ -277,7 +279,7 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private Thread thread;
 
         private void RunTestOnOwnThread(int timeout, ApartmentState apartment)
@@ -288,7 +290,7 @@ namespace NUnit.Framework.Internal.Execution
         }
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private void RunThread(int timeout)
         {
             thread.CurrentCulture = Context.CurrentCulture;
@@ -374,7 +376,7 @@ namespace NUnit.Framework.Internal.Execution
             if (!force)
                 return;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Thread tThread;
 
             lock (threadLock)
@@ -402,9 +404,9 @@ namespace NUnit.Framework.Internal.Execution
 #endif
         }
 
-#endregion
+        #endregion
 
-#region Protected Methods
+        #region Protected Methods
 
         /// <summary>
         /// Method that performs actually performs the work. It should

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal.Filters
     /// Combines multiple filters so that a test must pass all 
     /// of them in order to pass this filter.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class AndFilter : CompositeFilter

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal.Filters
     /// based on their categories.
     /// </summary>
     /// 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class CategoryFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// ClassName filter selects tests based on the class FullName
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class ClassNameFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class FullNameFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// IdFilter selects tests based on their id
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class IdFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class MethodNameFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// NotFilter negates the operation of another filter
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class NotFilter : TestFilter

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal.Filters
     /// Combines multiple filters so that a test must pass one 
     /// of them in order to pass this filter.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class OrFilter : CompositeFilter

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal.Filters
     /// based on their properties.
     /// </summary>
     /// 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class PropertyFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// TestName filter selects tests based on their Name
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class TestNameFilter : ValueMatchFilter

--- a/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
     /// ValueMatchFilter selects tests based on some value, which
     /// is expected to be contained in the test.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public abstract class ValueMatchFilter : TestFilter

--- a/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// InvalidTestFixtureException is thrown when an appropriate test
     /// fixture constructor using the provided arguments cannot be found.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class InvalidDataSourceException : Exception
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Internal
         public InvalidDataSourceException(string message, Exception inner) : base(message, inner)
         { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// InvalidTestFixtureException is thrown when an appropriate test
     /// fixture constructor using the provided arguments cannot be found.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class InvalidTestFixtureException : Exception
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Internal
         public InvalidTestFixtureException(string message, Exception inner) : base(message, inner)
         { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Logging/Logger.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/Logger.cs
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Internal
             writer.WriteLine(TRACE_FMT,
                 DateTime.Now.ToString(TIME_FMT),
                 level == InternalTraceLevel.Verbose ? "Debug" : level.ToString(),
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
                 System.Environment.CurrentManagedThreadId,
 #else
                 System.Threading.Thread.CurrentThread.ManagedThreadId,

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -162,7 +162,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return MethodInfo.GetAttributes<T>(inherit).ToArray();
 #else
             return (T[])MethodInfo.GetCustomAttributes(typeof(T), inherit);
@@ -174,7 +174,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool IsDefined<T>(bool inherit)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return MethodInfo.GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
 #else
             return MethodInfo.IsDefined(typeof(T), inherit);

--- a/src/NUnitFramework/framework/Internal/NUnitException.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// Thrown when an assertion failed. Here to preserve the inner
     /// exception and hence its stack trace.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class NUnitException : Exception 
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal
             base(message, inner) 
         { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -99,7 +99,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool IsDefined<T>(bool inherit)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return ParameterInfo.GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
 #else
             return ParameterInfo.IsDefined(typeof(T), inherit);

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -27,7 +27,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
-#if PORTABLE
+#if PORTABLE|| NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return ParameterInfo.GetAttributes<T>(inherit).ToArray();
 #else
             return (T[])ParameterInfo.GetCustomAttributes(typeof(T), inherit);

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Linq;
 
@@ -69,8 +69,8 @@ namespace NUnit.Framework.Internal
         /// Construct a PlatformHelper for a particular operating
         /// system and common language runtime. Used in testing.
         /// </summary>
-        /// <param name="os">OperatingSystem to be used</param>
         /// <param name="rt">RuntimeFramework to be used</param>
+        /// <param name="os">OperatingSystem to be used</param>
         public PlatformHelper( OSPlatform os, RuntimeFramework rt )
         {
             _os = os;

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Internal
                 {
                     return method.Invoke(fixture, args);
                 }
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 catch (System.Threading.ThreadAbortException)
                 {
                     // No need to wrap or rethrow ThreadAbortException

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -28,7 +28,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Internal
         /// <returns>True if found, otherwise false</returns>
         public static bool HasMethodWithAttribute(Type fixtureType, Type attributeType)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return fixtureType.GetMethods(AllMembers | BindingFlags.FlattenHierarchy)
                 .Any(m => m.GetCustomAttributes(false).Any(a => attributeType.IsAssignableFrom(a.GetType())));
 #else

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -99,7 +99,7 @@ namespace NUnit.Framework.Internal
             Test = test;
             ResultState = ResultState.Inconclusive;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             OutWriter = new StringWriter(_output);
 #else
             OutWriter = TextWriter.Synchronized(new StringWriter(_output));
@@ -481,7 +481,7 @@ namespace NUnit.Framework.Internal
 
                 SetResult(((ResultStateException)ex).ResultState, message, stackTrace);
             }
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             else if (ex is System.Threading.ThreadAbortException)
                 SetResult(ResultState.Cancelled,
                     "Test cancelled by user",
@@ -507,7 +507,7 @@ namespace NUnit.Framework.Internal
                 SetResult(((ResultStateException)ex).ResultState.WithSite(site),
                     ex.Message,
                     StackFilter.DefaultFilter.Filter(ex.StackTrace));
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             else if (ex is System.Threading.ThreadAbortException)
                 SetResult(ResultState.Cancelled.WithSite(site),
                     "Test cancelled by user",

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Internal
     /// RuntimeFramework represents a particular version
     /// of a common language runtime implementation.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public sealed class RuntimeFramework

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -53,9 +53,7 @@ namespace NUnit.Framework.Internal
     /// RuntimeFramework represents a particular version
     /// of a common language runtime implementation.
     /// </summary>
-#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
-#endif
     public sealed class RuntimeFramework
     {
         // NOTE: This version of RuntimeFramework is for use
@@ -63,7 +61,7 @@ namespace NUnit.Framework.Internal
         // than the version in the test engine because it does
         // not need to know what frameworks are available,
         // only what framework is currently running.
-#region Static and Instance Fields
+        #region Static and Instance Fields
 
         /// <summary>
         /// DefaultVersion is an empty Version, used to indicate that
@@ -144,9 +142,9 @@ namespace NUnit.Framework.Internal
             return currentFramework;
         });
 
-#endregion
+        #endregion
 
-#region Constructor
+        #region Constructor
 
         /// <summary>
         /// Construct from a runtime type and version. If the version has
@@ -226,9 +224,9 @@ namespace NUnit.Framework.Internal
                 FrameworkVersion = new Version(1, 0);
         }
 
-#endregion
+        #endregion
 
-#region Properties
+        #region Properties
         /// <summary>
         /// Static method to return a RuntimeFramework object
         /// for the framework that is currently in use.
@@ -270,9 +268,9 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public string DisplayName { get; private set; }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         /// <summary>
         /// Parses a string representing a RuntimeFramework.
@@ -357,9 +355,9 @@ namespace NUnit.Framework.Internal
             return FrameworkVersion.Major >= target.FrameworkVersion.Major && FrameworkVersion.Minor >= target.FrameworkVersion.Minor;
         }
 
-#endregion
+        #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
         private static bool IsRuntimeTypeName(string name)
         {
@@ -384,7 +382,7 @@ namespace NUnit.Framework.Internal
                   (v1.Revision < 0 || v2.Revision < 0 || v1.Revision == v2.Revision);
         }
 
-#endregion
+        #endregion
     }
 }
 #endif

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -31,7 +31,7 @@ using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System.Runtime.Remoting.Messaging;
 using System.Security;
 using System.Security.Principal;
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Internal
     /// are called.
     /// </summary>
     public class TestExecutionContext
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         : LongLivedMarshalByRefObject, ILogicalThreadAffinative
 #endif
     {
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         private TestResult _currentResult;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// The current Principal.
         /// </summary>
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Internal
             _currentCulture = CultureInfo.CurrentCulture;
             _currentUICulture = CultureInfo.CurrentUICulture;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             _currentPrincipal = Thread.CurrentPrincipal;
 #endif
 
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Internal
             _currentCulture = other.CurrentCulture;
             _currentUICulture = other.CurrentUICulture;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             _currentPrincipal = other.CurrentPrincipal;
 #endif
 
@@ -174,7 +174,7 @@ namespace NUnit.Framework.Internal
         // We create a new context, which is automatically
         // populated with values taken from the current thread.
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         // In the Silverlight and portable builds, we use a ThreadStatic
         // field to hold the current TestExecutionContext.
 
@@ -197,6 +197,16 @@ namespace NUnit.Framework.Internal
             {
                 _currentContext = value;
             }
+        }
+
+        /// <summary>
+        /// Get the current context or return null if none is found.
+        /// </summary>
+        /// <remarks></remarks>
+        public static TestExecutionContext GetTestExecutionContext()
+        {
+            // TODO: Does this actually work now that there is no threading?
+            return _currentContext;
         }
 #else
         // In all other builds, we use the CallContext
@@ -415,7 +425,7 @@ namespace NUnit.Framework.Internal
             set
             {
                 _currentCulture = value;
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 Thread.CurrentThread.CurrentCulture = _currentCulture;
 #endif
             }
@@ -430,13 +440,13 @@ namespace NUnit.Framework.Internal
             set
             {
                 _currentUICulture = value;
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 Thread.CurrentThread.CurrentUICulture = _currentUICulture;
 #endif
             }
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Gets or sets the current <see cref="IPrincipal"/> for the Thread.
         /// </summary>
@@ -475,7 +485,7 @@ namespace NUnit.Framework.Internal
             _currentCulture = CultureInfo.CurrentCulture;
             _currentUICulture = CultureInfo.CurrentUICulture;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             _currentPrincipal = Thread.CurrentPrincipal;
 #endif
         }
@@ -487,7 +497,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public void EstablishExecutionEnvironment()
         {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Thread.CurrentThread.CurrentCulture = _currentCulture;
             Thread.CurrentThread.CurrentUICulture = _currentUICulture;
             Thread.CurrentPrincipal = _currentPrincipal;
@@ -527,7 +537,7 @@ namespace NUnit.Framework.Internal
 
         #region InitializeLifetimeService
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Obtain lifetime service object
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Internal
         /// <remarks></remarks>
         public static TestExecutionContext GetTestExecutionContext()
         {
-            // TODO: Does this actually work now that there is no threading?
+            // TODO: This will need to be reworked if we re-introduce threading in .NET Standard
             return _currentContext;
         }
 #else

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Internal
     /// The filter applies when running the test, after it has been
     /// loaded, since this is the only time an ITest exists.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public abstract class TestFilter : ITestFilter
@@ -200,7 +200,7 @@ namespace NUnit.Framework.Internal
         /// Nested class provides an empty filter - one that always
         /// returns true when called. It never matches explicitly.
         /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Serializable]
 #endif
         private class EmptyFilter : TestFilter

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -306,7 +306,7 @@ namespace NUnit.Framework.Internal
         /// <returns>A TestResult suitable for this type of test.</returns>
         public abstract TestResult MakeTestResult();
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         /// <summary>
         /// Modify a newly constructed test by applying any of NUnit's common
         /// attributes, based on a supplied ICustomAttributeProvider, which is

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -27,7 +27,7 @@ using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
 using System.Threading.Tasks;
 #endif
 
@@ -254,7 +254,7 @@ namespace NUnit.Framework.Internal
                      !method.IsPublic && !method.IsFamily ||
                      method.GetParameters().Length > 0 ||
                      method.ReturnType != typeof(void)
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
                      &&
                      method.ReturnType != typeof(Task)
 #endif

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -27,7 +27,7 @@ using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -254,7 +254,7 @@ namespace NUnit.Framework.Internal
                      !method.IsPublic && !method.IsFamily ||
                      method.GetParameters().Length > 0 ||
                      method.ReturnType != typeof(void)
-#if NET_4_0 || NET_4_5 || PORTABLE || NETSTANDARD1_6
+#if ASYNC
                      &&
                      method.ReturnType != typeof(Task)
 #endif

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -206,7 +206,7 @@ namespace NUnit.Framework.Internal
         /// <returns></returns>
         public bool IsDefined<T>(bool inherit)
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return Type.GetTypeInfo().GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
 #else
             return Type.GetTypeInfo().IsDefined(typeof(T), inherit);

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -191,7 +191,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return Type.GetTypeInfo().GetAttributes<T>(inherit).ToArray();
 #else
             return (T[])Type.GetCustomAttributes(typeof(T), inherit);

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -171,7 +171,7 @@ namespace NUnit.Framework
 
         #region BinarySerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in binary format.
         /// </summary>
@@ -185,7 +185,7 @@ namespace NUnit.Framework
 
         #region XmlSerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in xml format.
         /// </summary>

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -143,10 +143,10 @@ namespace NUnit.Framework
         }
 #endif
 
-                /// <summary>
-                /// Gets the directory to be used for outputting files created
-                /// by this test run.
-                /// </summary>
+        /// <summary>
+        /// Gets the directory to be used for outputting files created
+        /// by this test run.
+        /// </summary>
         public string WorkDirectory
         {
             get { return _testExecutionContext.WorkDirectory; }

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework
             get { return _testExecutionContext.WorkerId; }
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Gets the directory containing the current test assembly.
         /// </summary>

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework
             get { return _testExecutionContext.WorkerId; }
         }
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
         /// <summary>
         /// Gets the directory containing the current test assembly.
         /// </summary>
@@ -130,17 +130,23 @@ namespace NUnit.Framework
                 if (test != null)
                     return AssemblyHelper.GetDirectoryName(test.TypeInfo.Assembly);
 
+#if NETSTANDARD1_6
+                // Test is null, we may be loading tests rather than executing.
+                // Assume that the NUnit framework is in the same directory as the tests
+                return AssemblyHelper.GetDirectoryName(typeof(TestContext).GetTypeInfo().Assembly);
+#else
                 // Test is null, we may be loading tests rather than executing.
                 // Assume that calling assembly is the test assembly.
                 return AssemblyHelper.GetDirectoryName(Assembly.GetCallingAssembly());
+#endif
             }
         }
 #endif
 
-        /// <summary>
-        /// Gets the directory to be used for outputting files created
-        /// by this test run.
-        /// </summary>
+                /// <summary>
+                /// Gets the directory to be used for outputting files created
+                /// by this test run.
+                /// </summary>
         public string WorkDirectory
         {
             get { return _testExecutionContext.WorkDirectory; }

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_0;PARALLEL</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\nunit.framework.xml</DocumentationFile>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_0;PARALLEL</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\nunit.framework.xml</DocumentationFile>

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_5;PARALLEL</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\nunit.framework.xml</DocumentationFile>
@@ -35,7 +35,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_5;PARALLEL</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\nunit.framework.xml</DocumentationFile>

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -87,6 +87,7 @@
     </Compile>
     <Compile Include="AssertionHelper.cs" />
     <Compile Include="Assume.cs" />
+    <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CategoryAttribute.cs" />
     <Compile Include="Attributes\CombinatorialAttribute.cs" />
@@ -192,6 +193,7 @@
     <Compile Include="Constraints\GreaterThanOrEqualConstraint.cs" />
     <Compile Include="Constraints\IConstraint.cs" />
     <Compile Include="Constraints\InstanceOfTypeConstraint.cs" />
+    <Compile Include="Constraints\Interval.cs" />
     <Compile Include="Constraints\IResolveConstraint.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
@@ -2,7 +2,8 @@
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "System.Runtime.Loader": "4.0.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\portable\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 #if !PORTABLE
@@ -74,7 +75,7 @@ namespace NUnit.Tests
 
             public const int TestStartedEvents = Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests;
             public const int TestFinishedEvents = Tests;
-#if PORTABLE
+#if PORTABLE && !NETSTANDARD1_6
             public const int TestOutputEvents = 0;
 #else
             public const int TestOutputEvents = 1;
@@ -100,12 +101,22 @@ namespace NUnit.Tests
             public const int Success = TestsRun - Errors - Failures - Inconclusive;
 
 #if !PORTABLE
+#if NETSTANDARD1_6
+            public static readonly Assembly ThisAssembly = typeof(MockAssembly).GetTypeInfo().Assembly;
+            public static readonly string AssemblyPath = AssemblyHelper.GetAssemblyPath(ThisAssembly);
+
+            public static void Main(string[] args)
+            {
+                new AutoRun(ThisAssembly).Execute(args);
+            }
+#else
             public static readonly string AssemblyPath = AssemblyHelper.GetAssemblyPath(typeof(MockAssembly).Assembly);
 
             public static void Main(string[] args)
             {
                 new AutoRun().Execute(args);
             }
+#endif
 #endif
         }
 

--- a/src/NUnitFramework/mock-assembly/mock-assembly-netstandard.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly-netstandard.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-netstandard.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-netstandard.csproj
@@ -24,7 +24,7 @@
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
     <StartArguments>..\..\..\bin\Debug\netstandard16\nunitlite-runner.exe nunit.framework.tests.dll</StartArguments>
-    <DefineConstants>TRACE;DEBUG;PORTABLE;NETCOREAPP1_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -37,7 +37,7 @@
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
     <StartArguments>..\..\..\bin\Release\netstandard16\nunitlite-runner.exe nunit.framework.tests.dll</StartArguments>
-    <DefineConstants>TRACE;PORTABLE;NETCOREAPP1_0</DefineConstants>
+    <DefineConstants>TRACE;NETCOREAPP1_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -48,12 +48,6 @@
     </Compile>
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-    <Compile Include="..\nunitlite\ColorConsole.cs">
-      <Link>ColorConsole.cs</Link>
-    </Compile>
-    <Compile Include="..\nunitlite\ColorConsoleWriter.cs">
-      <Link>ColorConsoleWriter.cs</Link>
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETCOREAPP1_0
 using System;
 using System.IO;
 using System.Text;

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE;NETCOREAPP1_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETCOREAPP1_0;NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -32,7 +32,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE;NETCOREAPP1_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETCOREAPP1_0;NUNITLITE</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.csproj
@@ -67,12 +67,6 @@
     <Compile Include="..\FrameworkVersion.cs">
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
-    <Compile Include="..\nunitlite\ColorConsole.cs">
-      <Link>ColorConsole.cs</Link>
-    </Compile>
-    <Compile Include="..\nunitlite\ColorConsoleWriter.cs">
-      <Link>ColorConsoleWriter.cs</Link>
-    </Compile>
     <Compile Include="..\TestBuilder.cs">
       <Link>TestUtilities\TestBuilder.cs</Link>
     </Compile>

--- a/src/NUnitFramework/nunitlite/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite/AutoRun.cs
@@ -66,10 +66,12 @@ namespace NUnitLite
         }
 
 #if !PORTABLE
+#if !NETSTANDARD1_6
         /// <summary>
         /// Default Constructor, only used where GetCallingAssembly is available
         /// </summary>
         public AutoRun() : this(Assembly.GetCallingAssembly()) { }
+#endif
 
         /// <summary>
         /// Execute the tests in the assembly, passing in

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -368,12 +368,8 @@ namespace NUnit.Common
                     {
                         try
                         {
-#if NETSTANDARD1_6
                             using (var str = new FileStream(fullTestListPath, FileMode.Open))
                             using (var rdr = new StreamReader(str))
-#else
-                            using (var rdr = new StreamReader(fullTestListPath))
-#endif
                             {
                                 while (!rdr.EndOfStream)
                                 {
@@ -392,7 +388,7 @@ namespace NUnit.Common
                 });
 
 #endif
-                                this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
+            this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
 
             this.Add("params|p=", "Define a test parameter.",

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -45,7 +45,7 @@ namespace NUnit.Common
 #if PORTABLE
             @"\My Documents";
 #else
-            Environment.CurrentDirectory;
+            Directory.GetCurrentDirectory();
 #endif
 
         private bool validated;
@@ -368,7 +368,12 @@ namespace NUnit.Common
                     {
                         try
                         {
+#if NETSTANDARD1_6
+                            using (var str = new FileStream(fullTestListPath, FileMode.Open))
+                            using (var rdr = new StreamReader(str))
+#else
                             using (var rdr = new StreamReader(fullTestListPath))
+#endif
                             {
                                 while (!rdr.EndOfStream)
                                 {
@@ -387,7 +392,7 @@ namespace NUnit.Common
                 });
 
 #endif
-            this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
+                                this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
 
             this.Add("params|p=", "Define a test parameter.",

--- a/src/NUnitFramework/nunitlite/DebugWriter.cs
+++ b/src/NUnitFramework/nunitlite/DebugWriter.cs
@@ -105,7 +105,11 @@ namespace NUnitLite
         /// </returns>
         public override System.Text.Encoding Encoding
         {
+#if NETSTANDARD1_6
+            get { return System.Text.Encoding.UTF8; }
+#else
             get { return System.Text.Encoding.Default; }
+#endif
         }
     }
 }

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -143,7 +143,7 @@ using System.Text.RegularExpressions;
 // Missing XML Docs
 #pragma warning disable 1591
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using NUnit.Compatibility;
 #else
 using System.Security.Permissions;
@@ -362,7 +362,7 @@ namespace Mono.Options
         protected static T Parse<T> (string value, OptionContext c)
         {
             Type tt = typeof (T);
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             bool nullable = tt.GetTypeInfo().IsValueType && tt.GetTypeInfo().IsGenericType && 
                 !tt.GetTypeInfo().IsGenericTypeDefinition && 
                 tt.GetGenericTypeDefinition () == typeof (Nullable<>);
@@ -374,13 +374,13 @@ namespace Mono.Options
             Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             TypeConverter conv = TypeDescriptor.GetConverter (targetType);
 #endif
             T t = default (T);
             try {
                 if (value != null)
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
                     t = (T)Convert.ChangeType(value, tt, CultureInfo.InvariantCulture);
 #else
                     t = (T) conv.ConvertFromString (value);
@@ -490,7 +490,7 @@ namespace Mono.Options
         }
     }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class OptionException : Exception
@@ -513,7 +513,7 @@ namespace Mono.Options
             this.option = optionName;
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         protected OptionException (SerializationInfo info, StreamingContext context)
             : base (info, context)
         {
@@ -525,7 +525,7 @@ namespace Mono.Options
             get {return this.option;}
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
         public override void GetObjectData (SerializationInfo info, StreamingContext context)
         {
@@ -539,23 +539,6 @@ namespace Mono.Options
 
     public class OptionSet : KeyedCollection<string, Option>
     {
-#if !PORTABLE
-        public OptionSet ()
-            : this (delegate (string f) {return f;})
-        {
-        }
-
-        public OptionSet (Converter<string, string> localizer)
-        {
-            this.localizer = localizer;
-        }
-
-        Converter<string, string> localizer;
-
-        public Converter<string, string> MessageLocalizer {
-            get {return localizer;}
-        }
-#else
         string localizer(string msg)
         {
             return msg;
@@ -565,7 +548,6 @@ namespace Mono.Options
         {
             return msg;
         }
-#endif
 
         protected override string GetKeyForItem (Option item)
         {

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -31,6 +31,9 @@ using System.IO;
 using NUnit.Common;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+#if NETSTANDARD1_6
+using System.Runtime.InteropServices;
+#endif
 
 namespace NUnitLite
 {
@@ -61,19 +64,10 @@ namespace NUnitLite
         /// <param name="filter"></param>
         public override void WriteResultFile(ITestResult result, TextWriter writer, IDictionary<string, object> runSettings, TestFilter filter)
         {
-            // NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
-            // but does implement Close(). Hence we cannot use a 'using' clause.
-            //using (XmlTextWriter xmlWriter = new XmlTextWriter(writer))
-            XmlTextWriter xmlWriter = new XmlTextWriter(writer);
-            xmlWriter.Formatting = Formatting.Indented;
-
-            try
+            var settings = new XmlWriterSettings { Indent = true };
+            using (var xmlWriter = XmlWriter.Create(writer, settings))
             {
                 WriteXmlOutput(result, xmlWriter);
-            }
-            finally
-            {
-                writer.Close();
             }
         }
 
@@ -122,6 +116,19 @@ namespace NUnitLite
             xmlWriter.WriteEndElement();
         }
 
+#if NETSTANDARD1_6
+        private void WriteEnvironment()
+        {
+            xmlWriter.WriteStartElement("environment");
+            var assemblyName = AssemblyHelper.GetAssemblyName(typeof(NUnit2XmlOutputWriter).GetTypeInfo().Assembly);
+            xmlWriter.WriteAttributeString("nunit-version", assemblyName.Version.ToString());
+            xmlWriter.WriteAttributeString("clr-version", RuntimeInformation.FrameworkDescription);
+            xmlWriter.WriteAttributeString("os-version", RuntimeInformation.OSDescription);
+            xmlWriter.WriteAttributeString("cwd", Directory.GetCurrentDirectory());
+            xmlWriter.WriteAttributeString("machine-name", Environment.MachineName);
+            xmlWriter.WriteEndElement();
+        }
+#else
         private void WriteEnvironment()
         {
             xmlWriter.WriteStartElement("environment");
@@ -144,6 +151,7 @@ namespace NUnitLite
                                            Environment.UserDomainName);
             xmlWriter.WriteEndElement();
         }
+#endif
 
         private void WriteResultElement(ITestResult result)
         {
@@ -174,11 +182,13 @@ namespace NUnitLite
             xmlWriter.WriteEndElement(); // test-results
             xmlWriter.WriteEndDocument();
             xmlWriter.Flush();
+#if !NETSTANDARD1_6
             xmlWriter.Close();
+#endif
         }
 
 
-        #region Element Creation Helpers
+#region Element Creation Helpers
 
         private void StartTestElement(ITestResult result)
         {
@@ -331,9 +341,9 @@ namespace NUnitLite
             xmlWriter.WriteEndElement();
         }
 
-        #endregion
+#endregion
 
-        #region Output Helpers
+#region Output Helpers
         ///// <summary>
         ///// Makes string safe for xml parsing, replacing control chars with '?'
         ///// </summary>
@@ -387,6 +397,6 @@ namespace NUnitLite
                 xmlWriter.WriteCData(text);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -170,7 +170,7 @@ namespace NUnitLite
                     WriteFailureElement(result.Message, result.StackTrace);
                     break;
             }
-            
+
             if (result.Test is TestSuite)
                 WriteChildResults(result);
 
@@ -188,7 +188,7 @@ namespace NUnitLite
         }
 
 
-#region Element Creation Helpers
+        #region Element Creation Helpers
 
         private void StartTestElement(ITestResult result)
         {
@@ -341,9 +341,9 @@ namespace NUnitLite
             xmlWriter.WriteEndElement();
         }
 
-#endregion
+        #endregion
 
-#region Output Helpers
+        #region Output Helpers
         ///// <summary>
         ///// Makes string safe for xml parsing, replacing control chars with '?'
         ///// </summary>
@@ -397,6 +397,6 @@ namespace NUnitLite
                 xmlWriter.WriteCData(text);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -86,7 +86,9 @@ namespace NUnitLite
 
             TNode testRun = MakeTestRunElement(result);
 
+#if !NETSTANDARD1_6
             testRun.ChildNodes.Add(MakeCommandLineElement());
+#endif
             testRun.ChildNodes.Add(MakeTestFilterElement(filter));
             testRun.ChildNodes.Add(resultNode);
 
@@ -126,10 +128,12 @@ namespace NUnitLite
             return testRun;
         }
 
+#if !NETSTANDARD1_6
         private static TNode MakeCommandLineElement()
         {
             return new TNode("command-line", Environment.CommandLine, true);
         }
+#endif
 
         private static TNode MakeTestFilterElement(TestFilter filter)
         {

--- a/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
@@ -45,12 +45,8 @@ namespace NUnitLite
         /// <param name="runSettings">A dictionary of settings used for this test run</param>
         public void WriteResultFile(ITestResult result, string outputPath, IDictionary<string, object> runSettings, TestFilter filter)
         {
-#if NETSTANDARD1_6
             using (var stream = new FileStream(outputPath, FileMode.Create))
             using (var writer = new StreamWriter(stream, Encoding.UTF8))
-#else
-            using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
-#endif
             {
                 WriteResultFile(result, writer, runSettings, filter);
             }
@@ -63,12 +59,8 @@ namespace NUnitLite
         /// <param name="outputPath">Path to the file to which the test info is written</param>
         public void WriteTestFile(ITest test, string outputPath)
         {
-#if NETSTANDARD1_6
             using (var stream = new FileStream(outputPath, FileMode.Create))
             using (var writer = new StreamWriter(stream, Encoding.UTF8))
-#else
-            using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
-#endif
             {
                 WriteTestFile(test, writer);
             }

--- a/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
@@ -45,7 +45,12 @@ namespace NUnitLite
         /// <param name="runSettings">A dictionary of settings used for this test run</param>
         public void WriteResultFile(ITestResult result, string outputPath, IDictionary<string, object> runSettings, TestFilter filter)
         {
+#if NETSTANDARD1_6
+            using (var stream = new FileStream(outputPath, FileMode.OpenOrCreate | FileMode.Truncate))
+            using (var writer = new StreamWriter(stream, Encoding.UTF8))
+#else
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
+#endif
             {
                 WriteResultFile(result, writer, runSettings, filter);
             }
@@ -58,7 +63,12 @@ namespace NUnitLite
         /// <param name="outputPath">Path to the file to which the test info is written</param>
         public void WriteTestFile(ITest test, string outputPath)
         {
+#if NETSTANDARD1_6
+            using (var stream = new FileStream(outputPath, FileMode.OpenOrCreate | FileMode.Truncate))
+            using (var writer = new StreamWriter(stream, Encoding.UTF8))
+#else
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
+#endif
             {
                 WriteTestFile(test, writer);
             }

--- a/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
@@ -46,7 +46,7 @@ namespace NUnitLite
         public void WriteResultFile(ITestResult result, string outputPath, IDictionary<string, object> runSettings, TestFilter filter)
         {
 #if NETSTANDARD1_6
-            using (var stream = new FileStream(outputPath, FileMode.OpenOrCreate | FileMode.Truncate))
+            using (var stream = new FileStream(outputPath, FileMode.Create))
             using (var writer = new StreamWriter(stream, Encoding.UTF8))
 #else
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))
@@ -64,7 +64,7 @@ namespace NUnitLite
         public void WriteTestFile(ITest test, string outputPath)
         {
 #if NETSTANDARD1_6
-            using (var stream = new FileStream(outputPath, FileMode.OpenOrCreate | FileMode.Truncate))
+            using (var stream = new FileStream(outputPath, FileMode.Create))
             using (var writer = new StreamWriter(stream, Encoding.UTF8))
 #else
             using (StreamWriter writer = new StreamWriter(outputPath, false, Encoding.UTF8))

--- a/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
@@ -30,7 +30,7 @@ namespace NUnit.Common
     /// TestSelectionParserException is thrown when an error 
     /// is found while parsing the selection expression.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class TestSelectionParserException : Exception
@@ -47,7 +47,7 @@ namespace NUnit.Common
         /// <param name="innerException"></param>
         public TestSelectionParserException(string message, Exception innerException) : base(message, innerException) { }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization constructor
         /// </summary>

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -30,6 +30,9 @@ using NUnit.Common;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+#if NETSTANDARD1_6
+using System.Runtime.InteropServices;
+#endif
 
 namespace NUnitLite
 {
@@ -170,8 +173,13 @@ namespace NUnitLite
         {
 #if !PORTABLE
             WriteSectionHeader("Runtime Environment");
+#if NETSTANDARD1_6
+            Writer.WriteLabelLine("   OS Version: ", RuntimeInformation.OSDescription);
+            Writer.WriteLabelLine("  CLR Version: ", RuntimeInformation.FrameworkDescription);
+#else
             Writer.WriteLabelLine("   OS Version: ", Environment.OSVersion);
             Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
+#endif
             Writer.WriteLine();
 #endif
         }
@@ -217,7 +225,7 @@ namespace NUnitLite
 #endif
 
 #if !PORTABLE
-            Writer.WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? Environment.CurrentDirectory);
+            Writer.WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? Directory.GetCurrentDirectory());
 #endif
 
             Writer.WriteLabelLine("    Internal Trace: ", _options.InternalTraceLevel ?? "Off");

--- a/src/NUnitFramework/nunitlite/nunitlite-netstandard.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite-netstandard.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD1_6;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6;NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -34,7 +34,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE;NETSTANDARD1_6;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6;NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -48,15 +48,26 @@
       <Link>Properties\FrameworkVersion.cs</Link>
     </Compile>
     <Compile Include="AutoRun.cs" />
+    <Compile Include="ColorConsole.cs" />
+    <Compile Include="ColorConsoleWriter.cs" />
     <Compile Include="ColorStyle.cs" />
     <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="DebugWriter.cs" />
+    <Compile Include="DefaultOptionsProvider.cs" />
     <Compile Include="ExtendedTextWrapper.cs" />
     <Compile Include="ExtendedTextWriter.cs" />
     <Compile Include="IDefaultOptionsProvider.cs" />
     <Compile Include="NUnitLiteOptions.cs" />
     <Compile Include="Options.cs" />
+    <Compile Include="OutputManager.cs" />
+    <Compile Include="OutputSpecification.cs" />
+    <Compile Include="OutputWriters\NUnit2XmlOutputWriter.cs" />
+    <Compile Include="OutputWriters\NUnit3XmlOutputWriter.cs" />
+    <Compile Include="OutputWriters\OutputWriter.cs" />
+    <Compile Include="OutputWriters\TestCaseOutputWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultSummary.cs" />
+    <Compile Include="TcpWriter.cs" />
     <Compile Include="TeamCityEventListener.cs" />
     <Compile Include="TestNameParser.cs" />
     <Compile Include="TestSelectionParser.cs" />

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Tests
 
         private static void Delay()
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             System.Threading.Tasks.Task.Delay(DELAY);
 #else
             System.Threading.Thread.Sleep(DELAY);

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/testdata/AsyncDummyFixture.cs
+++ b/src/NUnitFramework/testdata/AsyncDummyFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System.Threading.Tasks;
 using NUnit.Framework;
 using System;

--- a/src/NUnitFramework/testdata/AsyncRealFixture.cs
+++ b/src/NUnitFramework/testdata/AsyncRealFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -42,7 +42,7 @@ namespace NUnit.TestData
             Assert.AreEqual(1, result);
         }
 
-        #region async Task
+#region async Task
 
         [Test]
         public async System.Threading.Tasks.Task AsyncTaskSuccess()
@@ -68,9 +68,9 @@ namespace NUnit.TestData
             Assert.Fail("Should never get here");
         }
 
-        #endregion
+#endregion
 
-        #region non-async Task
+#region non-async Task
 
         [Test]
         public System.Threading.Tasks.Task TaskSuccess()
@@ -90,7 +90,7 @@ namespace NUnit.TestData
             throw new InvalidOperationException();
         }
 
-        #endregion
+#endregion
 
 
         [Test]
@@ -105,7 +105,7 @@ namespace NUnit.TestData
             return ReturnOne();
         }
 
-        #region async Task<T>
+#region async Task<T>
 
         [TestCase(ExpectedResult = 1)]
         public async Task<int> AsyncTaskResultCheckSuccess()
@@ -125,10 +125,10 @@ namespace NUnit.TestData
             return await ThrowException();
         }
 
-        #endregion
+#endregion
 
 
-        #region non-async Task<T>
+#region non-async Task<T>
 
         [TestCase(ExpectedResult = 1)]
         public Task<int> TaskResultCheckSuccess()
@@ -148,7 +148,7 @@ namespace NUnit.TestData
             return ThrowException();
         }
 
-        #endregion
+#endregion
 
         [TestCase(1, 2)]
         public async System.Threading.Tasks.Task AsyncTaskTestCaseWithParametersSuccess(int a, int b)

--- a/src/NUnitFramework/testdata/AsyncSetupTearDownFixture.cs
+++ b/src/NUnitFramework/testdata/AsyncSetupTearDownFixture.cs
@@ -1,4 +1,4 @@
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System;
 using System.Threading.Tasks;
 

--- a/src/NUnitFramework/testdata/CultureAttributeData.cs
+++ b/src/NUnitFramework/testdata/CultureAttributeData.cs
@@ -39,7 +39,7 @@ namespace NUnit.TestData.CultureAttributeData
         public void FrenchCanadaTest() { }
     }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [TestFixture, SetCulture("xx-XX")]
     public class FixtureWithInvalidSetCultureAttribute
     {

--- a/src/NUnitFramework/testdata/MaxTimeFixture.cs
+++ b/src/NUnitFramework/testdata/MaxTimeFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 

--- a/src/NUnitFramework/testdata/SingleThreadedFixtureData.cs
+++ b/src/NUnitFramework/testdata/SingleThreadedFixtureData.cs
@@ -1,4 +1,4 @@
-﻿#if !PORTABLE
+﻿#if !PORTABLE && !NETSTANDARD1_6
 using System.Threading;
 using NUnit.Framework;
 

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -82,8 +82,8 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         public void MethodWithExplicitTestCases(int num)
         {
         }
-        
-#if !PORTABLE
+
+#if !PORTABLE && !NETSTANDARD1_6
         [TestCase(1, IncludePlatform = "Win")]
         [TestCase(2, IncludePlatform = "Linux")]
         [TestCase(3, IncludePlatform = "MacOSX")]

--- a/src/NUnitFramework/testdata/TestFixtureData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureData.cs
@@ -482,7 +482,7 @@ namespace NUnit.TestData.TestFixtureTests
         }
     }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [TestFixture]
     public class FixtureThatChangesTheCurrentPrincipal
     {

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using NUnit.Framework;

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -43,7 +43,7 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
                     new Exception("Inner Inner Exception")));
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [Test]
         public void ThrowsWithAggregateException()
         {

--- a/src/NUnitFramework/testdata/UnhandledExceptions.cs
+++ b/src/NUnitFramework/testdata/UnhandledExceptions.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections;
 using System.Text;

--- a/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD1_6;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-portable.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\portable\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PORTABLE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;PORTABLE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -37,14 +37,18 @@ namespace NUnit.Framework.Api
     // Functional tests of the FrameworkController and all subordinate classes
     public class FrameworkControllerTests
     {
+#if NETSTANDARD1_6
+        private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";
+#else
         private const string MOCK_ASSEMBLY_FILE = "mock-assembly.exe";
+#endif
         private const string BAD_FILE = "mock-assembly.pdb";
         private const string MISSING_FILE = "junk.dll";
         private const string MISSING_NAME = "junk";
         private const string EMPTY_FILTER = "<filter/>";
 
         private static readonly string MOCK_ASSEMBLY_NAME = typeof(MockAssembly).GetTypeInfo().Assembly.FullName;
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
         private static readonly string EXPECTED_NAME = MOCK_ASSEMBLY_NAME;
 #else
         private static readonly string EXPECTED_NAME = MOCK_ASSEMBLY_FILE;
@@ -113,7 +117,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void LoadTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
@@ -170,7 +174,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The Explore method was called but no test has been loaded"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void ExploreTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
@@ -224,7 +228,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The CountTestCases method was called but no test has been loaded"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void CountTestsAction_FileNotFound_ReturnsZero()
         {
@@ -275,7 +279,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void RunTestsAction_FileNotFound_ReturnsNonRunnableSuite()
         {
@@ -342,7 +346,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void RunAsyncAction_FileNotFound_ReturnsNonRunnableSuite()
         {

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Api
         private const string EMPTY_FILTER = "<filter/>";
 
         private static readonly string MOCK_ASSEMBLY_NAME = typeof(MockAssembly).GetTypeInfo().Assembly.FullName;
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         private static readonly string EXPECTED_NAME = MOCK_ASSEMBLY_NAME;
 #else
         private static readonly string EXPECTED_NAME = MOCK_ASSEMBLY_FILE;
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Api
         [SetUp]
         public void CreateController()
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             _controller = new FrameworkController(typeof(MockAssembly).GetTypeInfo().Assembly, "ID", _settings);
 #else
             _controller = new FrameworkController(MOCK_ASSEMBLY_PATH, "ID", _settings);
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Api
         {
             Assert.That(_controller.Builder, Is.TypeOf<DefaultTestAssemblyBuilder>());
             Assert.That(_controller.Runner, Is.TypeOf<NUnitTestAssemblyRunner>());
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             Assert.That(_controller.AssemblyNameOrPath, Is.EqualTo(MOCK_ASSEMBLY_NAME));
 #else
             Assert.That(_controller.AssemblyNameOrPath, Is.EqualTo(MOCK_ASSEMBLY_PATH));

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -419,7 +419,7 @@ namespace NUnit.Framework.Api
 
         private ITest LoadMockAssembly()
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return _runner.Load(
                 typeof(MockAssembly).GetTypeInfo().Assembly, 
                 EMPTY_SETTINGS);
@@ -432,7 +432,7 @@ namespace NUnit.Framework.Api
 
         private ITest LoadSlowTests()
         {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return _runner.Load(typeof(SlowTests).GetTypeInfo().Assembly, EMPTY_SETTINGS);
 #else
             return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SLOW_TESTS_FILE), EMPTY_SETTINGS);

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -39,7 +39,13 @@ namespace NUnit.Framework.Api
     // Functional tests of the TestAssemblyRunner and all subordinate classes
     public class TestAssemblyRunnerTests : ITestListener
     {
+#if NETSTANDARD1_6
+        private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";
+        private const string COULD_NOT_LOAD_MSG = "The system cannot find the file specified.";
+#else
         private const string MOCK_ASSEMBLY_FILE = "mock-assembly.exe";
+        private const string COULD_NOT_LOAD_MSG = "Could not load";
+#endif
         private const string BAD_FILE = "mock-assembly.pdb";
         private const string SLOW_TESTS_FILE = "slow-nunit-tests.dll";
         private const string MISSING_FILE = "junk.dll";
@@ -59,7 +65,7 @@ namespace NUnit.Framework.Api
         private int _failCount;
         private int _skipCount;
         private int _inconclusiveCount;
-        
+
         [SetUp]
         public void CreateRunner()
         {
@@ -103,7 +109,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.NotRunnable));
             Assert.That(result.TestCaseCount, Is.EqualTo(0));
             Assert.That(result.Properties.Get(PropertyNames.SkipReason),
-                Does.StartWith("Could not load"));
+                Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
         [Test]
@@ -120,9 +126,9 @@ namespace NUnit.Framework.Api
                 Does.StartWith("Could not load").And.Contains(BAD_FILE));
         }
 
-#endregion
+        #endregion
 
-#region CountTestCases
+        #region CountTestCases
 
         [Test]
         public void CountTestCases_AfterLoad_ReturnsCorrectCount()
@@ -153,9 +159,9 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.CountTestCases(TestFilter.Empty), Is.EqualTo(0));
         }
 
-#endregion
+        #endregion
 
-#region Run
+        #region Run
 
         [Test]
         public void Run_AfterLoad_ReturnsRunnableSuite()
@@ -212,7 +218,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
             Assert.That(result.Message,
-                Does.StartWith("Could not load"));
+                Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
         [Test]
@@ -230,9 +236,9 @@ namespace NUnit.Framework.Api
                 Does.StartWith("Could not load"));
         }
 
-#endregion
+        #endregion
 
-#region RunAsync
+        #region RunAsync
 
         [Test]
         public void RunAsync_AfterLoad_ReturnsRunnableSuite()
@@ -291,7 +297,7 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Test.TestCaseCount, Is.EqualTo(0));
             Assert.That(_runner.Result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
             Assert.That(_runner.Result.Message,
-                Does.StartWith("Could not load"));
+                Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
         [Test]
@@ -311,9 +317,9 @@ namespace NUnit.Framework.Api
                 Does.StartWith("Could not load"));
         }
 
-#endregion
+        #endregion
 
-#region StopRun
+        #region StopRun
 
         [Test]
         public void StopRun_WhenNoTestIsRunning_Succeeds()
@@ -339,9 +345,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        #endregion
 
-#region Cancel Run
+        #region Cancel Run
 
         [Test]
         public void CancelRun_WhenNoTestIsRunning_Succeeds()
@@ -370,9 +376,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-#endregion
+        #endregion
 
-#region ITestListener Implementation
+        #region ITestListener Implementation
 
         void ITestListener.TestStarted(ITest test)
         {
@@ -415,30 +421,30 @@ namespace NUnit.Framework.Api
 
         #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
         private ITest LoadMockAssembly()
         {
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
             return _runner.Load(
                 typeof(MockAssembly).GetTypeInfo().Assembly, 
                 EMPTY_SETTINGS);
 #else
             return _runner.Load(
-                Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE), 
+                Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE),
                 EMPTY_SETTINGS);
 #endif
         }
 
         private ITest LoadSlowTests()
         {
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
             return _runner.Load(typeof(SlowTests).GetTypeInfo().Assembly, EMPTY_SETTINGS);
 #else
             return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SLOW_TESTS_FILE), EMPTY_SETTINGS);
 #endif
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -27,7 +27,7 @@ using NUnit.Framework.Internal;
 using NUnit.TestData;
 using NUnit.TestUtilities;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System;
 using System.Threading.Tasks;
 #endif
@@ -332,7 +332,7 @@ namespace NUnit.Framework.Assertions
             return 5;
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [Test]
         public void AssertThatSuccess()
         {
@@ -346,7 +346,7 @@ namespace NUnit.Framework.Assertions
                 Assert.That(async () => await AsyncReturnOne(), Is.EqualTo(2)));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test, Platform(Exclude="Linux", Reason="Intermittent failures on Linux")]
         public void AssertThatErrorTask()
         {

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET_4_0 || NET_4_5 || PORTABLE
+﻿#if ASYNC
 using System;
 using System.Threading.Tasks;
 using NUnit.TestUtilities;

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -313,7 +313,7 @@ namespace NUnit.Framework.Syntax
 
         #region After
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void After()
         {
@@ -713,7 +713,7 @@ namespace NUnit.Framework.Syntax
 
         #region BinarySerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void BinarySerializableConstraint()
         {
@@ -727,7 +727,7 @@ namespace NUnit.Framework.Syntax
 
         #region XmlSerializable
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void XmlSerializableConstraint()
         {

--- a/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
@@ -24,7 +24,7 @@
 using System;
 using NUnit.Framework.Constraints;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -363,7 +363,7 @@ namespace NUnit.Framework.Assertions
             return 5;
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [Test]
         public void AssumeThatSuccess()
         {

--- a/src/NUnitFramework/tests/Assertions/AsyncThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AsyncThrowsTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System;
 using System.Threading.Tasks;
 using NUnit.Framework.Constraints;

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -27,7 +27,7 @@ using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System.Data;
 #endif
 

--- a/src/NUnitFramework/tests/Assertions/ConditionAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ConditionAssertTests.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Assertions
             Assert.IsEmpty( new int[0], "Failed on empty Array" );
             Assert.IsEmpty((IEnumerable)new int[0], "Failed on empty IEnumerable");
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Assert.IsEmpty( new ArrayList(), "Failed on empty ArrayList" );
             Assert.IsEmpty( new Hashtable(), "Failed on empty Hashtable" );
 #endif
@@ -209,7 +209,7 @@ namespace NUnit.Framework.Assertions
             Assert.IsNotEmpty( array, "Failed on Array" );
             Assert.IsNotEmpty( (IEnumerable)array, "Failed on IEnumerable" );
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             ArrayList list = new ArrayList(array);
             Hashtable hash = new Hashtable();
             hash.Add("array", array);
@@ -249,7 +249,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void IsNotEmptyFailsOnEmptyArrayList()
         {

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -21,8 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-// TODO: Test uses features not available in Silverlight
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -156,7 +155,7 @@ namespace NUnit.Framework.Tests
         public void CorrectNumberOfEventsReceived()
         {
             Assert.That(ActionAttributeFixture.Events.Count, Is.EqualTo(
-                NumTestCaseEvents+ 2 * (NumParameterizedTestActions + NumTestFixtureActions + NumSetUpFixtureActions + NumAssemblyActions)));
+                NumTestCaseEvents + 2 * (NumParameterizedTestActions + NumTestFixtureActions + NumSetUpFixtureActions + NumAssemblyActions)));
         }
 
         [TestCase("CaseOne")]
@@ -167,7 +166,7 @@ namespace NUnit.Framework.Tests
             CheckActionsOnTestCase(testName);
         }
 
-#region Helper Methods
+        #region Helper Methods
 
         private void CheckActionsOnSuite(string suiteName, int firstEvent, int lastEvent, params string[] tags)
         {
@@ -176,7 +175,7 @@ namespace NUnit.Framework.Tests
 
             if (firstEvent > 0)
             {
-                var beforeEvent = ActionAttributeFixture.Events[firstEvent-1];
+                var beforeEvent = ActionAttributeFixture.Events[firstEvent - 1];
                 Assert.That(beforeEvent, Does.Not.StartWith(suiteName), "Extra ActionAttribute Before: {0}", beforeEvent);
             }
 
@@ -214,11 +213,11 @@ namespace NUnit.Framework.Tests
             Assert.That(event2, Does.EndWith(target1), "Event mismatch");
         }
 
-#endregion
+        #endregion
 
-#region Expected Attributes and Events
+        #region Expected Attributes and Events
 
-        private static readonly string[] ExpectedAssemblyActions = new string[] { 
+        private static readonly string[] ExpectedAssemblyActions = new string[] {
                         "OnAssembly", "OnAssembly", "OnAssembly" };
 
         private static readonly string[] ExpectedSetUpFixtureActions = new string[] {
@@ -413,7 +412,7 @@ namespace NUnit.Framework.Tests
         private static readonly int NumSetUpFixtureActions = ExpectedSetUpFixtureActions.Length;
         private static readonly int NumAssemblyActions = ExpectedAssemblyActions.Length;
 
-#endregion
+        #endregion
     }
 }
 #endif

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -25,8 +25,10 @@
 #if !PORTABLE
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using NUnit.Framework;
+using NUnit.Compatibility;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -44,7 +46,7 @@ namespace NUnit.Framework.Tests
         // different runtimes, so we now look only at the relative position
         // of before and after actions with respect to the test.
 
-        private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(ActionAttributeFixture).Assembly);
+        private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(ActionAttributeFixture).GetTypeInfo().Assembly);
         private static readonly string ASSEMBLY_NAME = System.IO.Path.GetFileName(ASSEMBLY_PATH);
 
         private ITestResult _result = null;

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Attributes
             Assert.True(_context.IsSingleThreaded);
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void SetCultureAttribute()
         {

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -459,7 +459,7 @@ namespace NUnit.Framework.Attributes
 
         #region RequiresThreadAttribute
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void RequiresThreadAttributeSetsRequiresThread()
         {
@@ -508,7 +508,7 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 
         #region SetCultureAttribute
 

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -353,7 +353,7 @@ namespace NUnit.Framework.Attributes
 
         #region PlatformAttribute
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void PlatformAttributeRunsTest()
         {
@@ -411,7 +411,7 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 
         #region RequiresMTAAttribute
 
@@ -476,7 +476,7 @@ namespace NUnit.Framework.Attributes
         }
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void RequiresThreadAttributeMaySetApartmentState()
         {

--- a/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [TestCase(typeof(ParallelizableAttribute), PropertyNames.ParallelScope, ParallelScope.Self)]
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [TestCase(typeof(RequiresThreadAttribute), PropertyNames.RequiresThread, true)]
 #endif
         public void ConstructWithNoArgs<T>(Type attrType, string propName, T propValue)

--- a/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(typeof(LevelOfParallelismAttribute), PropertyNames.LevelOfParallelism, 7)]
         [TestCase(typeof(MaxTimeAttribute), PropertyNames.MaxTime, 50)]
         [TestCase(typeof(ParallelizableAttribute), PropertyNames.ParallelScope, ParallelScope.Fixtures)]
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [TestCase(typeof(SetCultureAttribute), PropertyNames.SetCulture, "fr-FR")]
         [TestCase(typeof(SetUICultureAttribute), PropertyNames.SetUICulture, "fr-FR")]
         [TestCase(typeof(ApartmentAttribute), PropertyNames.ApartmentState, ApartmentState.MTA)]

--- a/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Linq;
 using NUnit.Framework.Interfaces;

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -373,7 +373,7 @@ namespace NUnit.Framework.Attributes
         }
     }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [TestFixture]
     class ChangesMadeInFixtureSetUp
     {

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -413,7 +413,7 @@ namespace NUnit.Framework.Attributes
         {
             var method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             var param = method.GetParameters()[0];
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false).First() as ValuesAttribute;
 #else
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
@@ -425,7 +425,7 @@ namespace NUnit.Framework.Attributes
         {
             var method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             var param = method.GetParameters()[0];
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false).First() as ValuesAttribute;
 #else
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;

--- a/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 

--- a/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using System.Globalization;

--- a/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 using NUnit.TestData.TestCaseAttributeFixture;
 using NUnit.TestUtilities;
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -518,7 +518,7 @@ namespace NUnit.Framework.Attributes
             return arg1;
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [TestCase(1, ExpectedResult = 1)]
         public async Task<T> TestWithAsyncGenericReturnType<T>(T arg1)
         {
@@ -526,6 +526,6 @@ namespace NUnit.Framework.Attributes
         }
 #endif
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -301,7 +301,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Connection failing"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void CanIncludePlatform()
         {

--- a/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System.Threading;
 
 namespace NUnit.Framework.Attributes

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
 using System.Linq;
 #endif
 
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Attributes
         {
             MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             ParameterInfo param = method.GetParameters()[0];
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false).First() as ValuesAttribute;
 #else
             var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;

--- a/src/NUnitFramework/tests/Constraints/BinarySerializableTest.cs
+++ b/src/NUnitFramework/tests/Constraints/BinarySerializableTest.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 

--- a/src/NUnitFramework/tests/Constraints/CollectionContainsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionContainsConstraintTests.cs
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(list, new CollectionContainsConstraint(item));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test, TestCaseSource("testValidKVCases")]
         public void DictionaryTestValidKeyPair(KeyValuePair<object, object> kvTest)
         {

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -131,7 +131,7 @@ namespace NUnit.Framework.Constraints
                     yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"A", 1}, {"b", 2}});
                     yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }}, new Dictionary<char, int> {{'a', 1}});
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                     yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"},{2, "B"}});
                     yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{1, 'a'},{2, 'b'}});
                     yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}, {"b", 2}});

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Constraints
                     yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"b", 2}});
                     yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }, {'B', 2}}, new Dictionary<char, int> {{'a', 1}});
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                     yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"}});
                     yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{2, 'b'}});
                     yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}});

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Framework.Constraints
                     yield return new TestCaseData(new Dictionary<string, int> { { "b", 2 } }, new Dictionary<string, int> { { "b", 2 }, { "a", 1 } });
                     yield return new TestCaseData(new Dictionary<char, int> { { 'a', 1 } }, new Dictionary<char, int> { { 'A', 1 }, { 'B', 2 } });
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                     yield return new TestCaseData(new Hashtable { { 1, "A" } }, new Hashtable { { 1, "a" }, { 2, "b" } });
                     yield return new TestCaseData(new Hashtable { { 2, 'b' } }, new Hashtable { { 1, 'A' }, { 2, 'B' } });
                     yield return new TestCaseData(new Hashtable { { "A", 1 } }, new Hashtable { { "b", 2 }, { "a", 1 } });

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.ArgumentException.With.Message.Contains("IDictionary"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void WorksWithNonGenericDictionary()
         {

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.ArgumentException.With.Message.Contains("IDictionary"));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void WorksWithNonGenericDictionary()
         {

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Constraints
         {
             string.Empty,
             new object[0],
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             new ArrayList(),
 #endif
             new System.Collections.Generic.List<int>()
@@ -114,10 +114,14 @@ namespace NUnit.Framework.Constraints
             using (var testDir = new TestDirectory())
             {
                 var stream = File.Create(Path.Combine(testDir.Directory.FullName, "DUMMY.FILE"));
+#if NETSTANDARD1_6
+                stream.Dispose();
+#else
                 stream.Close();
+#endif
                 Assert.That(testDir.Directory, Is.Not.Empty);
             }
         }
     }
 #endif
-}
+            }

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -124,4 +124,4 @@ namespace NUnit.Framework.Constraints
         }
     }
 #endif
-            }
+}

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -359,7 +359,7 @@ namespace NUnit.Framework.Constraints
                                 new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}});
             }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             [Test]
             public void CanMatchHashtables_SameOrder()
             {

--- a/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
+++ b/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -23,6 +23,8 @@
 
 #if !PORTABLE
 using System.IO;
+using System.Reflection;
+using NUnit.Compatibility;
 
 namespace NUnit.Framework.Internal.Tests
 {
@@ -35,14 +37,14 @@ namespace NUnit.Framework.Internal.Tests
         [Test]
         public void GetNameForAssembly()
         {
-            var assemblyName = AssemblyHelper.GetAssemblyName(this.GetType().Assembly);
+            var assemblyName = AssemblyHelper.GetAssemblyName(this.GetType().GetTypeInfo().Assembly);
             Assert.That(assemblyName.Name, Is.EqualTo(THIS_ASSEMBLY_NAME).IgnoreCase);
         }
 
         [Test]
         public void GetPathForAssembly()
         {
-            string path = AssemblyHelper.GetAssemblyPath(this.GetType().Assembly);
+            string path = AssemblyHelper.GetAssemblyPath(this.GetType().GetTypeInfo().Assembly);
             Assert.That(Path.GetFileName(path), Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
 
             Assert.That(File.Exists(path));

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System.Collections;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class AsyncTestMethodTests
     {
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
         private static readonly bool PLATFORM_IGNORE = true;
 #else
         private static readonly bool PLATFORM_IGNORE = OSPlatform.CurrentPlatform.IsUnix;

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Internal
             ExpectFailure( attr, "Not supported under culture fr-FR" );
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test,SetCulture("fr-FR")]
         public void LoadWithFrenchCulture()
         {

--- a/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Internal.Filters
     /// 
     /// It would be better to use a Mocking-Framework for this.
     /// </summary>
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
     public class MockTestFilter : TestFilter

--- a/src/NUnitFramework/tests/Internal/GenericTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestFixtureTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
 {
     [TestFixture(typeof(List<int>))]
     [TestFixture(TypeArgs=new Type[] {typeof(List<object>)} )]
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [TestFixture(TypeArgs=new Type[] {typeof(ArrayList)} )]
 #endif
     public class GenericTestFixture_IList<T> where T : IList, new()

--- a/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class NUnitTestCaseBuilderTests
     {
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         private readonly Type fixtureType = typeof(AsyncDummyFixture);
 
         [TestCase("AsyncVoid", RunState.NotRunnable)]

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections;
 

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -447,13 +447,13 @@ namespace NUnit.Framework.Internal
             bool is64BitProcess = helper.IsPlatformSupported(attr64);
             Assert.False(is32BitProcess & is64BitProcess, "Process cannot be both 32 and 64 bit");
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
             // For .NET 4.0 and 4.5, we can check further
             Assert.That(is64BitProcess, Is.EqualTo(Environment.Is64BitProcess));
 #endif
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [Test]
         public void PlatformAttribute_OperatingSystemBitNess()
         {

--- a/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
 using System.Threading.Tasks;
 
 namespace NUnit.Framework.Internal

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Reflection;
 

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -4,7 +4,7 @@
 // obtain a copy of the license at http://nunit.org
 // ****************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -6,6 +6,8 @@
 
 #if !PORTABLE
 using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Compatibility;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 
@@ -14,21 +16,21 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class SetUpFixtureTests
     {
-        private static readonly string testAssembly = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).Assembly);
+        private static readonly string testAssembly = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).GetTypeInfo().Assembly);
 
         ITestAssemblyBuilder builder;
         ITestAssemblyRunner runner;
 
-#region SetUp
+        #region SetUp
         [SetUp]
         public void SetUp()
         {
             TestUtilities.SimpleEventRecorder.Clear();
-            
+
             builder = new DefaultTestAssemblyBuilder();
             runner = new NUnitTestAssemblyRunner(builder);
         }
-#endregion SetUp
+        #endregion SetUp
 
         private ITestResult runTests(string nameSpace)
         {
@@ -49,7 +51,7 @@ namespace NUnit.Framework.Internal
             return null;
         }
 
-#region Builder Tests
+        #region Builder Tests
 
         /// <summary>
         /// Tests that the TestSuiteBuilder correctly interperets a SetupFixture class as a 'virtual namespace' into which 
@@ -134,24 +136,24 @@ namespace NUnit.Framework.Internal
             Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
         }
 
-#endregion
+        #endregion
 
-#region Simple
+        #region Simple
         [NUnit.Framework.Test]
         public void NamespaceSetUpFixtureWrapsExecutionOfSingleTest()
         {
             Assert.That(runTests("NUnit.TestData.SetupFixture.Namespace1").ResultState.Status, Is.EqualTo(TestStatus.Passed));
             TestUtilities.SimpleEventRecorder.Verify("NS1.OneTimeSetup",
-                                                     "NS1.Fixture.SetUp", 
-                                                     "NS1.Test.SetUp", 
-                                                     "NS1.Test", 
-                                                     "NS1.Test.TearDown", 
+                                                     "NS1.Fixture.SetUp",
+                                                     "NS1.Test.SetUp",
+                                                     "NS1.Test",
+                                                     "NS1.Test.TearDown",
                                                      "NS1.Fixture.TearDown",
                                                      "NS1.OneTimeTearDown");
         }
-#endregion Simple
+        #endregion Simple
 
-#region Static
+        #region Static
         [Test]
         public void NamespaceSetUpMethodsMayBeStatic()
         {
@@ -164,9 +166,9 @@ namespace NUnit.Framework.Internal
                                                      "NS5.Fixture.TearDown",
                                                      "NS5.OneTimeTearDown");
         }
-#endregion
+        #endregion
 
-#region TwoTestFixtures
+        #region TwoTestFixtures
         [NUnit.Framework.Test]
         public void NamespaceSetUpFixtureWrapsExecutionOfTwoTests()
         {
@@ -186,9 +188,9 @@ namespace NUnit.Framework.Internal
                                                      "NS2.Fixture.TearDown",
                                                      "NS2.OneTimeTearDown");
         }
-#endregion TwoTestFixtures
+        #endregion TwoTestFixtures
 
-#region SubNamespace
+        #region SubNamespace
         [NUnit.Framework.Test]
         public void NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture()
         {
@@ -196,8 +198,8 @@ namespace NUnit.Framework.Internal
             TestUtilities.SimpleEventRecorder.Verify("NS3.OneTimeSetUp",
                                                      "NS3.Fixture.SetUp",
                                                      "NS3.Test.SetUp",
-                                                     "NS3.Test", 
-                                                     "NS3.Test.TearDown", 
+                                                     "NS3.Test",
+                                                     "NS3.Test.TearDown",
                                                      "NS3.Fixture.TearDown",
                                                      "NS3.SubNamespace.OneTimeSetUp",
                                                      "NS3.SubNamespace.Fixture.SetUp",
@@ -208,9 +210,9 @@ namespace NUnit.Framework.Internal
                                                      "NS3.SubNamespace.OneTimeTearDown",
                                                      "NS3.OneTimeTearDown");
         }
-#endregion SubNamespace
+        #endregion SubNamespace
 
-#region TwoSetUpFixtures
+        #region TwoSetUpFixtures
         [NUnit.Framework.Test]
         public void WithTwoSetUpFixturesBothAreUsed()
         {
@@ -224,9 +226,9 @@ namespace NUnit.Framework.Internal
                                              .AndThen("NS4.OneTimeTearDown1", "NS4.OneTimeTearDown2")
                                              .Verify();
         }
-#endregion TwoSetUpFixtures
+        #endregion TwoSetUpFixtures
 
-#region InvalidSetUpFixture
+        #region InvalidSetUpFixture
 
         [Test]
         public void InvalidSetUpFixtureTest()
@@ -235,9 +237,9 @@ namespace NUnit.Framework.Internal
             TestUtilities.SimpleEventRecorder.Verify(new string[0]);
         }
 
-#endregion
+        #endregion
 
-#region NoNamespaceSetupFixture
+        #region NoNamespaceSetupFixture
         [NUnit.Framework.Test]
         public void AssemblySetupFixtureWrapsExecutionOfTest()
         {
@@ -248,7 +250,7 @@ namespace NUnit.Framework.Internal
                                                      "NoNamespaceTest",
                                                      "Assembly.OneTimeTearDown");
         }
-#endregion NoNamespaceSetupFixture
+        #endregion NoNamespaceSetupFixture
     }
 }
 #endif

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal
         TestExecutionContext fixtureContext;
         TestExecutionContext setupContext;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         string originalDirectory;
         IPrincipal originalPrincipal;
 #endif
@@ -74,12 +74,12 @@ namespace NUnit.Framework.Internal
         public void Initialize()
         {
             setupContext = new TestExecutionContext(TestExecutionContext.CurrentContext);
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             originalCulture = CultureInfo.CurrentCulture;
             originalUICulture = CultureInfo.CurrentUICulture;
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             originalDirectory = Environment.CurrentDirectory;
             originalPrincipal = Thread.CurrentPrincipal;
 #endif
@@ -88,12 +88,12 @@ namespace NUnit.Framework.Internal
         [TearDown]
         public void Cleanup()
         {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Thread.CurrentThread.CurrentCulture = originalCulture;
             Thread.CurrentThread.CurrentUICulture = originalUICulture;
 #endif
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Environment.CurrentDirectory = originalDirectory;
             Thread.CurrentPrincipal = originalPrincipal;
 #endif
@@ -196,7 +196,7 @@ namespace NUnit.Framework.Internal
             Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void TestHasWorkerIdWhenParallel()
         {
@@ -217,7 +217,7 @@ namespace NUnit.Framework.Internal
 
         #region CurrentCulture and CurrentUICulture
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         CultureInfo originalCulture;
         CultureInfo originalUICulture;
 
@@ -309,7 +309,7 @@ namespace NUnit.Framework.Internal
 
         #region CurrentPrincipal
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void FixtureSetUpContextReflectsCurrentPrincipal()
         {
@@ -439,7 +439,7 @@ namespace NUnit.Framework.Internal
 
         #region Cross-domain Tests
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void CanCreateObjectInAppDomain()
         {
@@ -464,7 +464,7 @@ namespace NUnit.Framework.Internal
         #endregion
     }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
     [TestFixture]
     public class TextExecutionContextInAppDomain
     {

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(expectedMessage, result.Message);
         }
 
-#if NET_4_0 || NET_4_5 || PORTABLE
+#if ASYNC
         [Test]
         public void FailRecordsInnerExceptionsAsPartOfAggregateException()
         {

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Threading;
 using System.Collections.Generic;

--- a/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
+++ b/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.Collections;
 using System.CodeDom.Compiler;

--- a/src/NUnitFramework/tests/Syntax/SerializableConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/SerializableConstraints.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 namespace NUnit.Framework.Syntax
 {
     [TestFixture]

--- a/src/NUnitFramework/tests/Syntax/TestCompiler.cs
+++ b/src/NUnitFramework/tests/Syntax/TestCompiler.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
 using System;
 using System.CodeDom.Compiler;
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Tests
 
         private string _name;
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
         private string _testDirectory;
 #endif
         private string _workDirectory;
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Tests
         {
             _name = TestContext.CurrentContext.Test.Name;
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
             _testDirectory = TestContext.CurrentContext.TestDirectory;
 #endif
             _workDirectory = TestContext.CurrentContext.WorkDirectory;
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests
             _setupContext = TestContext.CurrentContext;
         }
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
         [Test]
         public void ConstructorCanAccessTestDirectory()
         {
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Tests
             Assert.That(context.Result.Outcome, Is.EqualTo(ResultState.Success));
             Assert.That(context.Result.PassCount, Is.EqualTo(1));
             Assert.That(context.Result.FailCount, Is.EqualTo(0));
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
             Assert.That(context.TestDirectory, Is.Not.Null);
             Assert.That(context.WorkDirectory, Is.Not.Null);
 #endif

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Tests
 
         private string _name;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         private string _testDirectory;
 #endif
         private string _workDirectory;
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Tests
         {
             _name = TestContext.CurrentContext.Test.Name;
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             _testDirectory = TestContext.CurrentContext.TestDirectory;
 #endif
             _workDirectory = TestContext.CurrentContext.WorkDirectory;
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests
             _setupContext = TestContext.CurrentContext;
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         [Test]
         public void ConstructorCanAccessTestDirectory()
         {
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Tests
             Assert.That(context.Result.Outcome, Is.EqualTo(ResultState.Success));
             Assert.That(context.Result.PassCount, Is.EqualTo(1));
             Assert.That(context.Result.FailCount, Is.EqualTo(0));
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
             Assert.That(context.TestDirectory, Is.Not.Null);
             Assert.That(context.WorkDirectory, Is.Not.Null);
 #endif

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -1,4 +1,4 @@
-﻿#if NET_4_0 || NET_4_5 || PORTABLE
+﻿#if ASYNC
 
 using System;
 using System.Threading.Tasks;

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectComparer.cs
@@ -38,7 +38,7 @@ namespace NUnit.TestUtilities.Comparers
         int IComparer.Compare(object x, object y)
         {
             WasCalled = true;
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return Comparer<object>.Default.Compare(x, y);
 #else
             return Comparer.Default.Compare(x, y);

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectEqualityComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectEqualityComparer.cs
@@ -37,7 +37,7 @@ namespace NUnit.TestUtilities.Comparers
         bool IEqualityComparer.Equals(object x, object y)
         {
             Called = true;
-#if PORTABLE
+#if PORTABLE || NETSTANDARD1_6
             return Comparer<object>.Default.Compare(x, y) == 0;
 #else
             return Comparer.Default.Compare(x, y) == 0;

--- a/src/NUnitFramework/tests/WorkItemTests.cs
+++ b/src/NUnitFramework/tests/WorkItemTests.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Internal.Execution
             Assert.That(_context.ExecutionStatus, Is.EqualTo(TestExecutionStatus.StopRequested));
         }
 
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
         Thread _thread;
 
         private void StartExecution()
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal.Execution
 
             public static void DummyTest()
             {
-#if !PORTABLE
+#if !PORTABLE && !NETSTANDARD1_6
                 if (Delay > 0)
                     Thread.Sleep(Delay);
 #else

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -20,14 +20,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;NUNITLITE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0414</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_0;PARALLEL;NUNITLITE;ASYNC</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\net-4.0\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;NUNITLITE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -28,7 +28,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NET_4_5;PARALLEL;NUNITLITE;ASYNC</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\net-4.5\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -23,13 +23,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -23,13 +23,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\netstandard16\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NETSTANDARD1_6;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;NETSTANDARD1_6;ASYNC</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\netstandard16\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -21,13 +21,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\portable\</OutputPath>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PORTABLE;ASYNC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NUNIT_FRAMEWORK;PORTABLE;ASYNC</DefineConstants>
     <OutputPath>..\..\..\bin\Debug\portable\</OutputPath>
     <DebugType>full</DebugType>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
This started off as just dropping the PORTABLE define from the .NET Standard builds so that we can start to re-enable some of the features that are not available in the PORTABLE version of the framework. As a part of that, I have documented what is still not enabled and will create issues to document or re-enable those that are remaining.

As a part of this, I enabled all of the file, path and directory based asserts that weren't available in PORTABLE. I don't have an issue for that, so I am marking this PR with the 3.6 milestone to track for the release.

The steps I took for this were,

1. Remove the PORTABLE define in all of the .NET Standard projects
2. Wherever possible, rewrite code that wasn't compiling to work in .NET Standard
3. As a last resort, add the needed `#if NETSTANDARD1_6` blocks and document the not supported functionality

This is a large PR because so many files were touched, but most of the changes are fairly rote.

I also updated the nuspec files which fixes #1904