### PR TITLE
Prevent NUnitlite runner from crushing when run with no file provided

### DIFF
--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -230,6 +230,11 @@ namespace NUnitLite
                     if (_testAssembly == null)
                         _testAssembly = AssemblyHelper.Load(testFile);
                 }
+                else
+                {
+                    _textUI.DisplayHelp();
+                    return TextRunner.OK;
+                }
 
 
                 if (_options.WaitBeforeExit && _options.OutFile != null)


### PR DESCRIPTION
This is the solution I was thinking of. When NUnit lite is sure there is absolutely no files to test it returns.

Fixes #2045 