### PR TITLE
Ability to abort threads running a message pump

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Internal.Commands
     {
         Timer _commandTimer;
         private bool _commandTimedOut = false;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeoutCommand"/> class.
         /// </summary>
@@ -54,13 +54,14 @@ namespace NUnit.Framework.Internal.Commands
             BeforeTest = (context) =>
             {
                 var testThread = Thread.CurrentThread;
+                var nativeThreadId = ThreadUtility.GetCurrentThreadNativeId();
 
                 // Create a timer to cancel the current thread
                 _commandTimer = new Timer(
                     (o) =>
                     {
                         _commandTimedOut = true;
-                        testThread.Abort();
+                        ThreadUtility.Abort(testThread, nativeThreadId);
                         // No join here, since the thread doesn't really terminate
                     },
                     null,

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -173,13 +173,24 @@ namespace NUnit.Framework.Internal
 
 
 
+        private static bool isNotOnWindows;
+
         /// <summary>
         /// Captures the current thread's native id. If provided to <see cref="Kill(Thread,int)"/> later, allows the thread to be killed if it's in a message pump native blocking wait.
         /// </summary>
         [SecuritySafeCritical]
         public static int GetCurrentThreadNativeId()
         {
-            return GetCurrentThreadId();
+            if (isNotOnWindows) return 0;
+            try
+            {
+                return GetCurrentThreadId();
+            }
+            catch (EntryPointNotFoundException)
+            {
+                isNotOnWindows = true;
+                return 0;
+            }
         }
 
 

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -23,6 +23,9 @@
 
 #if !PORTABLE && !NETSTANDARD1_6
 using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Threading;
 
 namespace NUnit.Framework.Internal
@@ -33,13 +36,66 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class ThreadUtility
     {
+        private const int ThreadAbortedCheckDelay = 100;
+
+
         /// <summary>
-        /// Do our best to Kill a thread
+        /// Pre-Task compatibility
+        /// </summary>
+        public static void Delay(int milliseconds, WaitCallback threadPoolWork, object state = null)
+        {
+            new DelayClosure(milliseconds, threadPoolWork, state);
+        }
+
+        private sealed class DelayClosure
+        {
+            private readonly Timer _timer;
+            private readonly WaitCallback _threadPoolWork;
+            private readonly object _state;
+
+            public DelayClosure(int milliseconds, WaitCallback threadPoolWork, object state)
+            {
+                _threadPoolWork = threadPoolWork;
+                _state = state;
+                _timer = new Timer(Callback, null, Timeout.Infinite, Timeout.Infinite);
+                // Make sure _timer is set before starting the timer so that it is disposed.
+                _timer.Change(milliseconds, Timeout.Infinite);
+            }
+
+            private void Callback(object _)
+            {
+                _timer.Dispose();
+                _threadPoolWork.Invoke(_state);
+            }
+        }
+
+
+        /// <summary>
+        /// Abort a thread, helping to dislodging it if it is blocked in native code
+        /// </summary>
+        /// <param name="thread">The thread to abort</param>
+        /// <param name="nativeId">The native thread id (if known), otherwise 0.
+        /// If provided, allows the thread to be killed if it's in a message pump native blocking wait.
+        /// This must have previously been captured by calling <see cref="GetCurrentThreadNativeId"/> from the running thread itself.</param>
+        public static void Abort(Thread thread, int nativeId = 0)
+        {
+            if (nativeId != 0)
+                DislodgeThreadInNativeMessageWait(thread, nativeId);
+
+            thread.Abort();
+        }
+
+
+        /// <summary>
+        /// Do our best to kill a thread
         /// </summary>
         /// <param name="thread">The thread to kill</param>
-        public static void Kill(Thread thread)
+        /// <param name="nativeId">The native thread id (if known), otherwise 0.
+        /// If provided, allows the thread to be killed if it's in a message pump native blocking wait.
+        /// This must have previously been captured by calling <see cref="GetCurrentThreadNativeId"/> from the running thread itself.</param>
+        public static void Kill(Thread thread, int nativeId = 0)
         {
-            Kill(thread, null);
+            Kill(thread, null, nativeId);
         }
 
         /// <summary>
@@ -47,8 +103,15 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="thread">The thread to kill</param>
         /// <param name="stateInfo">Info for the ThreadAbortException handler</param>
-        public static void Kill(Thread thread, object stateInfo)
+        /// <param name="nativeId">The native thread id (if known), otherwise 0.
+        /// If provided, allows the thread to be killed if it's in a message pump native blocking wait.
+        /// This must have previously been captured by calling <see cref="GetCurrentThreadNativeId"/> from the running thread itself.</param>
+        public static void Kill(Thread thread, object stateInfo, int nativeId = 0)
         {
+            if (nativeId != 0)
+                DislodgeThreadInNativeMessageWait(thread, nativeId);
+
+
             try
             {
                 if (stateInfo == null)
@@ -67,6 +130,85 @@ namespace NUnit.Framework.Internal
 
             if ( (thread.ThreadState & ThreadState.WaitSleepJoin) != 0 )
                 thread.Interrupt();
+        }
+
+        /// <summary>
+        /// Schedule a threadpool thread to check on the aborting thread in case it's in a message pump native blocking wait
+        /// </summary>
+        private static void DislodgeThreadInNativeMessageWait(Thread thread, int nativeId)
+        {
+            if (nativeId == 0) throw new ArgumentOutOfRangeException(nameof(nativeId), "Native thread ID must not be zero.");
+
+            // Schedule a threadpool thread to check on the aborting thread in case it's in a message pump native blocking wait
+            Delay(ThreadAbortedCheckDelay, CheckOnAbortingThread, new CheckOnAbortingThreadState(thread, nativeId));
+        }
+
+        private static void CheckOnAbortingThread(object state)
+        {
+            var context = (CheckOnAbortingThreadState)state;
+
+            switch (context.Thread.ThreadState)
+            {
+                case ThreadState.Aborted:
+                    return;
+                case ThreadState.AbortRequested:
+                    PostThreadCloseMessage(context.NativeId);
+                    break;
+            }
+
+            Delay(ThreadAbortedCheckDelay, CheckOnAbortingThread, state);
+        }
+
+        private sealed class CheckOnAbortingThreadState
+        {
+            public Thread Thread { get; }
+            public int NativeId { get; }
+
+            public CheckOnAbortingThreadState(Thread thread, int nativeId)
+            {
+                Thread = thread;
+                NativeId = nativeId;
+            }
+        }
+
+
+
+        /// <summary>
+        /// Captures the current thread's native id. If provided to <see cref="Kill(Thread,int)"/> later, allows the thread to be killed if it's in a message pump native blocking wait.
+        /// </summary>
+        [SecuritySafeCritical]
+        public static int GetCurrentThreadNativeId()
+        {
+            return GetCurrentThreadId();
+        }
+
+
+        /// <summary>
+        /// Sends a message to the thread to dislodge it from native code and allow a return to managed code, where a ThreadAbortException can be generated.
+        /// The message is meaningless (WM_CLOSE without a window handle) but it will end any blocking message wait.
+        /// </summary>
+        [SecuritySafeCritical]
+        private static void PostThreadCloseMessage(int nativeId)
+        {
+            if (!PostThreadMessage(nativeId, WM.CLOSE, IntPtr.Zero, IntPtr.Zero))
+            {
+                const int ERROR_INVALID_THREAD_ID = 0x5A4;
+                var errorCode = Marshal.GetLastWin32Error();
+                if (errorCode != ERROR_INVALID_THREAD_ID)
+                    throw new Win32Exception(errorCode);
+            }
+        }
+
+
+        [DllImport("kernel32.dll")]
+        private static extern int GetCurrentThreadId();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostThreadMessage(int id, WM msg, IntPtr wParam, IntPtr lParam);
+
+        private enum WM : uint
+        {
+            CLOSE = 0x0010
         }
     }
 }

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -23,6 +23,7 @@
 
 #if !PORTABLE && !NETSTANDARD1_6
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
 
@@ -50,6 +51,20 @@ namespace NUnit.TestData
         {
             while (true) { }
         }
+
+
+        [Test, Timeout(500)]
+        public void TimeoutWithMessagePumpShouldAbort()
+        {
+            // Simulate System.Windows.Forms.Application.Run or .ShowDialog,
+            // or System.Windows.Threading.Dispatcher.PushFrame,
+            // which block on native calls to WaitMessage or MsgWaitForMultipleObjectsEx.
+            while (true)
+                WaitMessage();
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool WaitMessage();
     }
 
     public class TimeoutFixtureWithTimeoutInSetUp : TimeoutFixture

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -158,7 +158,7 @@ namespace NUnit.Framework.Attributes
             }
         }
 
-        [Test]
+        [Test, Platform("Win")]
         public void TimeoutWithMessagePumpShouldAbort()
         {
             ITestResult result = TestBuilder.RunTest(

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -156,6 +156,18 @@ namespace NUnit.Framework.Attributes
                 Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.Success), "First test");
                 Assert.That(result.Children.ToArray()[1].ResultState, Is.EqualTo(ResultState.Failure), "Second test");
             }
+        }
+
+        [Test]
+        public void TimeoutWithMessagePumpShouldAbort()
+        {
+            ITestResult result = TestBuilder.RunTest(
+                TestBuilder.MakeTestFromMethod(typeof(TimeoutFixture), nameof(TimeoutFixture.TimeoutWithMessagePumpShouldAbort)),
+                new TimeoutFixture());
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+            Assert.That(result.Message, Is.EqualTo("Test exceeded Timeout value of 500ms"));
+            Assert.That(result.Duration, Is.EqualTo(0.5).Within(0.2));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -8,6 +8,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class ThreadUtilityTests
     {
+        [Platform("Win")]
         [Timeout(1000)]
         [TestCase(false, TestName = "Abort")]
         [TestCase(true, TestName = "Kill")]

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -1,0 +1,46 @@
+﻿#if !PORTABLE && !NETSTANDARD1_6
+
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class ThreadUtilityTests
+    {
+        [Timeout(1000)]
+        [TestCase(false, TestName = "Abort")]
+        [TestCase(true, TestName = "Kill")]
+        public void AbortOrKillThreadWithMessagePump(bool kill)
+        {
+            using (var isThreadAboutToWait = new ManualResetEvent(false))
+            {
+                var nativeId = 0;
+                var thread = new Thread(() =>
+                {
+                    nativeId = ThreadUtility.GetCurrentThreadNativeId();
+                    isThreadAboutToWait.Set();
+                    while (true)
+                        WaitMessage();
+                });
+                thread.Start();
+
+                isThreadAboutToWait.WaitOne();
+                Thread.Sleep(1);
+
+                if (kill)
+                    ThreadUtility.Kill(thread, nativeId);
+                else
+                    ThreadUtility.Abort(thread, nativeId);
+
+                thread.Join();
+            }
+
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool WaitMessage();
+    }
+}
+
+#endif

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Internal\TestMethodTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Internal\TestMethodTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Assertions\ArrayEqualsFailureMessageFixture.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\Results\TestResultOutputTests.cs" />
     <Compile Include="Internal\Results\TestResultSuccessTests.cs" />
     <Compile Include="Internal\Results\TestResultTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TestMethodTests.cs" />
     <Compile Include="TestParametersTests.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />
+    <Compile Include="Internal\ThreadUtilityTests.cs" />
     <Compile Include="Internal\TypeHelperTests.cs" />
     <Compile Include="Internal\TypeParameterUsedWithTestMethod.cs" />
     <Compile Include="Internal\UnexpectedExceptionTests.cs" />


### PR DESCRIPTION
Closes everything in #1996 that is actionable at this time.
For reference to make it easy to see what is involved in aborting threads when testing GUI.