### PR TITLE
Resolve differences with console runner wrt argument files

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -83,7 +83,9 @@ namespace NUnitLite.Tests
         [TestCase("--arg1 @file1.txt --arg2", "file1.txt:", "--arg1", "--arg2")]
         // Blank lines
         [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--fileArg1\n\n\n--fileArg2", "--arg1", "--fileArg1", "--fileArg2", "--arg2")]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--fileArg1\n    \n\t\t\n--fileArg2", "--arg1", "--fileArg1", "--fileArg2", "--arg2")]
         [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--fileArg1\r\n\r\n\r\n--fileArg2", "--arg1", "--fileArg1", "--fileArg2", "--arg2")]
+        [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--fileArg1\r\n    \r\n\t\t\r\n--fileArg2", "--arg1", "--fileArg1", "--fileArg2", "--arg2")]
         [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--filearg1 --filearg2\r\n\n--filearg3 --filearg4", "--arg1", "--filearg1", "--filearg2", "--filearg3", "--filearg4", "--arg2")]
 
         // Comments

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -146,7 +146,7 @@ namespace NUnit.Common
 
             foreach (var line in File.ReadAllLines(filename))
             {
-                if (!string.IsNullOrEmpty(line) && line[0] != '#')
+                if (!string.IsNullOrEmpty(line) && line[0] != '#' && line.Trim().Length > 0)
                 {
                     if (sb.Length > 0)
                         sb.Append(' ');


### PR DESCRIPTION
Fixes #1877 

**Discuss before merging**

This resolves differences in the implementation of argument files between nunitlite and the console runner. The following changes have been made.

1. The "alternate separator" feature has been removed

2. Comments are supported in argument files.

However...

@rprouse has suggested we remove support for argument files from NUnitLite, so we should probably resolve that before we merge this commit.