### PR TITLE
Catch potential exceptions from launching debugger

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -229,6 +229,16 @@ namespace NUnit.Framework.Internal.Execution
 #endif
         }
 
+        /// <summary>
+        /// Marks the WorkItem as NotRunnable.
+        /// </summary>
+        /// <param name="reason">Reason for test being NotRunnable.</param>
+        public void MarkNotRunnable(string reason)
+        {
+            Result.SetResult(ResultState.NotRunnable, reason);
+            WorkItemComplete();
+        }
+
         private object threadLock = new object();
 
         /// <summary>


### PR DESCRIPTION
In addition to the NotImplementedException thrown by mono, also catches SecurityExceptions, as per [MSDN docs](https://msdn.microsoft.com/en-us/library/system.diagnostics.debugger.launch(v=vs.110).aspx).

Fixes #2191 