### PR TITLE
Include type in start-suite/start-test report elements

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/ITest.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITest.cs
@@ -44,6 +44,11 @@ namespace NUnit.Framework.Interfaces
         string Name { get; }
 
         /// <summary>
+        /// Gets the type of the test
+        /// </summary>
+        string TestType { get; }
+
+        /// <summary>
         /// Gets the fully qualified name of the test
         /// </summary>
         string FullName { get; }

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -63,12 +63,13 @@ namespace NUnit.Framework.Internal
             try
             {
                 string report = string.Format(
-                    "<{0} id=\"{1}\" parentId=\"{2}\" name=\"{3}\" fullname=\"{4}\"/>",
+                    "<{0} id=\"{1}\" parentId=\"{2}\" name=\"{3}\" fullname=\"{4}\" type=\"{5}\"/>",
                     startElement,
                     test.Id,
                     parent != null ? parent.Id : string.Empty,
                     FormatAttributeValue(test.Name),
-                    FormatAttributeValue(test.FullName));
+                    FormatAttributeValue(test.FullName),
+                    test.TestType);
 
                 handler.RaiseCallbackEvent(report);
             }

--- a/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
@@ -1,0 +1,131 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.TestUtilities;
+using NUnit.TestData.TestFixtureTests;
+
+namespace NUnit.Framework.Internal.Tests
+{
+	public class TestProgressReporterTests
+	{
+		private ReportCollector _listener;
+		private TestProgressReporter _reporter;
+
+		[OneTimeSetUp]
+		public void SetupFixture()
+		{
+			_listener = new ReportCollector();
+			_reporter = new TestProgressReporter(_listener);
+		}
+
+		[SetUp]
+		public void Setup()
+		{
+			_listener.Reports.Clear();
+		}
+
+		[Test]
+		public void TestStarted_FixtureEmitsStartSuiteElement()
+		{
+			var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestFixtureAttribute));
+			var work = TestBuilder.PrepareWorkItem(fixture, null);
+			work.Context.Listener = _reporter;
+
+			TestBuilder.ExecuteWorkItem(work);
+
+			var startReport = _listener.Reports.FirstOrDefault();
+			Assert.NotNull(startReport);
+			StringAssert.StartsWith("<start-suite", startReport);
+		}
+
+		[Test]
+		public void TestStarted_TestMethodEmitsStartTestElement()
+		{
+			var test = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
+			var work = TestBuilder.PrepareWorkItem(test, null);
+			work.Context.Listener = _reporter;
+
+			TestBuilder.ExecuteWorkItem(work);
+
+			var startReport = _listener.Reports.FirstOrDefault();
+			Assert.NotNull(startReport);
+			StringAssert.StartsWith("<start-test", startReport);
+		}
+
+		[Test]
+		public void TestStarted_ReportAttributes()
+		{
+			var fixture = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
+			var work = TestBuilder.PrepareWorkItem(fixture, null);
+			work.Context.Listener = _reporter;
+
+			TestBuilder.ExecuteWorkItem(work);
+
+			var startReport = _listener.Reports.FirstOrDefault();
+			Assert.NotNull(startReport);
+			StringAssert.StartsWith("<start-test", startReport);
+			StringAssert.Contains($"id=\"{work.Test.Id}\"", startReport);
+			StringAssert.Contains($"parentId=\"{work.Test.Parent?.Id}\"", startReport);
+			StringAssert.Contains($"name=\"{work.Test.Name}\"", startReport);
+			StringAssert.Contains($"fullname=\"{work.Test.FullName}\"", startReport);
+			StringAssert.Contains($"type=\"{work.Test.TestType}\"", startReport);
+		}
+
+		[Test]
+		public void TestFinished_AdditionalReportAttributes()
+		{
+			var test = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
+			var work = TestBuilder.PrepareWorkItem(test, null);
+			work.Context.Listener = _reporter;
+
+			TestBuilder.ExecuteWorkItem(work);
+
+			var endReport = _listener.Reports.LastOrDefault();
+			Assert.NotNull(endReport);
+			StringAssert.DoesNotStartWith("<start", endReport);
+			StringAssert.Contains($"parentId=\"{work.Test.Parent?.Id}\"", endReport);
+		}
+
+		#region Nested ReportCollector Class
+
+		private class ReportCollector : System.Web.UI.ICallbackEventHandler
+		{
+			public List<string> Reports { get; } = new List<string>();
+
+			public void RaiseCallbackEvent(string report)
+			{
+				Reports.Add(report);
+			}
+
+			public string GetCallbackResult()
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		#endregion
+	}
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -257,6 +257,7 @@
     </Compile>
     <Compile Include="Internal\TestFixtureTests.cs" />
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -255,6 +255,7 @@
     </Compile>
     <Compile Include="Internal\TestFixtureTests.cs" />
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Internal\TestMethodSignatureTests.cs" />
     <Compile Include="Internal\TestNameGeneratorTests.cs" />
     <Compile Include="Internal\TestNamingTests.cs" />
+    <Compile Include="Internal\TestProgressReporterTests.cs" />
     <Compile Include="Internal\TestWorkerTests.cs" />
     <Compile Include="Internal\TestXmlTests.cs" />
     <Compile Include="Internal\TextMessageWriterTests.cs" />


### PR DESCRIPTION
It would really help me if `start-suite`/`start-test` reports emitted by the TestProgressReporter included the `TestType`.

This seems to do the trick, but I'm wondering if I'm missing some reason that `TestType` isn't already part of `ITest`?