### PR TITLE
Add method to mark tests as invalid with a reason

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -115,8 +115,7 @@ namespace NUnit.Framework.Api
             catch (Exception ex)
             {
                 testAssembly = new TestAssembly(assemblyName);
-                testAssembly.RunState = RunState.NotRunnable;
-                testAssembly.Properties.Set(PropertyNames.SkipReason, ExceptionHelper.BuildFriendlyMessage(ex));
+                testAssembly.MakeInvalid(ExceptionHelper.BuildFriendlyMessage(ex));
             }
 
             return testAssembly;
@@ -174,8 +173,7 @@ namespace NUnit.Framework.Api
             catch (Exception ex)
             {
                 testAssembly = new TestAssembly(assemblyPath);
-                testAssembly.RunState = RunState.NotRunnable;
-                testAssembly.Properties.Set(PropertyNames.SkipReason, ExceptionHelper.BuildFriendlyMessage(ex));
+                testAssembly.MakeInvalid(ExceptionHelper.BuildFriendlyMessage(ex));
             }
 
             return testAssembly;
@@ -266,8 +264,7 @@ namespace NUnit.Framework.Api
 
             if (fixtures.Count == 0)
             {
-                testAssembly.RunState = RunState.NotRunnable;
-                testAssembly.Properties.Set(PropertyNames.SkipReason, "Has no TestFixtures");
+                testAssembly.MakeInvalid("Has no TestFixtures");
             }
             else
             {

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -84,10 +84,7 @@ namespace NUnit.Framework
             test.Properties.Add(PropertyNames.Category, this.Name);
 
             if (this.Name.IndexOfAny(new char[] { ',', '!', '+', '-' }) >= 0)
-            {
-                test.RunState = RunState.NotRunnable;
-                test.Properties.Set(PropertyNames.SkipReason, "Category name must not contain ',', '!', '+' or '-'");
-            }
+                test.MakeInvalid("Category name must not contain ',', '!', '+' or '-'");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -51,10 +51,7 @@ namespace NUnit.Framework
             {
                 string reason = null;
                 if (!IsValidFixtureType(typeInfo, ref reason))
-                {
-                    fixture.RunState = RunState.NotRunnable;
-                    fixture.Properties.Set(PropertyNames.SkipReason, reason);
-                }
+                    fixture.MakeInvalid(reason);
             }
 
             return new TestSuite[] { fixture };

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -96,12 +96,10 @@ namespace NUnit.Framework.Internal.Builders
             catch (Exception ex)
             {
                 var fixture = new TestFixture(typeInfo);
-                fixture.RunState = RunState.NotRunnable;
-
                 if (ex is System.Reflection.TargetInvocationException)
                     ex = ex.InnerException;
-                var msg = "An exception was thrown while loading the test." + Environment.NewLine + ex.ToString();
-                fixture.Properties.Add(PropertyNames.SkipReason, msg);
+
+                fixture.MakeInvalid("An exception was thrown while loading the test." + Environment.NewLine + ex.ToString());
 
                 return fixture;
             }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -219,8 +219,7 @@ namespace NUnit.Framework.Internal.Builders
 
         private static bool MarkAsNotRunnable(TestMethod testMethod, string reason)
         {
-            testMethod.RunState = RunState.NotRunnable;
-            testMethod.Properties.Set(PropertyNames.SkipReason, reason);
+            testMethod.MakeInvalid(reason);
             return false;
         }
 

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -166,8 +166,7 @@ namespace NUnit.Framework.Internal.Builders
             // TODO: Check this logic added from Neil's build.
             if (fixture.TypeInfo.ContainsGenericParameters)
             {
-                fixture.RunState = RunState.NotRunnable;
-                fixture.Properties.Set(PropertyNames.SkipReason, NO_TYPE_ARGS_MSG);
+                fixture.MakeInvalid(NO_TYPE_ARGS_MSG);
                 return;
             }
 
@@ -210,8 +209,7 @@ namespace NUnit.Framework.Internal.Builders
         {
             if (fixture.TypeInfo.ContainsGenericParameters)
             {
-                fixture.RunState = RunState.NotRunnable;
-                fixture.Properties.Set(PropertyNames.SkipReason, NO_TYPE_ARGS_MSG);
+                fixture.MakeInvalid(NO_TYPE_ARGS_MSG);
             }
             else if (!fixture.TypeInfo.IsStaticClass)
             {
@@ -219,8 +217,7 @@ namespace NUnit.Framework.Internal.Builders
 
                 if (!fixture.TypeInfo.HasConstructor(argTypes))
                 {
-                    fixture.RunState = RunState.NotRunnable;
-                    fixture.Properties.Set(PropertyNames.SkipReason, "No suitable constructor was found");
+                    fixture.MakeInvalid("No suitable constructor was found");
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -355,6 +355,8 @@ namespace NUnit.Framework.Internal
         /// <param name="reason">The reason the test is not runnable</param>
         public void MakeInvalid(string reason)
         {
+            Guard.ArgumentNotNullOrEmpty(reason, "reason");
+
             RunState = RunState.NotRunnable;
             Properties.Add(PropertyNames.SkipReason, reason);
         }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -260,10 +260,7 @@ namespace NUnit.Framework.Internal
 #endif
                     )
                 {
-                    this.Properties.Set(
-                        PropertyNames.SkipReason,
-                        string.Format("Invalid signature for SetUp or TearDown method: {0}", method.Name));
-                    this.RunState = RunState.NotRunnable;
+                    this.MakeInvalid(string.Format("Invalid signature for SetUp or TearDown method: {0}", method.Name));
                     break;
                 }
         }

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -107,8 +107,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IgnoreAttributeDoesNotAffectNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            test.Properties.Set(PropertyNames.SkipReason, "UNCHANGED");
+            test.MakeInvalid("UNCHANGED");
             new IgnoreAttribute("BECAUSE").ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
@@ -207,8 +206,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ExplicitAttributeDoesNotAffectNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            test.Properties.Set(PropertyNames.SkipReason, "UNCHANGED");
+            test.MakeInvalid("UNCHANGED");
             new ExplicitAttribute("BECAUSE").ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));


### PR DESCRIPTION
This is a small refactoring suggested by @jnm2 in reviewing an earlier PR. It simplifies marking a test as invalid while requiring a reason to be given.