### PR TITLE
Suppress reason in xml if null or whitespace

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -386,8 +386,7 @@ namespace NUnit.Framework.Internal
                 case TestStatus.Passed:
                 case TestStatus.Inconclusive:
                 case TestStatus.Warning:
-                    if(Message != null)
-                    //if (Message != null && Message.Trim().Length > 0)
+                    if (Message != null && Message.Trim().Length > 0)
                         AddReasonElement(thisNode);
                     break;
             }
@@ -397,7 +396,6 @@ namespace NUnit.Framework.Internal
 
             if (AssertionResults.Count > 0)
                 AddAssertionsElement(thisNode);
-
 
             if (recursive && HasChildren)
                 foreach (TestResult child in Children)

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -386,7 +386,8 @@ namespace NUnit.Framework.Internal
                 case TestStatus.Passed:
                 case TestStatus.Inconclusive:
                 case TestStatus.Warning:
-                    if (Message != null)
+                    //if(Message != null)
+                    if (Message != null && Message.Trim().Length > 0)
                         AddReasonElement(thisNode);
                     break;
             }

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -386,8 +386,8 @@ namespace NUnit.Framework.Internal
                 case TestStatus.Passed:
                 case TestStatus.Inconclusive:
                 case TestStatus.Warning:
-                    //if(Message != null)
-                    if (Message != null && Message.Trim().Length > 0)
+                    if(Message != null)
+                    //if (Message != null && Message.Trim().Length > 0)
                         AddReasonElement(thisNode);
                     break;
             }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -50,12 +50,24 @@ namespace NUnit.Framework.Internal.Results
         public TestResultIgnoredWithEmptyReasonGivenTests() : base(string.Empty)
         {
         }
+
+        protected override void ReasonAssertions(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.IsNull(reason);
+        }
     }
 
     public class TestResultIgnoredWithWhitespaceReasonGivenTests : TestResultIgnoredTests
     {
         public TestResultIgnoredWithWhitespaceReasonGivenTests() : base(" ")
         {
+        }
+
+        protected override void ReasonAssertions(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.IsNull(reason);
         }
     }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -126,14 +126,5 @@ namespace NUnit.Framework.Internal.Results
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.IsNull(reason, "This test expects no reason element to be present in the xml representation.");
         }
-
-        public static void ReasonNodeExpectedValidation(TNode testNode, string ignoreReason)
-        {
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.NotNull(reason);
-            Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(ignoreReason, reason.SelectSingleNode("message").Value);
-            Assert.Null(reason.SelectSingleNode("stack-trace"));
-        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -25,9 +25,48 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Results
 {
-    public class TestResultIgnoredTests : TestResultTests
+    public class TestResultIgnoredWithReasonGivenTests : TestResultIgnoredTests
     {
-        protected string _ignoreReason = "because";
+        public TestResultIgnoredWithReasonGivenTests() : base("because")
+        {
+        }
+    }
+
+    public class TestResultIgnoredWithNullReasonGivenTests : TestResultIgnoredTests
+    {
+        public TestResultIgnoredWithNullReasonGivenTests() : base(null)
+        {
+        }
+
+        protected override void ReasonAssertions(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.IsNull(reason);
+        }
+    }
+
+    public class TestResultIgnoredWithEmptyReasonGivenTests : TestResultIgnoredTests
+    {
+        public TestResultIgnoredWithEmptyReasonGivenTests() : base(string.Empty)
+        {
+        }
+    }
+
+    public class TestResultIgnoredWithWhitespaceReasonGivenTests : TestResultIgnoredTests
+    {
+        public TestResultIgnoredWithWhitespaceReasonGivenTests() : base(" ")
+        {
+        }
+    }
+
+    public abstract class TestResultIgnoredTests : TestResultTests
+    {
+        protected string _ignoreReason;
+
+        public TestResultIgnoredTests(string ignoreReason)
+        {
+            _ignoreReason = ignoreReason;
+        }
 
         [SetUp]
         public void SimulateTestRun()
@@ -66,11 +105,7 @@ namespace NUnit.Framework.Internal.Results
             Assert.AreEqual("Ignored", testNode.Attributes["label"]);
             Assert.AreEqual(null, testNode.Attributes["site"]);
 
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.NotNull(reason);
-            Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(_ignoreReason, reason.SelectSingleNode("message").Value);
-            Assert.Null(reason.SelectSingleNode("stack-trace"));
+            ReasonAssertions(testNode);
         }
 
         [Test]
@@ -87,6 +122,15 @@ namespace NUnit.Framework.Internal.Results
             Assert.AreEqual("1", suiteNode.Attributes["skipped"]);
             Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
             Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
+        }
+
+        protected virtual void ReasonAssertions(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.NotNull(reason);
+            Assert.NotNull(reason.SelectSingleNode("message"));
+            Assert.AreEqual(_ignoreReason, reason.SelectSingleNode("message").Value);
+            Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -27,10 +27,12 @@ namespace NUnit.Framework.Internal.Results
 {
     public class TestResultIgnoredTests : TestResultTests
     {
+        private const string ignoreReason = "because";
+
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Ignored, "because");
+            _testResult.SetResult(ResultState.Ignored, ignoreReason);
             _suiteResult.AddResult(_testResult);
         }
 
@@ -38,7 +40,7 @@ namespace NUnit.Framework.Internal.Results
         public void TestResultIsIgnored()
         {
             Assert.AreEqual(ResultState.Ignored, _testResult.ResultState);
-            Assert.AreEqual("because", _testResult.Message);
+            Assert.AreEqual(ignoreReason, _testResult.Message);
         }
 
         [Test]
@@ -67,7 +69,7 @@ namespace NUnit.Framework.Internal.Results
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual("because", reason.SelectSingleNode("message").Value);
+            Assert.AreEqual(ignoreReason, reason.SelectSingleNode("message").Value);
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -120,11 +120,5 @@ namespace NUnit.Framework.Internal.Results
             Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
             Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
         }
-
-        public static void NoReasonNodeExpectedValidation(TNode testNode)
-        {
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.IsNull(reason, "This test expects no reason element to be present in the xml representation.");
-        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -27,12 +27,12 @@ namespace NUnit.Framework.Internal.Results
 {
     public class TestResultIgnoredTests : TestResultTests
     {
-        private const string ignoreReason = "because";
+        protected string _ignoreReason = "because";
 
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Ignored, ignoreReason);
+            _testResult.SetResult(ResultState.Ignored, _ignoreReason);
             _suiteResult.AddResult(_testResult);
         }
 
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Internal.Results
         public void TestResultIsIgnored()
         {
             Assert.AreEqual(ResultState.Ignored, _testResult.ResultState);
-            Assert.AreEqual(ignoreReason, _testResult.Message);
+            Assert.AreEqual(_ignoreReason, _testResult.Message);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Internal.Results
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(ignoreReason, reason.SelectSingleNode("message").Value);
+            Assert.AreEqual(_ignoreReason, reason.SelectSingleNode("message").Value);
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -28,7 +28,6 @@ namespace NUnit.Framework.Internal.Results
 {
     public class TestResultIgnoredWithReasonGivenTests : TestResultIgnoredTests
     {
-        private const string NonWhitespaceIgnoreReason = "because";
         public TestResultIgnoredWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, tnode => ReasonNodeExpectedValidation(tnode, NonWhitespaceIgnoreReason))
         {
         }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Internal.Results
         }
     }
 
-    public abstract class TestResultIgnoredTests : TestResultTests
+    public class TestResultIgnoredTests : TestResultTests
     {
         protected string _ignoreReason;
         private Action<TNode> _xmlReasonNodeValidation;

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -32,42 +32,37 @@ namespace NUnit.Framework.Internal.Results
         }
     }
 
-    public class TestResultIgnoredWithNullReasonGivenTests : TestResultIgnoredTests
+    public class TestResultIgnoredWhereNoReasonElementExpectedInXml : TestResultIgnoredTests
+    {
+        public TestResultIgnoredWhereNoReasonElementExpectedInXml(string ignoreReason) : base(ignoreReason)
+        {
+        }
+
+        protected override void ReasonAssertions(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.IsNull(reason);
+        }
+    }
+
+    public class TestResultIgnoredWithNullReasonGivenTests : TestResultIgnoredWhereNoReasonElementExpectedInXml
     {
         public TestResultIgnoredWithNullReasonGivenTests() : base(null)
         {
         }
-
-        protected override void ReasonAssertions(TNode testNode)
-        {
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.IsNull(reason);
-        }
     }
 
-    public class TestResultIgnoredWithEmptyReasonGivenTests : TestResultIgnoredTests
+    public class TestResultIgnoredWithEmptyReasonGivenTests : TestResultIgnoredWhereNoReasonElementExpectedInXml
     {
         public TestResultIgnoredWithEmptyReasonGivenTests() : base(string.Empty)
         {
         }
-
-        protected override void ReasonAssertions(TNode testNode)
-        {
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.IsNull(reason);
-        }
     }
 
-    public class TestResultIgnoredWithWhitespaceReasonGivenTests : TestResultIgnoredTests
+    public class TestResultIgnoredWithWhitespaceReasonGivenTests : TestResultIgnoredWhereNoReasonElementExpectedInXml
     {
         public TestResultIgnoredWithWhitespaceReasonGivenTests() : base(" ")
         {
-        }
-
-        protected override void ReasonAssertions(TNode testNode)
-        {
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.IsNull(reason);
         }
     }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -54,12 +54,12 @@ namespace NUnit.Framework.Internal.Results
         }
     }
 
-    public class TestResultIgnoredTests : TestResultTests
+    public abstract class TestResultIgnoredTests : TestResultTests
     {
         protected string _ignoreReason;
         private Action<TNode> _xmlReasonNodeValidation;
 
-        public TestResultIgnoredTests(string ignoreReason, Action<TNode> xmlReasonNodeValidation)
+        protected TestResultIgnoredTests(string ignoreReason, Action<TNode> xmlReasonNodeValidation)
         {
             _ignoreReason = ignoreReason;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -40,6 +40,20 @@ namespace NUnit.Framework.Internal.Results
         }
     }
 
+    public class TestResultInconclusiveWithEmptyReasonGivenTests : TestResultInconclusiveTests
+    {
+        public TestResultInconclusiveWithEmptyReasonGivenTests() : base(string.Empty, NoReasonNodeExpectedValidation)
+        {
+        }
+    }
+
+    public class TestResultInconclusiveWithWhitespaceReasonGivenTests : TestResultInconclusiveTests
+    {
+        public TestResultInconclusiveWithWhitespaceReasonGivenTests() : base(" ", NoReasonNodeExpectedValidation)
+        {
+        }
+    }
+
     public abstract class TestResultInconclusiveTests : TestResultTests
     {
         protected string _ignoreReason;

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -56,19 +56,19 @@ namespace NUnit.Framework.Internal.Results
 
     public abstract class TestResultInconclusiveTests : TestResultTests
     {
-        protected string _ignoreReason;
+        protected string _inconclusiveReason;
         private Action<TNode> _xmlReasonNodeValidation;
 
         protected TestResultInconclusiveTests(string ignoreReason, Action<TNode> xmlReasonNodeValidation)
         {
-            _ignoreReason = ignoreReason;
+            _inconclusiveReason = ignoreReason;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;
         }
 
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Inconclusive, _ignoreReason);
+            _testResult.SetResult(ResultState.Inconclusive, _inconclusiveReason);
             _suiteResult.AddResult(_testResult);
         }
 
@@ -76,7 +76,7 @@ namespace NUnit.Framework.Internal.Results
         public void TestResultIsInconclusive()
         {
             Assert.AreEqual(ResultState.Inconclusive, _testResult.ResultState);
-            Assert.AreEqual(_ignoreReason, _testResult.Message);
+            Assert.AreEqual(_inconclusiveReason, _testResult.Message);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -25,7 +25,7 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Results
 {
-    public class InconclusiveResultTests : TestResultTests
+    public class TestResultInconclusiveTests : TestResultTests
     {
         [SetUp]
         public void SimulateTestRun()

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -26,7 +26,14 @@ using System;
 
 namespace NUnit.Framework.Internal.Results
 {
-    public class TestResultInconclusiveTests : TestResultTests
+    public class TestResultInconclusiveWithReasonGivenTests : TestResultInconclusiveTests
+    {
+        public TestResultInconclusiveWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, x => { })
+        {
+        }
+    }
+
+    public abstract class TestResultInconclusiveTests : TestResultTests
     {
         protected string _ignoreReason;
         private Action<TNode> _xmlReasonNodeValidation;
@@ -35,10 +42,6 @@ namespace NUnit.Framework.Internal.Results
         {
             _ignoreReason = ignoreReason;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;
-        }
-
-        public TestResultInconclusiveTests() : this(NonWhitespaceIgnoreReason, x => { })
-        {
         }
 
         [SetUp]

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal.Results
 
     public class TestResultInconclusiveWithNullReasonGivenTests : TestResultInconclusiveTests
     {
-        public TestResultInconclusiveWithNullReasonGivenTests() : base(null, TestResultIgnoredTests.NoReasonNodeExpectedValidation)
+        public TestResultInconclusiveWithNullReasonGivenTests() : base(null, NoReasonNodeExpectedValidation)
         {
         }
     }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal.Results
 {
     public class TestResultInconclusiveWithReasonGivenTests : TestResultInconclusiveTests
     {
-        public TestResultInconclusiveWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, x => { })
+        public TestResultInconclusiveWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, node => TestResultIgnoredTests.ReasonNodeExpectedValidation(node, NonWhitespaceIgnoreReason))
         {
         }
     }
@@ -81,11 +81,7 @@ namespace NUnit.Framework.Internal.Results
             Assert.IsNull(testNode.Attributes["label"]);
             Assert.IsNull(testNode.Attributes["site"]);
 
-            TNode reason = testNode.SelectSingleNode("reason");
-            Assert.NotNull(reason);
-            Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(_ignoreReason, reason.SelectSingleNode("message").Value);
-            Assert.Null(reason.SelectSingleNode("stack-trace"));
+            _xmlReasonNodeValidation(testNode);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal.Results
 {
     public class TestResultInconclusiveWithReasonGivenTests : TestResultInconclusiveTests
     {
-        public TestResultInconclusiveWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, node => TestResultIgnoredTests.ReasonNodeExpectedValidation(node, NonWhitespaceIgnoreReason))
+        public TestResultInconclusiveWithReasonGivenTests() : base(NonWhitespaceIgnoreReason, node => ReasonNodeExpectedValidation(node, NonWhitespaceIgnoreReason))
         {
         }
     }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,15 +22,29 @@
 // ***********************************************************************
 
 using NUnit.Framework.Interfaces;
+using System;
 
 namespace NUnit.Framework.Internal.Results
 {
     public class TestResultInconclusiveTests : TestResultTests
     {
+        protected string _ignoreReason;
+        private Action<TNode> _xmlReasonNodeValidation;
+
+        protected TestResultInconclusiveTests(string ignoreReason, Action<TNode> xmlReasonNodeValidation)
+        {
+            _ignoreReason = ignoreReason;
+            _xmlReasonNodeValidation = xmlReasonNodeValidation;
+        }
+
+        public TestResultInconclusiveTests() : this(NonWhitespaceIgnoreReason, x => { })
+        {
+        }
+
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Inconclusive, NonWhitespaceIgnoreReason);
+            _testResult.SetResult(ResultState.Inconclusive, _ignoreReason);
             _suiteResult.AddResult(_testResult);
         }
 
@@ -38,7 +52,7 @@ namespace NUnit.Framework.Internal.Results
         public void TestResultIsInconclusive()
         {
             Assert.AreEqual(ResultState.Inconclusive, _testResult.ResultState);
-            Assert.AreEqual(NonWhitespaceIgnoreReason, _testResult.Message);
+            Assert.AreEqual(_ignoreReason, _testResult.Message);
         }
 
         [Test]
@@ -67,7 +81,7 @@ namespace NUnit.Framework.Internal.Results
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(NonWhitespaceIgnoreReason, reason.SelectSingleNode("message").Value);
+            Assert.AreEqual(_ignoreReason, reason.SelectSingleNode("message").Value);
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Inconclusive, "because");
+            _testResult.SetResult(ResultState.Inconclusive, NonWhitespaceIgnoreReason);
             _suiteResult.AddResult(_testResult);
         }
 
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Internal.Results
         public void TestResultIsInconclusive()
         {
             Assert.AreEqual(ResultState.Inconclusive, _testResult.ResultState);
-            Assert.AreEqual("because", _testResult.Message);
+            Assert.AreEqual(NonWhitespaceIgnoreReason, _testResult.Message);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Internal.Results
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual("because", reason.SelectSingleNode("message").Value);
+            Assert.AreEqual(NonWhitespaceIgnoreReason, reason.SelectSingleNode("message").Value);
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -33,6 +33,13 @@ namespace NUnit.Framework.Internal.Results
         }
     }
 
+    public class TestResultInconclusiveWithNullReasonGivenTests : TestResultInconclusiveTests
+    {
+        public TestResultInconclusiveWithNullReasonGivenTests() : base(null, TestResultIgnoredTests.NoReasonNodeExpectedValidation)
+        {
+        }
+    }
+
     public abstract class TestResultInconclusiveTests : TestResultTests
     {
         protected string _ignoreReason;

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -61,6 +61,12 @@ namespace NUnit.Framework.Internal.Results
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 
+        protected static void NoReasonNodeExpectedValidation(TNode testNode)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.IsNull(reason, "This test expects no reason element to be present in the xml representation.");
+        }
+
         #region Nested DummySuite
 
         public class DummySuite

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -52,12 +52,12 @@ namespace NUnit.Framework.Internal.Results
             _suiteResult = (TestSuiteResult)_suite.MakeTestResult();
         }
 
-        protected static void ReasonNodeExpectedValidation(TNode testNode, string ignoreReason)
+        protected static void ReasonNodeExpectedValidation(TNode testNode, string reasonMessage)
         {
             TNode reason = testNode.SelectSingleNode("reason");
             Assert.NotNull(reason);
             Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(ignoreReason, reason.SelectSingleNode("message").Value);
+            Assert.AreEqual(reasonMessage, reason.SelectSingleNode("message").Value);
             Assert.Null(reason.SelectSingleNode("stack-trace"));
         }
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -35,6 +35,7 @@ namespace NUnit.Framework.Internal.Results
     [TestFixture]
     public abstract class TestResultTests
     {
+        protected const string NonWhitespaceIgnoreReason = "because";
         protected TestMethod _test;
         protected TestResult _testResult;
 

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -52,6 +52,15 @@ namespace NUnit.Framework.Internal.Results
             _suiteResult = (TestSuiteResult)_suite.MakeTestResult();
         }
 
+        protected static void ReasonNodeExpectedValidation(TNode testNode, string ignoreReason)
+        {
+            TNode reason = testNode.SelectSingleNode("reason");
+            Assert.NotNull(reason);
+            Assert.NotNull(reason.SelectSingleNode("message"));
+            Assert.AreEqual(ignoreReason, reason.SelectSingleNode("message").Value);
+            Assert.Null(reason.SelectSingleNode("stack-trace"));
+        }
+
         #region Nested DummySuite
 
         public class DummySuite


### PR DESCRIPTION
This should address issue #1896.

First commit to the project (and a novice to git(hub) to boot), so please feel free to point out any issues - I'll do my best to address promptly.

Issue only mentions a problem with the Success case (e.g. using Assert.Pass), but it appears that Inconclusive and Ignore can also produce reason elements in the xml and therefore would also have this issue. It's possible other states could be a problem, but I was basing the work of existing tests that check for reason.

There is a fair bit of duplication across the (existing) tests - I've not really tried to address that, aside from some low hanging fruit.

Changes should be relatively self explanatory, but please let me know if you'd like any more details.

Chris