### PR TITLE
Timeout tests

### DIFF
--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -93,8 +93,8 @@ namespace NUnit.TestData
     public class TimeoutTestCaseFixture
     {
         const int TIME_OUT_TIME = 100;
-        const int NOT_TIMEOUTED_TIME = 50;
-        const int TIMEOUTED_TIME = 150;
+        const int NOT_TIMEOUTED_TIME = 10;
+        const int TIMEOUTED_TIME = 500;
 
         [Test]
         [Timeout(TIME_OUT_TIME)]

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -36,13 +36,13 @@ namespace NUnit.Framework.Attributes
     [NonParallelizable]
     public class TimeoutTests : ThreadingTests
     {
-        [Test, Timeout(50)]
+        [Test, Timeout(500)]
         public void TestWithTimeoutRunsOnSeparateThread()
         {
             Assert.That(Thread.CurrentThread, Is.Not.EqualTo(ParentThread));
         }
 
-        [Test, Timeout(50)]
+        [Test, Timeout(500)]
         public void TestWithTimeoutRunsSetUpAndTestOnSameThread()
         {
             Assert.That(Thread.CurrentThread, Is.EqualTo(SetupThread));


### PR DESCRIPTION
I increased some unnecessarily low limits that were causing failures on Linux. Since timeout relates to elapsed time, parallel execution requires bigger values.