### PR TITLE
Make mono:latest the standard (and only) mono version for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: csharp
 sudo: false
 mono:
   - latest
-  - 4.2.4
 os:
   - linux
   - osx
 matrix:
   allow_failures:
-    - mono: latest
     - os: osx
   fast_finish: true
 script:


### PR DESCRIPTION
We have been using 4.2.4, which is way behind latest (4.8). We run latest but allow it to fail. In fact, the "latest" tag for mono is the latest stable version build, not the latest development build as I once thought. I think we should use mono:latest for all our builds, just as @jnm2 did for the docker build.