### PR TITLE
Prevent crash in .NET standard with log file path

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Api
                         ? (string)Settings[FrameworkPackageSettings.WorkDirectory]
                         : Directory.GetCurrentDirectory();
 #if NETSTANDARD1_6
-                    var id = DateTime.Now.ToString("o");
+                    var id = DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss");
 #else      
                     var id = Process.GetCurrentProcess().Id;
 #endif

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -440,7 +440,7 @@ namespace NUnitLite
                     : "NUnitLite";
 
 #if NETSTANDARD1_6
-            var id = DateTime.Now.ToString("o");
+            var id = DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss");
 #else
             var id = Process.GetCurrentProcess().Id;
 #endif


### PR DESCRIPTION
`DateTime.Now.ToString("o")` was producing a time stamp with colons, which was an invalid file path. Swapped it out for a fixed format.