### PR TITLE
Test the full framework using NUnit console

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -558,7 +558,10 @@ void RunNUnitTests(DirectoryPath workingDir, string testAssembly, string framewo
     try
     {
         var path = workingDir.CombineWithFilePath(new FilePath(testAssembly));
-        NUnit3(path.ToString());
+        var settings = new NUnit3Settings();
+        if(!IsRunningOnWindows())
+            settings.Process = NUnit3ProcessOption.InProcess;
+        NUnit3(path.ToString(), settings);
     }
     catch(CakeException ce)
     {

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.5.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -279,7 +280,7 @@ Task("Test45")
     {
         var runtime = "net-4.5";
         var dir = BIN_DIR + runtime + "/";
-        RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
     });
 
@@ -291,7 +292,7 @@ Task("Test40")
     {
         var runtime = "net-4.0";
         var dir = BIN_DIR + runtime + "/";
-        RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
     });
 
@@ -303,7 +304,7 @@ Task("Test35")
     {
         var runtime = "net-3.5";
         var dir = BIN_DIR + runtime + "/";
-        RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
     });
 
@@ -315,7 +316,7 @@ Task("Test20")
     {
         var runtime = "net-2.0";
         var dir = BIN_DIR + runtime + "/";
-        RunTest(dir + NUNITLITE_RUNNER, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS, dir, runtime, ref ErrorDetail);
     });
 
@@ -551,6 +552,19 @@ void BuildProject(string projectPath, string configuration)
 //////////////////////////////////////////////////////////////////////
 // HELPER METHODS - TEST
 //////////////////////////////////////////////////////////////////////
+
+void RunNUnitTests(DirectoryPath workingDir, string testAssembly, string framework, ref List<string> errorDetail)
+{
+    try
+    {
+        var path = workingDir.CombineWithFilePath(new FilePath(testAssembly));
+        NUnit3(path.ToString());
+    }
+    catch(CakeException ce)
+    {
+        errorDetail.Add(string.Format("{0}: {1}", framework, ce.Message));
+    }
+}
 
 void RunTest(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
 {


### PR DESCRIPTION
Fixes #1924 

This switches testing of the full framework tests for 2.0 through 4.5 over to using the console. PCL and .NET Standard are still tested using the NUnitLite Runner and NUnitLite is still self-testing.

My thinking on this is,

- This gives us a measure of integration testing with the released version of the console and engine
- It also allows us to test the Cake NUnit task
- The console project using the released framework allows a measure of integration testing in the other direction
- The NUnitLite runner is still tested using the PCL and .NET Standard targets
- NUnitLite continues to test itself

I also tested that we get useful error messages at the end of the run by adding a failing test. The messages still contain the number of failing tests and is very similar to the previous output.