### PR TITLE
Report Warnings in NUnitLite

### DIFF
--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -86,20 +86,25 @@ namespace NUnit.Tests
             public const int ExplicitFixtures = 1;
             public const int SuitesRun = Suites - ExplicitFixtures;
 
-            public const int Ignored = MockTestFixture.Ignored + IgnoredFixture.Tests;
-            public const int Explicit = MockTestFixture.Explicit + ExplicitFixture.Tests;
-            public const int Skipped = Ignored + Explicit;
-            public const int Warnings = 0;
-            public const int NotRun = Ignored + Explicit + NotRunnable;
-            public const int TestsRun = Tests - NotRun;
-            public const int ResultCount = Tests - Explicit;
+            public const int Passed = MockTestFixture.Passed
+                        + Singletons.OneTestCase.Tests
+                        + TestAssembly.MockTestFixture.Tests
+                        + FixtureWithTestCases.Tests
+                        + ParameterizedFixture.Tests
+                        + GenericFixtureConstants.Tests;
 
-            public const int Errors = MockTestFixture.Errors;
-            public const int Failures = MockTestFixture.Failures;
-            public const int NotRunnable = MockTestFixture.NotRunnable + BadFixture.Tests;
-            public const int ErrorsAndFailures = Errors + Failures + NotRunnable;
+            public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
+            public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;
+            public const int Skipped = Skipped_Ignored + Skipped_Explicit;
+
+            public const int Warnings = MockTestFixture.Warnings;
+
+            public const int Failed_Error = MockTestFixture.Failed_Error;
+            public const int Failed_Other = MockTestFixture.Failed_Other;
+            public const int Failed_NotRunnable = MockTestFixture.Failed_NotRunnable + BadFixture.Tests;
+            public const int Failed = Failed_Error + Failed_Other + Failed_NotRunnable;
+
             public const int Inconclusive = MockTestFixture.Inconclusive;
-            public const int Success = TestsRun - Errors - Failures - Inconclusive;
 
 #if !PORTABLE
 #if NETSTANDARD1_6
@@ -125,20 +130,21 @@ namespace NUnit.Tests
         [Category("FixtureCategory")]
         public class MockTestFixture
         {
-            public const int Tests = 8;
+            public const int Tests = 9;
             public const int Suites = 1;
 
-            public const int Ignored = 1;
-            public const int Explicit = 1;
+            public const int Passed = 1;
 
-            public const int NotRun = Ignored + Explicit;
-            public const int TestsRun = Tests - NotRun;
-            public const int ResultCount = Tests - Explicit;
+            public const int Skipped_Ignored = 1;
+            public const int Skipped_Explicit = 1;
+            public const int Skipped = Skipped_Ignored + Skipped_Explicit;
 
-            public const int Failures = 1;
-            public const int Errors = 1;
-            public const int NotRunnable = 2;
-            public const int ErrorsAndFailures = Errors + Failures + NotRunnable;
+            public const int Failed_Other = 1;
+            public const int Failed_Error = 1;
+            public const int Failed_NotRunnable = 2;
+            public const int Failed = Failed_Error + Failed_Other + Failed_NotRunnable;
+
+            public const int Warnings = 1;
 
             public const int Inconclusive = 1;
 
@@ -157,6 +163,12 @@ namespace NUnit.Tests
                 Console.Error.WriteLine("Immediate Error Message");
 #endif
                 Assert.Fail("Intentional failure");
+            }
+
+            [Test]
+            public void WarningTest()
+            {
+                Assert.Warn("Warning Message");
             }
 
             [Test, Ignore("Ignore Message")]

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -111,13 +111,13 @@ namespace NUnitLite.Tests
         }
 
         [TestCase("total", MockTestFixture.Tests)]
-        [TestCase("errors", MockTestFixture.Errors)]
-        [TestCase("failures", MockTestFixture.Failures)]
+        [TestCase("errors", MockTestFixture.Failed_Error)]
+        [TestCase("failures", MockTestFixture.Failed_Other)]
         [TestCase("inconclusive", MockTestFixture.Inconclusive)]
-        [TestCase("not-run", MockTestFixture.NotRun+MockTestFixture.NotRunnable-MockTestFixture.Explicit)]
-        [TestCase("ignored", MockTestFixture.Ignored)]
-        [TestCase("skipped", MockTestFixture.NotRun-MockTestFixture.Ignored-MockTestFixture.Explicit)]
-        [TestCase("invalid", MockTestFixture.NotRunnable)]
+        [TestCase("not-run", MockTestFixture.Skipped+MockTestFixture.Failed_NotRunnable-MockTestFixture.Skipped_Explicit)]
+        [TestCase("ignored", MockTestFixture.Skipped_Ignored)]
+        [TestCase("skipped", MockTestFixture.Skipped-MockTestFixture.Skipped_Ignored-MockTestFixture.Skipped_Explicit)]
+        [TestCase("invalid", MockTestFixture.Failed_NotRunnable)]
         public void TestResults_CounterIsCorrect(string name, int count)
         {
             Assert.That(RequiredAttribute(topNode, name), Is.EqualTo(count.ToString()));

--- a/src/NUnitFramework/nunitlite.tests/TextUITests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUITests.cs
@@ -198,7 +198,7 @@ namespace NUnitLite.Tests
             var expected = new string[] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-                "  Test Count: 8, Passed: 1, Failed: 4, Warnings: 0, Inconclusive: 1, Skipped: 2",
+                "  Test Count: 9, Passed: 1, Failed: 4, Warnings: 1, Inconclusive: 1, Skipped: 2",
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 2",
                 "    Skipped Tests - Ignored: 1, Explicit: 1, Other: 0",
                 "  Start time: 2014-12-02 12:34:56Z",
@@ -214,18 +214,20 @@ namespace NUnitLite.Tests
         [Test]
         public void ErrorsAndFailuresReportTest()
         {
-            _textUI.DisplayErrorsAndFailuresReport(_result);
+            _textUI.DisplayErrorsFailuresAndWarningsReport(_result);
             var lines = GetReportLines();
 
-            Assert.That(lines[0], Is.EqualTo("Errors and Failures"));
+            Assert.That(lines[0], Is.EqualTo("Errors, Failures and Warnings"));
             Assert.That(lines[2], Is.EqualTo("1) Invalid : NUnit.Tests.Assemblies.MockTestFixture.NonPublicTest"));
             Assert.That(lines[3], Is.EqualTo("Method is not public"));
             Assert.That(lines[5], Is.EqualTo("2) Failed : NUnit.Tests.Assemblies.MockTestFixture.FailingTest"));
             Assert.That(lines[6], Is.EqualTo("Intentional failure"));
-            Assert.That(lines[9], Is.EqualTo("3) Invalid : NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest"));
-            Assert.That(lines[10], Is.EqualTo("No arguments were provided"));
-            Assert.That(lines[12], Is.EqualTo("4) Error : NUnit.Tests.Assemblies.MockTestFixture.TestWithException"));
-            Assert.That(lines[13], Is.EqualTo("System.Exception : Intentional Exception"));
+            Assert.That(lines[9], Is.EqualTo("3) Warning : NUnit.Tests.Assemblies.MockTestFixture.WarningTest"));
+            Assert.That(lines[10], Is.EqualTo("Warning Message"));
+            Assert.That(lines[13], Is.EqualTo("4) Invalid : NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest"));
+            Assert.That(lines[14], Is.EqualTo("No arguments were provided"));
+            Assert.That(lines[16], Is.EqualTo("5) Error : NUnit.Tests.Assemblies.MockTestFixture.TestWithException"));
+            Assert.That(lines[17], Is.EqualTo("System.Exception : Intentional Exception"));
         }
 
 #region Private Properties and Methods

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -277,7 +277,7 @@ namespace NUnitLite
             var startTime = DateTime.UtcNow;
 
             ITestResult result = _runner.Run(this, filter);
-            
+
             ReportResults(result);
 
 #if !PORTABLE
@@ -302,8 +302,8 @@ namespace NUnitLite
             if (Summary.ExplicitCount + Summary.SkipCount + Summary.IgnoreCount > 0)
                 _textUI.DisplayNotRunReport(result);
 
-            if (result.ResultState.Status == TestStatus.Failed)
-                _textUI.DisplayErrorsAndFailuresReport(result);
+            if (result.ResultState.Status == TestStatus.Failed || result.ResultState.Status == TestStatus.Warning)
+                _textUI.DisplayErrorsFailuresAndWarningsReport(result);
 
 #if FULL
             if (_options.Full)

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -374,11 +374,11 @@ namespace NUnitLite
 
         #region DisplayErrorsAndFailuresReport
 
-        public void DisplayErrorsAndFailuresReport(ITestResult result)
+        public void DisplayErrorsFailuresAndWarningsReport(ITestResult result)
         {
             _reportIndex = 0;
-            WriteSectionHeader("Errors and Failures");
-            DisplayErrorsAndFailures(result);
+            WriteSectionHeader("Errors, Failures and Warnings");
+            DisplayErrorsFailuresAndWarnings(result);
             Writer.WriteLine();
 
             if (_options.StopOnError)
@@ -457,11 +457,15 @@ namespace NUnitLite
 
         #region Helper Methods
 
-        private void DisplayErrorsAndFailures(ITestResult result)
+        private void DisplayErrorsFailuresAndWarnings(ITestResult result)
         {
+            bool display = 
+                result.ResultState.Status == TestStatus.Failed || 
+                result.ResultState.Status == TestStatus.Warning;
+            
             if (result.Test.IsSuite)
             {
-                if (result.ResultState.Status == TestStatus.Failed)
+                if (display)
                 {
                     var suite = result.Test as TestSuite;
                     var site = result.ResultState.Site;
@@ -471,9 +475,9 @@ namespace NUnitLite
                 }
 
                 foreach (ITestResult childResult in result.Children)
-                    DisplayErrorsAndFailures(childResult);
+                    DisplayErrorsFailuresAndWarnings(childResult);
             }
-            else if (result.ResultState.Status == TestStatus.Failed)
+            else if (display)
                 DisplayTestResult(result);
         }
 
@@ -545,6 +549,9 @@ namespace NUnitLite
             {
                 case TestStatus.Failed:
                     style = ColorStyle.Failure;
+                    break;
+                case TestStatus.Warning:
+                    style = ColorStyle.Warning;
                     break;
                 case TestStatus.Skipped:
                     style = resultState.Label == "Ignored" ? ColorStyle.Warning : ColorStyle.Output;

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -267,8 +267,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.Attributes["result"], Is.EqualTo("Failed"));
-            Assert.That(result.Attributes["passed"], Is.EqualTo(MockAssembly.Success.ToString()));
-            Assert.That(result.Attributes["failed"], Is.EqualTo(MockAssembly.ErrorsAndFailures.ToString()));
+            Assert.That(result.Attributes["passed"], Is.EqualTo(MockAssembly.Passed.ToString()));
+            Assert.That(result.Attributes["failed"], Is.EqualTo(MockAssembly.Failed.ToString()));
             Assert.That(result.Attributes["warnings"], Is.EqualTo(MockAssembly.Warnings.ToString()));
             Assert.That(result.Attributes["skipped"], Is.EqualTo(MockAssembly.Skipped.ToString()));
             Assert.That(result.Attributes["inconclusive"], Is.EqualTo(MockAssembly.Inconclusive.ToString()));

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -174,8 +174,8 @@ namespace NUnit.Framework.Api
             Assert.That(result.Test.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(result.Test.TestCaseCount, Is.EqualTo(MockAssembly.Tests));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.ChildFailure));
-            Assert.That(result.PassCount, Is.EqualTo(MockAssembly.Success));
-            Assert.That(result.FailCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(result.PassCount, Is.EqualTo(MockAssembly.Passed));
+            Assert.That(result.FailCount, Is.EqualTo(MockAssembly.Failed));
             Assert.That(result.WarningCount, Is.EqualTo(MockAssembly.Warnings));
             Assert.That(result.SkipCount, Is.EqualTo(MockAssembly.Skipped));
             Assert.That(result.InconclusiveCount, Is.EqualTo(MockAssembly.Inconclusive));
@@ -193,8 +193,8 @@ namespace NUnit.Framework.Api
             Assert.That(_testOutputCount, Is.EqualTo(MockAssembly.TestOutputEvents));
 #endif
 
-            Assert.That(_successCount, Is.EqualTo(MockAssembly.Success));
-            Assert.That(_failCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(_successCount, Is.EqualTo(MockAssembly.Passed));
+            Assert.That(_failCount, Is.EqualTo(MockAssembly.Failed));
             Assert.That(_skipCount, Is.EqualTo(MockAssembly.Skipped));
             Assert.That(_inconclusiveCount, Is.EqualTo(MockAssembly.Inconclusive));
         }
@@ -254,8 +254,8 @@ namespace NUnit.Framework.Api
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(_runner.Result.Test.TestCaseCount, Is.EqualTo(MockAssembly.Tests));
             Assert.That(_runner.Result.ResultState, Is.EqualTo(ResultState.ChildFailure));
-            Assert.That(_runner.Result.PassCount, Is.EqualTo(MockAssembly.Success));
-            Assert.That(_runner.Result.FailCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(_runner.Result.PassCount, Is.EqualTo(MockAssembly.Passed));
+            Assert.That(_runner.Result.FailCount, Is.EqualTo(MockAssembly.Failed));
             Assert.That(_runner.Result.SkipCount, Is.EqualTo(MockAssembly.Skipped));
             Assert.That(_runner.Result.InconclusiveCount, Is.EqualTo(MockAssembly.Inconclusive));
         }
@@ -270,8 +270,8 @@ namespace NUnit.Framework.Api
             Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests));
             Assert.That(_testFinishedCount, Is.EqualTo(MockAssembly.Tests));
 
-            Assert.That(_successCount, Is.EqualTo(MockAssembly.Success));
-            Assert.That(_failCount, Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(_successCount, Is.EqualTo(MockAssembly.Passed));
+            Assert.That(_failCount, Is.EqualTo(MockAssembly.Failed));
             Assert.That(_skipCount, Is.EqualTo(MockAssembly.Skipped));
             Assert.That(_inconclusiveCount, Is.EqualTo(MockAssembly.Inconclusive));
         }


### PR DESCRIPTION
Fixes #1913 

This PR updates NUnitLite so that Warnings show up along with errors and failures in the renamed "Errors, Failures and Warnings" report.

I also took this opportunity to restructure the naming of constants in MockAssembly.cs to match our new statuses and results and to eliminate unused fields.