### PR TITLE
Fix remoting issue with isolated context

### DIFF
--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Assertions
             });
         }
 
-        //[Test, Platform(Exclude="Mono,MonoTouch", Reason= "Mono does not implement Code Access Security")]
+        [Test, Platform(Exclude="Mono,MonoTouch", Reason= "Mono does not implement Code Access Security")]
         // TODO: This test fails to run correctly when Assert.Throws
         // attempts to create an isolated TestExecutionContext.
         // The TestExecutionContext class would have to be modified

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -62,11 +62,6 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test, Platform(Exclude="Mono,MonoTouch", Reason= "Mono does not implement Code Access Security")]
-        // TODO: This test fails to run correctly when Assert.Throws
-        // attempts to create an isolated TestExecutionContext.
-        // The TestExecutionContext class would have to be modified
-        // in order to allow chaining of contexts across a 
-        // remoting boundary.
         public void AssertThrowsInLowTrustSandBox()
         {
             _sandBox.Run(() =>


### PR DESCRIPTION
Fixes #1917 

This problem arose when the isolated context was being created in a separate, user-created AppDomain. The IsolatedContext constructor would try to create a new TestExecutionContext in the user AppDomain, initializing it with values from the original context in the original AppDomain. This caused an exception, since some fields that need to be copied are not serializable.

The fix puts everything back in the original AppDomain. The IsolatedContext calls a method on the original TestExecutionContext (which is MBR) so that __it__ will create the new context. Both the old and the new contexts are in the original AppDomain.

This solves the immediate problem but some things will still not work. If any user code tries to access a non-serializable member of the TestExecutionContext, an exception will be thrown. However, TestExecutionContext is an internal class, so I think this is acceptable.

Before merging, I want to look at how TestContext accesses TestExecutionContext, since that is more likely to be used by users.