### PR TITLE
Implemented TestExecutionContext to use AsyncLocal<> for NETSTANDARD1_6

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,6 +55,7 @@ important top-level tasks to use are listed here:
  * Test35              Tests the 3.5 framework without building first.
  * Test20              Tests the 2.0 framework without building first.
  * TestPortable        Tests the portable framework without building first.
+ * TestNetStandard     Tests the NetStandard framework without building first.
  * Package             Creates all packages without building first. See Note below.
 ```
 

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -173,8 +173,32 @@ namespace NUnit.Framework.Internal
         // automatically creates threads for async methods.
         // We create a new context, which is automatically
         // populated with values taken from the current thread.
+#if NETSTANDARD1_6
+        private static readonly AsyncLocal<TestExecutionContext> _currentContext = new AsyncLocal<TestExecutionContext>();
+        /// <summary>
+        /// Gets and sets the current context.
+        /// </summary>
+        public static TestExecutionContext CurrentContext
+        {
+            get
+            {
+                return _currentContext.Value ?? (_currentContext.Value = new TestExecutionContext());
+            }
+            private set
+            {
+                _currentContext.Value = value;
+            }
+        }
 
-#if PORTABLE || NETSTANDARD1_6
+        /// <summary>
+        /// Get the current context or return null if none is found.
+        /// </summary>
+        /// <remarks></remarks>
+        public static TestExecutionContext GetTestExecutionContext()
+        {
+            return _currentContext.Value;
+        }
+#elif PORTABLE
         // In the Silverlight and portable builds, we use a ThreadStatic
         // field to hold the current TestExecutionContext.
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -21,9 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.IO;
 using System.Collections.Generic;
-#if ASYNC && !NET_4_0
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 using NUnit.Framework.Interfaces;
@@ -141,7 +142,7 @@ namespace NUnit.Framework.Tests
         {
             Assert.That(TestContext.CurrentContext.Test.MethodName, Is.EqualTo("TestCanAccessItsOwnMethodName"));
         }
-        
+
         [TestCase(5)]
         public void TestCaseCanAccessItsOwnMethodName(int x)
         {
@@ -236,7 +237,7 @@ namespace NUnit.Framework.Tests
             Assert.That(fixture.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
             Assert.That(fixture.StackTrace, Is.Null);
         }
-#if ASYNC && !NET_4_0
+#if ASYNC
 
 #if PORTABLE
         [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
@@ -245,7 +246,7 @@ namespace NUnit.Framework.Tests
         public async Task TestContextOut_ShouldFlowWithAsyncExecution()
         {
             var expected = TestContext.Out;
-            await Task.Yield();
+            await YieldAsync();
             Assert.AreSame(expected, TestContext.Out);
         }
 
@@ -256,8 +257,43 @@ namespace NUnit.Framework.Tests
         public async Task TestExecutionContextCurrentContext_ShouldFlowWithAsyncExecution()
         {
             var expected = TestExecutionContext.CurrentContext;
-            await Task.Yield();
+            await YieldAsync();
             Assert.AreSame(expected, TestExecutionContext.CurrentContext);
+        }
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
+#endif
+        [Test]
+        public async Task TestExecutionContextCurrentContext_ShouldFlowWithParallelAsyncExecution()
+        {
+            var expected = TestExecutionContext.CurrentContext;
+            var parallelResult = await WhenAllAsync(YieldAndReturnContext(), YieldAndReturnContext());
+
+            Assert.AreSame(expected, TestExecutionContext.CurrentContext);
+            Assert.AreSame(expected, parallelResult[0]);
+            Assert.AreSame(expected, parallelResult[1]);
+        }
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
+#endif
+        [Test]
+        public async Task TestExecutionContext_ShouldFlowWithAsyncExecution_ExecutedInParallel()
+        {
+            Func<Task<TestExecutionContext>> functionWithSeparateContext = async () =>
+            {
+                await YieldAsync(); //to start both functions
+                TestExecutionContext.ClearCurrentContext(); //establish new context
+                var expected = TestExecutionContext.CurrentContext;
+                await DelayAsync(300);
+                Assert.AreSame(expected, TestExecutionContext.CurrentContext); //ensure that is still the same within given function call
+                return expected;
+            };
+
+            var results = await WhenAllAsync(functionWithSeparateContext(), functionWithSeparateContext());
+            // both calls have to be successful but have different context
+            Assert.AreNotSame(results[0], results[1]);
         }
 
 #if PORTABLE
@@ -267,7 +303,7 @@ namespace NUnit.Framework.Tests
         public async Task TestContextWriteLine_ShouldNotThrow_WhenExecutedFromAsyncMethod()
         {
             Assert.DoesNotThrow(TestContext.WriteLine);
-            await Task.Yield();
+            await YieldAsync();
             Assert.DoesNotThrow(TestContext.WriteLine);
         }
 
@@ -283,6 +319,39 @@ namespace NUnit.Framework.Tests
                 isTestContextOutAvailable = TestContext.Out != null;
             }).Wait();
             Assert.True(isTestContextOutAvailable);
+        }
+
+        private async Task YieldAsync()
+        {
+#if NET_4_0
+            await TaskEx.Yield();
+#else
+            await Task.Yield();
+#endif
+        }
+
+        private Task<T[]> WhenAllAsync<T>(params Task<T>[] tasks)
+        {
+#if NET_4_0
+            return TaskEx.WhenAll(tasks);
+#else
+            return Task.WhenAll(tasks);
+#endif
+        }
+
+        private Task DelayAsync(int milliseconds)
+        {
+#if NET_4_0
+            return TaskEx.Delay(milliseconds);
+#else
+            return Task.Delay(milliseconds);
+#endif
+        }
+
+        private async Task<TestExecutionContext> YieldAndReturnContext()
+        {
+            await YieldAsync();
+            return TestExecutionContext.CurrentContext;
         }
 #endif
     }

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -23,6 +23,9 @@
 
 using System.IO;
 using System.Collections.Generic;
+#if ASYNC && !NET_4_0
+using System.Threading.Tasks;
+#endif
 using NUnit.Framework.Interfaces;
 using NUnit.TestData.TestContextData;
 using NUnit.TestUtilities;
@@ -233,6 +236,30 @@ namespace NUnit.Framework.Tests
             Assert.That(fixture.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
             Assert.That(fixture.StackTrace, Is.Null);
         }
+#if ASYNC && !NET_4_0
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implmentation")]
+#endif
+        [Test]
+        public async Task TestContext_Out_should_flow_with_async_execution()
+        {
+            var expected = TestContext.Out;
+            await Task.Yield();
+            Assert.AreSame(expected, TestContext.Out);
+        }
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implmentation")]
+#endif
+        [Test]
+        public async Task TestExecutionContext_CurrentContext_should_flow_with_async_execution()
+        {
+            var expected = TestExecutionContext.CurrentContext;
+            await Task.Yield();
+            Assert.AreSame(expected, TestExecutionContext.CurrentContext);
+        }
+#endif
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -239,10 +239,10 @@ namespace NUnit.Framework.Tests
 #if ASYNC && !NET_4_0
 
 #if PORTABLE
-        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implmentation")]
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
 #endif
         [Test]
-        public async Task TestContext_Out_should_flow_with_async_execution()
+        public async Task TestContextOut_ShouldFlowWithAsyncExecution()
         {
             var expected = TestContext.Out;
             await Task.Yield();
@@ -250,14 +250,39 @@ namespace NUnit.Framework.Tests
         }
 
 #if PORTABLE
-        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implmentation")]
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
 #endif
         [Test]
-        public async Task TestExecutionContext_CurrentContext_should_flow_with_async_execution()
+        public async Task TestExecutionContextCurrentContext_ShouldFlowWithAsyncExecution()
         {
             var expected = TestExecutionContext.CurrentContext;
             await Task.Yield();
             Assert.AreSame(expected, TestExecutionContext.CurrentContext);
+        }
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
+#endif
+        [Test]
+        public async Task TestContextWriteLine_ShouldNotThrow_WhenExecutedFromAsyncMethod()
+        {
+            Assert.DoesNotThrow(TestContext.WriteLine);
+            await Task.Yield();
+            Assert.DoesNotThrow(TestContext.WriteLine);
+        }
+
+#if PORTABLE
+        [Ignore("Not implemented yet as TestExecutionContext uses TLS in portable implementation")]
+#endif
+        [Test]
+        public void TestContextOut_ShouldBeAvailableFromOtherThreads()
+        {
+            var isTestContextOutAvailable = false;
+            Task.Factory.StartNew(() =>
+            {
+                isTestContextOutAvailable = TestContext.Out != null;
+            }).Wait();
+            Assert.True(isTestContextOutAvailable);
         }
 #endif
     }


### PR DESCRIPTION
This is a partial fix for #1965.
I tested the change later with project using `net46` as well as `netcoreapp1.0`.
The pull request contains also test covering #1952 
