### PR TITLE
Re-enable use of --trace in nunitlite

### DIFF
--- a/src/NUnitFramework/nunitlite-runner/Program.cs
+++ b/src/NUnitFramework/nunitlite-runner/Program.cs
@@ -35,14 +35,15 @@ namespace NUnitLite
     /// be used for test assemblies built against that framework version.
     /// 
     /// In the special case of the portable version of nunitlite-runner,
-    /// the program is a .NET 4.5 console application.
+    /// the program is a .NET 4.5 console application. In that case, we
+    /// create a ColorConsoleWriter, since the portable build can't do it.
     /// </summary>
     class Program
     {
         static int Main(string[] args)
         {
 #if PORTABLE
-            return new TextRunner().Execute(new ColorConsoleWriter(), Console.In, args);
+            return new TextRunner().Execute(new ColorConsoleWriter(), Console.In, new NUnitLiteOptions(args));
 #else
             return new TextRunner().Execute(args);
 #endif

--- a/src/NUnitFramework/nunitlite/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite/AutoRun.cs
@@ -95,7 +95,7 @@ namespace NUnitLite
         /// <param name="reader">A TextReader used when waiting for input</param>
         public int Execute(string[] args, ExtendedTextWriter writer, TextReader reader)
         {
-            return new TextRunner(_testAssembly).Execute(writer, reader, args);
+            return new TextRunner(_testAssembly).Execute(writer, reader, new NUnitLiteOptions(args));
         }
     }
 }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -112,14 +112,12 @@ namespace NUnitLite
 #if !PORTABLE
         public int Execute(string[] args)
         {
-            var options = new NUnitLiteOptions(args);
-
-            InitializeInternalTrace(options);
+            _options = new NUnitLiteOptions(args);
 
             ExtendedTextWriter outWriter = null;
-            if (options.OutFile != null)
+            if (_options.OutFile != null)
             {
-                var outFile = Path.Combine(options.WorkDirectory, options.OutFile);
+                var outFile = Path.Combine(_options.WorkDirectory, _options.OutFile);
 #if NETSTANDARD1_6                 
                 var textWriter = File.CreateText(outFile);
 #else
@@ -134,9 +132,9 @@ namespace NUnitLite
             }
 
             TextWriter errWriter = null;
-            if (options.ErrFile != null)
+            if (_options.ErrFile != null)
             {
-                var errFile = Path.Combine(options.WorkDirectory, options.ErrFile);
+                var errFile = Path.Combine(_options.WorkDirectory, _options.ErrFile);
 #if NETSTANDARD1_6
                 errWriter = File.CreateText(errFile);
 #else
@@ -147,18 +145,19 @@ namespace NUnitLite
 
             try
             {
-                return Execute(outWriter, Console.In, options);
+                _textUI = new TextUI(outWriter, Console.In, _options);
+                return Execute();
             }
             finally
             {
-                if (options.OutFile != null && outWriter != null)
+                if (_options.OutFile != null && outWriter != null)
 #if NETSTANDARD1_6
                     outWriter.Dispose();
 #else
                     outWriter.Close();
 #endif
 
-                if (options.ErrFile != null && errWriter != null)
+                if (_options.ErrFile != null && errWriter != null)
 #if NETSTANDARD1_6
                     errWriter.Dispose();
 #else
@@ -168,26 +167,23 @@ namespace NUnitLite
         }
 #endif
 
-        public int Execute(ExtendedTextWriter writer, TextReader reader, string[] args)
-        {
-            return Execute(writer, reader, new NUnitLiteOptions(args));
-        }
-
+        // Entry point called by AutoRun and by the portable nunitlite.runner
         public int Execute(ExtendedTextWriter writer, TextReader reader, NUnitLiteOptions options)
         {
-            var textUI = new TextUI(writer, reader, options);
-            return Execute(textUI, options);
+            _textUI = new TextUI(writer, reader, options);
+            _options = options;
+
+            return Execute();
         }
 
-        /// <summary>
-        /// Execute a test run
-        /// </summary>
-        /// <param name="callingAssembly">The assembly from which tests are loaded</param>
-        public int Execute(TextUI textUI, NUnitLiteOptions options)
+        // Internal Execute depends on _textUI and _options having been set already.
+        private int Execute()
         {
-            _textUI = textUI;
-            _options = options;
             _runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
+
+#if !PORTABLE
+            InitializeInternalTrace();
+#endif
 
             try
             {
@@ -349,6 +345,9 @@ namespace NUnitLite
             if (options.NumberOfTestWorkers >= 0)
                 runSettings[FrameworkPackageSettings.NumberOfTestWorkers] = options.NumberOfTestWorkers;
 
+            if (options.InternalTraceLevel != null)
+                runSettings[FrameworkPackageSettings.InternalTraceLevel] = options.InternalTraceLevel;
+
             if (options.RandomSeed >= 0)
                 runSettings[FrameworkPackageSettings.RandomSeed] = options.RandomSeed;
 
@@ -405,7 +404,7 @@ namespace NUnitLite
         }
 
 #if !PORTABLE
-        private void InitializeInternalTrace(NUnitLiteOptions _options)
+        private void InitializeInternalTrace()
         {
             var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), _options.InternalTraceLevel ?? "Off", true);
 


### PR DESCRIPTION
Fixes #1994 

I need trace to be able to work on parallel threads and found it wasn't working. I also found and fixed a few errors at the same time and refactored the various Execute overloads so I could better understand what was going on. NUnitLite seems to have accrued a lot of technical debt, but this is all I have time for at the moment.

I'd like to get this in as soon as it looks good so I can rebase my other work on top of it.