### PR TITLE
Fix error message for invalid attributes in a single-threaded fixture

### DIFF
--- a/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
@@ -43,25 +43,19 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestWithTimeoutIsInvalid()
         {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeout>("Timeout");
+            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeout>("TimeoutAttribute may not be specified");
         }
 
         [Test]
         public void TestWithRequiresThreadIsInvalid()
         {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithRequiresThread>("RequiresThread");
-        }
-
-        [Test]
-        public void TestWithTimeoutAndRequiresThreadIsInvalid()
-        {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeoutAndRequiresThread>("RequiresThread", "Timeout");
+            CheckTestIsInvalid<SingleThreadedFixture_TestWithRequiresThread>("RequiresThreadAttribute may not be specified");
         }
 
         [Test]
         public void TestWithDifferentApartmentIsInvalid()
         {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithDifferentApartment>("DifferentApartment");
+            CheckTestIsInvalid<SingleThreadedFixture_TestWithDifferentApartment>("may not specify a different apartment");
         }
 
         [Test, Apartment(ApartmentState.MTA)]
@@ -71,30 +65,12 @@ namespace NUnit.Framework.Attributes
             Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
         }
 
-        [Test]
-        public void TestWithTimeoutAndDifferentApartmentIsInvalid()
-        {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeoutAndDifferentApartment>("Timeout", "DifferentApartment");
-        }
-        [Test]
-        public void TestWithRequiresTheadAndDifferentApartmentSTAIsInvalid()
-        {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithRequiresThreadAndDifferentApartment>("RequiresThread", "DifferentApartment");
-        }
-        [Test]
-        public void TestWithTimeoutRequiresThreadAndDifferentApartmentSTAIsInvalid()
-        {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeoutRequiresThreadAndDifferentApartment>("Timeout", "RequiresThread", "DifferentApartment");
-        }
-
-        private void CheckTestIsInvalid<TFixture>(params string[] reasons)
+        private void CheckTestIsInvalid<TFixture>(string reason)
         {
             var result = TestBuilder.RunTestFixture(typeof(TFixture));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure.WithSite(FailureSite.Child)));
             Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
-
-            foreach (string reason in reasons)
-                Assert.That(result.Children.ToArray()[0].Message, Does.Contain(reason));
+            Assert.That(result.Children.ToArray()[0].Message, Does.Contain(reason));
         }
     }
 


### PR DESCRIPTION
Fixes #2087

I implemented separate messages for Timeout, RequiredThread and different apartment. I simplified things by not trying to display a message for all errors, but only for the first one detected.

There is one remaining question, not addressed in this fix. It's possible to specify a timeout at a  higher level, rather than on the test, or even at the command line. Currently, this gives the same message in all cases. Options we could consider:

1. Silently ignore a timeout specified at a higher level or at the command-line when we are in a single threaded fixture. We could still give the error message if Timeout is actually specified on the test itself.

2. Treat the entire fixture as an error if a non-zero timeout attribute is specified on the fixture.

3. Treat the entire fixture as an error if a non-zero timeout is specified at a higher level or at the command line.

To my thinking, options 1 and 2 are reasonable, as is leaving it as it is now. Option 3 seems to me to be too intrusive since it prevents using a global timeout for other tests. 

As stated earlier, __allowing__ timeout on a single-threaded fixture is a bigger and separate issue.