### PR TITLE
Require filename with nunitlite-runner and disallow it with AutoRun

### DIFF
--- a/src/NUnitFramework/nunitlite-runner/Program.cs
+++ b/src/NUnitFramework/nunitlite-runner/Program.cs
@@ -43,7 +43,7 @@ namespace NUnitLite
         static int Main(string[] args)
         {
 #if PORTABLE
-            return new TextRunner().Execute(new ColorConsoleWriter(), Console.In, new NUnitLiteOptions(args));
+            return new TextRunner().Execute(new ColorConsoleWriter(), Console.In, args);
 #else
             return new TextRunner().Execute(args);
 #endif

--- a/src/NUnitFramework/nunitlite/AutoRun.cs
+++ b/src/NUnitFramework/nunitlite/AutoRun.cs
@@ -95,7 +95,7 @@ namespace NUnitLite
         /// <param name="reader">A TextReader used when waiting for input</param>
         public int Execute(string[] args, ExtendedTextWriter writer, TextReader reader)
         {
-            return new TextRunner(_testAssembly).Execute(writer, reader, new NUnitLiteOptions(args));
+            return new TextRunner(_testAssembly).Execute(writer, reader, args);
         }
     }
 }

--- a/src/NUnitFramework/nunitlite/NUnitLiteOptions.cs
+++ b/src/NUnitFramework/nunitlite/NUnitLiteOptions.cs
@@ -36,9 +36,11 @@ namespace NUnitLite
         /// <summary>
         /// Constructor
         /// </summary>
-        public NUnitLiteOptions(params string[] args) : base(args) { }
+        public NUnitLiteOptions(params string[] args) : base(false, args) { }
+
+        public NUnitLiteOptions(bool requireInputFile, params string[] args) : base(requireInputFile, args) { }
 
         // Currently used only by test
-        internal NUnitLiteOptions(IDefaultOptionsProvider provider, params string[] args) : base(provider, args) { }
+        internal NUnitLiteOptions(IDefaultOptionsProvider provider, params string[] args) : base(provider, false, args) { }
     }
 }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -52,17 +52,7 @@ namespace NUnitLite
             _options = options;
         }
 
-        public TextUI(ExtendedTextWriter writer, TextReader reader)
-            : this(writer, reader, new NUnitLiteOptions()) { }
-
-        public TextUI(ExtendedTextWriter writer)
-#if PORTABLE
-            : this(writer, null, new NUnitLiteOptions()) { }
-#else
-            : this(writer, Console.In, new NUnitLiteOptions()) { }
-#endif
-
-    #endregion
+        #endregion
 
         #region Public Methods
 
@@ -112,17 +102,16 @@ namespace NUnitLite
 
         public void DisplayHelp()
         {
-            WriteHeader("Usage: NUNITLITE [assembly] [options]");
+            WriteHeader("Usage: NUNITLITE-RUNNER assembly [options]");
+            WriteHeader("       USER-EXECUTABLE [options]");
             Writer.WriteLine();
             WriteHelpLine("Runs a set of NUnitLite tests from the console.");
             Writer.WriteLine();
 
             WriteSectionHeader("Assembly:");
-            WriteHelpLine("      An alternate assembly from which to execute tests. Normally, the tests");
-            WriteHelpLine("      contained in the executable test assembly itself are run. An alternate");
-            WriteHelpLine("      assembly is specified using the assembly name, without any path or.");
-            WriteHelpLine("      extension. It must be in the same in the same directory as the executable");
-            WriteHelpLine("      or on the probing path.");
+            WriteHelpLine("      File name or path of the assembly from which to execute tests. Required");
+            WriteHelpLine("      when using the nunitlite-runner executable to run the tests. Not allowed");
+            WriteHelpLine("      when running a self-executing user test assembly.");
             Writer.WriteLine();
 
             WriteSectionHeader("Options:");


### PR DESCRIPTION
Fixes #344 

Hopefully, this resolves the question of what we want NUnitLite to support.