### PR TITLE
Ensure all work finishes before shutdown

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -192,7 +192,7 @@ namespace NUnit.Framework.Internal.Execution
                 q.Pause();
 
             // Signal the dispatcher that shift ended
-            EndOfShift(this, EventArgs.Empty);
+            EndOfShift?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2209 (not 2143 as the branch name suggests - sorry)

To deal with the window during which all queues are empty and all workers are idle, but the teardowns for some fixtures may not yet have been scheduled, I added code to simply busy-wait on completion of the top level item. Rather than shutting down when there is no work to do, we don't shut down until there is no work AND the top level item is complete. Meanwhile, we keep trying to start a new shift to deal with the any one-time teardowns or other tasks that may be scheduled.

At some point, we may need to structure this better with more events to wait on but as a hotfix I think the busy-waiting is a better solution.

As far as testing... I set up a script that was reliably duplicating the hang reported in #2209. After the fix, I was able to rapidly run the script commands hundreds of times in a loop without a hang. No guarantee that other problems won't arise, of course.

Because this has to do with timing and race conditions, I think at least two reviews would be a good idea.
