### PR TITLE
Print loader exception messages on ReflectionTypeLoadException

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Api
             {
                 testAssembly = new TestAssembly(assemblyName);
                 testAssembly.RunState = RunState.NotRunnable;
-                testAssembly.Properties.Set(PropertyNames.SkipReason, ex.Message);
+                testAssembly.Properties.Set(PropertyNames.SkipReason, ExceptionHelper.BuildFriendlyMessage(ex));
             }
 
             return testAssembly;
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Api
             {
                 testAssembly = new TestAssembly(assemblyPath);
                 testAssembly.RunState = RunState.NotRunnable;
-                testAssembly.Properties.Set(PropertyNames.SkipReason, ex.Message);
+                testAssembly.Properties.Set(PropertyNames.SkipReason, ExceptionHelper.BuildFriendlyMessage(ex));
             }
 
             return testAssembly;


### PR DESCRIPTION
Fixes #1238.

This one kept biting me. I think this has mostly been encountered due to issues with the console/engine (e.g. the framework flag problem) - however, can also occur under 'user error' - such as #1651. This prints out the loader exceptions when a ReflectionTypeLoadException is encountered, in the same way as we would handle an innerexceptions. It changes the (console) output from:

```
1) Invalid : C:\Users\ChristopherMaddock\Downloads\UnitTestProject1\UnitTestProject1\bin\Debug\UnitTestProject1.dll
Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
```

to:
```
1) Invalid : C:\Users\ChristopherMaddock\Downloads\UnitTestProject1\UnitTestProject1\bin\Debug\UnitTestProject1.dll
Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
  ----> Could not load file or assembly 'ClassLibrary1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.
```

I changed two occurrences in the DefaultTestAssemblyBuilder - I'm not sure if this covers everything, but I did a quick check for other places where exception messages are recorded without using ExceptionHelper, and they mostly seem to be specific (unrelated) exception types. 
