### PR TITLE
Correct platform name

### DIFF
--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -367,7 +367,7 @@ namespace NUnit.Framework.Tests
 
         [TestCase(null)]
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
-        [TestCase("bad<>path.png", IncludePlatform = "Windows")]
+        [TestCase("bad<>path.png", IncludePlatform = "Win")]
 #endif
         public void InvalidFilePathsThrowsArgumentException(string filePath)
         {


### PR DESCRIPTION
Just spotted in a CI log that I'd used an invalid platform name here - I guess I missed the 'skipped' message before in amongst all the 'Explict' tests.