### PR TITLE
Remove dependency on Microsoft.NETCore.Portable.Compatibility

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -30,7 +30,6 @@ Supported platforms:
     <dependencies>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
         <dependency id="System.Runtime.Loader" version="4.0.0" />
       </group>
     </dependencies>
@@ -50,7 +49,11 @@ Supported platforms:
     <file src="bin/net-4.5/nunit.framework.xml" target="lib/net45" />
     <file src="bin/netstandard16/nunit.framework.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard16/nunit.framework.xml" target="lib/netstandard1.6" />
-    <file src="bin/portable/nunit.framework.dll" target="lib/portable-net45+win8+wp8+wpa81+Xamarin.Mac+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="bin/portable/nunit.framework.xml" target="lib/portable-net45+win8+wp8+wpa81+Xamarin.Mac+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="bin/portable/nunit.framework.dll" target="lib/portable-net45+win8+wp8+wpa81" />
+    <file src="bin/portable/nunit.framework.xml" target="lib/portable-net45+win8+wp8+wpa81" />
+    <file src="bin/portable/nunit.framework.dll" target="lib/MonoAndroid" />
+    <file src="bin/portable/nunit.framework.xml" target="lib/MonoAndroid" />
+    <file src="bin/portable/nunit.framework.dll" target="lib/Xamarin.iOS10" />
+    <file src="bin/portable/nunit.framework.xml" target="lib/Xamarin.iOS10" />
   </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -32,7 +32,6 @@ How to use this package:
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,7 +24,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NETSTANDARD1_6
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// InvalidTestFixtureException is thrown when an appropriate test
@@ -59,7 +61,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Serialization Constructor
         /// </summary>
-        protected InvalidDataSourceException(SerializationInfo info, 
+        protected InvalidDataSourceException(SerializationInfo info,
             StreamingContext context) : base(info,context){}
 #endif
     }

--- a/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,7 +24,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NETSTANDARD1_6
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// InvalidTestFixtureException is thrown when an appropriate test
@@ -59,7 +61,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Serialization Constructor
         /// </summary>
-        protected InvalidTestFixtureException(SerializationInfo info, 
+        protected InvalidTestFixtureException(SerializationInfo info,
             StreamingContext context) : base(info,context){}
 #endif
     }

--- a/src/NUnitFramework/framework/Internal/NUnitException.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitException.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21,10 +21,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Framework.Internal 
+namespace NUnit.Framework.Internal
 {
     using System;
+#if !NETSTANDARD1_6
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// Thrown when an assertion failed. Here to preserve the inner
@@ -33,18 +35,18 @@ namespace NUnit.Framework.Internal
 #if !PORTABLE && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class NUnitException : Exception 
+    public class NUnitException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitException"/> class.
         /// </summary>
-        public NUnitException () : base() 
-        {} 
+        public NUnitException () : base()
+        {}
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitException"/> class.
         /// </summary>
-        /// <param name="message">The error message that explains 
+        /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         public NUnitException(string message) : base (message)
         {}
@@ -52,19 +54,19 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitException"/> class.
         /// </summary>
-        /// <param name="message">The error message that explains 
+        /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        /// <param name="inner">The exception that caused the 
+        /// <param name="inner">The exception that caused the
         /// current exception</param>
         public NUnitException(string message, Exception inner) :
-            base(message, inner) 
+            base(message, inner)
         { }
 
 #if !PORTABLE && !NETSTANDARD1_6
         /// <summary>
         /// Serialization Constructor
         /// </summary>
-        protected NUnitException(SerializationInfo info, 
+        protected NUnitException(SerializationInfo info,
             StreamingContext context) : base(info,context){}
 #endif
     }

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
@@ -2,7 +2,6 @@
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "System.Runtime.Loader": "4.0.0"
   },
   "frameworks": {

--- a/src/NUnitFramework/mock-assembly/mock-assembly-netstandard.project.json
+++ b/src/NUnitFramework/mock-assembly/mock-assembly-netstandard.project.json
@@ -1,8 +1,7 @@
 {
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.project.json
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests-netstandard.project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.1",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.App": "1.0.1"
   },
   "runtimes": {
     "win7-x64": {},

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -13,10 +13,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,16 +37,16 @@
 // A Getopt::Long-inspired option parsing library for C#.
 //
 // NDesk.Options.OptionSet is built upon a key/value table, where the
-// key is a option format string and the value is a delegate that is 
+// key is a option format string and the value is a delegate that is
 // invoked when the format string is matched.
 //
 // Option format strings:
-//  Regex-like BNF Grammar: 
+//  Regex-like BNF Grammar:
 //    name: .+
 //    type: [=:]
 //    sep: ( [^{}]+ | '{' .+ '}' )?
 //    aliases: ( name type sep ) ( '|' name type sep )*
-// 
+//
 // Each '|'-delimited name is an alias for the associated action.  If the
 // format string ends in a '=', it has a required value.  If the format
 // string ends in a ':', it has an optional value.  If neither '=' or ':'
@@ -92,7 +92,7 @@
 //  p.Parse (new string[]{"-v", "--v", "/v", "-name=A", "/name", "B", "extra"});
 //
 // The above would parse the argument string array, and would invoke the
-// lambda expression three times, setting `verbose' to 3 when complete.  
+// lambda expression three times, setting `verbose' to 3 when complete.
 // It would also print out "A" and "B" to standard output.
 // The returned array would contain the string "extra".
 //
@@ -122,11 +122,11 @@
 //      p.Parse (new string[]{"-a+"});  // sets v != null
 //      p.Parse (new string[]{"-a-"});  // sets v == null
 //
-// The NUnit version of this file introduces conditional compilation for 
+// The NUnit version of this file introduces conditional compilation for
 // building under a portable class library  (PORTABLE).
 //
 // 11/5/2015 -
-// Change namespace to avoid conflict with user code use of mono.options 
+// Change namespace to avoid conflict with user code use of mono.options
 
 using System;
 using System.Collections;
@@ -136,7 +136,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -147,6 +146,7 @@ using System.Text.RegularExpressions;
 using NUnit.Compatibility;
 #else
 using System.Security.Permissions;
+using System.Runtime.Serialization;
 #endif
 
 #if LINQ
@@ -224,7 +224,7 @@ namespace Mono.Options
             if (c.Option.OptionValueType == OptionValueType.Required &&
                     index >= values.Count)
                 throw new OptionException (string.Format (
-                            c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName), 
+                            c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName),
                         c.OptionName);
         }
 
@@ -273,7 +273,7 @@ namespace Mono.Options
             set {option = value;}
         }
 
-        public string OptionName { 
+        public string OptionName {
             get {return name;}
             set {name = value;}
         }
@@ -293,7 +293,7 @@ namespace Mono.Options
     }
 
     public enum OptionValueType {
-        None, 
+        None,
         Optional,
         Required,
     }
@@ -334,7 +334,7 @@ namespace Mono.Options
                 throw new ArgumentException (
                         string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
                         "maxValueCount");
-            if (Array.IndexOf (names, "<>") >= 0 && 
+            if (Array.IndexOf (names, "<>") >= 0 &&
                     ((names.Length == 1 && this.type != OptionValueType.None) ||
                      (names.Length > 1 && this.MaxValueCount > 1)))
                 throw new ArgumentException (
@@ -363,13 +363,13 @@ namespace Mono.Options
         {
             Type tt = typeof (T);
 #if PORTABLE || NETSTANDARD1_6
-            bool nullable = tt.GetTypeInfo().IsValueType && tt.GetTypeInfo().IsGenericType && 
-                !tt.GetTypeInfo().IsGenericTypeDefinition && 
+            bool nullable = tt.GetTypeInfo().IsValueType && tt.GetTypeInfo().IsGenericType &&
+                !tt.GetTypeInfo().IsGenericTypeDefinition &&
                 tt.GetGenericTypeDefinition () == typeof (Nullable<>);
             Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
 #else
-            bool nullable = tt.IsValueType && tt.IsGenericType && 
-                !tt.IsGenericTypeDefinition && 
+            bool nullable = tt.IsValueType && tt.IsGenericType &&
+                !tt.IsGenericTypeDefinition &&
                 tt.GetGenericTypeDefinition () == typeof (Nullable<>);
             Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
 #endif
@@ -416,7 +416,7 @@ namespace Mono.Options
                 names [i] = name.Substring (0, end);
                 if (type == '\0' || type == name [end])
                     type = name [end];
-                else 
+                else
                     throw new ArgumentException (
                             string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name [end]),
                             "prototype");
@@ -647,7 +647,7 @@ namespace Mono.Options
         {
             if (action == null)
                 throw new ArgumentNullException ("action");
-            Option p = new ActionOption (prototype, description, 1, 
+            Option p = new ActionOption (prototype, description, 1,
                     delegate (OptionValueCollection v) { action (v [0]); });
             base.Add (p);
             return this;
@@ -662,7 +662,7 @@ namespace Mono.Options
         {
             if (action == null)
                 throw new ArgumentNullException ("action");
-            Option p = new ActionOption (prototype, description, 2, 
+            Option p = new ActionOption (prototype, description, 2,
                     delegate (OptionValueCollection v) {action (v [0], v [1]);});
             base.Add (p);
             return this;
@@ -736,18 +736,18 @@ namespace Mono.Options
             OptionContext c = CreateOptionContext ();
             c.OptionIndex = -1;
             var def = GetOptionForName ("<>");
-            var unprocessed = 
+            var unprocessed =
                 from argument in arguments
                 where ++c.OptionIndex >= 0 && (process || def != null)
                     ? process
-                        ? argument == "--" 
+                        ? argument == "--"
                             ? (process = false)
                             : !Parse (argument, c)
-                                ? def != null 
-                                    ? Unprocessed (null, def, c, argument) 
+                                ? def != null
+                                    ? Unprocessed (null, def, c, argument)
                                     : true
                                 : false
-                        : def != null 
+                        : def != null
                             ? Unprocessed (null, def, c, argument)
                             : true
                     : true
@@ -840,7 +840,7 @@ namespace Mono.Options
                         c.Option.Invoke (c);
                         break;
                     case OptionValueType.Optional:
-                    case OptionValueType.Required: 
+                    case OptionValueType.Required:
                         ParseValue (v, c);
                         break;
                 }
@@ -859,17 +859,17 @@ namespace Mono.Options
         private void ParseValue (string option, OptionContext c)
         {
             if (option != null)
-                foreach (string o in c.Option.ValueSeparators != null 
+                foreach (string o in c.Option.ValueSeparators != null
                         ? option.Split (c.Option.ValueSeparators, StringSplitOptions.None)
                         : new string[]{option}) {
                     c.OptionValues.Add (o);
                 }
-            if (c.OptionValues.Count == c.Option.MaxValueCount || 
+            if (c.OptionValues.Count == c.Option.MaxValueCount ||
                     c.Option.OptionValueType == OptionValueType.Optional)
                 c.Option.Invoke (c);
             else if (c.OptionValues.Count > c.Option.MaxValueCount) {
                 throw new OptionException (localizer (string.Format (
-                                "Error: Found {0} option values when expecting {1}.", 
+                                "Error: Found {0} option values when expecting {1}.",
                                 c.OptionValues.Count, c.Option.MaxValueCount)),
                         c.OptionName);
             }
@@ -953,7 +953,7 @@ namespace Mono.Options
                 bool indent = false;
                 string prefix = new string (' ', OptionWidth+2);
                 foreach (string line in GetLines (localizer (GetDescription (p.Description)))) {
-                    if (indent) 
+                    if (indent)
                         o.Write (prefix);
                     o.WriteLine (line);
                     indent = true;
@@ -978,7 +978,7 @@ namespace Mono.Options
                 Write (o, ref written, names [0]);
             }
 
-            for ( i = GetNextOptionIndex (names, i+1); 
+            for ( i = GetNextOptionIndex (names, i+1);
                     i < names.Length; i = GetNextOptionIndex (names, i+1)) {
                 Write (o, ref written, ", ");
                 Write (o, ref written, names [i].Length == 1 ? "-" : "--");
@@ -991,7 +991,7 @@ namespace Mono.Options
                     Write (o, ref written, localizer ("["));
                 }
                 Write (o, ref written, localizer ("=" + GetArgumentName (0, p.MaxValueCount, p.Description)));
-                string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0 
+                string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0
                     ? p.ValueSeparators [0]
                     : " ";
                 for (int c = 1; c < p.MaxValueCount; ++c) {

--- a/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,12 +22,14 @@
 // ***********************************************************************
 
 using System;
+#if !NETSTANDARD1_6
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Common
 {
     /// <summary>
-    /// TestSelectionParserException is thrown when an error 
+    /// TestSelectionParserException is thrown when an error
     /// is found while parsing the selection expression.
     /// </summary>
 #if !PORTABLE && !NETSTANDARD1_6

--- a/src/NUnitFramework/nunitlite/nunitlite-netstandard.project.json
+++ b/src/NUnitFramework/nunitlite/nunitlite-netstandard.project.json
@@ -1,8 +1,7 @@
 {
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.project.json
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.project.json
@@ -1,8 +1,7 @@
 {
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.6": {}


### PR DESCRIPTION
Fixes #1966 

I have tested this change by building locally and upgrading the Xamarin runner to use the fixed package.