### PR TITLE
Implement tolerance for comparison constraints

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -54,15 +54,15 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Initializes a new instance of the <see cref="ComparisonConstraint"/> class.
         /// </summary>
-        /// <param name="value">The value against which to make a comparison.</param>
-        protected ComparisonConstraint(object value) : base(value)
+        /// <param name="expected">The value against which to make a comparison.</param>
+        protected ComparisonConstraint(object expected) : base(expected)
         {
-            _expected = value;
+            _expected = expected;
         }
 
         #endregion
 
-        #region Apply Constraint
+        #region Overrides
 
         /// <summary>
         /// Test whether the constraint is satisfied by a given value   
@@ -126,10 +126,30 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Set the tolerance for use in this comparison
         /// </summary>
-        public ComparisonConstraint Within(object tol)
+        public ComparisonConstraint Within(object amount)
         {
-            _tolerance = new Tolerance(tol);
+            if (!_tolerance.IsUnsetOrDefault)
+                throw new InvalidOperationException("Within modifier may appear only once in a constraint expression");
+
+            _tolerance = new Tolerance(amount);
+            Description += " within " + MsgUtils.FormatValue(amount);
             return this;
+        }
+
+        /// <summary>
+        /// Switches the .Within() modifier to interpret its tolerance as
+        /// a percentage that the actual _values is allowed to deviate from
+        /// the expected value.
+        /// </summary>
+        /// <returns>Self</returns>
+        public ComparisonConstraint Percent
+        {
+            get
+            {
+                _tolerance = _tolerance.Percent;
+                Description += " percent";
+                return this;
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -57,6 +57,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The value against which to make a comparison.</param>
         protected ComparisonConstraint(object expected) : base(expected)
         {
+            Guard.ArgumentValid(expected != null, "Cannot compare using a null reference.", nameof(_expected));
             _expected = expected;
         }
 
@@ -71,20 +72,15 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            Guard.ArgumentValid(_expected != null, "Cannot compare using a null reference.", nameof(_expected));
             Guard.ArgumentValid(actual != null, "Cannot compare to a null reference.", nameof(actual));
-            Guard.OperationValid(IsSuccess != null, "Internal Error: Derived class didn't set IsSuccess.");
 
-            if (!_tolerance.IsUnsetOrDefault && new NUnitEqualityComparer().AreEqual(_expected, actual, ref _tolerance))
-                return new ConstraintResult(this, actual, true);
-
-            return new ConstraintResult(this, actual, IsSuccess(_comparer.Compare(actual, _expected)));
+            return new ConstraintResult(this, actual, PerformComparison(_comparer, actual, _expected, _tolerance));
         }
 
         /// <summary>
-        /// Protected function assigned by derived class to evaluate comparison result
+        /// Protected function overridden by derived class to actually perform the comparison
         /// </summary>
-        protected Func<int, bool> IsSuccess;
+        protected abstract bool PerformComparison(ComparisonAdapter comparer, object actual, object expected, Tolerance tolerance);
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -40,6 +40,11 @@ namespace NUnit.Framework.Constraints
         private object _expected;
 
         /// <summary>
+        /// Tolerance used in making the comparison
+        /// </summary>
+        private Tolerance _tolerance = Tolerance.Default;
+
+        /// <summary>
         /// ComparisonAdapter to be used in making the comparison
         /// </summary>
         private ComparisonAdapter _comparer = ComparisonAdapter.Default;
@@ -69,6 +74,9 @@ namespace NUnit.Framework.Constraints
             Guard.ArgumentValid(_expected != null, "Cannot compare using a null reference.", nameof(_expected));
             Guard.ArgumentValid(actual != null, "Cannot compare to a null reference.", nameof(actual));
             Guard.OperationValid(IsSuccess != null, "Internal Error: Derived class didn't set IsSuccess.");
+
+            if (!_tolerance.IsUnsetOrDefault && new NUnitEqualityComparer().AreEqual(_expected, actual, ref _tolerance))
+                return new ConstraintResult(this, actual, true);
 
             return new ConstraintResult(this, actual, IsSuccess(_comparer.Compare(actual, _expected)));
         }
@@ -112,6 +120,15 @@ namespace NUnit.Framework.Constraints
         public ComparisonConstraint Using<T>(Comparison<T> comparer)
         {
             this._comparer = ComparisonAdapter.For(comparer);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the tolerance for use in this comparison
+        /// </summary>
+        public ComparisonConstraint Within(object tol)
+        {
+            _tolerance = new Tolerance(tol);
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -383,7 +383,7 @@ namespace NUnit.Framework.Constraints
                 if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
                 {
                     sb.Append(" +/- ");
-                    sb.Append(MsgUtils.FormatValue(_tolerance.Value));
+                    sb.Append(MsgUtils.FormatValue(_tolerance.Amount));
                     if (_tolerance.Mode != ToleranceMode.Linear)
                     {
                         sb.Append(" ");

--- a/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
@@ -36,8 +36,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public GreaterThanConstraint(object expected) : base(expected)
         {
-            Description = "greater than " + MsgUtils.FormatValue(expected);
             IsSuccess = (comp) => comp > 0;
+            Description = "greater than " + MsgUtils.FormatValue(expected);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -32,6 +34,10 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="GreaterThanConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
-        public GreaterThanConstraint(object expected) : base(expected, false, false, true, "greater than") { }
+        public GreaterThanConstraint(object expected) : base(expected)
+        {
+            Description = "greater than " + MsgUtils.FormatValue(expected);
+            IsSuccess = (comp) => comp > 0;
+        }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanConstraint.cs
@@ -36,8 +36,15 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public GreaterThanConstraint(object expected) : base(expected)
         {
-            IsSuccess = (comp) => comp > 0;
             Description = "greater than " + MsgUtils.FormatValue(expected);
+        }
+
+        /// <summary>
+        /// Perform the comparison
+        /// </summary>
+        protected override bool PerformComparison(ComparisonAdapter comparer, object actual, object expected, Tolerance tolerance)
+        {
+            return comparer.Compare(actual, tolerance.ApplyToValue(expected).LowerBound) > 0;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
@@ -34,8 +34,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public GreaterThanOrEqualConstraint(object expected) : base(expected)
         {
-            Description = "greater than or equal to " + MsgUtils.FormatValue(expected);
             IsSuccess = (comp) => comp >= 0;
+            Description = "greater than or equal to " + MsgUtils.FormatValue(expected);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
@@ -34,8 +34,15 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public GreaterThanOrEqualConstraint(object expected) : base(expected)
         {
-            IsSuccess = (comp) => comp >= 0;
             Description = "greater than or equal to " + MsgUtils.FormatValue(expected);
+        }
+
+        /// <summary>
+        /// Perform the comparison
+        /// </summary>
+        protected override bool PerformComparison(ComparisonAdapter comparer, object actual, object expected, Tolerance tolerance)
+        {
+            return comparer.Compare(actual, tolerance.ApplyToValue(expected).LowerBound) >= 0;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/GreaterThanOrEqualConstraint.cs
@@ -32,6 +32,10 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="GreaterThanOrEqualConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
-        public GreaterThanOrEqualConstraint(object expected) : base(expected, false, true, true, "greater than or equal to") { }
+        public GreaterThanOrEqualConstraint(object expected) : base(expected)
+        {
+            Description = "greater than or equal to " + MsgUtils.FormatValue(expected);
+            IsSuccess = (comp) => comp >= 0;
+        }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
@@ -34,8 +34,15 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public LessThanConstraint(object expected) : base(expected)
         {
-            IsSuccess = (comp) => comp < 0;
             Description = "less than " + MsgUtils.FormatValue(expected);
+        }
+
+        /// <summary>
+        /// Perform the comparison
+        /// </summary>
+        protected override bool PerformComparison(ComparisonAdapter comparer, object actual, object expected, Tolerance tolerance)
+        {
+            return comparer.Compare(actual, tolerance.ApplyToValue(expected).UpperBound) < 0;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
@@ -32,6 +32,10 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="LessThanConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
-        public LessThanConstraint(object expected) : base(expected, true, false, false, "less than") { }
+        public LessThanConstraint(object expected) : base(expected)
+        {
+            Description = "less than " + MsgUtils.FormatValue(expected);
+            IsSuccess = (comp) => comp < 0;
+        }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanConstraint.cs
@@ -34,8 +34,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public LessThanConstraint(object expected) : base(expected)
         {
-            Description = "less than " + MsgUtils.FormatValue(expected);
             IsSuccess = (comp) => comp < 0;
+            Description = "less than " + MsgUtils.FormatValue(expected);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
@@ -34,8 +34,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public LessThanOrEqualConstraint(object expected) : base(expected)
         {
-            Description = "less than or equal to " + MsgUtils.FormatValue(expected);
             IsSuccess = (comp) => comp <= 0;
+            Description = "less than or equal to " + MsgUtils.FormatValue(expected);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
@@ -34,8 +34,15 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value.</param>
         public LessThanOrEqualConstraint(object expected) : base(expected)
         {
-            IsSuccess = (comp) => comp <= 0;
             Description = "less than or equal to " + MsgUtils.FormatValue(expected);
+        }
+
+        /// <summary>
+        /// Perform the comparison
+        /// </summary>
+        protected override bool PerformComparison(ComparisonAdapter comparer, object actual, object expected, Tolerance tolerance)
+        {
+            return comparer.Compare(actual, tolerance.ApplyToValue(expected).UpperBound) <= 0;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/LessThanOrEqualConstraint.cs
@@ -32,6 +32,10 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="LessThanOrEqualConstraint"/> class.
         /// </summary>
         /// <param name="expected">The expected value.</param>
-        public LessThanOrEqualConstraint(object expected) : base(expected, true, true, false, "less than or equal to") { }
+        public LessThanOrEqualConstraint(object expected) : base(expected)
+        {
+            Description = "less than or equal to " + MsgUtils.FormatValue(expected);
+            IsSuccess = (comp) => comp <= 0;
+        }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -202,9 +202,9 @@ namespace NUnit.Framework.Constraints
                 DateTimeOffset xAsOffset = (DateTimeOffset)x;
                 DateTimeOffset yAsOffset = (DateTimeOffset)y;
 
-                if (tolerance != null && tolerance.Value is TimeSpan)
+                if (tolerance != null && tolerance.Amount is TimeSpan)
                 {
-                    TimeSpan amount = (TimeSpan)tolerance.Value;
+                    TimeSpan amount = (TimeSpan)tolerance.Amount;
                     result = (xAsOffset - yAsOffset).Duration() <= amount;
                 }
                 else
@@ -220,9 +220,9 @@ namespace NUnit.Framework.Constraints
                 return result;
             }
 
-            if (tolerance != null && tolerance.Value is TimeSpan)
+            if (tolerance != null && tolerance.Amount is TimeSpan)
             {
-                TimeSpan amount = (TimeSpan)tolerance.Value;
+                TimeSpan amount = (TimeSpan)tolerance.Amount;
 
                 if (x is DateTime && y is DateTime)
                     return ((DateTime)x - (DateTime)y).Duration() <= amount;

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -141,18 +141,18 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    return Math.Abs(expected - actual) <= Convert.ToDouble(tolerance.Value);
+                    return Math.Abs(expected - actual) <= Convert.ToDouble(tolerance.Amount);
 
                 case ToleranceMode.Percent:
                     if (expected == 0.0)
                         return expected.Equals(actual);
 
                     double relativeError = Math.Abs((expected - actual) / expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 case ToleranceMode.Ulps:
                     return FloatingPointNumerics.AreAlmostEqualUlps(
-                        expected, actual, Convert.ToInt64(tolerance.Value));
+                        expected, actual, Convert.ToInt64(tolerance.Amount));
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -181,17 +181,17 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    return Math.Abs(expected - actual) <= Convert.ToDouble(tolerance.Value);
+                    return Math.Abs(expected - actual) <= Convert.ToDouble(tolerance.Amount);
 
                 case ToleranceMode.Percent:
                     if (expected == 0.0f)
                         return expected.Equals(actual);
                     float relativeError = Math.Abs((expected - actual) / expected);
-                    return (relativeError <= Convert.ToSingle(tolerance.Value) / 100.0f);
+                    return (relativeError <= Convert.ToSingle(tolerance.Amount) / 100.0f);
 
                 case ToleranceMode.Ulps:
                     return FloatingPointNumerics.AreAlmostEqualUlps(
-                        expected, actual, Convert.ToInt32(tolerance.Value));
+                        expected, actual, Convert.ToInt32(tolerance.Amount));
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    decimal decimalTolerance = Convert.ToDecimal(tolerance.Value);
+                    decimal decimalTolerance = Convert.ToDecimal(tolerance.Amount);
                     if (decimalTolerance > 0m)
                         return Math.Abs(expected - actual) <= decimalTolerance;
 
@@ -219,7 +219,7 @@ namespace NUnit.Framework.Constraints
 
                     double relativeError = Math.Abs(
                         (double)(expected - actual) / (double)expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -234,7 +234,7 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    ulong ulongTolerance = Convert.ToUInt64(tolerance.Value);
+                    ulong ulongTolerance = Convert.ToUInt64(tolerance.Amount);
                     if (ulongTolerance > 0ul)
                     {
                         ulong diff = expected >= actual ? expected - actual : actual - expected;
@@ -250,7 +250,7 @@ namespace NUnit.Framework.Constraints
                     // Can't do a simple Math.Abs() here since it's unsigned
                     ulong difference = Math.Max(expected, actual) - Math.Min(expected, actual);
                     double relativeError = Math.Abs((double)difference / (double)expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -265,7 +265,7 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    long longTolerance = Convert.ToInt64(tolerance.Value);
+                    long longTolerance = Convert.ToInt64(tolerance.Amount);
                     if (longTolerance > 0L)
                         return Math.Abs(expected - actual) <= longTolerance;
 
@@ -277,7 +277,7 @@ namespace NUnit.Framework.Constraints
 
                     double relativeError = Math.Abs(
                         (double)(expected - actual) / (double)expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -292,7 +292,7 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    uint uintTolerance = Convert.ToUInt32(tolerance.Value);
+                    uint uintTolerance = Convert.ToUInt32(tolerance.Amount);
                     if (uintTolerance > 0)
                     {
                         uint diff = expected >= actual ? expected - actual : actual - expected;
@@ -308,7 +308,7 @@ namespace NUnit.Framework.Constraints
                     // Can't do a simple Math.Abs() here since it's unsigned
                     uint difference = Math.Max(expected, actual) - Math.Min(expected, actual);
                     double relativeError = Math.Abs((double)difference / (double)expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");
@@ -323,7 +323,7 @@ namespace NUnit.Framework.Constraints
                     return expected.Equals(actual);
 
                 case ToleranceMode.Linear:
-                    int intTolerance = Convert.ToInt32(tolerance.Value);
+                    int intTolerance = Convert.ToInt32(tolerance.Amount);
                     if (intTolerance > 0)
                         return Math.Abs(expected - actual) <= intTolerance;
 
@@ -335,7 +335,7 @@ namespace NUnit.Framework.Constraints
 
                     double relativeError = Math.Abs(
                         (double)(expected - actual) / (double)expected);
-                    return (relativeError <= Convert.ToDouble(tolerance.Value) / 100.0);
+                    return (relativeError <= Convert.ToDouble(tolerance.Amount) / 100.0);
 
                 default:
                     throw new ArgumentException("Unknown tolerance mode specified", "mode");

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// The Numerics class contains common operations on numeric _values.
     /// </summary>
-    public class Numerics
+    public static class Numerics
     {
         #region Numeric Type Recognition
         /// <summary>
@@ -344,6 +344,7 @@ namespace NUnit.Framework.Constraints
         #endregion
 
         #region Numeric Comparisons
+
         /// <summary>
         /// Compare two numeric _values, performing the usual numeric conversions.
         /// </summary>
@@ -373,9 +374,5 @@ namespace NUnit.Framework.Constraints
             return Convert.ToInt32(expected).CompareTo(Convert.ToInt32(actual));
         }
         #endregion
-
-        private Numerics()
-        {
-        }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -34,6 +34,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class Tolerance
     {
+        #region Constants and Static Properties
+
         private const string ModeMustFollowTolerance = "Tolerance amount must be specified before setting mode";
         private const string MultipleToleranceModes = "Tried to use multiple tolerance modes at the same time";
         private const string NumericToleranceRequired = "A numeric tolerance is required";
@@ -59,6 +61,10 @@ namespace NUnit.Framework.Constraints
             get { return new Tolerance(0, ToleranceMode.Linear); }
         }
 
+        #endregion
+
+        #region Constructors
+
         /// <summary>
         /// Constructs a linear tolerance of a specified amount
         /// </summary>
@@ -73,31 +79,9 @@ namespace NUnit.Framework.Constraints
             Mode = mode;
         }
 
-        /// <summary>
-        /// Gets the <see cref="ToleranceMode"/> for the current Tolerance
-        /// </summary>
-        public ToleranceMode Mode { get; private set; }
-        
+        #endregion
 
-        /// <summary>
-        /// Tests that the current Tolerance is linear with a 
-        /// numeric value, throwing an exception if it is not.
-        /// </summary>
-        private void CheckLinearAndNumeric()
-        {
-            if (Mode != ToleranceMode.Linear)
-                throw new InvalidOperationException(Mode == ToleranceMode.Unset
-                    ? ModeMustFollowTolerance
-                    : MultipleToleranceModes);
-
-            if (!Numerics.IsNumericType(Amount))
-                throw new InvalidOperationException(NumericToleranceRequired);
-        }
-
-        /// <summary>
-        /// Gets the magnitude of the current Tolerance instance.
-        /// </summary>
-        public object Amount { get; private set; }
+        #region Modifier Properties
 
         /// <summary>
         /// Returns a new tolerance, using the current amount as a percentage.
@@ -201,6 +185,20 @@ namespace NUnit.Framework.Constraints
             }
         }
 
+        #endregion
+
+        #region Other Public Properties
+
+        /// <summary>
+        /// Gets the <see cref="ToleranceMode"/> for the current Tolerance
+        /// </summary>
+        public ToleranceMode Mode { get; }
+
+        /// <summary>
+        /// Gets the magnitude of the current Tolerance instance.
+        /// </summary>
+        public object Amount { get; }
+
         /// <summary>
         /// Returns true if the current tolerance has not been set or is using the .
         /// </summary>
@@ -208,6 +206,10 @@ namespace NUnit.Framework.Constraints
         {
             get { return Mode == ToleranceMode.Unset; }
         }
+
+        #endregion
+
+        #region Public Methods
 
         /// <summary>
         /// Apply the tolerance to an expected value and return
@@ -230,6 +232,25 @@ namespace NUnit.Framework.Constraints
                 case ToleranceMode.Percent:
                     return PercentRange(value);
             }
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Tests that the current Tolerance is linear with a 
+        /// numeric value, throwing an exception if it is not.
+        /// </summary>
+        private void CheckLinearAndNumeric()
+        {
+            if (Mode != ToleranceMode.Linear)
+                throw new InvalidOperationException(Mode == ToleranceMode.Unset
+                    ? ModeMustFollowTolerance
+                    : MultipleToleranceModes);
+
+            if (!Numerics.IsNumericType(Amount))
+                throw new InvalidOperationException(NumericToleranceRequired);
         }
 
         private Range LinearRange(object value)
@@ -297,6 +318,10 @@ namespace NUnit.Framework.Constraints
             return new Range(v - offset, v + offset);
         }
 
+        #endregion
+
+        #region Nested Range Class
+
         /// <summary>
         /// Tolerance.Range represents the range of values that match
         /// a specific tolerance, when applied to a specific value.
@@ -322,5 +347,7 @@ namespace NUnit.Framework.Constraints
                 UpperBound = upperBound;
             }
         }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -290,7 +290,7 @@ namespace NUnit.Framework.Internal
             if (tolerance != null && !tolerance.IsUnsetOrDefault)
             {
                 Write(" +/- ");
-                Write(MsgUtils.FormatValue(tolerance.Value));
+                Write(MsgUtils.FormatValue(tolerance.Amount));
                 if (tolerance.Mode != ToleranceMode.Linear)
                     Write(" {0}", tolerance.Mode);
             }

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -81,5 +81,29 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(ex.Message, Contains.Substring("Expected: greater than " + expected.ToString()));
         }
+
+        [TestCase(6.0, 5.0, 1)]
+        [TestCase(5.0001, 5.0, 1)]
+        [TestCase(4.9999, 5.0, 1)]
+        [TestCase(198, 200, 2.5)]
+        [TestCase(202, 200, 2.5)]
+        [TestCase(204, 200, 2.5)]
+        [TestCase(195, 200, 2.5)] // This should really fail
+        public void PercentTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.GreaterThan(expected).Within(tolerance).Percent);
+        }
+
+        [TestCase(4.9, 5.0, 1)]
+        [TestCase(194, 200, 2.5)]
+        [TestCase(190, 200, 2.5)]
+        public void PercentTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.GreaterThan(expected).Within(tolerance).Percent),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: greater than " + MsgUtils.FormatValue(expected) + " within " + MsgUtils.FormatValue(tolerance) + " percent"));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -59,18 +59,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(6.0, 5.0, 0.05)]
+        [TestCase(5.05, 5.0, 0.05)] // upper range bound
         [TestCase(5.0001, 5.0, 0.05)]
         [TestCase(4.9999, 5.0, 0.05)]
-        [TestCase(198, 200, 5)]
+        [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01
+        [TestCase(210, 200, 5)]
+        [TestCase(205, 200, 5)] // upper range bound
         [TestCase(202, 200, 5)]
-        [TestCase(204, 200, 5)]
+        [TestCase(198, 200, 5)]
+        [TestCase(196, 200, 5)] // lower range bound + 1
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThan(expected).Within(tolerance));
         }
 
+        [TestCase(4.95, 5.0, 0.05)] // lower range bound
         [TestCase(4.9, 5.0, 0.05)]
-        [TestCase(195, 200, 5)]
+        [TestCase(195, 200, 5)] // lower range bound
         [TestCase(190, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -82,18 +87,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(6.0, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)] // upper range bound
         [TestCase(5.0001, 5.0, 1)]
         [TestCase(4.9999, 5.0, 1)]
-        [TestCase(198, 200, 2.5)]
+        [TestCase(4.9501, 5.0, 1)] // lower range bound + .01
+        [TestCase(210, 200, 2.5)]
+        [TestCase(205, 200, 2.5)] // upper range bound
         [TestCase(202, 200, 2.5)]
-        [TestCase(204, 200, 2.5)]
+        [TestCase(198, 200, 2.5)]
+        [TestCase(196, 200, 2.5)] // lower range bound + 1
         public void PercentTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThan(expected).Within(tolerance).Percent);
         }
 
+        [TestCase(4.95, 5.0, 1)] // lower range bound
         [TestCase(4.9, 5.0, 1)]
-        [TestCase(195, 200, 2.5)]
+        [TestCase(195, 200, 2.5)] // lower range bound
         [TestCase(190, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -64,14 +64,13 @@ namespace NUnit.Framework.Constraints
         [TestCase(198, 200, 5)]
         [TestCase(202, 200, 5)]
         [TestCase(204, 200, 5)]
-        [TestCase(195, 200, 5)] // This should really fail
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThan(expected).Within(tolerance));
         }
 
         [TestCase(4.9, 5.0, 0.05)]
-        [TestCase(194, 200, 5)]
+        [TestCase(195, 200, 5)]
         [TestCase(190, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -88,14 +87,13 @@ namespace NUnit.Framework.Constraints
         [TestCase(198, 200, 2.5)]
         [TestCase(202, 200, 2.5)]
         [TestCase(204, 200, 2.5)]
-        [TestCase(195, 200, 2.5)] // This should really fail
         public void PercentTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThan(expected).Within(tolerance).Percent);
         }
 
         [TestCase(4.9, 5.0, 1)]
-        [TestCase(194, 200, 2.5)]
+        [TestCase(195, 200, 2.5)]
         [TestCase(190, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -57,5 +57,29 @@ namespace NUnit.Framework.Constraints
             ClassWithIComparableOfT actual = new ClassWithIComparableOfT(42);
             Assert.That(actual, Is.GreaterThan(expected));
         }
+
+        [TestCase(6.0, 5.0, 0.05)]
+        [TestCase(5.0001, 5.0, 0.05)]
+        [TestCase(4.9999, 5.0, 0.05)]
+        [TestCase(198, 200, 5)]
+        [TestCase(202, 200, 5)]
+        [TestCase(204, 200, 5)]
+        [TestCase(195, 200, 5)] // This should really fail
+        public void SimpleTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.GreaterThan(expected).Within(tolerance));
+        }
+
+        [TestCase(4.9, 5.0, 0.05)]
+        [TestCase(194, 200, 5)]
+        [TestCase(190, 200, 5)]
+        public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.GreaterThan(expected).Within(tolerance)),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: greater than " + expected.ToString()));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -4,6 +4,7 @@
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
+
 // without limitation the rights to use, copy, modify, merge, publish,
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
@@ -16,7 +17,7 @@
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIONg
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -60,19 +60,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(6.0, 5.0, 0.05)]
+        [TestCase(5.05, 5.0, 0.05)] // upper range bound
         [TestCase(5.0001, 5.0, 0.05)]
         [TestCase(4.9999, 5.0, 0.05)]
+        [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01
+        [TestCase(4.95, 5.0, 0.05)] // lower range bound
         [TestCase(210, 200, 5)]
+        [TestCase(205, 200, 5)] // upper range bound
         [TestCase(202, 200, 5)]
         [TestCase(198, 200, 5)]
-        [TestCase(195, 200, 5)]
+        [TestCase(196, 200, 5)] // lower range bound + 1
+        [TestCase(195, 200, 5)] // lower range bound
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance));
         }
 
         [TestCase(4.9, 5.0, 0.05)]
-        [TestCase(194, 200, 5)]
         [TestCase(190, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -84,19 +88,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(6.0, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)] // upper range bound
         [TestCase(5.0001, 5.0, 1)]
         [TestCase(4.9999, 5.0, 1)]
+        [TestCase(4.9501, 5.0, 1)] // lower range bound + .01
+        [TestCase(4.95, 5.0, 1)] // lower range bound
         [TestCase(210, 200, 2.5)]
+        [TestCase(205, 200, 2.5)] // upper range bound
         [TestCase(202, 200, 2.5)]
         [TestCase(198, 200, 2.5)]
-        [TestCase(195, 200, 2.5)]
+        [TestCase(196, 200, 2.5)] // lower range bound + 1
+        [TestCase(195, 200, 2.5)] // lower range bound
         public void PercentTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance).Percent);
         }
 
         [TestCase(4.9, 5.0, 1)]
-        [TestCase(194, 200, 2.5)]
         [TestCase(190, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -81,5 +81,29 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(ex.Message, Contains.Substring("Expected: greater than or equal to " + expected.ToString()));
         }
+
+        [TestCase(6.0, 5.0, 1)]
+        [TestCase(5.0001, 5.0, 1)]
+        [TestCase(4.9999, 5.0, 1)]
+        [TestCase(210, 200, 2.5)]
+        [TestCase(202, 200, 2.5)]
+        [TestCase(198, 200, 2.5)]
+        [TestCase(195, 200, 2.5)]
+        public void PercentTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance).Percent);
+        }
+
+        [TestCase(4.9, 5.0, 1)]
+        [TestCase(194, 200, 2.5)]
+        [TestCase(190, 200, 2.5)]
+        public void PercentTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance).Percent),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: greater than or equal to " + MsgUtils.FormatValue(expected) + " within " + MsgUtils.FormatValue(tolerance) + " percent" ));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -4,7 +4,6 @@
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
-
 // without limitation the rights to use, copy, modify, merge, publish,
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
@@ -17,7 +16,7 @@
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIONg
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -57,5 +57,29 @@ namespace NUnit.Framework.Constraints
             ClassWithIComparableOfT actual = new ClassWithIComparableOfT(42);
             Assert.That(actual, Is.GreaterThanOrEqualTo(expected));
         }
+
+        [TestCase(6.0, 5.0, 0.05)]
+        [TestCase(5.0001, 5.0, 0.05)]
+        [TestCase(4.9999, 5.0, 0.05)]
+        [TestCase(210, 200, 5)]
+        [TestCase(202, 200, 5)]
+        [TestCase(198, 200, 5)]
+        [TestCase(195, 200, 5)]
+        public void SimpleTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance));
+        }
+
+        [TestCase(4.9, 5.0, 0.05)]
+        [TestCase(194, 200, 5)]
+        [TestCase(190, 200, 5)]
+        public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.GreaterThanOrEqualTo(expected).Within(tolerance)),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: greater than or equal to " + expected.ToString()));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -61,18 +61,17 @@ namespace NUnit.Framework.Constraints
         [TestCase(4.0, 5.0, 0.05)]
         [TestCase(4.9999, 5.0, 0.05)]
         [TestCase(5.04, 5.0, 0.05)]
-        [TestCase(5.05, 5.0, 0.05)] // This should really fail
         [TestCase(198, 200, 5)]
         [TestCase(202, 200, 5)]
         [TestCase(204, 200, 5)]
-        [TestCase(205, 200, 5)] // This should really fail
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.LessThan(expected).Within(tolerance));
         }
 
         [TestCase(5.1, 5.0, 0.05)]
-        [TestCase(206, 200, 5)]
+        [TestCase(5.05, 5.0, 0.05)]
+        [TestCase(205, 200, 5)]
         [TestCase(210, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -86,19 +85,18 @@ namespace NUnit.Framework.Constraints
         [TestCase(4.0, 5.0, 1)]
         [TestCase(4.9999, 5.0, 1)]
         [TestCase(5.04, 5.0, 1)]
-        [TestCase(5.05, 5.0, 1)] // This should really fail
         [TestCase(198, 200, 2.5)]
         [TestCase(202, 200, 2.5)]
         [TestCase(204, 200, 2.5)]
-        [TestCase(205, 200, 2.5)] // This should really fail
         public void PercentTolerance(object actual, object expected, object percent)
         {
             Assert.That(actual, Is.LessThan(expected).Within(percent).Percent);
         }
 
         [TestCase(5.1, 5.0, 1)]
-        [TestCase(206, 200, 2.5)]
+        [TestCase(5.05, 5.0, 1)]
         [TestCase(210, 200, 2.5)]
+        [TestCase(205, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {
             var ex = Assert.Throws<AssertionException>(

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -57,5 +57,30 @@ namespace NUnit.Framework.Constraints
             ClassWithIComparableOfT actual = new ClassWithIComparableOfT(0);
             Assert.That(actual, Is.LessThan(expected));
         }
+
+        [TestCase(4.0, 5.0, 0.05)]
+        [TestCase(4.9999, 5.0, 0.05)]
+        [TestCase(5.04, 5.0, 0.05)]
+        [TestCase(5.05, 5.0, 0.05)] // This should really fail
+        [TestCase(198, 200, 5)]
+        [TestCase(202, 200, 5)]
+        [TestCase(204, 200, 5)]
+        [TestCase(205, 200, 5)] // This should really fail
+        public void SimpleTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.LessThan(expected).Within(tolerance));
+        }
+
+        [TestCase(5.1, 5.0, 0.05)]
+        [TestCase(206, 200, 5)]
+        [TestCase(210, 200, 5)]
+        public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.LessThan(expected).Within(tolerance)),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: less than " + expected.ToString()));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -80,7 +80,32 @@ namespace NUnit.Framework.Constraints
                 () => Assert.That(actual, Is.LessThan(expected).Within(tolerance)),
                 "Assertion should have failed");
 
-            Assert.That(ex.Message, Contains.Substring("Expected: less than " + expected.ToString()));
+            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + tolerance.ToString()));
+        }
+
+        [TestCase(4.0, 5.0, 1)]
+        [TestCase(4.9999, 5.0, 1)]
+        [TestCase(5.04, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)] // This should really fail
+        [TestCase(198, 200, 2.5)]
+        [TestCase(202, 200, 2.5)]
+        [TestCase(204, 200, 2.5)]
+        [TestCase(205, 200, 2.5)] // This should really fail
+        public void PercentTolerance(object actual, object expected, object percent)
+        {
+            Assert.That(actual, Is.LessThan(expected).Within(percent).Percent);
+        }
+
+        [TestCase(5.1, 5.0, 1)]
+        [TestCase(206, 200, 2.5)]
+        [TestCase(210, 200, 2.5)]
+        public void PercentTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.LessThan(expected).Within(tolerance).Percent),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + MsgUtils.FormatValue(tolerance) + " percent"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -59,19 +59,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(4.0, 5.0, 0.05)]
+        [TestCase(4.95, 5.0, 0.05)] // lower range bound
+        [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01
         [TestCase(4.9999, 5.0, 0.05)]
-        [TestCase(5.04, 5.0, 0.05)]
+        [TestCase(5.0001, 5.0, 0.05)]
+        [TestCase(190, 200, 5)]
+        [TestCase(195, 200, 5)] // lower range bound
+        [TestCase(196, 200, 5)] // lower range bound + 1
         [TestCase(198, 200, 5)]
         [TestCase(202, 200, 5)]
-        [TestCase(204, 200, 5)]
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.LessThan(expected).Within(tolerance));
         }
 
-        [TestCase(5.1, 5.0, 0.05)]
-        [TestCase(5.05, 5.0, 0.05)]
-        [TestCase(205, 200, 5)]
+        [TestCase(5.05, 5.0, 0.05)] // upper range bound
+        [TestCase(6.0, 5.0, 0.05)]
+        [TestCase(205, 200, 5)] // upper range bound
         [TestCase(210, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -83,20 +87,24 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(4.0, 5.0, 1)]
+        [TestCase(4.95, 5.0, 1)] // lower range bound
+        [TestCase(4.9501, 5.0, 1)] // lower range bound + .01
         [TestCase(4.9999, 5.0, 1)]
-        [TestCase(5.04, 5.0, 1)]
+        [TestCase(5.0001, 5.0, 1)]
+        [TestCase(190, 200, 2.5)]
+        [TestCase(195, 200, 2.5)] // lower range bound
+        [TestCase(196, 200, 5)] // lower range bound + 1
         [TestCase(198, 200, 2.5)]
         [TestCase(202, 200, 2.5)]
-        [TestCase(204, 200, 2.5)]
         public void PercentTolerance(object actual, object expected, object percent)
         {
             Assert.That(actual, Is.LessThan(expected).Within(percent).Percent);
         }
 
-        [TestCase(5.1, 5.0, 1)]
-        [TestCase(5.05, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)] // upper range bound
+        [TestCase(6.0, 5.0, 1)]
+        [TestCase(205, 200, 2.5)] // upper range bound
         [TestCase(210, 200, 2.5)]
-        [TestCase(205, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {
             var ex = Assert.Throws<AssertionException>(

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -59,20 +59,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(4.0, 5.0, 0.05)]
+        [TestCase(4.95, 5.0, 0.05)] // lower range bound
+        [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01
         [TestCase(4.9999, 5.0, 0.05)]
         [TestCase(5.0001, 5.0, 0.05)]
-        [TestCase(5.05, 5.0, 0.05)]
+        [TestCase(5.05, 5.0, 0.05)] // upper range bound
         [TestCase(190, 200, 5)]
+        [TestCase(195, 200, 5)] // lower range bound
+        [TestCase(196, 200, 5)] // lower range bound + 1
         [TestCase(198, 200, 5)]
         [TestCase(202, 200, 5)]
-        [TestCase(205, 200, 5)]
+        [TestCase(205, 200, 5)] // upper range bound
         public void SimpleTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance));
         }
 
-        [TestCase(5.1, 5.0, 0.05)]
-        [TestCase(206, 200, 5)]
+        [TestCase(6.0, 5.0, 0.05)]
         [TestCase(210, 200, 5)]
         public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
         {
@@ -84,20 +87,23 @@ namespace NUnit.Framework.Constraints
         }
 
         [TestCase(4.0, 5.0, 1)]
+        [TestCase(4.95, 5.0, 1)] // lower range bound
+        [TestCase(4.9501, 5.0, 1)] // lower range bound + .01
         [TestCase(4.9999, 5.0, 1)]
         [TestCase(5.0001, 5.0, 1)]
-        [TestCase(5.05, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)] // upper range bound
         [TestCase(190, 200, 2.5)]
+        [TestCase(195, 200, 2.5)] // lower range bound
+        [TestCase(196, 200, 2.5)] // lower range bound + 1
         [TestCase(198, 200, 2.5)]
         [TestCase(202, 200, 2.5)]
-        [TestCase(205, 200, 2.5)]
+        [TestCase(205, 200, 2.5)] // upper range bound
         public void PercentTolerance(object actual, object expected, object tolerance)
         {
             Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance).Percent);
         }
 
-        [TestCase(5.1, 5.0, 1)]
-        [TestCase(206, 200, 2.5)]
+        [TestCase(6.0, 5.0, 1)]
         [TestCase(210, 200, 2.5)]
         public void PercentTolerance_Failure(object actual, object expected, object tolerance)
         {

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -57,5 +57,30 @@ namespace NUnit.Framework.Constraints
             ClassWithIComparableOfT actual = new ClassWithIComparableOfT(0);
             Assert.That(actual, Is.LessThanOrEqualTo(expected));
         }
+
+        [TestCase(4.0, 5.0, 0.05)]
+        [TestCase(4.9999, 5.0, 0.05)]
+        [TestCase(5.0001, 5.0, 0.05)]
+        [TestCase(5.05, 5.0, 0.05)]
+        [TestCase(190, 200, 5)]
+        [TestCase(198, 200, 5)]
+        [TestCase(202, 200, 5)]
+        [TestCase(205, 200, 5)]
+        public void SimpleTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance));
+        }
+
+        [TestCase(5.1, 5.0, 0.05)]
+        [TestCase(206, 200, 5)]
+        [TestCase(210, 200, 5)]
+        public void SimpleTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance)),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: less than or equal to " + expected.ToString()));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -82,5 +82,30 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(ex.Message, Contains.Substring("Expected: less than or equal to " + expected.ToString()));
         }
+
+        [TestCase(4.0, 5.0, 1)]
+        [TestCase(4.9999, 5.0, 1)]
+        [TestCase(5.0001, 5.0, 1)]
+        [TestCase(5.05, 5.0, 1)]
+        [TestCase(190, 200, 2.5)]
+        [TestCase(198, 200, 2.5)]
+        [TestCase(202, 200, 2.5)]
+        [TestCase(205, 200, 2.5)]
+        public void PercentTolerance(object actual, object expected, object tolerance)
+        {
+            Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance).Percent);
+        }
+
+        [TestCase(5.1, 5.0, 1)]
+        [TestCase(206, 200, 2.5)]
+        [TestCase(210, 200, 2.5)]
+        public void PercentTolerance_Failure(object actual, object expected, object tolerance)
+        {
+            var ex = Assert.Throws<AssertionException>(
+                () => Assert.That(actual, Is.LessThanOrEqualTo(expected).Within(tolerance).Percent),
+                "Assertion should have failed");
+
+            Assert.That(ex.Message, Contains.Substring("Expected: less than or equal to " + MsgUtils.FormatValue(expected) + " within " + MsgUtils.FormatValue(tolerance) + " percent"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #2095 

This required a completely separate implementation from the use of tolerance in equality comparisons. I limited the feature set to what appeared to me to be useful in this context.

* Linear and Percent tolerances are supported
* Only numeric values can use tolerances