### PR TITLE
Fix tests failing on systems with CultureInfo other than en

### DIFF
--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace NUnit.Framework.Constraints
 {
@@ -84,7 +83,7 @@ namespace NUnit.Framework.Constraints
                 () => Assert.That(actual, Is.LessThan(expected).Within(tolerance)),
                 "Assertion should have failed");
 
-            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + Convert.ToDouble(tolerance).ToString(CultureInfo.InvariantCulture)));
+            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + MsgUtils.FormatValue(tolerance)));
         }
 
         [TestCase(4.0, 5.0, 1)]

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace NUnit.Framework.Constraints
 {
@@ -83,7 +84,7 @@ namespace NUnit.Framework.Constraints
                 () => Assert.That(actual, Is.LessThan(expected).Within(tolerance)),
                 "Assertion should have failed");
 
-            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + tolerance.ToString()));
+            Assert.That(ex.Message, Contains.Substring("Expected: less than " + MsgUtils.FormatValue(expected) + " within " + Convert.ToDouble(tolerance).ToString(CultureInfo.InvariantCulture)));
         }
 
         [TestCase(4.0, 5.0, 1)]

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
@@ -34,6 +35,7 @@ namespace NUnit.Framework.Internal
     {
         private static readonly string STREAM_NAME = "EventListenerTextWriterTestsStream";
         private static readonly string NL = Environment.NewLine;
+        private readonly string decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
         TestListenerIntercepter ListenerResult;
         TextWriter ListenerWriter;
@@ -95,7 +97,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0, arg1);
             ListenerWriter.WriteLine(format, arg0, arg1);
 
-            var expected = "05.00 @";
+            var expected = $"05{decimalSeparator}00 @";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -112,7 +114,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0, arg1, arg2);
             ListenerWriter.WriteLine(format, arg0, arg1, arg2);
 
-            var expected = "Quick 9.00 Fox";
+            var expected = $"Quick 9{decimalSeparator}00 Fox";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -155,7 +157,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(value);
             ListenerWriter.WriteLine(value);
 
-            var expected = "2.731";
+            var expected = $"2{decimalSeparator}731";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -169,7 +171,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(value);
             ListenerWriter.WriteLine(value);
 
-            var expected = "-1.5";
+            var expected = $"-1{decimalSeparator}5";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0);
             ListenerWriter.WriteLine(format, arg0);
 
-            var expected = "20 Apr 2017";
+            var expected = $"20 {CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(4)} 2017";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
@@ -80,7 +79,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0);
             ListenerWriter.WriteLine(format, arg0);
 
-            var expected = $"20 {CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(4)} 2017";
+            var expected = $"{arg0:dd MMM yyyy}";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -35,7 +35,6 @@ namespace NUnit.Framework.Internal
     {
         private static readonly string STREAM_NAME = "EventListenerTextWriterTestsStream";
         private static readonly string NL = Environment.NewLine;
-        private readonly string decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
         TestListenerIntercepter ListenerResult;
         TextWriter ListenerWriter;
@@ -97,7 +96,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0, arg1);
             ListenerWriter.WriteLine(format, arg0, arg1);
 
-            var expected = $"05{decimalSeparator}00 @";
+            var expected = $"{5:00.00} @";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -114,7 +113,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(format, arg0, arg1, arg2);
             ListenerWriter.WriteLine(format, arg0, arg1, arg2);
 
-            var expected = $"Quick 9{decimalSeparator}00 Fox";
+            var expected = $"Quick {9:#.00} Fox";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -157,7 +156,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(value);
             ListenerWriter.WriteLine(value);
 
-            var expected = $"2{decimalSeparator}731";
+            var expected = $"{2.731:0.000}";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
@@ -171,7 +170,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.Write(value);
             ListenerWriter.WriteLine(value);
 
-            var expected = $"-1{decimalSeparator}5";
+            var expected = $"{-1.5:0.0}";
             Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));


### PR DESCRIPTION
Some tests contain comparisons to strings with hardcoded dot decimal mark in double numbers, which fails on systems using comma decimal mark. One test contains comparison to string with hardcoded month abbreviation, which fails on systems using language other than English. Since it's known what is expected in those tests, changing those values to take culture info into consideration fixes the issue.

Fixes #2179 