### PR TITLE
First steps toward parallel test cases

### DIFF
--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -209,6 +209,11 @@ namespace NUnit.TestUtilities
         /// </summary>
         class SuperSimpleDispatcher : IWorkItemDispatcher
         {
+            public void Start(WorkItem topLevelWorkItem)
+            {
+                topLevelWorkItem.Execute();
+            }
+
             public void Dispatch(WorkItem work)
             {
                 work.Execute();

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -297,7 +297,7 @@ namespace NUnit.Framework.Api
 
 #endif
 
-            Context.Dispatcher.Dispatch(TopLevelWorkItem);
+            Context.Dispatcher.Start(TopLevelWorkItem);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
@@ -41,23 +41,5 @@ namespace NUnit.Framework
         {
             Properties.Add(PropertyNames.ParallelScope, ParallelScope.None);
         }
-
-        /// <summary>
-        /// Overridden to check for invalid combinations of settings
-        /// </summary>
-        /// <param name="test"></param>
-        public override void ApplyToTest(Test test)
-        {
-            base.ApplyToTest(test);
-
-            if (test.RunState != RunState.NotRunnable && test is TestAssembly)
-                MarkTestInvalid(test, "Assemblies may not be marked as NonParallel");
-        }
-
-        private void MarkTestInvalid(Test test, string message)
-        {
-            test.RunState = RunState.NotRunnable;
-            test.Properties.Add(PropertyNames.SkipReason, message);
-        }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.ComponentModel;
 
 namespace NUnit.Framework
 {
@@ -33,20 +34,46 @@ namespace NUnit.Framework
     public enum ParallelScope
     {
         /// <summary>
-        /// No Parallelism is permitted
+        /// No ParallelScope was specified on the test
         /// </summary>
-        None = 0,
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Default = 0,
+
         /// <summary>
-        /// The test itself may be run in parallel with others at the same level
+        /// The test may be run in parallel with others at the same level.
+        /// Valid on classes and methods but not assemblies.
         /// </summary>
         Self = 1,
         /// <summary>
-        /// Descendants of the test may be run in parallel with one another
+        /// Test may not be run in parallel with any others. Valid on
+        /// classes and methods but not assemblies.
         /// </summary>
-        Children = 2,
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        None = 2,
         /// <summary>
-        /// Descendants of the test down to the level of TestFixtures may be run in parallel
+        /// Mask used to extract the flags that apply to the item on which a
+        /// ParallelizableAttribute has been placed, as opposed to descendants.
         /// </summary>
-        Fixtures = 4
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ItemMask = Self + None,
+
+
+        /// <summary>
+        /// Descendants of the test may be run in parallel with one another.
+        /// Valid on assemblies and classes but not on methods.
+        /// </summary>
+        Children = 256,
+        /// <summary>
+        /// Descendants of the test down to the level of TestFixtures may be 
+        /// run in parallel with one another. Valid on assemblies and classes
+        /// but not on methods.
+        /// </summary>
+        Fixtures = 512,
+        /// <summary>
+        /// Mask used to extract all the flags that impact descendants of a 
+        /// test and place them in the TestExecutionContext.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ContextMask = Children + Fixtures
     }
 }

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -64,16 +64,10 @@ namespace NUnit.Framework
                 return;
 
             if (_scope.HasFlag(ParallelScope.Self) && _scope.HasFlag(ParallelScope.None))
-                MarkTestInvalid(test, "Test may not be both Parallel and NonParallel");
+                test.MakeInvalid("Test may not be both parallel and non-parallel");
 
             if (test is TestMethod && _scope.HasFlag(ParallelScope.ContextMask))
-                MarkTestInvalid(test, "ParallelScope of a test method may not specify Children or Fixtures");
-        }
-
-        private void MarkTestInvalid(Test test, string message)
-        {
-            test.RunState = RunState.NotRunnable;
-            test.Properties.Add(PropertyNames.SkipReason, message);
+                test.MakeInvalid("ParallelScope of a test method may not specify Children or Fixtures");
         }
 
         #region IApplyToContext Interface

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -257,7 +257,9 @@ namespace NUnit.Framework.Internal.Execution
                 if (_childFilter.Pass(test))
                 {
                     var child = WorkItem.CreateWorkItem(test, _childFilter);
-                    child.WorkerId = this.WorkerId;
+#if PARALLEL
+                    child.TestWorker = this.TestWorker;
+#endif
 
 #if !PORTABLE && !NETSTANDARD1_6
                     if (child.TargetApartment == ApartmentState.Unknown && TargetApartment != ApartmentState.Unknown)

--- a/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
+// Copyright (c) 2014-2017 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -28,6 +28,12 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public interface IWorkItemDispatcher
     {
+        /// <summary>
+        /// Start execution, performing any initialization. Sets
+        /// the top level work item and dispatches it.
+        /// </summary>
+        void Start(WorkItem topLevelWorkItem);
+
         /// <summary>
         /// Dispatch a single work item for execution. The first
         /// work item dispatched is saved as the top-level

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -22,6 +22,9 @@
 // ***********************************************************************
 
 #if PARALLEL
+
+#define NO_PARALLEL_CASES
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -34,24 +37,32 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class ParallelWorkItemDispatcher : IWorkItemDispatcher
     {
-        private static readonly Logger log = InternalTrace.GetLogger("WorkItemDispatcher");
+        private static readonly Logger log = InternalTrace.GetLogger("Dispatcher");
 
         private readonly int _levelOfParallelism;
         private int _itemsDispatched;
 
-        // Non-STA
+        // WorkShifts - Dispatcher processes tests in three non-overlapping shifts.
+        // See comment in Workshift.cs for a more detailed explanation.
         private readonly WorkShift _parallelShift = new WorkShift("Parallel");
         private readonly WorkShift _nonParallelShift = new WorkShift("NonParallel");
+        private readonly WorkShift _nonParallelSTAShift = new WorkShift("NonParallelSTA");
+
+        /// <summary>
+        /// Enumerates all the shifts supported by the dispatcher
+        /// </summary>
+        public IEnumerable<WorkShift> Shifts { get; private set; }
+
+        // Queues used by WorkShifts
         private readonly Lazy<WorkItemQueue> _parallelQueue;
         private readonly Lazy<WorkItemQueue> _nonParallelQueue;
-
-        // STA
-        private readonly WorkShift _nonParallelSTAShift = new WorkShift("NonParallelSTA");
         private readonly Lazy<WorkItemQueue> _parallelSTAQueue;
         private readonly Lazy<WorkItemQueue> _nonParallelSTAQueue;
 
         // The first WorkItem to be dispatched, assumed to be top-level item
         private WorkItem _topLevelWorkItem;
+
+        #region Constructor
 
         /// <summary>
         /// Construct a ParallelWorkItemDispatcher
@@ -61,15 +72,18 @@ namespace NUnit.Framework.Internal.Execution
         {
             _levelOfParallelism = levelOfParallelism;
 
+            // Initialize WorkShifts
             Shifts = new WorkShift[]
             {
                 _parallelShift,
                 _nonParallelShift,
                 _nonParallelSTAShift
             };
+
             foreach (var shift in Shifts)
                 shift.EndOfShift += OnEndOfShift;
 
+            // Set up queues for lazy initialization
             _parallelQueue = new Lazy<WorkItemQueue>(() =>
             {
                 var parallelQueue = new WorkItemQueue("ParallelQueue");
@@ -112,10 +126,7 @@ namespace NUnit.Framework.Internal.Execution
             });
         }
 
-        /// <summary>
-        /// Enumerates all the shifts supported by the dispatcher
-        /// </summary>
-        public IEnumerable<WorkShift> Shifts { get; private set; }
+        #endregion
 
         #region IWorkItemDispatcher Members
 
@@ -125,7 +136,12 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Start(WorkItem topLevelWorkItem)
         {
-            Enqueue(_topLevelWorkItem = topLevelWorkItem);
+            var strategy = topLevelWorkItem.ParallelScope.HasFlag(ParallelScope.None)
+                ? ExecutionStrategy.NonParallel
+                : ExecutionStrategy.Parallel;
+
+            Dispatch(_topLevelWorkItem = topLevelWorkItem, strategy);
+          
             StartNextShift();
         }
 
@@ -137,54 +153,34 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="work">The item to dispatch</param>
         public void Dispatch(WorkItem work)
         {
-            if (ShouldExecuteDirectly(work))
-                Execute(work);
-            else
-                Enqueue(work);
+            Dispatch(work, GetExecutionStrategy(work));
+        }
+
+        private void Dispatch(WorkItem work, ExecutionStrategy strategy)
+        {
+            log.Debug("Using {0} strategy for {1}.", strategy, work.Test.Name);
+
+            switch (strategy)
+            {
+                default:
+                case ExecutionStrategy.Direct:
+                    work.Execute();
+                    break;
+                case ExecutionStrategy.Parallel:
+                    if (work.TargetApartment == ApartmentState.STA)
+                        ParallelSTAQueue.Enqueue(work);
+                    else
+                        ParallelQueue.Enqueue(work);
+                    break;
+                case ExecutionStrategy.NonParallel:
+                    if (work.TargetApartment == ApartmentState.STA)
+                        NonParallelSTAQueue.Enqueue(work);
+                    else
+                        NonParallelQueue.Enqueue(work);
+                    break;
+            }
 
             Interlocked.Increment(ref _itemsDispatched);
-        }
-
-        private static bool ShouldExecuteDirectly(WorkItem work)
-        {
-            // We run child items directly, rather than enqueuing them...
-            // 1. If the context is single-threaded. This is required by the
-            //    definition of the single-threaded feature.
-            // 2. If there is no fixture and so nothing to do but dispatch 
-            //    grandchildren. This is a significant savings in time that
-            //    would otherwise be spent enqueuing and dequeing items.
-            //    TODO: Avoid creating these work items in the first place.
-            // 3. For now, if this represents a test case. This avoids issues
-            //    caused by tests that access the fixture state and allows handling 
-            //    ApartmentState preferences set on the fixture more easily.
-
-            return
-                work.Context.IsSingleThreaded ||
-                work.Test.TypeInfo == null ||
-                work is SimpleWorkItem;
-        }
-
-        private void Execute(WorkItem work)
-        {
-            log.Debug("Directly executing {0}", work.Test.Name);
-            work.Execute();
-        }
-
-        private void Enqueue(WorkItem work)
-        {
-            log.Debug("Enqueuing {0}", work.Test.Name);
-
-            if (work.IsParallelizable)
-            {
-                if (work.TargetApartment == ApartmentState.STA)
-                    ParallelSTAQueue.Enqueue(work);
-                else
-                ParallelQueue.Enqueue(work);
-            }
-            else if (work.TargetApartment == ApartmentState.STA)
-                NonParallelSTAQueue.Enqueue(work);
-            else
-                NonParallelQueue.Enqueue(work);
         }
 
         /// <summary>
@@ -262,8 +258,66 @@ namespace NUnit.Framework.Internal.Execution
             return false;
         }
 
-        #endregion
+        private enum ExecutionStrategy
+        {
+            Direct,
+            Parallel,
+            NonParallel,
+        }
+        
+        private static ExecutionStrategy GetExecutionStrategy(WorkItem work)
+        {
+            // If there is no fixture and so nothing to do but dispatch 
+            // grandchildren we run directly. This saves time that would 
+            // otherwise be spent enqueuing and dequeing items.
+            // TODO: It would be even better if we could avoid creating 
+            // these "do-nothing" work items in the first place.
+            if (work.Test.TypeInfo == null)
+                return ExecutionStrategy.Direct;
+
+            // If the context is single-threaded we are required to run
+            // the tests one by one on the same thread as the fixture.
+            if (work.Context.IsSingleThreaded)
+                return ExecutionStrategy.Direct;
+
+#if NO_PARALLEL_CASES
+            // For now, if this represents a test case, run directly. 
+            // This avoids issues caused by tests that access the fixture 
+            // state and allows handling ApartmentState preferences set on 
+            // the fixture more easily.
+            if (work is SimpleWorkItem)
+                return ExecutionStrategy.Direct;
+#endif
+
+            if (work.ParallelScope.HasFlag(ParallelScope.Self) ||
+                work.Context.ParallelScope.HasFlag(ParallelScope.Children) ||
+                work.Test is TestFixture && work.Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
+            {
+                return ExecutionStrategy.Parallel;
+            }
+            else
+            if (work.ParallelScope.HasFlag(ParallelScope.None))
+            {
+                return ExecutionStrategy.NonParallel;
+            }
+            else
+            {
+                return ExecutionStrategy.Direct;
+            }
+        }
+
+#endregion
     }
+
+#if NET_2_0 || NET_3_5
+    static class ParallelScopeHelper
+    {
+        public static bool HasFlag(this ParallelScope scope, ParallelScope value)
+        {
+            return (scope & value) != 0;
+        }
+    }
+#endif
 }
 
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -59,9 +59,6 @@ namespace NUnit.Framework.Internal.Execution
         private readonly Lazy<WorkItemQueue> _parallelSTAQueue;
         private readonly Lazy<WorkItemQueue> _nonParallelSTAQueue;
 
-        // The first WorkItem to be dispatched, assumed to be top-level item
-        private WorkItem _topLevelWorkItem;
-
         #region Constructor
 
         /// <summary>
@@ -140,7 +137,7 @@ namespace NUnit.Framework.Internal.Execution
                 ? ExecutionStrategy.NonParallel
                 : ExecutionStrategy.Parallel;
 
-            Dispatch(_topLevelWorkItem = topLevelWorkItem, strategy);
+            Dispatch(topLevelWorkItem, strategy);
           
             StartNextShift();
         }

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Internal.Execution
                     if (Busy != null)
                         Busy(this, EventArgs.Empty);
 
-                    _currentWorkItem.WorkerId = Name;
+                    _currentWorkItem.TestWorker = this;
                     _currentWorkItem.Execute();
 
                     if (Idle != null)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -136,10 +136,12 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public TestExecutionContext Context { get; private set; }
 
+#if PARALLEL
         /// <summary>
-        /// The unique id of the worker executing this item.
+        /// The worker executing this item.
         /// </summary>
-        public string WorkerId {get; internal set;}
+        public TestWorker TestWorker {get; internal set;}
+#endif
 
         /// <summary>
         /// The test actions to be performed before and after this test
@@ -319,7 +321,10 @@ namespace NUnit.Framework.Internal.Execution
             Context.Listener.TestStarted(this.Test);
             Context.StartTime = DateTime.UtcNow;
             Context.StartTicks = Stopwatch.GetTimestamp();
-            Context.WorkerId = this.WorkerId;
+#if PARALLEL
+            Context.TestWorker = this.TestWorker;
+#endif
+
             Context.EstablishExecutionEnvironment();
 
             State = WorkItemState.Running;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -373,11 +373,13 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public ParallelScope ParallelScope { get; set; }
 
+#if PARALLEL
         /// <summary>
-        /// The unique name of the worker that spawned the context.
-        /// For builds with out the parallel feature, it is null.
+        /// The worker that spawned the context.
+        /// For builds without the parallel feature, it is null.
         /// </summary>
-        public string WorkerId {get; internal set;}
+        public TestWorker TestWorker {get; internal set;}
+#endif
 
         /// <summary>
         /// Gets the RandomGenerator specific to this Test

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -349,6 +349,16 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
+        /// <summary>
+        /// Mark the test as Invalid (not runnable) specifying a reason
+        /// </summary>
+        /// <param name="reason">The reason the test is not runnable</param>
+        public void MakeInvalid(string reason)
+        {
+            RunState = RunState.NotRunnable;
+            Properties.Add(PropertyNames.SkipReason, reason);
+        }
+
         #endregion
 
         #region Protected Methods

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -110,13 +110,15 @@ namespace NUnit.Framework
             get { return _result ?? (_result = new ResultAdapter(_testExecutionContext.CurrentResult)); }
         }
 
+#if PARALLEL
         /// <summary>
         /// Gets the unique name of the  Worker that is executing this test.
         /// </summary>
         public string WorkerId
         {
-            get { return _testExecutionContext.WorkerId; }
+            get { return _testExecutionContext.TestWorker.Name; }
         }
+#endif
 
 #if !PORTABLE
         /// <summary>

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Attributes\ApartmentAttribute.cs" />
     <Compile Include="Attributes\AuthorAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Attributes\CategoryAttribute.cs" />
     <Compile Include="Attributes\CombinatorialAttribute.cs" />
     <Compile Include="Attributes\CombiningStrategyAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -88,6 +88,7 @@
     </Compile>
     <Compile Include="AssertionHelper.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Warn.cs" />
     <Compile Include="Assume.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Attributes\ExplicitAttribute.cs" />
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Attributes\ExplicitAttribute.cs" />
     <Compile Include="Attributes\IgnoreAttribute.cs" />
     <Compile Include="Attributes\IncludeExcludeAttribute.cs" />
+    <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\SingleThreadedAttribute.cs" />
     <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -28,7 +28,6 @@ using System.IO;
 namespace NUnit.Framework.Assertions
 {
 	[TestFixture]
-    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
     public class AssertEqualsTests
     {
         [Test]
@@ -513,7 +512,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Does.Contain( "+/- 0.001"));
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void DoubleNotEqualMessageDisplaysDefaultTolerance()
         {
             double d1 = 0.15;
@@ -534,7 +533,7 @@ namespace NUnit.Framework.Assertions
             }
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance()
         {
             double d1 = double.NaN;

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -35,8 +35,7 @@ using NUnit.TestData.ActionAttributeTests;
 
 namespace NUnit.Framework.Tests
 {
-    [TestFixture]
-    [Parallelizable(ParallelScope.None)]
+    [TestFixture, NonParallelizable]
     public class ActionAttributeTests
     {
         // NOTE: An earlier version of this fixture attempted to test

--- a/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Attributes
     /// <summary>
     /// Tests for MaxTime decoration.
     /// </summary>
-    [TestFixture, Parallelizable(ParallelScope.None)]
+    [TestFixture, NonParallelizable]
     public class MaxTimeTests
     {
         [Test,MaxTime(1000)]

--- a/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
@@ -37,6 +37,8 @@ namespace NUnit.Framework.Attributes
         {
             ParentThread = Thread.CurrentThread;
             ParentThreadApartment = GetApartmentState(ParentThread);
+
+            TestContext.AddFormatter<Thread>((t) => "Thread #" + ((Thread)t).ManagedThreadId);
         }
 
         [SetUp]

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -33,7 +33,7 @@ using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
-    [Parallelizable(ParallelScope.None)]
+    [NonParallelizable]
     public class TimeoutTests : ThreadingTests
     {
         [Test, Timeout(50)]

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -31,7 +31,7 @@ using ActualValueDelegate = NUnit.Framework.Constraints.ActualValueDelegate<obje
 
 namespace NUnit.Framework.Constraints
 {
-    [TestFixture, Parallelizable(ParallelScope.None)]
+    [TestFixture, NonParallelizable]
     public class DelayedConstraintTests : ConstraintTestBase
     {
         // NOTE: This class tests the functioning of the DelayConstraint,

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -31,8 +31,7 @@ using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
-    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
+    [TestFixture, NonParallelizable] // Uses GlobalSettings
     public class ToleranceTests
     {
         private NUnitEqualityComparer _comparer;

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -198,11 +198,11 @@ namespace NUnit.Framework.Internal
 
 #if !PORTABLE && !NETSTANDARD1_6
         [Test]
-        public void TestHasWorkerIdWhenParallel()
+        public void TestHasWorkerWhenParallel()
         {
-            var workerId = TestExecutionContext.CurrentContext.WorkerId;
+            var worker = TestExecutionContext.CurrentContext.TestWorker;
             var isRunningUnderTestWorker = TestExecutionContext.CurrentContext.Dispatcher is ParallelWorkItemDispatcher;
-            Assert.That(workerId != null || !isRunningUnderTestWorker);
+            Assert.That(worker != null || !isRunningUnderTestWorker);
         }
 #endif
 

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Syntax
 {
-    [Parallelizable(ParallelScope.None)] // Uses GlobalSettings
     public class EqualToTest : SyntaxTest
     {
         [SetUp]
@@ -132,7 +131,7 @@ namespace NUnit.Framework.Syntax
                 "ulong actual, int expected, int tolerance");
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void EqualityTestsUsingDefaultFloatingPointTolerance()
         {
             var savedTolerance = GlobalSettings.DefaultFloatingPointTolerance;


### PR DESCRIPTION
This started as initial work toward #164 - parallel test cases - but ended up also incorporating changes in how users express parallelism of tests. It now fixes #2003.

The changes toward parallel test cases are primarily around recognizing that we have three - rather than two - ways of running tests: from the parallel queue, from the non-parallel queue and directly on the thread of the parent. Creating `ParallelScope.Default` allows recognizing the situation where no attribute has been specified, which leads to the third way of running.

In the current commit, test cases are still not run in parallel. If the `#define` that keeps them from running in parallel is removed, other things have to be fixed. So that will be for a further PR. However, I think that the new code structure in place for __deciding__ how to run the tests is the way it will need to be in the future.

As far as the user-facing stuff goes, I added `NonParallelizableAttribute` as an equivalent for `Parallelizable(ParallelScope.None)`. Rather than deprecating anything, I hid it from Intellisense so that old code will still compile but users will not be prompted to use it in new code. Some other new fields, used internally only, are also hidden in this way.

This approach is one of several I could have used. It's the one that requires the least change by users but complicates our own code a bit more to accomodate. Two alternatives to consider, which could be implemented pretty easily:

1. Define some new internal enumeration to replace ParallelScope and keep ParallelScope pretty much as is for users. In that case, I would still need to either deprecate or hide ParallelScope.None.

2. Make the constructor that uses ParallelScope obsolete and create some new, simpler enumeration for public use. Use ParallelScope internally only. This would simplify our code a bit but would be the biggest change for users.

I would like to merge this with or without changes before moving on to do more work on parallelizing test cases.