### PR TITLE
Rename zip and remove source zip

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -63,8 +63,7 @@ var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
 var EXECUTABLE_NUNITLITE_TESTS = "nunitlite.tests.exe";
 
 // Packages
-var SRC_PACKAGE = PACKAGE_DIR + "NUnit-" + version + modifier + "-src.zip";
-var ZIP_PACKAGE = PACKAGE_DIR + "NUnit-" + packageVersion + ".zip";
+var ZIP_PACKAGE = PACKAGE_DIR + "NUnit.Framework." + packageVersion + ".zip";
 
 bool isDotNetCoreInstalled = false;
 
@@ -387,14 +386,6 @@ var FrameworkFiles = new FilePath[]
     "System.Runtime.dll",
     "System.Threading.Tasks.dll"
 };
-
-Task("PackageSource")
-    .Description("Creates a ZIP file of the source code")
-    .Does(() =>
-    {
-        CreateDirectory(PACKAGE_DIR);
-        RunGitCommand(string.Format("archive -o {0} HEAD", SRC_PACKAGE));
-    });
 
 Task("CreateImage")
     .Description("Copies all files into the image directory")

--- a/build.cake
+++ b/build.cake
@@ -63,7 +63,7 @@ var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
 var EXECUTABLE_NUNITLITE_TESTS = "nunitlite.tests.exe";
 
 // Packages
-var ZIP_PACKAGE = PACKAGE_DIR + "NUnit.Framework." + packageVersion + ".zip";
+var ZIP_PACKAGE = PACKAGE_DIR + "NUnit.Framework-" + packageVersion + ".zip";
 
 bool isDotNetCoreInstalled = false;
 


### PR DESCRIPTION
Relates to https://github.com/nunit/nunit-distribution/pull/11. This one's optional, but general consensus seemed to be that it was a good idea. 

This renames the framework zip to `NUnit.Framework.{Version}`, to avoid ambiguity. See general notes on https://github.com/nunit/nunit-distribution/pull/11.

I also removed the source zip at the same time. We stopped distributing this previously in favour of GitHub's automated version, and the task wasn't hooked up to everything. The equivalent has already been removed in the console project.