### PR TITLE
Add .gitattributes entry so that .sh files checked out in Windows have Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,7 @@
 # Monodevelop on Linux uses CRLF for these files
 *.sln	text	eol=crlf
 packages/repositories.config	text	eol=crlf
+
+# Allows checking out and developing in Windows
+# while mounting and running tests in Linux
+*.sh text eol=lf


### PR DESCRIPTION
See https://github.com/nunit/docs/issues/163#issuecomment-297059889

This makes the build.sh file usable when you check out and develop on Windows but mount the repo in Linux to run tests.

This fixes the problem for new clones of the repo. Existing clones will keep their problematic CRLFs unless you delete `build.sh` and run `git checkout build.sh` to replace it.