### PR TITLE
CollectionAssert changes

### DIFF
--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -170,7 +170,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void AreEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args) 
         {
-            Assert.That(actual, Is.EqualTo(expected), message, args);
+            Assert.That(actual, Is.EqualTo(expected).AsCollection, message, args);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void AreNotEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args) 
         {
-            Assert.That(actual, Is.Not.EqualTo(expected), message, args);
+            Assert.That(actual, Is.Not.EqualTo(expected).AsCollection, message, args);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -231,11 +231,14 @@ namespace NUnit.Framework.Constraints
                     return ((TimeSpan)x - (TimeSpan)y).Duration() <= amount;
             }
 
-            MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
-            if (equals != null)
-                return InvokeFirstIEquatableEqualsSecond(x, y, equals);
-            if (xType != yType && (equals = FirstImplementsIEquatableOfSecond(yType, xType)) != null)
-                return InvokeFirstIEquatableEqualsSecond(y, x, equals);
+            if (!compareAsCollection)
+            {
+                MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
+                if (equals != null)
+                    return InvokeFirstIEquatableEqualsSecond(x, y, equals);
+                if (xType != yType && (equals = FirstImplementsIEquatableOfSecond(yType, xType)) != null)
+                    return InvokeFirstIEquatableEqualsSecond(y, x, equals);
+            }
 
             if (x is IEnumerable && y is IEnumerable)
                 return EnumerablesEqual((IEnumerable) x, (IEnumerable) y, ref tolerance);

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class StackFilter
     {
-        private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.Ass(ert|ume)\.";
+        private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.(Assert|Assume|Warn|CollectionAssert|StringAssert|FileAssert|DirectoryAssert)\.";
         private const string DEFAULT_BOTTOM_OF_STACK_PATTERN = @" System\.R(eflection|untimeMethodHandle)\.";
 
         /// <summary>

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -133,8 +133,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AreEqual()
         {
-            var set1 = new SimpleObjectCollection("x", "y", "z");
-            var set2 = new SimpleObjectCollection("x", "y", "z");
+            var set1 = new SimpleEnumerable("x", "y", "z");
+            var set2 = new SimpleEnumerable("x", "y", "z");
 
             CollectionAssert.AreEqual(set1,set2);
             CollectionAssert.AreEqual(set1,set2,new TestComparer());
@@ -251,7 +251,22 @@ namespace NUnit.Framework.Assertions
                                     Contains("But was:  2"));
         }
 #endif
-        
+
+        [Test]
+        public void AreEqual_IEquatableImplementationIsIgnored()
+        {
+            var x = new Constraints.EquatableWithEnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 42);
+            var y = new Constraints.EnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 15);
+
+            // They are not equal using Assert
+            Assert.AreNotEqual(x, y, "Assert 1");
+            Assert.AreNotEqual(y, x, "Assert 2");
+
+            // Using CollectionAssert they are equal
+            CollectionAssert.AreEqual(x, y, "CollectionAssert 1");
+            CollectionAssert.AreEqual(y, x, "CollectionAssert 2");
+        }
+
         #endregion
 
         #region AreEquivalent
@@ -341,6 +356,21 @@ namespace NUnit.Framework.Assertions
 
             CollectionAssert.AreNotEqual(set1,set2);
             CollectionAssert.AreNotEqual(set1,set2,new TestComparer());
+        }
+
+        [Test]
+        public void AreNotEqual_IEquatableImplementationIsIgnored()
+        {
+            var x = new Constraints.EquatableWithEnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 42);
+            var y = new Constraints.EnumerableObject<int>(new[] { 5, 4, 3, 2, 1 }, 42);
+
+            // Equal using Assert
+            Assert.AreEqual(x, y, "Assert 1");
+            Assert.AreEqual(y, x, "Assert 2");
+
+            // Not equal using CollectionAssert
+            CollectionAssert.AreNotEqual(x, y, "CollectionAssert 1");
+            CollectionAssert.AreNotEqual(y, x, "CollectionAssert 2");
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -201,6 +201,26 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void IEquatableIsIgnoredAndEnumerableEqualsUsedWithAsCollection()
+        {
+            comparer.CompareAsCollection = true;
+
+            var x = new EquatableWithEnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 42);
+            var y = new EnumerableObject<int>(new[] { 5, 4, 3, 2, 1 }, 42);
+            var z = new EnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 15);
+
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
+            Assert.That(comparer.AreEqual(y, x, ref tolerance), Is.False);
+            Assert.That(comparer.AreEqual(x, z, ref tolerance), Is.True);
+            Assert.That(comparer.AreEqual(z, x, ref tolerance), Is.True);
+
+            Assert.That(y, Is.Not.EqualTo(x).AsCollection);
+            Assert.That(x, Is.Not.EqualTo(y).AsCollection);
+            Assert.That(z, Is.EqualTo(x).AsCollection);
+            Assert.That(x, Is.EqualTo(z).AsCollection);
+        }
+
+        [Test]
         public void InheritingAndOverridingIEquatable()
         {
             var obj1 = new InheritingEquatableObject { SomeProperty = 1, OtherProperty = 2 };


### PR DESCRIPTION
Fixes #2097 

The modifier `EqualTest.AsCollection` has two (compatible) effects now:

1. Treating a multi-dimensioned array as a straight collection of elements (the original effect)l.
2. Forcing equality testing to apply to the contained members, ignoring any IEquatable implementation.

I also noticed and fixed a problem with how we filter the stack display. CollectionAssert entries on top of the stack were not being skipped. I added the class to the filter, along with Warn, FIleAssert, DirectoryAssert and StringAssert.

I left the location and naming of various auxiliary collection classes used in testing as they are. We may want to refactor this at some point to move them all to TestUtilities and standardize the naming.
