### PR TITLE
Make WorkDirectory available to TestCaseSource

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Security;
 using NUnit.Compatibility;
@@ -129,6 +130,16 @@ namespace NUnit.Framework.Api
             {
                 if (options.ContainsKey(FrameworkPackageSettings.DefaultTestNamePattern))
                     TestNameGenerator.DefaultTestNamePattern = options[FrameworkPackageSettings.DefaultTestNamePattern] as string;
+
+                if (options.ContainsKey(FrameworkPackageSettings.WorkDirectory))
+                    TestContext.DefaultWorkDirectory = options[FrameworkPackageSettings.WorkDirectory] as string;
+                else
+                    TestContext.DefaultWorkDirectory =
+#if PORTABLE
+                        @"\My Documents";
+#else
+                        Directory.GetCurrentDirectory();
+#endif
 
                 if (options.ContainsKey(FrameworkPackageSettings.TestParametersDictionary))
                 {

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -310,15 +310,6 @@ namespace NUnit.Framework.Api
             if (Settings.ContainsKey(FrameworkPackageSettings.StopOnError))
                 Context.StopOnError = (bool)Settings[FrameworkPackageSettings.StopOnError];
 
-            if (Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory))
-                Context.WorkDirectory = (string)Settings[FrameworkPackageSettings.WorkDirectory];
-            else
-#if PORTABLE
-                Context.WorkDirectory = @"\My Documents";
-#else
-                Context.WorkDirectory = Directory.GetCurrentDirectory();
-#endif
-
             // Apply attributes to the context
 
             // Set the listener - overriding runners may replace this

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -138,7 +138,6 @@ namespace NUnit.Framework.Internal
             CurrentTest = other.CurrentTest;
             CurrentResult = other.CurrentResult;
             TestObject = other.TestObject;
-            WorkDirectory = other.WorkDirectory;
             _listener = other._listener;
             StopOnError = other.StopOnError;
             TestCaseTimeout = other.TestCaseTimeout;
@@ -268,11 +267,6 @@ namespace NUnit.Framework.Internal
         /// object on which tests are being executed.
         /// </summary>
         public object TestObject { get; set; }
-
-        /// <summary>
-        /// Get or set the working directory
-        /// </summary>
-        public string WorkDirectory { get; set; }
 
         /// <summary>
         /// Get or set indicator that run should stop on the first error

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -95,6 +95,13 @@ namespace NUnit.Framework
         public static readonly TestParameters Parameters = new TestParameters();
 
         /// <summary>
+        /// Static DefaultWorkDirectory is now used as the source
+        /// of the public instance property WorkDirectory. This is
+        /// a bit odd but necessary to avoid breaking user tests.
+        /// </summary>
+        internal static string DefaultWorkDirectory;
+
+        /// <summary>
         /// Get a representation of the current test.
         /// </summary>
         public TestAdapter Test
@@ -151,12 +158,10 @@ namespace NUnit.Framework
         /// </summary>
         public string WorkDirectory
         {
-            get { return _testExecutionContext?.WorkDirectory ??
-#if PORTABLE
-                    @"\My Documents"; }
-#else
-                    Directory.GetCurrentDirectory(); }
-#endif
+            get
+            {
+                return DefaultWorkDirectory;
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -484,32 +484,6 @@ namespace NUnit.Framework.Internal
 
         #endregion
 
-        #region WorkDirectory
-
-        [Test]
-        public void CanAccessWorkDirectory()
-        {
-            Assert.NotNull(_fixtureContext.WorkDirectory);
-#if !PORTABLE
-            DirectoryAssert.Exists(_fixtureContext.WorkDirectory);
-#endif
-            Assert.That(_setupContext.WorkDirectory, Is.EqualTo(_fixtureContext.WorkDirectory));
-            Assert.That(TestExecutionContext.CurrentContext.WorkDirectory, Is.EqualTo(_setupContext.WorkDirectory));
-        }
-
-#if ASYNC
-        [Test]
-        public async Task CanAccessWorkDirectory_Async()
-        {
-            var workDir = TestExecutionContext.CurrentContext.WorkDirectory;
-            Assert.That(workDir, Is.EqualTo(_setupContext.WorkDirectory));
-            await YieldAsync();
-            Assert.That(TestExecutionContext.CurrentContext.WorkDirectory, Is.EqualTo(workDir));
-        }
-#endif
-
-        #endregion
-
         #region StopOnError
 
         [Test]


### PR DESCRIPTION
Fixes @2061

Rather than fix `TestExecutionContext.WorkDirectory`, which was actually only used to supply `TestContext.WorkDirectory`, I removed it entirely. `TestContext.WorkDirectory` now gets the directory from a static internal field, which is set when the assembly is loaded.

Ideally, `TestContext.WorkDirectory` would be a static field itself, but that would break existing test code so it remains an instance property but gets its value from the static property. 