### PR TITLE
Extended TestContext.TestAdapter with IMethodInfo Method property to obtain access to test metadata

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -353,6 +353,11 @@ namespace NUnit.Framework
             }
 
             /// <summary>
+            /// The method representing the test, which may be null if test is not implemented as a method.
+            /// </summary>
+            public IMethodInfo Method { get { return _test.Method; } }
+
+            /// <summary>
             /// The FullName of the test
             /// </summary>
             public string FullName

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -138,7 +138,22 @@ namespace NUnit.Framework.Tests
         {
             Assert.That(TestContext.CurrentContext.Test.MethodName, Is.EqualTo("TestCanAccessItsOwnMethodName"));
         }
-        
+
+        [Test]
+        public void TestCanAccessItsOwnMethod()
+        {
+            Assert.That(TestContext.CurrentContext.Test.Method, Is.Not.Null);
+            Assert.That(TestContext.CurrentContext.Test.Method.Name, Is.EqualTo("TestCanAccessItsOwnMethod"));
+        }
+
+        [Test]
+        [Description("")]
+        public void TestCanAccessItsOwnMethodAttributes()
+        {
+            Assert.That(TestContext.CurrentContext.Test.Method, Is.Not.Null);
+            Assert.That(TestContext.CurrentContext.Test.Method.GetCustomAttributes<DescriptionAttribute>(false), Is.Not.Empty);
+        }
+
         [TestCase(5)]
         public void TestCaseCanAccessItsOwnMethodName(int x)
         {


### PR DESCRIPTION
Hello,

I have created a pull request extending the `TestContext.TestAdapter` class with `IMethodInfo Method` property.

The reason for that change is that I would like to get access to the test method metadata, such as:
* name,
* parameter types information
* attributes applied to method or method parameters.

While currently it would be possible to use `TextContext.Test.FullName` and then use reflection to findout the MethodInfo, such implementation would be problematic for overloaded test methods as well as more complicated to implement.

Thanks