### PR TITLE
[Discussion] Adding TestParameters.TryGetValue

### DIFF
--- a/src/NUnitFramework/framework/TestParameters.cs
+++ b/src/NUnitFramework/framework/TestParameters.cs
@@ -60,6 +60,18 @@ namespace NUnit.Framework
         }
 
         /// <summary>
+        /// Gets the value of the parameter with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the parameter. If <see langword="null"/>, throws <see cref="ArgumentNullException"/>.</param>
+        /// <param name="value">The value of the parameter, if the name is found.</param>
+        /// <returns>True if a parameter with the given name exists, otherwise false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is <see langword="null"/>.</exception>
+        public bool TryGetValue(string name, out string value)
+        {
+            return _parameters.TryGetValue(name, out value);
+        }
+
+        /// <summary>
         /// Get the value of a parameter or a default string
         /// </summary>
         /// <param name="name">Name of the parameter</param>

--- a/src/NUnitFramework/tests/TestParametersTests.cs
+++ b/src/NUnitFramework/tests/TestParametersTests.cs
@@ -107,6 +107,34 @@ namespace NUnit.Framework.Tests
 
         #endregion
 
+        #region TryGetValue
+
+        [Test]
+        public void TryGetValue_Existing()
+        {
+            _parameters.Add("SomeParm", "5");
+            string value;
+            Assert.That(_parameters.TryGetValue("SomeParm", out value), Is.True);
+            Assert.That(value, Is.EqualTo("5"));
+        }
+
+        [Test]
+        public void TryGetValue_Missing()
+        {
+            _parameters.Add("SomeParm", "5");
+            string _;
+            Assert.That(_parameters.TryGetValue("SomeOtherParm", out _), Is.False);
+        }
+
+        [Test]
+        public void TryGetValue_NullKeyThrowsException()
+        {
+            string _;
+            Assert.That(() => _parameters.TryGetValue(null, out _), Throws.ArgumentNullException);
+        }
+
+        #endregion
+
         #region Get String
 
         [Test]


### PR DESCRIPTION
Please do not merge until consensus is reached.

This is a primitive that comes in very handy.

```c#
var foo = TestContext.Parameters.TryGetValue("name", out var passedValue)
    ? ParseFoo(passedValue)
    : defaultFooValue;
```