### PR TITLE
Add DelayedConstraint in NetStandard 1.6 build

### DIFF
--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -179,7 +179,7 @@ namespace NUnit.TestUtilities
             // TODO: Replace with an event - but not while method is static
             while (work.State != WorkItemState.Complete)
             {
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
                 System.Threading.Tasks.Task.Delay(1);
 #else
                 Thread.Sleep(1);

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -232,11 +232,7 @@ namespace NUnit.Framework.Api
         /// <returns>True if the run completed, otherwise false</returns>
         public bool WaitForCompletion(int timeout)
         {
-#if !PORTABLE && !NETSTANDARD1_6
-            return _runComplete.WaitOne(timeout, false);
-#else
             return _runComplete.WaitOne(timeout);
-#endif
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -290,7 +290,7 @@ namespace NUnit.Framework.Constraints
 
         #region After Modifier
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
         /// <summary>
         /// Returns a DelayedConstraint.WithRawDelayInterval with the specified delay time.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.project.json
@@ -2,7 +2,8 @@
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "System.Runtime.Loader": "4.0.0"
+    "System.Runtime.Loader": "4.0.0",
+    "System.Threading.Thread": "4.3.0" 
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Tests
 
         private static void Delay()
         {
-#if PORTABLE || NETSTANDARD1_6
+#if PORTABLE
             System.Threading.Tasks.Task.Delay(DELAY);
 #else
             System.Threading.Thread.Sleep(DELAY);

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.project.json
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard.project.json
@@ -1,7 +1,8 @@
 {
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.0",
+    "System.Threading.Thread": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/testdata/MaxTimeFixture.cs
+++ b/src/NUnitFramework/testdata/MaxTimeFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
 using System;
 using System.Threading;
 

--- a/src/NUnitFramework/testdata/UnhandledExceptions.cs
+++ b/src/NUnitFramework/testdata/UnhandledExceptions.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
 using System;
 using System.Collections;
 using System.Text;

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard.project.json
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard.project.json
@@ -2,7 +2,8 @@
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "System.Threading.Thread": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -259,7 +259,7 @@ namespace NUnit.Framework.Constraints
 
         private static void Delay(int delay)
         {
-            waitEvent.WaitOne(delay, false);
+            waitEvent.WaitOne(delay);
         }
 
         private static void MethodSetsValues()

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
 using System;
 using System.Threading;
 using System.Collections.Generic;

--- a/src/NUnitFramework/tests/WorkItemTests.cs
+++ b/src/NUnitFramework/tests/WorkItemTests.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal.Execution
 
             public static void DummyTest()
             {
-#if !PORTABLE && !NETSTANDARD1_6
+#if !PORTABLE
                 if (Delay > 0)
                     Thread.Sleep(Delay);
 #else

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.project.json
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.project.json
@@ -2,7 +2,8 @@
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "System.Threading.Thread": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {}


### PR DESCRIPTION
@rprouse - this is related to our discussion on #1638. I'd already done this as feasibility check, so thought it made sense to push it, and continue the discussion as to if we actually want to use it or not here - I'm not worried if we close instead. 😄 

This re-enables DelayedConstraint in the netstandard build. It includes the `System.Threading.Thread` package - so I also tidied up a few places where `Thread.Sleep()` had been excluded, as that's now available. 

This doesn't tackle timeout's, as I don't think Thread.Abort() is available in netstandard - notes on that are in #1638.