### PR TITLE
Handle null or empty filter when exploring tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -16,7 +16,7 @@ var ErrorDetail = new List<string>();
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "3.7.0";
+var version = "3.7.1";
 var modifier = "";
 
 var isAppveyor = BuildSystem.IsRunningOnAppVeyor;

--- a/src/NUnitFramework/FrameworkVersion.cs
+++ b/src/NUnitFramework/FrameworkVersion.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 //
 // Current version for the NUnit Framework
 //
-[assembly: AssemblyVersion("3.7.0.0")]
-[assembly: AssemblyFileVersion("3.7.0.0")]
+[assembly: AssemblyVersion("3.7.1.0")]
+[assembly: AssemblyFileVersion("3.7.1.0")]

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -336,8 +336,6 @@ namespace NUnit.Framework.Api
 
         private void ExploreTests(ICallbackEventHandler handler, string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             if (Runner.LoadedTest == null)
                 throw new InvalidOperationException("The Explore method was called but no test has been loaded");
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -216,8 +216,6 @@ namespace NUnit.Framework.Api
         /// <returns>The XML result of exploring the tests</returns>
         public string ExploreTests(string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             if (Runner.LoadedTest == null)
                 throw new InvalidOperationException("The Explore method was called but no test has been loaded");
 
@@ -231,8 +229,6 @@ namespace NUnit.Framework.Api
         /// <returns>The XML result of the test run</returns>
         public string RunTests(string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             TNode result = Runner.Run(new TestProgressReporter(null), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
@@ -275,8 +271,6 @@ namespace NUnit.Framework.Api
         /// <returns>The XML result of the test run</returns>
         public string RunTests(Action<string> callback, string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             var handler = new ActionCallback(callback);
 
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
@@ -296,8 +290,6 @@ namespace NUnit.Framework.Api
         /// <param name="filter">A string containing the XML representation of the filter to use</param>
         private void RunAsync(Action<string> callback, string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             var handler = new ActionCallback(callback);
 
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
@@ -320,8 +312,6 @@ namespace NUnit.Framework.Api
         /// <returns>The number of tests</returns>
         public int CountTests(string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             return Runner.CountTestCases(TestFilter.FromXml(filter));
         }
 
@@ -344,8 +334,6 @@ namespace NUnit.Framework.Api
 
         private void RunTests(ICallbackEventHandler handler, string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
 
             // Insert elements as first child in reverse order
@@ -358,8 +346,6 @@ namespace NUnit.Framework.Api
 
         private void RunAsync(ICallbackEventHandler handler, string filter)
         {
-            Guard.ArgumentNotNull(filter, "filter");
-
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
         }
 

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -58,9 +58,9 @@ namespace NUnit.Framework.Internal
         public bool TopLevel { get; set; }
 
         /// <summary>
-        /// Determine if a particular test passes the filter criteria. The default 
+        /// Determine if a particular test passes the filter criteria. The default
         /// implementation checks the test itself, its parents and any descendants.
-        /// 
+        ///
         /// Derived classes may override this method or any of the Match methods
         /// to change the behavior of the filter.
         /// </summary>
@@ -125,6 +125,9 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestFilter FromXml(string xmlText)
         {
+            if (string.IsNullOrEmpty(xmlText))
+                xmlText = "<filter />";
+
             TNode topNode = TNode.FromXml(xmlText);
 
             if (topNode.Name != "filter")
@@ -169,7 +172,7 @@ namespace NUnit.Framework.Internal
                     return new NotFilter(FromXml(node.FirstChild));
 
                 case "id":
-                    return new IdFilter(node.Value); 
+                    return new IdFilter(node.Value);
 
                 case "test":
                     return new FullNameFilter(node.Value) { IsRegex = isRegex };

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -177,11 +177,13 @@ namespace NUnit.Framework.Api
             Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");
         }
 
-        [Test]
-        public void ExploreTestsAction_AfterLoad_ReturnsRunnableSuite()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(EMPTY_FILTER)]
+        public void ExploreTestsAction_AfterLoad_ReturnsRunnableSuite(string filter)
         {
             new FrameworkController.LoadTestsAction(_controller, _handler);
-            new FrameworkController.ExploreTestsAction(_controller, EMPTY_FILTER, _handler);
+            new FrameworkController.ExploreTestsAction(_controller, filter, _handler);
             var result = TNode.FromXml(_handler.GetCallbackResult());
 
             Assert.That(result.Name.ToString(), Is.EqualTo("test-suite"));

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -56,6 +56,16 @@ namespace NUnit.Framework.Api
         private FrameworkController _controller;
         private ICallbackEventHandler _handler;
 
+        public static IEnumerable EmptyFilters
+        {
+            get
+            {
+                yield return new TestCaseData(null);
+                yield return new TestCaseData("");
+                yield return new TestCaseData(EMPTY_FILTER);
+            }
+        }
+
         public class FixtureCategoryTester
         {
             [Category("FixtureCategory")]
@@ -177,9 +187,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");
         }
 
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(EMPTY_FILTER)]
+        [TestCaseSource(nameof(EmptyFilters))]
         public void ExploreTestsAction_AfterLoad_ReturnsRunnableSuite(string filter)
         {
             new FrameworkController.LoadTestsAction(_controller, _handler);
@@ -257,11 +265,11 @@ namespace NUnit.Framework.Api
         #endregion
 
         #region CountTestsAction
-        [Test]
-        public void CountTestsAction_AfterLoad_ReturnsCorrectCount()
+        [TestCaseSource(nameof(EmptyFilters))]
+        public void CountTestsAction_AfterLoad_ReturnsCorrectCount(string filter)
         {
             new FrameworkController.LoadTestsAction(_controller, _handler);
-            new FrameworkController.CountTestsAction(_controller, EMPTY_FILTER, _handler);
+            new FrameworkController.CountTestsAction(_controller, filter, _handler);
             Assert.That(_handler.GetCallbackResult(), Is.EqualTo(MockAssembly.Tests.ToString()));
         }
 
@@ -295,11 +303,11 @@ namespace NUnit.Framework.Api
         #endregion
 
         #region RunTestsAction
-        [Test]
-        public void RunTestsAction_AfterLoad_ReturnsRunnableSuite()
+        [TestCaseSource(nameof(EmptyFilters))]
+        public void RunTestsAction_AfterLoad_ReturnsRunnableSuite(string filter)
         {
             new FrameworkController.LoadTestsAction(_controller, _handler);
-            new FrameworkController.RunTestsAction(_controller, EMPTY_FILTER, _handler);
+            new FrameworkController.RunTestsAction(_controller, filter, _handler);
             var result = TNode.FromXml(_handler.GetCallbackResult());
 
             // TODO: Any failure here throws an exception because the call to RunTestsAction
@@ -366,11 +374,11 @@ namespace NUnit.Framework.Api
         #endregion
 
         #region RunAsyncAction
-        [Test]
-        public void RunAsyncAction_AfterLoad_ReturnsRunnableSuite()
+        [TestCaseSource(nameof(EmptyFilters))]
+        public void RunAsyncAction_AfterLoad_ReturnsRunnableSuite(string filter)
         {
             new FrameworkController.LoadTestsAction(_controller, _handler);
-            new FrameworkController.RunAsyncAction(_controller, EMPTY_FILTER, _handler);
+            new FrameworkController.RunAsyncAction(_controller, filter, _handler);
             //var result = TNode.FromXml(_handler.GetCallbackResult());
 
             //Assert.That(result.Name.ToString(), Is.EqualTo("test-suite"));

--- a/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -35,10 +35,12 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(TestFilter.Empty.IsEmpty);
         }
 
-        [Test]
-        public void BuildFromXml()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("<filter/>")]
+        public void BuildFromXml(string xml)
         {
-            TestFilter filter = TestFilter.FromXml("<filter/>");
+            TestFilter filter = TestFilter.FromXml(xml);
 
             Assert.That(filter.IsEmpty);
         }


### PR DESCRIPTION
Fixes #2205

Branched off the 3.7 release branch and merging back into that branch in preparation for the hotfix. Once the 3.7.1 release is out, I will merge those changes back into master in another PR.