### PR TITLE
Additional tests for issue 1941

### DIFF
--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -130,10 +130,10 @@ namespace NUnit.Tests
         [Category("FixtureCategory")]
         public class MockTestFixture
         {
-            public const int Tests = 9;
+            public const int Tests = 10;
             public const int Suites = 1;
 
-            public const int Passed = 1;
+            public const int Passed = 2;
 
             public const int Skipped_Ignored = 1;
             public const int Skipped_Explicit = 1;
@@ -184,6 +184,15 @@ namespace NUnit.Tests
             public void InconclusiveTest()
             {
                 Assert.Inconclusive("No valid data");
+            }
+
+            [Test]
+            public void DisplayRunParameters()
+            {
+#if !PORTABLE
+                foreach (string name in TestContext.Parameters.Names)
+                    Console.WriteLine("Parameter {0} = {1}", name, TestContext.Parameters[name]);
+#endif
             }
 
             [Test]

--- a/src/NUnitFramework/nunitlite.tests/TextUITests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUITests.cs
@@ -198,7 +198,7 @@ namespace NUnitLite.Tests
             var expected = new string[] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-                "  Test Count: 9, Passed: 1, Failed: 4, Warnings: 1, Inconclusive: 1, Skipped: 2",
+                "  Test Count: 10, Passed: 2, Failed: 4, Warnings: 1, Inconclusive: 1, Skipped: 2",
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 2",
                 "    Skipped Tests - Ignored: 1, Explicit: 1, Other: 0",
                 "  Start time: 2014-12-02 12:34:56Z",

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -223,6 +223,7 @@ namespace NUnit.Framework.Api
                 Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
+#if !PORTABLE
         [Test]
         public void Run_WithParameters()
         {
@@ -246,6 +247,7 @@ namespace NUnit.Framework.Api
             var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
             CheckParameterOutput(result);
         }
+#endif
 
         [Test]
         public void Run_BadFile_ReturnsNonRunnableSuite()

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -33,6 +33,7 @@ using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using NUnit.Tests;
 using NUnit.Tests.Assemblies;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Api
 {
@@ -220,6 +221,30 @@ namespace NUnit.Framework.Api
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
             Assert.That(result.Message,
                 Does.StartWith(COULD_NOT_LOAD_MSG));
+        }
+
+        [Test]
+        public void Run_WithParameters()
+        {
+            var dict = new Dictionary<string, string>();
+            dict.Add("X", "5");
+            dict.Add("Y", "7");
+
+            var settings = new Dictionary<string, object>();
+            settings.Add("TestParametersDictionary", dict);
+            LoadMockAssembly(settings);
+            var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
+            CheckParameterOutput(result);
+        }
+
+        [Test]
+        public void Run_WithLegacyParameters()
+        {
+            var settings = new Dictionary<string, object>();
+            settings.Add("TestParameters", "X=5;Y=7");
+            LoadMockAssembly(settings);
+            var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
+            CheckParameterOutput(result);
         }
 
         [Test]
@@ -426,14 +451,19 @@ namespace NUnit.Framework.Api
 
         private ITest LoadMockAssembly()
         {
+            return LoadMockAssembly(EMPTY_SETTINGS);
+        }
+
+        private ITest LoadMockAssembly(IDictionary<string, object> settings)
+        {
 #if PORTABLE
             return _runner.Load(
                 typeof(MockAssembly).GetTypeInfo().Assembly, 
-                EMPTY_SETTINGS);
+                settings);
 #else
             return _runner.Load(
                 Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE),
-                EMPTY_SETTINGS);
+                settings);
 #endif
         }
 
@@ -444,6 +474,16 @@ namespace NUnit.Framework.Api
 #else
             return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SLOW_TESTS_FILE), EMPTY_SETTINGS);
 #endif
+        }
+
+        private void CheckParameterOutput(ITestResult result)
+        {
+            var childResult = TestFinder.Find(
+                "DisplayRunParameters", result, true);
+
+            Assert.That(childResult.Output, Is.EqualTo(
+                "Parameter X = 5" + Environment.NewLine +
+                "Parameter Y = 7" + Environment.NewLine));
         }
 
         #endregion


### PR DESCRIPTION
This adds tests to those already in PR #1942 to verify that the framework properly recognizes run parameters using both the original string setting and the new dictionary.