### PR TITLE
#1954 assert equals error message fixed

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -66,6 +66,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE! Use Assert.AreEqual(...) instead.
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -74,19 +75,21 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Assert.Equals should not be used for Assertions");
+            throw new InvalidOperationException("Assert.Equals should not be used for Assertions, use Assert.AreEqual(...) instead.");
         }
 
         /// <summary>
+        /// DO NOT USE! Use Assert.AreEqual(...) instead.
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Assert.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("Assert.ReferenceEquals should not be used for Assertions, use Assert.AreEqual(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -79,17 +79,16 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// DO NOT USE! Use Assert.AreEqual(...) instead.
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// DO NOT USE!
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Assert.ReferenceEquals should not be used for Assertions, use Assert.AreEqual(...) instead.");
+            throw new InvalidOperationException("Assert.ReferenceEquals should not be used for Assertions, use Assert.AreSame(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -39,6 +39,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE!
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -52,6 +53,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
+        /// DO NOT USE!
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -49,20 +49,19 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Assume.Equals should not be used for Assertions");
+            throw new InvalidOperationException("Assume.Equals should not be used for Assertions.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
         /// <param name="b">The right object.</param>
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Assume.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("Assume.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -49,16 +49,15 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// DO NOT USE! Use CollectionAssert.AreEqual(...) instead.
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// DO NOT USE!
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used for Assertions, use CollectionAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -36,6 +36,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE! Use CollectionAssert.AreEqual(...) instead.
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -44,10 +45,11 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("CollectionAssert.Equals should not be used for Assertions");
+            throw new InvalidOperationException("CollectionAssert.Equals should not be used for Assertions, use CollectionAssert.AreEqual(...) instead.");
         }
 
         /// <summary>
+        /// DO NOT USE! Use CollectionAssert.AreEqual(...) instead.
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
@@ -56,7 +58,7 @@ namespace NUnit.Framework
         /// <param name="b"></param>
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used for Assertions, use CollectionAssert.AreEqual(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/DirectoryAssert.cs
+++ b/src/NUnitFramework/framework/DirectoryAssert.cs
@@ -37,6 +37,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE! Use DirectoryAssert.AreEqual(...) instead.
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -45,19 +46,21 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("DirectoryAssert.Equals should not be used for Assertions");
+            throw new InvalidOperationException("DirectoryAssert.Equals should not be used for Assertions, use DirectoryAssert.AreEqual(...) instead.");
         }
 
         /// <summary>
+        /// DO NOT USE! Use DirectoryAssert.AreEqual(...) instead.
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used for Assertions, use DirectoryAssert.AreEqual(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/DirectoryAssert.cs
+++ b/src/NUnitFramework/framework/DirectoryAssert.cs
@@ -50,17 +50,16 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// DO NOT USE! Use DirectoryAssert.AreEqual(...) instead.
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// DO NOT USE!
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used for Assertions, use DirectoryAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/FileAssert.cs
+++ b/src/NUnitFramework/framework/FileAssert.cs
@@ -50,17 +50,16 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// DO NOT USE! Use FileAssert.AreEqual(...) instead.
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// DO NOT USE!
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used for Assertions, use FileAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/FileAssert.cs
+++ b/src/NUnitFramework/framework/FileAssert.cs
@@ -37,6 +37,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE! Use FileAssert.AreEqual(...) instead.
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -45,19 +46,21 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("FileAssert.Equals should not be used for Assertions");
+            throw new InvalidOperationException("FileAssert.Equals should not be used for Assertions, use FileAssert.AreEqual(...) instead.");
         }
 
         /// <summary>
+        /// DO NOT USE! Use FileAssert.AreEqual(...) instead.
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used for Assertions, use FileAssert.AreEqual(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/StringAssert.cs
+++ b/src/NUnitFramework/framework/StringAssert.cs
@@ -48,17 +48,16 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// DO NOT USE! Use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// DO NOT USE!
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used for Assertions, use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.");
+            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/StringAssert.cs
+++ b/src/NUnitFramework/framework/StringAssert.cs
@@ -35,6 +35,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE! Use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -43,19 +44,21 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("StringAssert.Equals should not be used for Assertions");
+            throw new InvalidOperationException("StringAssert.Equals should not be used for Assertions, use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.");
         }
 
         /// <summary>
+        /// DO NOT USE! Use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used for Assertions, use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -48,21 +48,20 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Warn.Equals should not be used for Assertions");
+            throw new InvalidOperationException("Warn.Equals should not be used for Assertions.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// override the default ReferenceEquals to throw an InvalidOperationException. This 
-        /// implementation makes sure there is no mistake in calling this function 
-        /// as part of Assert. 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
         /// <param name="b">The right object.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Warn.ReferenceEquals should not be used for Assertions");
+            throw new InvalidOperationException("Warn.ReferenceEquals should not be used for Assertions.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -38,6 +38,7 @@ namespace NUnit.Framework
         #region Equals and ReferenceEquals
 
         /// <summary>
+        /// DO NOT USE!
         /// The Equals method throws an InvalidOperationException. This is done 
         /// to make sure there is no mistake by calling this function.
         /// </summary>
@@ -51,12 +52,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
+        /// DO NOT USE!
         /// override the default ReferenceEquals to throw an InvalidOperationException. This 
         /// implementation makes sure there is no mistake in calling this function 
         /// as part of Assert. 
         /// </summary>
         /// <param name="a">The left object.</param>
         /// <param name="b">The right object.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
             throw new InvalidOperationException("Warn.ReferenceEquals should not be used for Assertions");


### PR DESCRIPTION
Updated Summary and Exception Messages of the classes with the overridden Equals and ReferenceEquals with "DO NOT USE!" and suggested actual methods to use if they exist.

I assumed that AreEquals should also be used for ReferenceEquals.

Also I didn't really run any tests to check if the suggested methods are correct, I just looked at the code.

I couldn't find the appropriate methods for Warn and Assume.

Lastly, I think that the ReferenceEquals should probably be changed to something closer in test to Equals or vice versa?

Fixes #1954