### PR TITLE
Handle test timeout without running tests on their own thread

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -31,8 +31,9 @@ namespace NUnit.Framework.Internal.Commands
     using Interfaces;
 
     /// <summary>
-    /// SetUpTearDownCommand runs SetUp methods for a suite,
-    /// runs the test and then runs TearDown methods.
+    /// TimeoutCommand creates a timer in order to cancel
+    /// a test if it exceeds a specified time and adjusts
+    /// the test result if it did time out.
     /// </summary>
     public class TimeoutCommand : BeforeAndAfterTestCommand
     {
@@ -40,14 +41,14 @@ namespace NUnit.Framework.Internal.Commands
         private bool _commandTimedOut = false;
         
         /// <summary>
-        /// Initializes a new instance of the <see cref="SetUpTearDownCommand"/> class.
+        /// Initializes a new instance of the <see cref="TimeoutCommand"/> class.
         /// </summary>
         /// <param name="innerCommand">The inner command</param>
         /// <param name="timeout">Timeout value</param>
         public TimeoutCommand(TestCommand innerCommand, int timeout)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestMethod, "SetUpTearDownCommand may only apply to a TestMethod", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestMethod, "TimeoutCommand may only apply to a TestMethod", "innerCommand");
             Guard.ArgumentValid(timeout > 0, "Timeout value must be greater than zero", "timeout");
 
             BeforeTest = (context) =>

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -1,0 +1,83 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace NUnit.Framework.Internal.Commands
+{
+    using Execution;
+    using Interfaces;
+
+    /// <summary>
+    /// SetUpTearDownCommand runs SetUp methods for a suite,
+    /// runs the test and then runs TearDown methods.
+    /// </summary>
+    public class TimeoutCommand : BeforeAndAfterTestCommand
+    {
+        Timer _commandTimer;
+        private bool _commandTimedOut = false;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetUpTearDownCommand"/> class.
+        /// </summary>
+        /// <param name="innerCommand">The inner command</param>
+        /// <param name="timeout">Timeout value</param>
+        public TimeoutCommand(TestCommand innerCommand, int timeout)
+            : base(innerCommand)
+        {
+            Guard.ArgumentValid(innerCommand.Test is TestMethod, "SetUpTearDownCommand may only apply to a TestMethod", "innerCommand");
+            Guard.ArgumentValid(timeout > 0, "Timeout value must be greater than zero", "timeout");
+
+            BeforeTest = (context) =>
+            {
+                var testThread = Thread.CurrentThread;
+
+                // Create a timer to cancel the current thread
+                _commandTimer = new Timer(
+                    (o) =>
+                    {
+                        _commandTimedOut = true;
+                        testThread.Abort();
+                        // No join here, since the thread doesn't really terminate
+                    },
+                    null,
+                    timeout,
+                    Timeout.Infinite);
+            };
+
+            AfterTest = (context) =>
+            {
+                _commandTimer.Dispose();
+
+                // If the timer cancelled the current thread, change the result
+                if (_commandTimedOut)
+                {
+                    context.CurrentResult.SetResult(ResultState.Failure,
+                        string.Format("Test exceeded Timeout value of {0}ms", timeout));
+                }
+            };
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -236,10 +236,8 @@ namespace NUnit.Framework.Internal.Execution
                     return;
                 }
 
-#if DEBUG
                 log.Debug("Running on separate thread because {0} is specified.", 
                     Test.RequiresThread ? "RequiresThread" : "different Apartment");
-#endif
 
                 RunOnSeparateThread(targetApartment);
             }

--- a/src/NUnitFramework/framework/Internal/TestCaseTimeoutException.cs
+++ b/src/NUnitFramework/framework/Internal/TestCaseTimeoutException.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework.Internal
+{
+    using System;
+#if !NETSTANDARD1_6
+    using System.Runtime.Serialization;
+#endif
+
+    /// <summary>
+    /// TestCaseTimeoutException is thrown when a test running directly
+    /// on a TestWorker thread is cancelled due to timeout.
+    /// </summary>
+#if !PORTABLE && !NETSTANDARD1_6
+    [Serializable]
+#endif
+    public class TestCaseTimeoutException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCaseTimeoutException"/> class.
+        /// </summary>
+        public TestCaseTimeoutException() : base() {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCaseTimeoutException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public TestCaseTimeoutException(string message) : base(message)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCaseTimeoutException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public TestCaseTimeoutException(string message, Exception inner) : base(message, inner)
+        { }
+
+#if !PORTABLE && !NETSTANDARD1_6
+        /// <summary>
+        /// Serialization Constructor
+        /// </summary>
+        protected TestCaseTimeoutException(SerializationInfo info,
+            StreamingContext context) : base(info,context){}
+#endif
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Internal\Commands\ConstructFixtureCommand.cs" />
     <Compile Include="Internal\Commands\EmptyTestCommand.cs" />
     <Compile Include="Internal\Commands\DisposeFixtureCommand.cs" />
+    <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
@@ -156,6 +157,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Internal\ParameterWrapper.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\TestNameGenerator.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="TestFixtureData.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Internal\Commands\ConstructFixtureCommand.cs" />
     <Compile Include="Internal\Commands\DisposeFixtureCommand.cs" />
     <Compile Include="Internal\Commands\EmptyTestCommand.cs" />
+    <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
@@ -155,6 +156,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Internal\ParameterWrapper.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\TestNameGenerator.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
     <Compile Include="TestFixtureData.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -326,6 +326,7 @@
     <Compile Include="Internal\Commands\TestCommand.cs" />
     <Compile Include="Internal\Commands\TestMethodCommand.cs" />
     <Compile Include="Internal\Commands\TheoryResultCommand.cs" />
+    <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\CultureDetector.cs" />
     <Compile Include="Internal\ExceptionHelper.cs" />
     <Compile Include="Internal\Execution\CompositeWorkItem.cs" />
@@ -379,6 +380,7 @@
     <Compile Include="Internal\StackFilter.cs" />
     <Compile Include="Internal\StringUtil.cs" />
     <Compile Include="Internal\TestCaseParameters.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\TestExecutionContext.cs" />
     <Compile Include="Internal\TestExecutionStatus.cs" />
     <Compile Include="Internal\TestFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -98,6 +98,8 @@
     <Compile Include="Internal\Commands\BeforeTestActionCommand.cs" />
     <Compile Include="Internal\Commands\BeforeAndAfterTestCommand.cs" />
     <Compile Include="Internal\Commands\ConstructFixtureCommand.cs" />
+    <Compile Include="Internal\Commands\TimeoutCommand.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Warn.cs" />
     <Compile Include="Assume.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Internal\StackFilter.cs" />
     <Compile Include="Internal\StringUtil.cs" />
     <Compile Include="Internal\TestCaseParameters.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\TestExecutionContext.cs" />
     <Compile Include="Internal\TestExecutionStatus.cs" />
     <Compile Include="Internal\TestFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-portable.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-portable.csproj
@@ -385,6 +385,7 @@
     <Compile Include="Internal\StackFilter.cs" />
     <Compile Include="Internal\StringUtil.cs" />
     <Compile Include="Internal\TestCaseParameters.cs" />
+    <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\TestExecutionContext.cs" />
     <Compile Include="Internal\TestExecutionStatus.cs" />
     <Compile Include="Internal\TestFilter.cs" />

--- a/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2009 Charlie Poole
+// Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -40,10 +40,10 @@ namespace NUnit.Framework.Attributes
             Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
 
-        [Test]
-        public void TestWithTimeoutIsInvalid()
+        [Test, Timeout(100)]
+        public void TestWithTimeoutIsValid()
         {
-            CheckTestIsInvalid<SingleThreadedFixture_TestWithTimeout>("TimeoutAttribute may not be specified");
+            Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Attributes
     public class TimeoutTests : ThreadingTests
     {
         [Test, Timeout(500)]
-        public void TestWithTimeoutRunsOnSeparateThread()
+        public void TestWithTimeoutRunsOnSameThread()//SeparateThread()
         {
-            Assert.That(Thread.CurrentThread, Is.Not.EqualTo(ParentThread));
+            Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
 
         [Test, Timeout(500)]
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void TestTimeOutNotElapsed()
+        public void TestTimeoutNotElapsed()
         {
             TimeoutTestCaseFixture fixture = new TimeoutTestCaseFixture();
             TestSuite suite = TestBuilder.MakeFixture(fixture);
@@ -109,8 +109,9 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTest(testMethod, fixture);
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
         }
+
         [Test]
-        public void TestTimeOutElapsed()
+        public void TestTimeoutElapsed()
         {
             TimeoutTestCaseFixture fixture = new TimeoutTestCaseFixture();
             TestSuite suite = TestBuilder.MakeFixture(fixture);
@@ -120,19 +121,41 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.Message, Does.Contain("100ms"));
         }
 
-        // TODO: The test in TimeoutTestCaseFixture work as expected when run
-        // directly by NUnit. It's only when run via TestBuilder as a second
-        // level test that the result is incorrect. We need to fix this.
-        [Test, Explicit("Timing issue")]
-        public void TestTimeOutTestCaseWithOutElapsed()
+        [Explicit("Tests that demonstrate Timeout failure")]
+        public class ExplicitTests
         {
-            TimeoutTestCaseFixture fixture = new TimeoutTestCaseFixture();
-            TestSuite suite = TestBuilder.MakeFixture(fixture);
-            ParameterizedMethodSuite testMethod = (ParameterizedMethodSuite)TestFinder.Find("TestTimeOutTestCase", suite, false);
-            ITestResult result = TestBuilder.RunTest(testMethod, fixture);
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure), "Suite result");
-            Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.Success), "First test");
-            Assert.That(result.Children.ToArray()[1].ResultState, Is.EqualTo(ResultState.Failure), "Second test");
+            [Test, Timeout(50)]
+            public void TestTimesOut()
+            {
+                while (true) ;
+            }
+
+            [Test, Timeout(50), RequiresThread]
+            public void TestTimesOutUsingRequiresThread()
+            {
+                while (true) ;
+            }
+
+            [Test, Timeout(50), Apartment(ApartmentState.STA)]
+            public void TestTimesOutInSTA()
+            {
+                while (true) ;
+            }
+
+            // TODO: The test in TimeoutTestCaseFixture work as expected when run
+            // directly by NUnit. It's only when run via TestBuilder as a second
+            // level test that the result is incorrect. We need to fix this.
+            [Test]
+            public void TestTimeOutTestCaseWithOutElapsed()
+            {
+                TimeoutTestCaseFixture fixture = new TimeoutTestCaseFixture();
+                TestSuite suite = TestBuilder.MakeFixture(fixture);
+                ParameterizedMethodSuite methodSuite = (ParameterizedMethodSuite)TestFinder.Find("TestTimeOutTestCase", suite, false);
+                ITestResult result = TestBuilder.RunTest(methodSuite, fixture);
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure), "Suite result");
+                Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.Success), "First test");
+                Assert.That(result.Children.ToArray()[1].ResultState, Is.EqualTo(ResultState.Failure), "Second test");
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Attributes
     public class TimeoutTests : ThreadingTests
     {
         [Test, Timeout(500)]
-        public void TestWithTimeoutRunsOnSameThread()//SeparateThread()
+        public void TestWithTimeoutRunsOnSameThread()
         {
             Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -581,9 +581,12 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessTestWorker()
         {
-            Assert.That(_fixtureContext.TestWorker, Is.Not.Null);
-            Assert.That(_setupContext.TestWorker, Is.SameAs(_fixtureContext.TestWorker));
-            Assert.That(TestExecutionContext.CurrentContext.TestWorker, Is.SameAs(_setupContext.TestWorker));
+            if (TestExecutionContext.CurrentContext.Dispatcher is ParallelWorkItemDispatcher)
+            {
+                Assert.That(_fixtureContext.TestWorker, Is.Not.Null);
+                Assert.That(_setupContext.TestWorker, Is.SameAs(_fixtureContext.TestWorker));
+                Assert.That(TestExecutionContext.CurrentContext.TestWorker, Is.SameAs(_setupContext.TestWorker));
+            }
         }
 
 #if ASYNC


### PR DESCRIPTION
FIxes #1363

This fixes a long-standing issue around the handling of timeouts in NUnit.

Old approach:
* Test methods with a timeout were run on a separate thread. 
* A join with a time limit specified was used to synchronize the completion of the test.
* If the test timed out, the test thread was killed and a timeout failure reported.

Issues:
* Old code was very complex
* The WorkItem was involved in determining the result of the test, which is not the normal division of labor in NUnit
* It was impossible to have a Timeout on any method in a SingleThreaded fixture.

New Approach:
* Timeouts are now handled in the Command hierarchy rather than the WorkItem.
* A TimeoutCommand is added whenever a timeout is specified for the test
* A TImer is used to cancel the test if it exceeds the time limit.