### PR TITLE
Handle null arguments in TestFixtureAttribute 

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework
         public TestFixtureAttribute(params object[] arguments)
         {
             RunState = RunState.Runnable;
-            Arguments = arguments;
+            Arguments = arguments ?? new object[] { null };
             TypeArgs = new Type[0];
             Properties = new PropertyBag();
         }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Internal.Builders
             // Only TestFixtureAttribute can be used without arguments
             var temp = attr as TestFixtureAttribute;
 
-            return temp == null || temp.Arguments.Length > 0 || temp.TypeArgs.Length > 0;
+            return temp == null || (temp.Arguments != null && temp.Arguments.Length > 0) || (temp.TypeArgs != null && temp.TypeArgs.Length > 0);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Internal.Builders
             // Only TestFixtureAttribute can be used without arguments
             var temp = attr as TestFixtureAttribute;
 
-            return temp == null || (temp.Arguments != null && temp.Arguments.Length > 0) || (temp.TypeArgs != null && temp.TypeArgs.Length > 0);
+            return temp == null || temp.Arguments.Length > 0 || temp.TypeArgs.Length > 0;
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
@@ -80,5 +80,14 @@ namespace NUnit.Framework.Attributes
             Assert.That(attr.Arguments, Is.EqualTo(combinedArgs));
             Assert.That(attr.TypeArgs.Length, Is.EqualTo(0));
         }
+
+        [Test]
+        public void ConstructWithWeakTypedNullArgument()
+        {
+            TestFixtureAttribute attr = new TestFixtureAttribute(null);
+            Assert.That(attr.Arguments, Is.Not.Null);
+            Assert.That(attr.Arguments[0], Is.Null);
+            Assert.That(attr.TypeArgs, Is.Not.Null);
+        }
     }
 }


### PR DESCRIPTION
The null reference checks I added solve the issue of `NullReferenceException`, and a fixture with null argument is marked as invalid with "No suitable constructor was found" message instead. I believe that is the intention, because of the way .NET handles params method parameter.

I suppose this is by design:
```
// This code doesn't result in an invalid test fixture
[TestFixture((object)null)]
public class SomeTestFixture
{
    public SomeTestFixture(object someObject)
    {
    }
}

// This code does result in an invalid test fixture
[TestFixture(null)]
public class SomeTestFixture
{
    public SomeTestFixture(object someObject)
    {
    }
}
```

Unfortunately the bug is in `DefaultSuiteBuilder`, and there are no unit tests for builders, so I don't know whether I should write tests for that bug, or not.

Fixes #1934 