### PR TITLE
Fix tests failing on systems with comma decimal mark settings

### DIFF
--- a/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework.Interfaces;
 
@@ -161,7 +162,7 @@ namespace NUnit.Framework.Internal.Results
 
             Assert.AreEqual(EXPECTED_START.ToString("u"), testNode.Attributes["start-time"]);
             Assert.AreEqual(EXPECTED_END.ToString("u"), testNode.Attributes["end-time"]);
-            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000"), testNode.Attributes["duration"]);
+            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture), testNode.Attributes["duration"]);
         }
 
         [Test]
@@ -200,7 +201,7 @@ namespace NUnit.Framework.Internal.Results
 
             Assert.AreEqual(EXPECTED_START.ToString("u"), suiteNode.Attributes["start-time"]);
             Assert.AreEqual(EXPECTED_END.ToString("u"), suiteNode.Attributes["end-time"]);
-            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000"), suiteNode.Attributes["duration"]);
+            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture), suiteNode.Attributes["duration"]);
         }
     }
 }


### PR DESCRIPTION
Two tests fail because Assert.AreEqual expected double is transformed to a string with "0.000000" format. Such method call on systems with comma decimal mark returns a string with comma as decimal mark. Setting ToString provider to InvariantCulture ensures a string with point as decimal mark is returned.

Fixes #2017 