### PR TITLE
Make Theories fail if no data at all is provided

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -134,8 +134,24 @@ namespace NUnit.Framework
         /// <returns>One or more TestMethods</returns>
         public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
+            int count = 0;
+
             foreach (TestCaseParameters parms in GetTestCasesFor(method))
+            {
+                count++;
                 yield return _builder.BuildTestMethod(method, suite, parms);
+            }
+
+            // If count > 0, error messages will be shown for each case
+            // but if it's 0, we need to add an extra "test" to show the message.
+            if (count == 0 && method.GetParameters().Length == 0)
+            {
+                var parms = new TestCaseParameters();
+                parms.RunState = RunState.NotRunnable;
+                parms.Properties.Set(PropertyNames.SkipReason, "TestCaseSourceAttribute may not be used on a method without parameters");
+                    
+                yield return _builder.BuildTestMethod(method, suite, parms);
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -142,10 +142,10 @@ namespace NUnit.Framework.Internal.Builders
             foreach (var attr in builders)
             {
                 foreach (var test in attr.BuildFrom(method, parentSuite))
-                    tests.Add(test);
+                    tests.Add(test); 
             }
 
-            return hasBuildersSpecified || tests.Count > 0
+            return hasBuildersSpecified && method.GetParameters().Length > 0 || tests.Count > 0
                 ? BuildParameterizedMethodSuite(method, tests)
                 : BuildSingleTestMethod(method, parentSuite);
         }

--- a/src/NUnitFramework/framework/Internal/Commands/TheoryResultCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TheoryResultCommand.cs
@@ -47,23 +47,24 @@ namespace NUnit.Framework.Internal.Commands
         {
             TestResult theoryResult = innerCommand.Execute(context);
 
-            if (theoryResult.ResultState == ResultState.Success)
+            if (theoryResult.ResultState == ResultState.Inconclusive)
+//            if (theoryResult.ResultState == ResultState.Success)
             {
                 if (!theoryResult.HasChildren)
                     theoryResult.SetResult(ResultState.Failure, "No test cases were provided");
                 else
-                {
-                    bool wasInconclusive = true;
-                    foreach (TestResult childResult in theoryResult.Children)
-                        if (childResult.ResultState == ResultState.Success)
-                        {
-                            wasInconclusive = false;
-                            break;
-                        }
+                //{
+                //    bool wasInconclusive = true;
+                //    foreach (TestResult childResult in theoryResult.Children)
+                //        if (childResult.ResultState == ResultState.Success)
+                //        {
+                //            wasInconclusive = false;
+                //            break;
+                //        }
 
-                    if (wasInconclusive)
+                //    if (wasInconclusive)
                         theoryResult.SetResult(ResultState.Failure, "All test cases were inconclusive");
-                }
+                //}
             }
 
             return theoryResult;

--- a/src/NUnitFramework/framework/Internal/Commands/TheoryResultCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TheoryResultCommand.cs
@@ -48,23 +48,11 @@ namespace NUnit.Framework.Internal.Commands
             TestResult theoryResult = innerCommand.Execute(context);
 
             if (theoryResult.ResultState == ResultState.Inconclusive)
-//            if (theoryResult.ResultState == ResultState.Success)
             {
                 if (!theoryResult.HasChildren)
                     theoryResult.SetResult(ResultState.Failure, "No test cases were provided");
                 else
-                //{
-                //    bool wasInconclusive = true;
-                //    foreach (TestResult childResult in theoryResult.Children)
-                //        if (childResult.ResultState == ResultState.Success)
-                //        {
-                //            wasInconclusive = false;
-                //            break;
-                //        }
-
-                //    if (wasInconclusive)
-                        theoryResult.SetResult(ResultState.Failure, "All test cases were inconclusive");
-                //}
+                    theoryResult.SetResult(ResultState.Failure, "All test cases were inconclusive");
             }
 
             return theoryResult;

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal.Execution
                         case RunState.Runnable:
                         case RunState.Explicit:
                             // Assume success, since the result will otherwise
-                            // edault to inconclusive.
+                            // default to inconclusive.
                             Result.SetResult(ResultState.Success);
 
                             CreateChildWorkItems();

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -99,9 +99,8 @@ namespace NUnit.Framework.Internal.Execution
                         default:
                         case RunState.Runnable:
                         case RunState.Explicit:
-                            // Assume success, since the result will be inconclusive
-                            // if there is no setup method to run or if the
-                            // context initialization fails.
+                            // Assume success, since the result will otherwise
+                            // edault to inconclusive.
                             Result.SetResult(ResultState.Success);
 
                             CreateChildWorkItems();
@@ -135,6 +134,8 @@ namespace NUnit.Framework.Internal.Execution
                                 if (Context.ExecutionStatus != TestExecutionStatus.AbortRequested)
                                     PerformOneTimeTearDown();
                             }
+                            else if (Test.TestType == "Theory")
+                                Result.SetResult(ResultState.Failure, "No test cases were provided");
                             break;
 
                         case RunState.Skipped:
@@ -153,7 +154,6 @@ namespace NUnit.Framework.Internal.Execution
             // Fall through in case nothing was run.
             // Otherwise, this is done in the completion event.
             WorkItemComplete();
-
         }
 
         #region Helper Methods
@@ -223,6 +223,9 @@ namespace NUnit.Framework.Internal.Execution
 
         private void RunChildren()
         {
+            if (Test.TestType == "Theory")
+                Result.SetResult(ResultState.Inconclusive);
+
             int childCount = _children.Count;
             if (childCount == 0)
                 throw new InvalidOperationException("RunChildren called but item has no children");
@@ -384,6 +387,9 @@ namespace NUnit.Framework.Internal.Execution
             _childTestCountdown.Signal();
             if (_childTestCountdown.CurrentCount == 0)
             {
+                if (Test.TestType == "Theory" && Result.ResultState == ResultState.Success && Result.PassCount == 0)
+                    Result.SetResult(ResultState.Failure, "No test cases were provided");
+
                 if (Context.ExecutionStatus != TestExecutionStatus.AbortRequested)
                     PerformOneTimeTearDown();
 

--- a/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
@@ -220,74 +220,60 @@ namespace NUnit.Framework.Internal
         public virtual void AddResult(ITestResult result)
         {
 #if PARALLEL
-            var childrenAsConcurrentQueue = Children as ConcurrentQueue<ITestResult>;
-            if (childrenAsConcurrentQueue != null)
-                childrenAsConcurrentQueue.Enqueue(result);
-            else
-#endif
-            {
-                var childrenAsIList = Children as IList<ITestResult>;
-                if (childrenAsIList != null)
-                    childrenAsIList.Add(result);
-                else
-                    throw new NotSupportedException("cannot add results to Children");
-
-            }
-
-#if PARALLEL
+            _children.Enqueue(result);
             RwLock.EnterWriteLock();
-#endif
             try
             {
-                // If this result is marked cancelled, don't change it
-                if (ResultState != ResultState.Cancelled)
-                {
-                    switch (result.ResultState.Status)
-                    {
-                        case TestStatus.Passed:
-
-                            if (ResultState.Status == TestStatus.Inconclusive)
-                                SetResult(ResultState.Success);
-
-                            break;
-
-                        case TestStatus.Warning:
-
-                            if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
-                                SetResult(result.ResultState, CHILD_WARNINGS_MESSAGE);
-
-                            break;
-
-                        case TestStatus.Failed:
-
-
-                            if (ResultState.Status != TestStatus.Failed)
-                                SetResult(ResultState.ChildFailure, CHILD_ERRORS_MESSAGE);
-
-                            break;
-
-                        case TestStatus.Skipped:
-
-                            if (result.ResultState.Label == "Ignored")
-                                if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
-                                    SetResult(ResultState.Ignored, CHILD_IGNORE_MESSAGE);
-
-                            break;
-                    }
-                }
-
-                InternalAssertCount += result.AssertCount;
-                _passCount += result.PassCount;
-                _failCount += result.FailCount;
-                _warningCount += result.WarningCount;
-                _skipCount += result.SkipCount;
-                _inconclusiveCount += result.InconclusiveCount;
+                MergeChildResult(result);
             }
             finally
             {
-#if PARALLEL
                 RwLock.ExitWriteLock();
+            }
+#else
+            _children.Add(result);
+            MergeChildResult(result);
 #endif
+        }
+
+        private void MergeChildResult(ITestResult childResult)
+        {
+            // If this result is marked cancelled, don't change it
+            if (ResultState != ResultState.Cancelled)
+                UpdateResultState(childResult.ResultState);
+
+            InternalAssertCount += childResult.AssertCount;
+            _passCount += childResult.PassCount;
+            _failCount += childResult.FailCount;
+            _warningCount += childResult.WarningCount;
+            _skipCount += childResult.SkipCount;
+            _inconclusiveCount += childResult.InconclusiveCount;
+        }
+
+        private void UpdateResultState(ResultState childResultState)
+        {
+            switch (childResultState.Status)
+            {
+                case TestStatus.Passed:
+                    if (ResultState.Status == TestStatus.Inconclusive)
+                        SetResult(ResultState.Success);
+                    break;
+
+                case TestStatus.Warning:
+                    if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
+                        SetResult(childResultState, CHILD_WARNINGS_MESSAGE);
+                    break;
+
+                case TestStatus.Failed:
+                    if (ResultState.Status != TestStatus.Failed)
+                        SetResult(ResultState.ChildFailure, CHILD_ERRORS_MESSAGE);
+                    break;
+
+                case TestStatus.Skipped:
+                    if (childResultState.Label == "Ignored")
+                        if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
+                            SetResult(ResultState.Ignored, CHILD_IGNORE_MESSAGE);
+                    break;
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -294,16 +294,9 @@ namespace NUnit.Framework.Attributes
         private static IEnumerable<TestCaseData> ZeroTestCasesSource() => Enumerable.Empty<TestCaseData>();
 
         [TestCaseSource("ZeroTestCasesSource")]
-        public void TestWithZeroTestSourceCasesShouldNotBeRun()
-        {
-            Assert.Fail();
-        }
-
-        [TestCaseSource("ZeroTestCasesSource")]
         public void TestWithZeroTestSourceCasesShouldPassWithoutRequiringArguments(int requiredParameter)
         {
         }
-
 
         static object[] testCases =
         {

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Attributes
 {
     public class TestMethodBuilderTests
     {
+        #region TestAttribute
+
         [Test]
         public void TestAttribute_NoArgs_Runnable()
         {
@@ -45,6 +47,10 @@ namespace NUnit.Framework.Attributes
             TestMethod test = new TestAttribute().BuildFrom(method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
+
+        #endregion
+
+        #region TestCaseAttribute
 
         [Test]
         public void TestCaseAttribute_NoArgs_NotRunnable()
@@ -72,6 +78,10 @@ namespace NUnit.Framework.Attributes
             Assert.That(tests.Count, Is.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
+
+        #endregion
+
+        #region TestCaseSourceAttribute
 
         [Test]
         public void TestCaseSourceAttribute_NoArgs_NotRunnable()
@@ -112,6 +122,10 @@ namespace NUnit.Framework.Attributes
                 Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
+        #endregion
+
+        #region TheoryAttribute
+
 #if !PORTABLE
         [Test]
         public void TheoryAttribute_NoArgs_NoCases()
@@ -132,6 +146,10 @@ namespace NUnit.Framework.Attributes
         }
 #endif
 
+        #endregion
+
+        #region CombinatorialAttribute
+
         [Test]
         public void CombinatorialAttribute_NoArgs_NoCases()
         {
@@ -149,6 +167,10 @@ namespace NUnit.Framework.Attributes
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
+
+        #endregion
+
+        #region PairwiseAttribute
 
         [Test]
         public void PairwiseAttribute_NoArgs_NoCases()
@@ -168,6 +190,10 @@ namespace NUnit.Framework.Attributes
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
+        #endregion
+
+        #region SequentialAttribute
+
         [Test]
         public void SequentialAttribute_NoArgs_NoCases()
         {
@@ -185,6 +211,10 @@ namespace NUnit.Framework.Attributes
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
+
+        #endregion
+
+        #region Helper Methods and Data
 
         private IMethodInfo GetMethod(string methodName)
         {
@@ -211,5 +241,7 @@ namespace NUnit.Framework.Attributes
 
         [DatapointSource]
         int[] ints = new int[] { 1, 2, 3 };
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -84,6 +84,15 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void TestCaseSourceAttribute_NoArgs_NoData_NotRunnable()
+        {
+            var method = GetMethod("MethodWithoutArgs");
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("ZeroData").BuildFrom(method, null));
+            Assert.That(tests.Count, Is.EqualTo(1));
+            Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
         public void TestCaseSourceAttribute_RightArgs_Runnable()
         {
             var method = GetMethod("MethodWithIntArgs");
@@ -187,6 +196,8 @@ namespace NUnit.Framework.Attributes
         public static void MethodWithIntValues(
             [Values(1, 2, 3)]int x,
             [Values(10, 20)]int y) { }
+
+        static object[] ZeroData = new object[0];
 
         static object[] GoodData = new object[] {
             new object[] { 12, 3 },

--- a/src/NUnitFramework/tests/Attributes/TheoryTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TheoryTests.cs
@@ -42,15 +42,15 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void TheoryWithNoDatapointsIsRunnable()
+        public void TheoryWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, "TheoryWithArgumentsButNoDatapoints");
+            TestAssert.IsRunnable(fixtureType, "TheoryWithArgumentsButNoDatapoints", ResultState.Failure);
         }
 
         [Test]
-        public void UnsupportedNullableTypeArgumentWithNoDatapointsAreRunnable()
+        public void UnsupportedNullableTypeArgumentWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, "TestWithUnsupportedNullableTypeArgumentWithNoDataPoints");
+            TestAssert.IsRunnable(fixtureType, "TestWithUnsupportedNullableTypeArgumentWithNoDataPoints", ResultState.Failure);
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(test.TestCaseCount, Is.EqualTo(2));
         }
 
-        [Theory]
+        [Test]
         public void TheoryFailsIfAllTestsAreInconclusive()
         {
             ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, "TestWithAllBadValues");


### PR DESCRIPTION
Fixes #1962 

With this fix, a Theory that gets no data shows the same failed result as a theory that gets data that fails the assumptions, as we would expect.

At the same time, I fixed an issue where test methods without any argument were being silently ignored if they had a TestCaseSourceAttribute. They are now marked as invalid.

This fixes the immediate issue but leaves even more knowledge about kinds of tests in the work item, where it really doesn't belong. Some sort of refactoring is needed eventually.