### PR TITLE
Modify public references from NUnit 3.0 -> NUnit 3

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
-# Building NUnit 3.0
+# Building NUnit 3
 
-NUnit 3.0 consists of three separate layers: the Framework, the Engine and the Console Runner.
+NUnit 3 consists of three separate layers: the Framework, the Engine and the Console Runner.
 The source code is kept in two GitHub repositories at http://github.com/nunit/nunit and
 http://github.com/nunit/nunit-console.
 

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -13,7 +13,7 @@
     <summary>NUnit is a unit-testing framework for all .NET languages with a strong TDD focus.</summary>
     <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible.
 
-This package includes the NUnit 3.0 framework assembly, which is referenced by your tests. You will need to install version 3.0 of the nunit3-console program or a third-party runner that supports NUnit 3.0 in order to execute tests. Runners intended for use with NUnit 2.x will not run 3.0 tests correctly.
+This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
 
 Supported platforms:
   - .NET 2.0+
@@ -23,7 +23,7 @@ Supported platforms:
   - Universal (Windows Phone 8.1+, Windows 8.1+)
   - Xamarin (MonoTouch, MonoAndroid, Xamarin iOS Universal)
   - Portable Libraries (supporting Profile259)</description>
-    <releaseNotes>This package includes the NUnit 3.0 framework assembly, which is referenced by your tests. You will need to install version 3.0 of the nunit3-console program or a third-party runner that supports NUnit 3.0 in order to execute tests. Runners intended for use with NUnit 2.x will not run 3.0 tests correctly.</releaseNotes>
+    <releaseNotes>This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd framework fluent assert theory plugin addin</tags>
     <copyright>Copyright (c) 2017 Charlie Poole</copyright>

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -37,7 +37,7 @@ namespace NUnitLite
 {
     /// <summary>
     /// NUnit3XmlOutputWriter is responsible for writing the results
-    /// of a test to a file in NUnit 3.0 format.
+    /// of a test to a file in NUnit 3 format.
     /// </summary>
     public class NUnit3XmlOutputWriter : OutputWriter
     {

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -150,11 +150,11 @@ namespace NUnitLite
             WriteHelpLine("          --OPTION:filename;transform=xsltfile");
             Writer.WriteLine();
             WriteHelpLine("      The --result option may use any of the following formats:");
-            WriteHelpLine("          nunit3 - the native XML format for NUnit 3.0");
+            WriteHelpLine("          nunit3 - the native XML format for NUnit 3");
             WriteHelpLine("          nunit2 - legacy XML format used by earlier releases of NUnit");
             Writer.WriteLine();
             WriteHelpLine("      The --explore option may use any of the following formats:");
-            WriteHelpLine("          nunit3 - the native XML format for NUnit 3.0");
+            WriteHelpLine("          nunit3 - the native XML format for NUnit 3");
             WriteHelpLine("          cases  - a text file listing the full names of all test cases.");
             WriteHelpLine("      If --explore is used without any specification following, a list of");
             WriteHelpLine("      test cases is output to the console.");


### PR DESCRIPTION
Spotted today that the NuGet package description still states the package includes NUnit 3.0. Did a quick search while I was here, and changed what I believe are all the public usages of "NUnit 3.0" to "NUnit 3".