### PR TITLE
Add namespace filter

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -63,10 +63,5 @@ namespace NUnit.Framework.Internal.Filters
         {
             get { return "namespace"; }
         }
-
-        private string GetNamespaceFromTest(Test test)
-        {
-            return test.TypeInfo.Namespace;
-        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -1,0 +1,72 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    /// <summary>
+    /// ClassName filter selects tests based on the class FullName
+    /// </summary>
+#if !PORTABLE && !NETSTANDARD1_6
+    [Serializable]
+#endif
+    public class NamespaceFilter : ValueMatchFilter
+    {
+        /// <summary>
+        /// Construct a NamespaceFilter for a single namespace
+        /// </summary>
+        /// <param name="expectedValue">The namespace the filter will recognize.</param>
+        public NamespaceFilter(string expectedValue) : base(expectedValue) { }
+
+        /// <summary>
+        /// Match a test against a single value.
+        /// </summary>
+        public override bool Match(ITest test)
+        {
+            string containingNamespace = null;
+
+            if (test.TypeInfo != null)
+            {
+                containingNamespace = test.TypeInfo.Namespace;
+            }
+
+            return Match(containingNamespace);
+        }
+
+        /// <summary>
+        /// Gets the element name
+        /// </summary>
+        /// <value>Element name</value>
+        protected override string ElementName
+        {
+            get { return "namespace"; }
+        }
+
+        private string GetNamespaceFromTest(Test test)
+        {
+            return test.TypeInfo.Namespace;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -183,6 +183,9 @@ namespace NUnit.Framework.Internal
                 case "class":
                     return new ClassNameFilter(node.Value) { IsRegex = isRegex };
 
+                case "namespace":
+                    return new NamespaceFilter(node.Value) { IsRegex = isRegex };
+
                 case "cat":
                     return new CategoryFilter(node.Value) { IsRegex = isRegex };
 

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Internal\Filters\FullNameFilter.cs" />
     <Compile Include="Internal\Filters\IdFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Filters\NotFilter.cs" />
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\FullNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Internal\Filters\FullNameFilter.cs" />
     <Compile Include="Internal\Filters\IdFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Filters\NotFilter.cs" />
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -349,6 +349,7 @@
     <Compile Include="Internal\Filters\FullNameFilter.cs" />
     <Compile Include="Internal\Filters\IdFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilter.cs" />
     <Compile Include="Internal\Filters\NotFilter.cs" />
     <Compile Include="Internal\Filters\OrFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/nunitlite/TestSelectionParser.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParser.cs
@@ -146,6 +146,7 @@ namespace NUnit.Common
                 case "class":
                 case "name":
                 case "test":
+                case "namespace":
                     Token op = lhs.Text == "id"
                         ? Expect(EQ_OPS)
                         : Expect(REL_OPS);

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Api
 #if PORTABLE
         private static readonly string MOCK_ASSEMBLY_NAME = typeof(MockAssembly).GetTypeInfo().Assembly.FullName;
 #endif
+        private const string INVALID_FILTER_ELEMENT_MESSAGE = "Invalid filter element: {0}";
 
         private static readonly IDictionary<string, object> EMPTY_SETTINGS = new Dictionary<string, object>();
 
@@ -221,6 +222,21 @@ namespace NUnit.Framework.Api
             Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable.WithSite(FailureSite.SetUp)));
             Assert.That(result.Message,
                 Does.StartWith(COULD_NOT_LOAD_MSG));
+        }
+
+        [Test]
+        public void RunTestsAction_WithInvalidFilterElement_ThrowsArgumentException()
+        {
+            LoadMockAssembly();
+
+            var ex = Assert.Catch(() =>
+                {
+                    var invalidFilter = TestFilter.FromXml("<filter><invalidElement>foo</invalidElement></filter>");
+                    _runner.Run(this, invalidFilter);
+                });
+
+            Assert.That(ex, Is.TypeOf<ArgumentException>());
+            Assert.That(ex.Message, Does.StartWith(string.Format(INVALID_FILTER_ELEMENT_MESSAGE, "invalidElement")));
         }
 
 #if !PORTABLE

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -229,13 +229,11 @@ namespace NUnit.Framework.Api
         {
             LoadMockAssembly();
 
-            var ex = Assert.Catch(() =>
+            var ex = Assert.Throws<ArgumentException>(() =>
                 {
-                    var invalidFilter = TestFilter.FromXml("<filter><invalidElement>foo</invalidElement></filter>");
-                    _runner.Run(this, invalidFilter);
+                    TestFilter.FromXml("<filter><invalidElement>foo</invalidElement></filter>");
                 });
 
-            Assert.That(ex, Is.TypeOf<ArgumentException>());
             Assert.That(ex.Message, Does.StartWith(string.Format(INVALID_FILTER_ELEMENT_MESSAGE, "invalidElement")));
         }
 

--- a/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
@@ -1,0 +1,69 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    [TestFixture("NUnit.Framework.Internal.Filters", false, true)]
+    [TestFixture("NUnit.Framework.*", true, true)]
+    [TestFixture("NUnit.Framework", false, false)]
+    public class NamespaceFilterTests : TestFilterTests
+    {
+        private readonly TestFilter _filter;
+        private readonly bool _expected;
+
+        public NamespaceFilterTests(string value, bool isRegex, bool expected)
+        {
+            _filter = new NamespaceFilter(value) { IsRegex = isRegex };
+            _expected = expected;
+        }
+
+        [Test]
+        public void IsNotEmpty()
+        {
+            Assert.False(_filter.IsEmpty);
+        }
+
+        [Test]
+        public void MatchTest()
+        {
+            Assert.That(_filter.Match(_dummyFixture.Tests[0]), Is.EqualTo(_expected));
+        }
+
+        [Test]
+        public void PassTest()
+        {
+            Assert.That(_filter.Pass(_nestingFixture), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(_nestedFixture), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(_emptyNestedFixture), Is.EqualTo(_expected));
+
+            Assert.That(_filter.Pass(_topLevelSuite), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(_dummyFixture), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(_dummyFixture.Tests[0]), Is.EqualTo(_expected));
+        }
+
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
@@ -43,6 +43,9 @@ namespace NUnit.Framework.Internal.Filters
     // Name filter
     //    <name>xxxxx</name>
     //
+    // Namespace filter
+    //    <namespace>xxxxx</namespace>
+    //
     // Category filter 
     //    <cat>cat1</cat>
     //    <cat>cat1,cat2,cat3</cat>
@@ -65,6 +68,9 @@ namespace NUnit.Framework.Internal.Filters
         protected readonly TestSuite _anotherFixture = TestBuilder.MakeFixture(typeof(AnotherFixture));
         protected readonly TestSuite _yetAnotherFixture = TestBuilder.MakeFixture(typeof(YetAnotherFixture));
         protected readonly TestSuite _fixtureWithMultipleTests = TestBuilder.MakeFixture (typeof (FixtureWithMultipleTests));
+        protected readonly TestSuite _nestingFixture = TestBuilder.MakeFixture(typeof(NestingFixture));
+        protected readonly TestSuite _nestedFixture = TestBuilder.MakeFixture(typeof(NestingFixture.NestedFixture));
+        protected readonly TestSuite _emptyNestedFixture = TestBuilder.MakeFixture(typeof(NestingFixture.EmptyNestedFixture));
         protected readonly TestSuite _topLevelSuite = new TestSuite("MySuite");
 
         [OneTimeSetUp]
@@ -74,6 +80,10 @@ namespace NUnit.Framework.Internal.Filters
             _topLevelSuite.Add(_anotherFixture);
             _topLevelSuite.Add(_yetAnotherFixture);
             _topLevelSuite.Add(_fixtureWithMultipleTests);
+            _topLevelSuite.Add(_nestingFixture);
+
+            _nestingFixture.Add(_nestedFixture);
+            _nestingFixture.Add(_emptyNestedFixture);
         }
 
         #region Fixtures Used by Tests
@@ -94,8 +104,7 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         private class YetAnotherFixture
-        {
-        }
+        { }
 
         private class FixtureWithMultipleTests
         {
@@ -104,6 +113,17 @@ namespace NUnit.Framework.Internal.Filters
 
             [Test, Category ("Dummy")]
             public void Test2 () {}
+        }
+
+        private class NestingFixture
+        {
+            public class NestedFixture
+            {
+                [Test]
+                public void Test() { }
+            }
+
+            internal class EmptyNestedFixture { }
         }
         #endregion
     }

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\PropertyFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
+	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />


### PR DESCRIPTION
Implementation of: https://github.com/nunit/nunit/issues/1990

I've added what I believe are the required changes on the framework side to add support for the namespace keyword. I'm not sure what the deal with this getting added to the different versions of .NET, but since I believe everything added it compatible, I went ahead with adding to all of them.

nunit-console change dependent on this PR is here: https://github.com/nunit/nunit-console/pull/165