### PR TITLE
Add KeyValuePair<K, V> to default formatters

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -26,6 +26,8 @@ using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
+using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -209,7 +211,7 @@ namespace NUnit.Framework.Constraints
                 return null;
 
             Type valueType = value.GetType();
-            if (!valueType.IsGenericType)
+            if (!valueType.GetTypeInfo().IsGenericType)
                 return null;
 
             Type baseValueType = valueType.GetGenericTypeDefinition();

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -226,19 +226,7 @@ namespace NUnit.Framework.Constraints
 
         private static string FormatKeyValuePair(object key, object value)
         {
-            StringBuilder s = new StringBuilder();
-            s.Append('[');
-            if (key != null)
-            {
-                s.Append(FormatValue(key));
-            }
-            s.Append(", ");
-            if (value != null)
-            {
-                s.Append(FormatValue(value));
-            }
-            s.Append(']');
-            return s.ToString();
+            return string.Format("[{0}, {1}]", FormatValue(key), FormatValue(value));
         }
 
         private static string FormatString(string s)

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
@@ -126,17 +127,33 @@ namespace NUnit.Framework.Constraints
             Assert.That(MsgUtils.FormatValue(new DateTime(2007, 7, 4, 9, 15, 30, 123)), Is.EqualTo("2007-07-04 09:15:30.123"));
         }
 
-		[Test]
+        [Test]
         public static void FormatValue_DateTimeOffsetTest()
         {
             Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8))), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
         }
 
-#endregion
+        [Test]
+        public static void FormatValue_KeyValuePairTest()
+        {
+            Assert.That(MsgUtils.FormatValue(new KeyValuePair<string, char>("Hello", 'h')), Is.EqualTo("[\"Hello\", 'h']"));
+        }
 
-		#region EscapeControlChars
+        [TestCase(null, null, "[, ]")]
+        [TestCase(null, "Second", "[, \"Second\"]")]
+        [TestCase("First", null, "[\"First\", ]")]
+        [TestCase("First", "Second", "[\"First\", \"Second\"]")]
+        public static void FormatValue_KeyValuePairWithNullsTest(string key, string value, string expectedResult)
+        {
+            string s = MsgUtils.FormatValue(new KeyValuePair<string, string>(key, value));
+            Assert.That(s, Is.EqualTo(expectedResult));
+        }
 
-		[TestCase ("\n", "\\n")]
+        #endregion
+
+        #region EscapeControlChars
+
+        [TestCase ("\n", "\\n")]
         [TestCase("\n\n", "\\n\\n")]
         [TestCase("\n\n\n", "\\n\\n\\n")]
         [TestCase("\r", "\\r")]

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -133,19 +133,14 @@ namespace NUnit.Framework.Constraints
             Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8))), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
         }
 
-        [Test]
-        public static void FormatValue_KeyValuePairTest()
-        {
-            Assert.That(MsgUtils.FormatValue(new KeyValuePair<string, char>("Hello", 'h')), Is.EqualTo("[\"Hello\", 'h']"));
-        }
-
-        [TestCase(null, null, "[, ]")]
-        [TestCase(null, "Second", "[, \"Second\"]")]
-        [TestCase("First", null, "[\"First\", ]")]
+        [TestCase(null, null, "[null, null]")]
+        [TestCase(null, "Second", "[null, \"Second\"]")]
+        [TestCase("First", null, "[\"First\", null]")]
         [TestCase("First", "Second", "[\"First\", \"Second\"]")]
-        public static void FormatValue_KeyValuePairWithNullsTest(string key, string value, string expectedResult)
+        [TestCase(123, 'h', "[123, 'h']")]
+        public static void FormatValue_KeyValuePairTest(object key, object value, string expectedResult)
         {
-            string s = MsgUtils.FormatValue(new KeyValuePair<string, string>(key, value));
+            string s = MsgUtils.FormatValue(new KeyValuePair<object, object>(key, value));
             Assert.That(s, Is.EqualTo(expectedResult));
         }
 
@@ -153,7 +148,7 @@ namespace NUnit.Framework.Constraints
 
         #region EscapeControlChars
 
-        [TestCase ("\n", "\\n")]
+        [TestCase("\n", "\\n")]
         [TestCase("\n\n", "\\n\\n")]
         [TestCase("\n\n\n", "\\n\\n\\n")]
         [TestCase("\r", "\\r")]


### PR DESCRIPTION
Also replaced some tabs with spaces and removed trailing spaces.

Fixes #2244