### PR TITLE
Fixed issue with sending extra new lines when writing to listeners

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Execution
     /// <summary>
     /// EventListenerTextWriter sends text output to the currently active
     /// ITestEventListener in the form of a TestOutput object. If no event 
-    /// listener is active in the contet, or if there is no context,
+    /// listener is active in the context, or if there is no context,
     /// the output is forwarded to the supplied default writer.
     /// </summary>
 	public class EventListenerTextWriter : TextWriter
@@ -50,33 +50,6 @@ namespace NUnit.Framework.Internal.Execution
 			_streamName = streamName;
             _defaultWriter = defaultWriter;
 		}
-
-        /// <summary>
-        /// Write a single char
-        /// </summary>
-        override public void Write(char aChar)
-        {
-            if (!TrySendToListener(aChar.ToString()))
-                _defaultWriter.Write(aChar);
-        }
-
-        /// <summary>
-        /// Write a string
-        /// </summary>
-        override public void Write(string aString)
-        {
-            if (!TrySendToListener(aString))
-                _defaultWriter.Write(aString);
-        }
-
-        /// <summary>
-        /// Write a string followed by a newline
-        /// </summary>
-        override public void WriteLine(string aString)
-        {
-            if (!TrySendToListener(aString + Environment.NewLine))
-                _defaultWriter.WriteLine(aString);
-        }
 
         /// <summary>
         /// Get the Encoding for this TextWriter
@@ -102,6 +75,372 @@ namespace NUnit.Framework.Internal.Execution
             context.Listener.TestOutput(new TestOutput(text, _streamName, testName));
             return true;
         }
-	}
+
+        private bool TrySendLineToListener(string text)
+        {
+            return TrySendToListener(text + Environment.NewLine);
+        }
+
+        #region Write/WriteLine Methods
+        // NB: We explicitly implement each of the Write and WriteLine methods so that
+        // we are not dependent on the implementation of the TextWriter base class.
+        //
+        // For example, ideally, calling WriteLine(char[]) will send the text once,
+        // however, the base implementation will send one character at a time.
+
+        /// <summary>
+        /// Write formatted string
+        /// </summary>
+        public override void Write(string format, params object[] arg)
+        {
+            if (!TrySendToListener(String.Format(FormatProvider, format, arg)))
+                _defaultWriter.Write(format, arg);
+        }
+
+        /// <summary>
+        /// Write formatted string
+        /// </summary>
+        public override void Write(string format, object arg0, object arg1, object arg2)
+        {
+            if (!TrySendToListener(String.Format(FormatProvider, format, arg0, arg1, arg2)))
+                _defaultWriter.Write(format, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Write formatted string
+        /// </summary>
+        public override void Write(string format, object arg0)
+        {
+            if (!TrySendToListener(String.Format(FormatProvider, format, arg0)))
+                _defaultWriter.Write(format, arg0);
+        }
+
+        /// <summary>
+        /// Write an object
+        /// </summary>
+        public override void Write(object value)
+        {
+            if (value != null)
+            {
+                IFormattable f = value as IFormattable;
+                if (f != null)
+                {
+                    if (!TrySendToListener(f.ToString(null, FormatProvider)))
+                        _defaultWriter.Write(value);
+                }
+                else
+                {
+                    if (!TrySendToListener(value.ToString()))
+                        _defaultWriter.Write(value);
+                }
+            }
+            else
+            {
+                _defaultWriter.Write(value);
+            }
+        }
+
+        /// <summary>
+        /// Write a string
+        /// </summary>
+        public override void Write(string value)
+        {
+            if (!TrySendToListener(value))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a decimal
+        /// </summary>
+        public override void Write(decimal value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a double
+        /// </summary>
+        public override void Write(double value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write formatted string
+        /// </summary>
+        public override void Write(string format, object arg0, object arg1)
+        {
+            if (!TrySendToListener(String.Format(FormatProvider, format, arg0, arg1)))
+                _defaultWriter.Write(format, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Write a ulong
+        /// </summary>
+        [CLSCompliant(false)]
+        public override void Write(ulong value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a long
+        /// </summary>
+        public override void Write(long value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a uint
+        /// </summary>
+        [CLSCompliant(false)]
+        public override void Write(uint value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write an int
+        /// </summary>
+        public override void Write(int value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a char
+        /// </summary>
+        public override void Write(char value)
+        {
+            if (!TrySendToListener(value.ToString()))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a boolean
+        /// </summary>
+        public override void Write(bool value)
+        {
+            if (!TrySendToListener(value ? Boolean.TrueString : Boolean.FalseString))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write chars
+        /// </summary>
+        public override void Write(char[] buffer, int index, int count)
+        {
+            if (!TrySendToListener(new string(buffer, index, count)))
+                _defaultWriter.Write(buffer, index, count);
+        }
+
+        /// <summary>
+        /// Write chars
+        /// </summary>
+        public override void Write(char[] buffer)
+        {
+            if (!TrySendToListener(new string(buffer)))
+                _defaultWriter.Write(buffer);
+        }
+
+        /// <summary>
+        /// Write a float
+        /// </summary>
+        public override void Write(float value)
+        {
+            if (!TrySendToListener(value.ToString(FormatProvider)))
+                _defaultWriter.Write(value);
+        }
+
+        /// <summary>
+        /// Write a string with newline
+        /// </summary>
+        public override void WriteLine(string value)
+        {
+            if (!TrySendLineToListener(value))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write an object with newline
+        /// </summary>
+        public override void WriteLine(object value)
+        {
+            if (value == null)
+            {
+                if (!TrySendLineToListener(string.Empty))
+                    _defaultWriter.WriteLine(value);
+            }
+            else
+            {
+                IFormattable f = value as IFormattable;
+                if (f != null)
+                {
+                    if (!TrySendLineToListener(f.ToString(null, FormatProvider)))
+                        _defaultWriter.WriteLine(value);
+                }
+                else
+                {
+                    if (!TrySendLineToListener(value.ToString()))
+                        _defaultWriter.WriteLine(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write formatted string with newline
+        /// </summary>
+        public override void WriteLine(string format, params object[] arg)
+        {
+            if (!TrySendLineToListener(String.Format(FormatProvider, format, arg)))
+                _defaultWriter.WriteLine(format, arg);
+        }
+
+        /// <summary>
+        /// Write formatted string with newline
+        /// </summary>
+        public override void WriteLine(string format, object arg0, object arg1)
+        {
+            if (!TrySendLineToListener(String.Format(FormatProvider, format, arg0, arg1)))
+                _defaultWriter.WriteLine(format, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Write formatted string with newline
+        /// </summary>
+        public override void WriteLine(string format, object arg0, object arg1, object arg2)
+        {
+            if (!TrySendLineToListener(String.Format(FormatProvider, format, arg0, arg1, arg2)))
+                _defaultWriter.WriteLine(format, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Write a decimal with newline
+        /// </summary>
+        public override void WriteLine(decimal value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a formatted string with newline
+        /// </summary>
+        public override void WriteLine(string format, object arg0)
+        {
+            if (!TrySendLineToListener(String.Format(FormatProvider, format, arg0)))
+                _defaultWriter.WriteLine(format, arg0);
+        }
+
+        /// <summary>
+        /// Write a double with newline
+        /// </summary>
+        public override void WriteLine(double value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a uint with newline
+        /// </summary>
+        [CLSCompliant(false)]
+        public override void WriteLine(uint value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a ulong with newline
+        /// </summary>
+        [CLSCompliant(false)]
+        public override void WriteLine(ulong value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a long with newline
+        /// </summary>
+        public override void WriteLine(long value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write an int with newline
+        /// </summary>
+        public override void WriteLine(int value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a bool with newline
+        /// </summary>
+        public override void WriteLine(bool value)
+        {
+            if (!TrySendLineToListener(value ? Boolean.TrueString : Boolean.FalseString))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write chars with newline
+        /// </summary>
+        public override void WriteLine(char[] buffer, int index, int count)
+        {
+            if (!TrySendLineToListener(new string(buffer, index, count)))
+                _defaultWriter.WriteLine(buffer, index, count);
+        }
+
+        /// <summary>
+        /// Write chars with newline
+        /// </summary>
+        public override void WriteLine(char[] buffer)
+        {
+            if (!TrySendLineToListener(new string(buffer)))
+                _defaultWriter.WriteLine(buffer);
+        }
+
+        /// <summary>
+        /// Write a char with newline
+        /// </summary>
+        public override void WriteLine(char value)
+        {
+            if (!TrySendLineToListener(value.ToString()))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write a float with newline
+        /// </summary>
+        public override void WriteLine(float value)
+        {
+            if (!TrySendLineToListener(value.ToString(FormatProvider)))
+                _defaultWriter.WriteLine(value);
+        }
+
+        /// <summary>
+        /// Write newline
+        /// </summary>
+        public override void WriteLine()
+        {
+            if (!TrySendLineToListener(string.Empty))
+                _defaultWriter.WriteLine();
+        }
+
+        #endregion
+    }
 }
 #endif

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -1,0 +1,336 @@
+﻿// ***********************************************************************
+// Copyright (c) 2007 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class EventListenerTextWriterTests
+    {
+        private static readonly string NL = Environment.NewLine;
+
+        TestListenerHelper TestResult;
+        TextWriter TestWriter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestResult = new TestListenerHelper();
+            TestExecutionContext.CurrentContext.Listener = TestResult;
+
+            TestWriter = TextWriter.Synchronized(TestContext.Error);
+        }
+
+        [Test]
+        public void TestWriteStringArgArray()
+        {
+            var format = "{0} {1} {2} {3}";
+            var arg = new object[] { "Hello", 4, 2, "World" };
+
+            TestWriter.Write(format, arg);
+            TestWriter.WriteLine(format, arg);
+
+            var expected = "Hello 4 2 World";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteStringArg1()
+        {
+            var format = "{0:dd MMM yyyy}";
+            var arg0 = new DateTime(2017, 4, 20);
+
+            TestWriter.Write(format, arg0);
+            TestWriter.WriteLine(format, arg0);
+
+            var expected = "20 Apr 2017";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteStringArg2()
+        {
+            var format = "{0:00.00} {1}";
+            var arg0 = 5;
+            var arg1 = "@";
+
+            TestWriter.Write(format, arg0, arg1);
+            TestWriter.WriteLine(format, arg0, arg1);
+
+            var expected = "05.00 @";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteStringArg3()
+        {
+            var format = "{0} {1:#.00} {2}";
+            var arg0 = "Quick";
+            var arg1 = 9.0;
+            var arg2 = "Fox";
+
+            TestWriter.Write(format, arg0, arg1, arg2);
+            TestWriter.WriteLine(format, arg0, arg1, arg2);
+
+            var expected = "Quick 9.00 Fox";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+
+        }
+
+        [Test]
+        public void TestWriteObject()
+        {
+            var obj = new { Mary = "Lamb", Sheep = "White" };
+
+            TestWriter.Write(obj);
+            TestWriter.WriteLine(obj);
+
+            var expected = "{ Mary = Lamb, Sheep = White }";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteString()
+        {
+            var str = "Insert coin here";
+
+            TestWriter.Write(str);
+            TestWriter.WriteLine(str);
+
+            var expected = "Insert coin here";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteDecimal()
+        {
+            decimal value = 2.731m;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "2.731";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteDouble()
+        {
+            double value = -1.5;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "-1.5";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteULong()
+        {
+            ulong value = 1234567890123456;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "1234567890123456";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteLong()
+        {
+            long value = -987654321;
+            
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "-987654321";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteUInt()
+        {
+            uint value = 0xff;
+            
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "255";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteInt()
+        {
+            int value = 0xff;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "255";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteBool()
+        {
+            bool value = true;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = Boolean.TrueString;
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteChar()
+        {
+            char value = 'x';
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "x";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteCharBuffer()
+        {
+            char[] buffer = new char[] { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd' };
+
+            TestWriter.Write(buffer);
+            TestWriter.WriteLine(buffer);
+
+            var expected = "Hello World";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteCharBufferSubstring()
+        {
+            char[] buffer = new char[] { 'L', 'i', 't', 't', 'l', 'e', ' ', 'M', 'i', 's', 's', ' ', 'M', 'u', 'f', 'f', 'e', 't' };
+            int index = 6;
+            int count = 7;
+
+            TestWriter.Write(buffer, index, count);
+            TestWriter.WriteLine(buffer, index, count);
+
+            var expected = " Miss M";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteFloat()
+        {
+            float value = -5.0f;
+
+            TestWriter.Write(value);
+            TestWriter.WriteLine(value);
+
+            var expected = "-5";
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+            Assert.That(TestResult.Outputs[1], Is.EqualTo(expected + NL));
+        }
+
+        [Test]
+        public void TestWriteLine()
+        {
+            TestWriter.WriteLine();
+
+            var expected = NL;
+            Assert.That(TestResult.Outputs.Count, Is.EqualTo(1));
+            Assert.That(TestResult.Outputs[0], Is.EqualTo(expected));
+        }
+
+        #region ITestListener implementation
+
+        private class TestListenerHelper : ITestListener
+        {
+            public IList<string> Outputs { get; internal set; }
+
+            public TestListenerHelper()
+            {
+                Outputs = new List<string>();
+            }
+
+            void ITestListener.TestStarted(ITest test)
+            {
+                // Intentionally empty
+            }
+
+            void ITestListener.TestFinished(ITestResult result)
+            {
+                // Intentionally empty
+            }
+
+            void ITestListener.TestOutput(TestOutput output)
+            {
+                Assert.IsNotNull(output);
+                Outputs.Add(output.Text);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
+    <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
+    <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Results\AssertionResultTests.cs" />
     <Compile Include="Internal\Results\TestResultFailureTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Internal\CallContextTests.cs" />
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
+    <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />


### PR DESCRIPTION
Fixes #1819

The issue with having a string being emitted as a single character per line is because of the base implementation of TextWriter.Write(char[]).

Refer to the .NET Reference Source Code:
http://referencesource.microsoft.com/#mscorlib/system/io/textwriter.cs

Each character of the array is emitted one at a time.

The proposed solution in this PR is to override all the Write and WriteLine methods so that we do not rely on the base implementation.