### PR TITLE
Remove "Version 3" suffix from NUnitLite NuGet Package

### DIFF
--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>NUnitLite</id>
-    <title>NUnitLite Version 3</title>
+    <title>NUnitLite</title>
     <version>$version$</version>
     <authors>Charlie Poole</authors>
     <owners>Charlie Poole</owners>


### PR DESCRIPTION
Just spotted this today. The NUnit NuGet package was renamed "NUnit Version 3" -> "NUnit" with 3.0, the NUnitLite package should be consistent. Otherwise it creates weird display strings like:

`NUnitLite Version 3 3.6.1`

This is just the display name, so shouldn't have any side effects.