### PR TITLE
Fix execution of non-parallel test fixtures

### DIFF
--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
@@ -1,0 +1,95 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if PARALLEL
+
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Internal.Execution
+{
+    public class ParallelExecutionStrategyTests
+    {
+        private TestExecutionContext _context;
+        private TestMethod _testMethod;
+        private TestFixture _testFixture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _context = new TestExecutionContext();
+            _testMethod = Fakes.GetTestMethod(GetType(), "TestMethod");
+            _testFixture = new TestFixture(new TypeWrapper(typeof(MyFixture)));
+        }
+
+        [TestCase(ParallelScope.Default, ParallelScope.Default, "Direct")]
+        [TestCase(ParallelScope.Self, ParallelScope.Default, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Default, "NonParallel")]
+        [TestCase(ParallelScope.Default, ParallelScope.Children, "Parallel")]
+        [TestCase(ParallelScope.Self, ParallelScope.Children, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Children, "NonParallel")]
+        [TestCase(ParallelScope.Default, ParallelScope.Fixtures, "Direct")]
+        [TestCase(ParallelScope.Self, ParallelScope.Fixtures, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Fixtures, "NonParallel")]
+        public void ParallelExecutionStrategy_TestCase(ParallelScope testScope, ParallelScope contextScope, string expectedStrategy)
+        {
+            _testMethod.Properties.Set(PropertyNames.ParallelScope, testScope);
+            _context.ParallelScope = contextScope;
+
+            WorkItem work = WorkItem.CreateWorkItem(_testMethod, TestFilter.Empty);
+            work.InitializeContext(_context);
+
+            // We use a string for expected because the ExecutionStrategy enum is internal and can't be an arg to a public method
+            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo(expectedStrategy));
+            
+            // Make context single threaded - should always be direct
+            _context.IsSingleThreaded = true;
+            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo("Direct"));
+        }
+
+        [TestCase(ParallelScope.Default, ParallelScope.Default, "Direct")]
+        [TestCase(ParallelScope.Self, ParallelScope.Default, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Default, "NonParallel")]
+        [TestCase(ParallelScope.Default, ParallelScope.Children, "Parallel")]
+        [TestCase(ParallelScope.Self, ParallelScope.Children, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Children, "NonParallel")]
+        [TestCase(ParallelScope.Default, ParallelScope.Fixtures, "Parallel")]
+        [TestCase(ParallelScope.Self, ParallelScope.Fixtures, "Parallel")]
+        [TestCase(ParallelScope.None, ParallelScope.Fixtures, "NonParallel")]
+        public void ParallelExeutionStrategy_TestFixture(ParallelScope testScope, ParallelScope contextScope, string expectedStrategy)
+        {
+            _testFixture.Properties.Set(PropertyNames.ParallelScope, testScope);
+            _context.ParallelScope = contextScope;
+
+            WorkItem work = WorkItem.CreateWorkItem(_testFixture, TestFilter.Empty);
+            work.InitializeContext(_context);
+
+            // We use a string for expected because the ExecutionStrategy enum is internal and can't be an arg to a public method
+            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo(expectedStrategy));
+        }
+
+        private void TestMethod() { }
+
+        private class MyFixture { }
+    }
+}
+#endif

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />
@@ -102,7 +103,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
-	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Results\AssertionResultTests.cs" />
     <Compile Include="Internal\Results\TestResultFailureTests.cs" />
@@ -231,7 +232,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
-	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />
@@ -201,7 +202,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
-	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-portable.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />
     <Compile Include="Internal\Filters\ClassNameFilterTests.cs" />
@@ -199,7 +200,7 @@
     <Compile Include="Internal\Filters\FullNameFilterTests.cs" />
     <Compile Include="Internal\Filters\IdFilterTests.cs" />
     <Compile Include="Internal\Filters\MethodNameFilterTests.cs" />
-	<Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
+    <Compile Include="Internal\Filters\NamespaceFilterTests.cs" />
     <Compile Include="Internal\Filters\NotFilterTests.cs" />
     <Compile Include="Internal\Filters\OrFilterTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />


### PR DESCRIPTION
This is the code that was missing in #2153 plus tests.