### PR TITLE
Suppress null or whitespace failure messages

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -645,10 +645,10 @@ namespace NUnit.Framework.Internal
         {
             TNode failureNode = targetNode.AddElement("failure");
 
-            if (Message != null)
+            if (Message != null && Message.Trim().Length > 0)
                 failureNode.AddElementWithCDATA("message", Message);
 
-            if (StackTrace != null)
+            if (StackTrace != null && StackTrace.Trim().Length > 0)
                 failureNode.AddElementWithCDATA("stack-trace", StackTrace);
 
             return failureNode;


### PR DESCRIPTION
Also covers null or whitespace failure stack traces.