### PR TITLE
Use ParallelScope.None for tests that change the default tolerance

### DIFF
--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -28,6 +28,7 @@ using System.IO;
 namespace NUnit.Framework.Assertions
 {
 	[TestFixture]
+    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
     public class AssertEqualsTests
     {
         [Test]

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -32,14 +32,22 @@ using NUnit.Framework.Constraints;
 namespace NUnit.Framework.Tests.Constraints
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
     public class ToleranceTests
     {
         private NUnitEqualityComparer _comparer;
+        private double _savedTolerance;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _savedTolerance = GlobalSettings.DefaultFloatingPointTolerance;
+        }
 
         [TearDown]
         public void TearDown()
         {
-            GlobalSettings.DefaultFloatingPointTolerance = 0d;
+            GlobalSettings.DefaultFloatingPointTolerance = _savedTolerance;
             _comparer = new NUnitEqualityComparer();
         }
 

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Syntax
 {
+    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
     public class EqualToTest : SyntaxTest
     {
         [SetUp]
@@ -134,6 +135,7 @@ namespace NUnit.Framework.Syntax
         [Test]
         public void EqualityTestsUsingDefaultFloatingPointTolerance()
         {
+            var savedTolerance = GlobalSettings.DefaultFloatingPointTolerance;
             GlobalSettings.DefaultFloatingPointTolerance = 0.05d;
 
             try
@@ -144,7 +146,7 @@ namespace NUnit.Framework.Syntax
             }
             finally
             {
-                GlobalSettings.DefaultFloatingPointTolerance = 0.0d;
+                GlobalSettings.DefaultFloatingPointTolerance = savedTolerance;
             }
         }
     }


### PR DESCRIPTION
This PR does a temporary fix, which will hopefully prevent breaking the build. Three fixtures change the default tolerance, which is a global static. I have attributed each of them so that they will not run in parallel with any other fixture. That's much more than they need but the best we have right now.

Ideally we should eliminate the use of GlobalSettings, but it's more than I want to undertake a few days before a release. I'll leave issue #1918 to deal with that.