### PR TITLE
Add AttributeUsage to two attributes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.ComponentModel;
 
 namespace NUnit.Framework
@@ -34,6 +35,7 @@ namespace NUnit.Framework
     /// depends on each individual runner.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     public class NonTestAssemblyAttribute : NUnitAttribute
     {
     }

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -36,6 +36,7 @@ namespace NUnit.Framework
     /// RandomAttribute is used to supply a set of random _values
     /// to a single parameter of a parameterized test.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public class RandomAttribute : DataAttribute, IParameterDataSource
     {
         private RandomDataSource _source;


### PR DESCRIPTION
I forgot AttributeUsage on the new NonTestAssemblyAttribute. I figured I would deal with the existing issue #1880 at the same time so this fixes #1880 as well