### PR TITLE
Prevent NullReferenceException when getting members from type with no getter property

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -197,7 +197,7 @@ namespace NUnit.Compatibility
         {
             var pinfo = info as PropertyInfo;
             if (pinfo != null)
-                return pinfo.GetMethod.IsPrivate == false;
+                return pinfo.GetMethod?.IsPrivate == false;
 
             var finfo = info as FieldInfo;
             if (finfo != null)

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -279,6 +279,15 @@ namespace NUnit.Framework.Tests.Compatibility
             Assert.That(attr, Is.Not.Null);
         }
 #endif
+
+#if PORTABLE || NETSTANDARD1_6
+        [Test]
+        public void CanHandleNoGetterPropertyMember()
+        {
+            var result = typeof(NoGetterPropertyDerivedClass).GetMember("NoGetter", BindingFlags.Default);
+            Assert.That(result, Is.Not.Null);
+        }
+#endif
     }
 
     public class BaseTestClass : IDisposable
@@ -341,4 +350,16 @@ namespace NUnit.Framework.Tests.Compatibility
             PropertyTwo = two;
         }
     }
+
+
+#if PORTABLE || NETSTANDARD1_6
+    public class NoGetterPropertyBaseClass
+    {
+        public string NoGetter { set { } }
+    }
+
+    public class NoGetterPropertyDerivedClass : NoGetterPropertyBaseClass
+    {
+    }
+#endif
 }


### PR DESCRIPTION
Fixes #2052 

Adding a no getter property to `BaseTestClass` in `ReflectionExtensionsTests` fixture breaks all `DerivedTestClass` cases of `CanGetMember` test as well as `GetStaticMemberOnBaseClass` test. Because I think unit tests should be specialized and point exactly at what's wrong, I decided to add two test classes specifically for that purpose. What do you think about it?

By the way, in `ReflectionExtensionsTests` fixture there is a `CanGetStaticMethodsOnBase` test without Test, or TestCase attribute. When run it fails. Looks similar to `GetStaticMemberOnBaseClass`. The difference is member/method I think.