### PR TITLE
Fix compatibility issue with AssertionException

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -360,19 +360,18 @@ namespace NUnit.Framework
 
         private static void ReportFailure(string message)
         {
-            // Failure is recorded in <assertion> element in all cases
-            TestExecutionContext.CurrentContext.CurrentResult.RecordAssertion(
-                AssertionStatus.Failed, message, GetStackTrace());
-
             // If we are outside any multiple assert block, then throw
             if (TestExecutionContext.CurrentContext.MultipleAssertLevel == 0)
                 throw new AssertionException(message);
+
+            // Otherwise, just record the failure in an <assertion> element
+            var result = TestExecutionContext.CurrentContext.CurrentResult;
+            result.RecordAssertion(AssertionStatus.Failed, message, GetStackTrace());
         }
 
         private static void IssueWarning(string message)
         {
             var result = TestExecutionContext.CurrentContext.CurrentResult;
-
             result.RecordAssertion(AssertionStatus.Warning, message, GetStackTrace());
         }
 

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -482,6 +482,11 @@ namespace NUnit.Framework.Internal
             if (ex is NUnitException)
                 ex = ex.InnerException;
 
+            if (ex is AssertionException)
+            {
+                AssertionResults.Add(new AssertionResult(AssertionStatus.Failed, ex.Message, StackFilter.DefaultFilter.Filter(ex.StackTrace)));
+            }
+
             if (ex is ResultStateException)
             {
                 string message = ex is MultipleAssertException

--- a/src/NUnitFramework/tests/Assertions/AssertFailTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertFailTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 using NUnit.TestData.AssertFailFixture;
 using NUnit.TestUtilities;
 
@@ -71,6 +72,10 @@ namespace NUnit.Framework.Assertions
                 "CallAssertFail");
 
             Assert.AreEqual(ResultState.Failure, result.ResultState);
+
+            Assert.AreEqual(result.AssertionResults.Count, 1);
+            var assertion = result.AssertionResults[0];
+            Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
         }
 
         [Test]
@@ -82,6 +87,11 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreEqual(ResultState.Failure, result.ResultState);
             Assert.AreEqual("MESSAGE", result.Message);
+
+            Assert.AreEqual(result.AssertionResults.Count, 1);
+            var assertion = result.AssertionResults[0];
+            Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
+            Assert.That(assertion.Message, Is.EqualTo("MESSAGE"));
         }
 
         [Test]
@@ -93,6 +103,27 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreEqual(ResultState.Failure, result.ResultState);
             Assert.AreEqual("MESSAGE: 2+2=4", result.Message);
+
+            Assert.AreEqual(result.AssertionResults.Count, 1);
+            var assertion = result.AssertionResults[0];
+            Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
+            Assert.That(assertion.Message, Is.EqualTo("MESSAGE: 2+2=4"));
+        }
+
+        [Test]
+        public void CatchingAssertionExceptionMakesTestPass()
+        {
+            try
+            {
+                Assert.Fail("This should not be seen");
+            }
+            catch
+            {
+                // Eat the exception
+            }
+
+            // Ensure that no spurious info was recorded from the assertion
+            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.AssertionResults.Count, Is.EqualTo(0));
         }
     }
 }


### PR DESCRIPTION
Fixes #2043 

This fix allows users to catch the AssertionException thereby preventing a test from failing. This used to work until NUnit 3.6 and some users have complained about the change so I refactored the implementation to allow the old code to keep working, so long as the failure didn't occur inside a multiple assert block.

This doesn't mean we are now supporting the practice as a feature of NUnit. Just that we are avoiding breaking things we don't have to break. I'd like to add a page on NUnit's use of exceptions in the docs and tell users that it's inadvisable to try to catch them.