### PR TITLE
Add missing ConstraintExpression.Contain overload

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -737,6 +737,15 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Returns a new CollectionContainsConstraint checking for the
+        /// presence of a particular object in the collection.
+        /// </summary>
+        public CollectionContainsConstraint Contain(object expected)
+        {
+            return Contains(expected);
+        }
+
+        /// <summary>
         /// Returns a new ContainsConstraint. This constraint
         /// will, in turn, make use of the appropriate second-level
         /// constraint, depending on the type of the actual argument. 
@@ -746,7 +755,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ContainsConstraint Contain(string expected)
         {
-            return (ContainsConstraint)this.Append(new ContainsConstraint(expected));
+            return Contains(expected);
         }
 
         #endregion


### PR DESCRIPTION
This works:
```cs
string str = "a";
Assert.That(str, Does.Contain("a"));
Assert.That(str, Does.Not.Contain("b"));
```

But this fails to compile (cannot convert from `int` to `string`):
```cs
int[] ints = { 2 };
Assert.That(ints, Does.Contain(2));
Assert.That(ints, Does.Not.Contain(1));
```

This PR adds the `Contain(object)` overload for consistency. The same can be achieved with at least `Has.No.Member()` and `Does.Not.Contains()`, so I don't object if this addition is considered unnecessary. This is somewhat related to #1758.

There are no test changes, since the `Contain(string)` overload is not tested either, as it duplicated work in `Contains()`, and now just calls it directly.