### PR TITLE
Refactor TestExecutionContext

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -249,10 +249,6 @@ namespace NUnit.Framework.Api
             InsertEnvironmentElement(result);
 #endif
 
-            // Ensure that the CallContext of the thread is not polluted
-            // by our TestExecutionContext, which is not serializable.
-            TestExecutionContext.ClearCurrentContext();
-
             return result.OuterXml;
         }
 
@@ -300,10 +296,6 @@ namespace NUnit.Framework.Api
 #if !PORTABLE
             InsertEnvironmentElement(result);
 #endif
-
-            // Ensure that the CallContext of the thread is not polluted
-            // by our TestExecutionContext, which is not serializable.
-            TestExecutionContext.ClearCurrentContext();
 
             return result.OuterXml;
         }
@@ -376,10 +368,6 @@ namespace NUnit.Framework.Api
 #if !PORTABLE
             InsertEnvironmentElement(result);
 #endif
-
-            // Ensure that the CallContext of the thread is not polluted
-            // by our TestExecutionContext, which is not serializable.
-            TestExecutionContext.ClearCurrentContext();
 
             handler.RaiseCallbackEvent(result.OuterXml);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal.Execution
 
         private bool TrySendToListener(string text)
         {
-            var context = TestExecutionContext.GetTestExecutionContext();
+            var context = TestExecutionContext.CurrentContext;
             if (context == null || context.Listener == null)
                 return false;
 

--- a/src/NUnitFramework/framework/Internal/Execution/TextCapture.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextCapture.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="value">The char to write</param>
         public override void Write(char value)
         {
-            var context = TestExecutionContext.GetTestExecutionContext();
+            var context = TestExecutionContext.CurrentContext;
 
             if (context != null && context.CurrentResult != null)
                 context.CurrentResult.OutWriter.Write(value);
@@ -76,7 +76,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="value">The string to write</param>
         public override void Write(string value)
         {
-            var context = TestExecutionContext.GetTestExecutionContext();
+            var context = TestExecutionContext.CurrentContext;
 
             if (context != null && context.CurrentResult != null)
                 context.CurrentResult.OutWriter.Write(value);
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="value">The string to write</param>
         public override void WriteLine(string value)
         {
-            var context = TestExecutionContext.GetTestExecutionContext();
+            var context = TestExecutionContext.CurrentContext;
 
             if (context != null && context.CurrentResult != null)
                 context.CurrentResult.OutWriter.WriteLine(value);

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -44,10 +44,6 @@ namespace NUnit.Framework.Internal
     /// Helper class used to save and restore certain static or
     /// singleton settings in the environment that affect tests
     /// or which might be changed by the user tests.
-    ///
-    /// An internal class is used to hold settings and a stack
-    /// of these objects is pushed and popped as Save and Restore
-    /// are called.
     /// </summary>
     public class TestExecutionContext
 #if !PORTABLE && !NETSTANDARD1_6
@@ -166,13 +162,8 @@ namespace NUnit.Framework.Internal
 
         #region CurrentContext Instance
 
-        // NOTE: We use different implementations for various platforms
+        // NOTE: We use different implementations for various platforms.
 
-        // If a user creates a thread then the current context
-        // will be null. This also happens when the compiler
-        // automatically creates threads for async methods.
-        // We create a new context, which is automatically
-        // populated with values taken from the current thread.
 #if NETSTANDARD1_6
         private static readonly AsyncLocal<TestExecutionContext> _currentContext = new AsyncLocal<TestExecutionContext>();
         /// <summary>

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework
         {
             get
             {
-                Test test = _testExecutionContext.CurrentTest;
+                Test test = _testExecutionContext?.CurrentTest;
                 if (test != null)
                     return AssemblyHelper.GetDirectoryName(test.TypeInfo.Assembly);
 
@@ -151,7 +151,12 @@ namespace NUnit.Framework
         /// </summary>
         public string WorkDirectory
         {
-            get { return _testExecutionContext.WorkDirectory; }
+            get { return _testExecutionContext?.WorkDirectory ??
+#if PORTABLE
+                    @"\My Documents"; }
+#else
+                    Directory.GetCurrentDirectory(); }
+#endif
         }
 
         /// <summary>
@@ -165,9 +170,9 @@ namespace NUnit.Framework
             get { return _testExecutionContext.RandomGenerator; }
         }
 
-        #endregion
+#endregion
 
-        #region Static Methods
+#region Static Methods
 
         /// <summary>Write the string representation of a boolean value to the current result</summary>
         public static void Write(bool value) { Out.Write(value); }
@@ -297,9 +302,9 @@ namespace NUnit.Framework
             AddFormatter(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
         }
 
-        #endregion
+#endregion
 
-        #region Nested TestAdapter Class
+#region Nested TestAdapter Class
 
         /// <summary>
         /// TestAdapter adapts a Test for consumption by
@@ -309,7 +314,7 @@ namespace NUnit.Framework
         {
             private readonly Test _test;
 
-            #region Constructor
+#region Constructor
 
             /// <summary>
             /// Construct a TestAdapter for a Test
@@ -320,9 +325,9 @@ namespace NUnit.Framework
                 _test = test;
             }
 
-            #endregion
+#endregion
 
-            #region Properties
+#region Properties
 
             /// <summary>
             /// Gets the unique Id of a test
@@ -378,12 +383,12 @@ namespace NUnit.Framework
                 get { return _test.Properties; }
             }
 
-            #endregion
+#endregion
         }
 
-        #endregion
+#endregion
 
-        #region Nested ResultAdapter Class
+#region Nested ResultAdapter Class
 
         /// <summary>
         /// ResultAdapter adapts a TestResult for consumption by
@@ -393,7 +398,7 @@ namespace NUnit.Framework
         {
             private readonly TestResult _result;
 
-            #region Constructor
+#region Constructor
 
             /// <summary>
             /// Construct a ResultAdapter for a TestResult
@@ -404,9 +409,9 @@ namespace NUnit.Framework
                 _result = result;
             }
 
-            #endregion
+#endregion
 
-            #region Properties
+#region Properties
 
             /// <summary>
             /// Gets a ResultState representing the outcome of the test.
@@ -479,9 +484,9 @@ namespace NUnit.Framework
                 get { return _result.InconclusiveCount; }
             }
 
-            #endregion
+#endregion
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -828,18 +828,20 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessCurrentPrincipal()
         {
-            Assert.That(_fixtureContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Fixture");
-            Assert.That(_setupContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "SetUp");
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Test");
+            Type expectedType = Thread.CurrentPrincipal.GetType();
+            Assert.That(_fixtureContext.CurrentPrincipal, Is.TypeOf(expectedType), "Fixture");
+            Assert.That(_setupContext.CurrentPrincipal, Is.TypeOf(expectedType), "SetUp");
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "Test");
         }
 
 #if ASYNC
         [Test]
         public async Task CanAccessCurrentPrincipal_Async()
         {
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Before yield");
+            Type expectedType = Thread.CurrentPrincipal.GetType();
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "Before yield");
             await YieldAsync();
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "After yield");
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "After yield");
         }
 #endif
 

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -137,7 +137,25 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
-        #endregion
+#if !PORTABLE && !NETSTANDARD1_6
+        [Test]
+        public void CurrentContextFlowsToUserCreatedThread()
+        {
+            TestExecutionContext threadContext = null;
+
+            Thread thread = new Thread(() =>
+            {
+                threadContext = TestExecutionContext.CurrentContext;
+            });
+
+            thread.Start();
+            thread.Join();
+
+            Assert.That(threadContext, Is.Not.Null.And.SameAs(TestExecutionContext.CurrentContext));
+        }
+#endif
+
+#endregion
 
         #region CurrentTest
 

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -43,21 +43,23 @@ namespace NUnit.Framework.Internal
     [TestFixture][Property("Question", "Why?")]
     public class TestExecutionContextTests
     {
-        TestExecutionContext fixtureContext;
-        TestExecutionContext setupContext;
+        TestExecutionContext _fixtureContext;
+        TestExecutionContext _setupContext;
+        ResultState _fixtureResult;
 
 #if !PORTABLE && !NETSTANDARD1_6
         string originalDirectory;
         IPrincipal originalPrincipal;
 #endif
 
-        DateTime _fixtureStartTime = DateTime.UtcNow;
-        long _fixtureStartTicks = Stopwatch.GetTimestamp();
+        DateTime _fixtureCreateTime = DateTime.UtcNow;
+        long _fixtureCreateTicks = Stopwatch.GetTimestamp();
         
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            fixtureContext = TestExecutionContext.CurrentContext;
+            _fixtureContext = TestExecutionContext.CurrentContext;
+            _fixtureResult = _fixtureContext.CurrentResult.ResultState;
         }
 
         [OneTimeTearDown]
@@ -70,14 +72,14 @@ namespace NUnit.Framework.Internal
             Assert.That(ec.CurrentTest.Name, Is.EqualTo("TestExecutionContextTests"));
             Assert.That(ec.CurrentTest.FullName,
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests"));
-            Assert.That(fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
-            Assert.That(fixtureContext.CurrentTest.Properties.Get("Question"), Is.EqualTo("Why?"));
+            Assert.That(_fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
+            Assert.That(_fixtureContext.CurrentTest.Properties.Get("Question"), Is.EqualTo("Why?"));
         }
 
         [SetUp]
         public void Initialize()
         {
-            setupContext = TestExecutionContext.CurrentContext;
+            _setupContext = TestExecutionContext.CurrentContext;
 
 #if !PORTABLE && !NETSTANDARD1_6
             originalCulture = CultureInfo.CurrentCulture;
@@ -103,12 +105,12 @@ namespace NUnit.Framework.Internal
 
             Assert.That(
                 TestExecutionContext.CurrentContext.CurrentTest.FullName,
-                Is.EqualTo(setupContext.CurrentTest.FullName),
+                Is.EqualTo(_setupContext.CurrentTest.FullName),
                 "Context at TearDown failed to match that saved from SetUp");
 
             Assert.That(
                 TestExecutionContext.CurrentContext.CurrentResult.Name,
-                Is.EqualTo(setupContext.CurrentResult.Name),
+                Is.EqualTo(_setupContext.CurrentResult.Name),
                 "Cannot access CurrentResult in TearDown");
         }
 
@@ -142,65 +144,65 @@ namespace NUnit.Framework.Internal
         [Test]
         public void FixtureSetUpCanAccessFixtureName()
         {
-            Assert.That(fixtureContext.CurrentTest.Name, Is.EqualTo("TestExecutionContextTests"));
+            Assert.That(_fixtureContext.CurrentTest.Name, Is.EqualTo("TestExecutionContextTests"));
         }
 
         [Test]
         public void FixtureSetUpCanAccessFixtureFullName()
         {
-            Assert.That(fixtureContext.CurrentTest.FullName,
+            Assert.That(_fixtureContext.CurrentTest.FullName,
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests"));
         }
 
         [Test]
         public void FixtureSetUpHasNullMethodName()
         {
-            Assert.That(fixtureContext.CurrentTest.MethodName, Is.Null);
+            Assert.That(_fixtureContext.CurrentTest.MethodName, Is.Null);
         }
 
         [Test]
         public void FixtureSetUpCanAccessFixtureId()
         {
-            Assert.That(fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
+            Assert.That(_fixtureContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
         public void FixtureSetUpCanAccessFixtureProperties()
         {
-            Assert.That(fixtureContext.CurrentTest.Properties.Get("Question"), Is.EqualTo("Why?"));
+            Assert.That(_fixtureContext.CurrentTest.Properties.Get("Question"), Is.EqualTo("Why?"));
         }
 
         [Test]
         public void SetUpCanAccessTestName()
         {
-            Assert.That(setupContext.CurrentTest.Name, Is.EqualTo("SetUpCanAccessTestName"));
+            Assert.That(_setupContext.CurrentTest.Name, Is.EqualTo("SetUpCanAccessTestName"));
         }
 
         [Test]
         public void SetUpCanAccessTestFullName()
         {
-            Assert.That(setupContext.CurrentTest.FullName,
+            Assert.That(_setupContext.CurrentTest.FullName,
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests.SetUpCanAccessTestFullName"));
         }
 
         [Test]
         public void SetUpCanAccessTestMethodName()
         {
-            Assert.That(setupContext.CurrentTest.MethodName,
+            Assert.That(_setupContext.CurrentTest.MethodName,
                 Is.EqualTo("SetUpCanAccessTestMethodName"));
         }
 
         [Test]
         public void SetUpCanAccessTestId()
         {
-            Assert.That(setupContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
+            Assert.That(_setupContext.CurrentTest.Id, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
         [Property("Answer", 42)]
         public void SetUpCanAccessTestProperties()
         {
-            Assert.That(setupContext.CurrentTest.Properties.Get("Answer"), Is.EqualTo(42));
+            Assert.That(_setupContext.CurrentTest.Properties.Get("Answer"), Is.EqualTo(42));
         }
 
         [Test]
@@ -300,16 +302,16 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessResultName()
         {
-            Assert.That(fixtureContext.CurrentResult.Name, Is.EqualTo("TestExecutionContextTests"));
-            Assert.That(setupContext.CurrentResult.Name, Is.EqualTo("CanAccessResultName"));
+            Assert.That(_fixtureContext.CurrentResult.Name, Is.EqualTo("TestExecutionContextTests"));
+            Assert.That(_setupContext.CurrentResult.Name, Is.EqualTo("CanAccessResultName"));
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Name, Is.EqualTo("CanAccessResultName"));
         }
 
         [Test]
         public void CanAccessResultFullName()
         {
-            Assert.That(fixtureContext.CurrentResult.FullName, Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests"));
-            Assert.That(setupContext.CurrentResult.FullName, 
+            Assert.That(_fixtureContext.CurrentResult.FullName, Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests"));
+            Assert.That(_setupContext.CurrentResult.FullName, 
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests.CanAccessResultFullName"));
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.FullName, 
                 Is.EqualTo("NUnit.Framework.Internal.TestExecutionContextTests.CanAccessResultFullName"));
@@ -318,16 +320,17 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessResultTest()
         {
-            Assert.That(fixtureContext.CurrentResult.Test, Is.SameAs(fixtureContext.CurrentTest));
-            Assert.That(setupContext.CurrentResult.Test, Is.SameAs(setupContext.CurrentTest));
+            Assert.That(_fixtureContext.CurrentResult.Test, Is.SameAs(_fixtureContext.CurrentTest));
+            Assert.That(_setupContext.CurrentResult.Test, Is.SameAs(_setupContext.CurrentTest));
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Test, Is.SameAs(TestExecutionContext.CurrentContext.CurrentTest));
         }
 
         [Test]
         public void CanAccessResultState()
         {
-            Assert.That(fixtureContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Success));
-            Assert.That(setupContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
+            // This is copied in setup because it can change if any test fails
+            Assert.That(_fixtureResult, Is.EqualTo(ResultState.Success));
+            Assert.That(_setupContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
         }
 
@@ -376,9 +379,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessStartTime()
         {
-            Assert.That(fixtureContext.StartTime, Is.EqualTo(_fixtureStartTime).Within(1).Seconds);
-            Assert.That(setupContext.StartTime, Is.GreaterThanOrEqualTo(fixtureContext.StartTime));
-            Assert.That(TestExecutionContext.CurrentContext.StartTime, Is.GreaterThanOrEqualTo(setupContext.StartTime));
+            Assert.That(_fixtureContext.StartTime, Is.GreaterThan(DateTime.MinValue).And.LessThanOrEqualTo(_fixtureCreateTime));
+            Assert.That(_setupContext.StartTime, Is.GreaterThanOrEqualTo(_fixtureContext.StartTime));
+            Assert.That(TestExecutionContext.CurrentContext.StartTime, Is.GreaterThanOrEqualTo(_setupContext.StartTime));
         }
 
 #if ASYNC
@@ -386,7 +389,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessStartTime_Async()
         {
             var startTime = TestExecutionContext.CurrentContext.StartTime;
-            Assert.That(startTime, Is.GreaterThanOrEqualTo(setupContext.StartTime));
+            Assert.That(startTime, Is.GreaterThanOrEqualTo(_setupContext.StartTime));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.StartTime, Is.EqualTo(startTime));
         }
@@ -399,9 +402,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessStartTicks()
         {
-            Assert.That(fixtureContext.StartTicks, Is.EqualTo(_fixtureStartTicks).Within(Stopwatch.Frequency));
-            Assert.That(setupContext.StartTicks, Is.GreaterThanOrEqualTo(fixtureContext.StartTicks));
-            Assert.That(TestExecutionContext.CurrentContext.StartTicks, Is.GreaterThanOrEqualTo(setupContext.StartTicks));
+            Assert.That(_fixtureContext.StartTicks, Is.LessThanOrEqualTo(_fixtureCreateTicks));
+            Assert.That(_setupContext.StartTicks, Is.GreaterThanOrEqualTo(_fixtureContext.StartTicks));
+            Assert.That(TestExecutionContext.CurrentContext.StartTicks, Is.GreaterThanOrEqualTo(_setupContext.StartTicks));
         }
 
 #if ASYNC
@@ -409,7 +412,7 @@ namespace NUnit.Framework.Internal
         public async Task AsyncTestCanAccessStartTicks()
         {
             var startTicks = TestExecutionContext.CurrentContext.StartTicks;
-            Assert.That(startTicks, Is.GreaterThanOrEqualTo(setupContext.StartTicks));
+            Assert.That(startTicks, Is.GreaterThanOrEqualTo(_setupContext.StartTicks));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.StartTicks, Is.EqualTo(startTicks));
         }
@@ -422,9 +425,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessOutWriter()
         {
-            Assert.That(fixtureContext.OutWriter, Is.Not.Null);
-            Assert.That(setupContext.OutWriter, Is.Not.Null);
-            Assert.That(TestExecutionContext.CurrentContext.OutWriter, Is.SameAs(setupContext.OutWriter));
+            Assert.That(_fixtureContext.OutWriter, Is.Not.Null);
+            Assert.That(_setupContext.OutWriter, Is.Not.Null);
+            Assert.That(TestExecutionContext.CurrentContext.OutWriter, Is.SameAs(_setupContext.OutWriter));
         }
 
 #if ASYNC
@@ -432,7 +435,7 @@ namespace NUnit.Framework.Internal
         public async Task AsyncTestCanAccessOutWriter()
         {
             var outWriter = TestExecutionContext.CurrentContext.OutWriter;
-            Assert.That(outWriter, Is.SameAs(setupContext.OutWriter));
+            Assert.That(outWriter, Is.SameAs(_setupContext.OutWriter));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.OutWriter, Is.SameAs(outWriter));
         }
@@ -445,9 +448,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessTestObject()
         {
-            Assert.That(fixtureContext.TestObject, Is.Not.Null.And.TypeOf(GetType()));
-            Assert.That(setupContext.TestObject, Is.SameAs(fixtureContext.TestObject));
-            Assert.That(TestExecutionContext.CurrentContext.TestObject, Is.SameAs(setupContext.TestObject));
+            Assert.That(_fixtureContext.TestObject, Is.Not.Null.And.TypeOf(GetType()));
+            Assert.That(_setupContext.TestObject, Is.SameAs(_fixtureContext.TestObject));
+            Assert.That(TestExecutionContext.CurrentContext.TestObject, Is.SameAs(_setupContext.TestObject));
         }
 
 #if ASYNC
@@ -455,7 +458,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessTestObject_Async()
         {
             var testObject = TestExecutionContext.CurrentContext.TestObject;
-            Assert.That(testObject, Is.SameAs(setupContext.TestObject));
+            Assert.That(testObject, Is.SameAs(_setupContext.TestObject));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.TestObject, Is.SameAs(testObject));
         }
@@ -468,12 +471,12 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessWorkDirectory()
         {
-            Assert.NotNull(fixtureContext.WorkDirectory);
+            Assert.NotNull(_fixtureContext.WorkDirectory);
 #if !PORTABLE
-            DirectoryAssert.Exists(fixtureContext.WorkDirectory);
+            DirectoryAssert.Exists(_fixtureContext.WorkDirectory);
 #endif
-            Assert.That(setupContext.WorkDirectory, Is.EqualTo(fixtureContext.WorkDirectory));
-            Assert.That(TestExecutionContext.CurrentContext.WorkDirectory, Is.EqualTo(setupContext.WorkDirectory));
+            Assert.That(_setupContext.WorkDirectory, Is.EqualTo(_fixtureContext.WorkDirectory));
+            Assert.That(TestExecutionContext.CurrentContext.WorkDirectory, Is.EqualTo(_setupContext.WorkDirectory));
         }
 
 #if ASYNC
@@ -481,7 +484,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessWorkDirectory_Async()
         {
             var workDir = TestExecutionContext.CurrentContext.WorkDirectory;
-            Assert.That(workDir, Is.EqualTo(setupContext.WorkDirectory));
+            Assert.That(workDir, Is.EqualTo(_setupContext.WorkDirectory));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.WorkDirectory, Is.EqualTo(workDir));
         }
@@ -494,8 +497,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessStopOnError()
         {
-            Assert.That(setupContext.StopOnError, Is.EqualTo(fixtureContext.StopOnError));
-            Assert.That(TestExecutionContext.CurrentContext.StopOnError, Is.EqualTo(setupContext.StopOnError));
+            Assert.That(_setupContext.StopOnError, Is.EqualTo(_fixtureContext.StopOnError));
+            Assert.That(TestExecutionContext.CurrentContext.StopOnError, Is.EqualTo(_setupContext.StopOnError));
         }
 
 #if ASYNC
@@ -503,7 +506,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessStopOnError_Async()
         {
             var stop = TestExecutionContext.CurrentContext.StopOnError;
-            Assert.That(stop, Is.EqualTo(setupContext.StopOnError));
+            Assert.That(stop, Is.EqualTo(_setupContext.StopOnError));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.StopOnError, Is.EqualTo(stop));
         }
@@ -516,9 +519,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessListener()
         {
-            Assert.That(fixtureContext.Listener, Is.Not.Null);
-            Assert.That(setupContext.Listener, Is.SameAs(fixtureContext.Listener));
-            Assert.That(TestExecutionContext.CurrentContext.Listener, Is.SameAs(setupContext.Listener));
+            Assert.That(_fixtureContext.Listener, Is.Not.Null);
+            Assert.That(_setupContext.Listener, Is.SameAs(_fixtureContext.Listener));
+            Assert.That(TestExecutionContext.CurrentContext.Listener, Is.SameAs(_setupContext.Listener));
         }
 
 #if ASYNC
@@ -526,7 +529,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessListener_Async()
         {
             var listener = TestExecutionContext.CurrentContext.Listener;
-            Assert.That(listener, Is.SameAs(setupContext.Listener));
+            Assert.That(listener, Is.SameAs(_setupContext.Listener));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.Listener, Is.SameAs(listener));
         }
@@ -539,9 +542,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessDispatcher()
         {
-            Assert.That(fixtureContext.RandomGenerator, Is.Not.Null);
-            Assert.That(setupContext.Dispatcher, Is.SameAs(fixtureContext.Dispatcher));
-            Assert.That(TestExecutionContext.CurrentContext.Dispatcher, Is.SameAs(setupContext.Dispatcher));
+            Assert.That(_fixtureContext.RandomGenerator, Is.Not.Null);
+            Assert.That(_setupContext.Dispatcher, Is.SameAs(_fixtureContext.Dispatcher));
+            Assert.That(TestExecutionContext.CurrentContext.Dispatcher, Is.SameAs(_setupContext.Dispatcher));
         }
 
 #if ASYNC
@@ -549,7 +552,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessDispatcher_Async()
         {
             var dispatcher = TestExecutionContext.CurrentContext.Dispatcher;
-            Assert.That(dispatcher, Is.SameAs(setupContext.Dispatcher));
+            Assert.That(dispatcher, Is.SameAs(_setupContext.Dispatcher));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.Dispatcher, Is.SameAs(dispatcher));
         }
@@ -562,8 +565,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessParallelScope()
         {
-            var scope = fixtureContext.ParallelScope;
-            Assert.That(setupContext.ParallelScope, Is.EqualTo(scope));
+            var scope = _fixtureContext.ParallelScope;
+            Assert.That(_setupContext.ParallelScope, Is.EqualTo(scope));
             Assert.That(TestExecutionContext.CurrentContext.ParallelScope, Is.EqualTo(scope));
         }
 
@@ -572,7 +575,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessParallelScope_Async()
         {
             var scope = TestExecutionContext.CurrentContext.ParallelScope;
-            Assert.That(scope, Is.EqualTo(setupContext.ParallelScope));
+            Assert.That(scope, Is.EqualTo(_setupContext.ParallelScope));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.ParallelScope, Is.EqualTo(scope));
         }
@@ -586,9 +589,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessTestWorker()
         {
-            Assert.That(fixtureContext.TestWorker, Is.Not.Null);
-            Assert.That(setupContext.TestWorker, Is.SameAs(fixtureContext.TestWorker));
-            Assert.That(TestExecutionContext.CurrentContext.TestWorker, Is.SameAs(setupContext.TestWorker));
+            Assert.That(_fixtureContext.TestWorker, Is.Not.Null);
+            Assert.That(_setupContext.TestWorker, Is.SameAs(_fixtureContext.TestWorker));
+            Assert.That(TestExecutionContext.CurrentContext.TestWorker, Is.SameAs(_setupContext.TestWorker));
         }
 
 #if ASYNC
@@ -596,7 +599,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessTestWorker_Async()
         {
             var worker = TestExecutionContext.CurrentContext.TestWorker;
-            Assert.That(worker, Is.SameAs(setupContext.TestWorker));
+            Assert.That(worker, Is.SameAs(_setupContext.TestWorker));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.TestWorker, Is.SameAs(worker));
         }
@@ -610,9 +613,9 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessRandomGenerator()
         {
-            Assert.That(fixtureContext.RandomGenerator, Is.Not.Null);
-            Assert.That(setupContext.RandomGenerator, Is.Not.Null);
-            Assert.That(TestExecutionContext.CurrentContext.RandomGenerator, Is.SameAs(setupContext.RandomGenerator));
+            Assert.That(_fixtureContext.RandomGenerator, Is.Not.Null);
+            Assert.That(_setupContext.RandomGenerator, Is.Not.Null);
+            Assert.That(TestExecutionContext.CurrentContext.RandomGenerator, Is.SameAs(_setupContext.RandomGenerator));
         }
 
 #if ASYNC
@@ -620,7 +623,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessRandomGenerator_Async()
         {
             var random = TestExecutionContext.CurrentContext.RandomGenerator;
-            Assert.That(random, Is.SameAs(setupContext.RandomGenerator));
+            Assert.That(random, Is.SameAs(_setupContext.RandomGenerator));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.RandomGenerator, Is.SameAs(random));
         }
@@ -633,8 +636,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessAssertCount()
         {
-            Assert.That(fixtureContext.AssertCount, Is.EqualTo(0));
-            Assert.That(setupContext.AssertCount, Is.EqualTo(1));
+            Assert.That(_fixtureContext.AssertCount, Is.EqualTo(0));
+            Assert.That(_setupContext.AssertCount, Is.EqualTo(1));
             Assert.That(TestExecutionContext.CurrentContext.AssertCount, Is.EqualTo(2));
             Assert.That(2 + 2, Is.EqualTo(4));
             Assert.That(TestExecutionContext.CurrentContext.AssertCount, Is.EqualTo(4));
@@ -659,8 +662,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessMultipleAssertLevel()
         {
-            Assert.That(fixtureContext.MultipleAssertLevel, Is.EqualTo(0));
-            Assert.That(setupContext.MultipleAssertLevel, Is.EqualTo(0));
+            Assert.That(_fixtureContext.MultipleAssertLevel, Is.EqualTo(0));
+            Assert.That(_setupContext.MultipleAssertLevel, Is.EqualTo(0));
             Assert.That(TestExecutionContext.CurrentContext.MultipleAssertLevel, Is.EqualTo(0));
             Assert.Multiple(() =>
             {
@@ -689,8 +692,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessTestCaseTimeout()
         {
-            var timeout = fixtureContext.TestCaseTimeout;
-            Assert.That(setupContext.TestCaseTimeout, Is.EqualTo(timeout));
+            var timeout = _fixtureContext.TestCaseTimeout;
+            Assert.That(_setupContext.TestCaseTimeout, Is.EqualTo(timeout));
             Assert.That(TestExecutionContext.CurrentContext.TestCaseTimeout, Is.EqualTo(timeout));
         }
 
@@ -699,7 +702,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessTestCaseTimeout_Async()
         {
             var timeout = TestExecutionContext.CurrentContext.TestCaseTimeout;
-            Assert.That(timeout, Is.EqualTo(setupContext.TestCaseTimeout));
+            Assert.That(timeout, Is.EqualTo(_setupContext.TestCaseTimeout));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.TestCaseTimeout, Is.EqualTo(timeout));
         }
@@ -712,8 +715,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessUpstreamActions()
         {
-            var actions = fixtureContext.UpstreamActions;
-            Assert.That(setupContext.UpstreamActions, Is.EqualTo(actions));
+            var actions = _fixtureContext.UpstreamActions;
+            Assert.That(_setupContext.UpstreamActions, Is.EqualTo(actions));
             Assert.That(TestExecutionContext.CurrentContext.UpstreamActions, Is.EqualTo(actions));
         }
 
@@ -722,7 +725,7 @@ namespace NUnit.Framework.Internal
         public async Task CanAccessUpstreamAcxtions_Async()
         {
             var actions = TestExecutionContext.CurrentContext.UpstreamActions;
-            Assert.That(actions, Is.SameAs(setupContext.UpstreamActions));
+            Assert.That(actions, Is.SameAs(_setupContext.UpstreamActions));
             await YieldAsync();
             Assert.That(TestExecutionContext.CurrentContext.UpstreamActions, Is.SameAs(actions));
         }
@@ -739,16 +742,16 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessCurrentCulture()
         {
-            Assert.That(fixtureContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
-            Assert.That(setupContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
+            Assert.That(_fixtureContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
+            Assert.That(_setupContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
             Assert.That(TestExecutionContext.CurrentContext.CurrentCulture, Is.EqualTo(CultureInfo.CurrentCulture));
         }
 
         [Test]
         public void CanAccessCurrentUICulture()
         {
-            Assert.That(fixtureContext.CurrentUICulture, Is.EqualTo(CultureInfo.CurrentUICulture));
-            Assert.That(setupContext.CurrentUICulture, Is.EqualTo(CultureInfo.CurrentUICulture));
+            Assert.That(_fixtureContext.CurrentUICulture, Is.EqualTo(CultureInfo.CurrentUICulture));
+            Assert.That(_setupContext.CurrentUICulture, Is.EqualTo(CultureInfo.CurrentUICulture));
             Assert.That(TestExecutionContext.CurrentContext.CurrentUICulture, Is.EqualTo(CultureInfo.CurrentUICulture));
         }
 
@@ -773,7 +776,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void SetAndRestoreCurrentCulture()
         {
-            var context = new TestExecutionContext(setupContext);
+            var context = new TestExecutionContext(_setupContext);
 
             try
             {
@@ -782,21 +785,21 @@ namespace NUnit.Framework.Internal
                 context.CurrentCulture = otherCulture;
                 Assert.AreEqual(otherCulture, CultureInfo.CurrentCulture, "Culture was not set");
                 Assert.AreEqual(otherCulture, context.CurrentCulture, "Culture not in new context");
-                Assert.AreEqual(setupContext.CurrentCulture, originalCulture, "Original context should not change");
+                Assert.AreEqual(_setupContext.CurrentCulture, originalCulture, "Original context should not change");
             }
             finally
             {
-                setupContext.EstablishExecutionEnvironment();
+                _setupContext.EstablishExecutionEnvironment();
             }
 
             Assert.AreEqual(CultureInfo.CurrentCulture, originalCulture, "Culture was not restored");
-            Assert.AreEqual(setupContext.CurrentCulture, originalCulture, "Culture not in final context");
+            Assert.AreEqual(_setupContext.CurrentCulture, originalCulture, "Culture not in final context");
         }
 
         [Test]
         public void SetAndRestoreCurrentUICulture()
         {
-            var context = new TestExecutionContext(setupContext);
+            var context = new TestExecutionContext(_setupContext);
 
             try
             {
@@ -805,15 +808,15 @@ namespace NUnit.Framework.Internal
                 context.CurrentUICulture = otherCulture;
                 Assert.AreEqual(otherCulture, CultureInfo.CurrentUICulture, "UICulture was not set");
                 Assert.AreEqual(otherCulture, context.CurrentUICulture, "UICulture not in new context");
-                Assert.AreEqual(setupContext.CurrentUICulture, originalUICulture, "Original context should not change");
+                Assert.AreEqual(_setupContext.CurrentUICulture, originalUICulture, "Original context should not change");
             }
             finally
             {
-                setupContext.EstablishExecutionEnvironment();
+                _setupContext.EstablishExecutionEnvironment();
             }
 
             Assert.AreEqual(CultureInfo.CurrentUICulture, originalUICulture, "UICulture was not restored");
-            Assert.AreEqual(setupContext.CurrentUICulture, originalUICulture, "UICulture not in final context");
+            Assert.AreEqual(_setupContext.CurrentUICulture, originalUICulture, "UICulture not in final context");
         }
 #endif
 
@@ -825,25 +828,25 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessCurrentPrincipal()
         {
-            Assert.That(fixtureContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
-            Assert.That(setupContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+            Assert.That(_fixtureContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Fixture");
+            Assert.That(_setupContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "SetUp");
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Test");
         }
 
 #if ASYNC
         [Test]
         public async Task CanAccessCurrentPrincipal_Async()
         {
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Before yield");
             await YieldAsync();
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "After yield");
         }
 #endif
 
         [Test]
         public void SetAndRestoreCurrentPrincipal()
         {
-            var context = new TestExecutionContext(setupContext);
+            var context = new TestExecutionContext(_setupContext);
 
             try
             {
@@ -851,15 +854,15 @@ namespace NUnit.Framework.Internal
                 context.CurrentPrincipal = new GenericPrincipal(identity, new string[0]);
                 Assert.AreEqual("foo", Thread.CurrentPrincipal.Identity.Name, "Principal was not set");
                 Assert.AreEqual("foo", context.CurrentPrincipal.Identity.Name, "Principal not in new context");
-                Assert.AreEqual(setupContext.CurrentPrincipal, originalPrincipal, "Original context should not change");
+                Assert.AreEqual(_setupContext.CurrentPrincipal, originalPrincipal, "Original context should not change");
             }
             finally
             {
-                setupContext.EstablishExecutionEnvironment();
+                _setupContext.EstablishExecutionEnvironment();
             }
 
             Assert.AreEqual(Thread.CurrentPrincipal, originalPrincipal, "Principal was not restored");
-            Assert.AreEqual(setupContext.CurrentPrincipal, originalPrincipal, "Principal not in final context");
+            Assert.AreEqual(_setupContext.CurrentPrincipal, originalPrincipal, "Principal not in final context");
         }
 #endif
 
@@ -870,7 +873,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void SetAndRestoreValueFormatter()
         {
-            var context = new TestExecutionContext(setupContext);
+            var context = new TestExecutionContext(_setupContext);
             var originalFormatter = context.CurrentValueFormatter;
 
             try
@@ -884,7 +887,7 @@ namespace NUnit.Framework.Internal
             }
             finally
             {
-                setupContext.EstablishExecutionEnvironment();
+                _setupContext.EstablishExecutionEnvironment();
             }
 
             Assert.That(TestExecutionContext.CurrentContext.CurrentValueFormatter, Is.EqualTo(originalFormatter));


### PR DESCRIPTION
Fixes #2050 

Changes:
* As described in issue #2050, removed the "lazy" creation of TestExecution Context
* This caused five tests to fail, which I fixed.
* I eliminated the clearing of the current context before exiting the framework controller. This was needed at some point but I can't seem to make anything fail right now. Any ideas? We used to have tests for this in NUnit V2 so maybe I'll take a look at them and see if there's a way to make it fail. I don't want us to have code that used to be needed if it isn't needed any longer.

The travis build is not passing. Right now, it's not even succeeding in installing Mono. That may be a drawback of mono latest.