### PR TITLE
Fixing regression that caused NUnit to be sensitive to windows timer resolution

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
@@ -197,6 +197,8 @@ namespace NUnit.Framework.Internal.Execution
                 break;
             } while (true);
 
+            // Setting this to anything other than 0 causes NUnit to be sensitive
+            // to the windows timer resolution - see issue #2217 
             Thread.Sleep(0);  // give EventPump thread a chance to process the event
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
@@ -197,7 +197,7 @@ namespace NUnit.Framework.Internal.Execution
                 break;
             } while (true);
 
-            Thread.Sleep(1);  // give EventPump thread a chance to process the event
+            Thread.Sleep(0);  // give EventPump thread a chance to process the event
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #2217 covers this regression in detail.