### PR TITLE
Fix travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: csharp
 sudo: false
 mono:
+  - 4.8.1
   - latest
 os:
   - linux
   - osx
 matrix:
+  exclude:
+    - os: osx
+      mono: latest
   allow_failures:
     - os: osx
+    - mono: latest
   fast_finish: true
 script:
   - ./build.sh --target "Travis"

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -500,7 +500,9 @@ namespace NUnit.Framework.Internal
             if (context.CurrentTest != null)
                 context.CurrentResult = context.CurrentTest.MakeTestResult();
 
+#if PARALLEL
             context.TestWorker = TestWorker;
+#endif
 
             return context;
         }

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -500,6 +500,8 @@ namespace NUnit.Framework.Internal
             if (context.CurrentTest != null)
                 context.CurrentResult = context.CurrentTest.MakeTestResult();
 
+            context.TestWorker = TestWorker;
+
             return context;
         }
 


### PR DESCRIPTION
I have travis set up to only require the Linux Mono 4.8.1 job to succeed. We can keep this until we figure out what's up with Mono 5.0.0.

This also fixes #2157