### PR TITLE
Allow failure on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ os:
 matrix:
   allow_failures:
     - mono: latest
+    - os: osx
   fast_finish: true
 script:
   - ./build.sh --target "Travis"


### PR DESCRIPTION
We haven't had a successful run for two days. Even before that, I found myself restarting the osx build several times before it somehow, magically worked. 

I'm for moving osx to the allowed failures, at least for now.