### PR TITLE
Add testcases for formatting of char

### DIFF
--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -132,7 +132,15 @@ namespace NUnit.Framework.Constraints
             Assert.That(MsgUtils.FormatValue(new DateTimeOffset(2007, 7, 4, 9, 15, 30, 123, TimeSpan.FromHours(8))), Is.EqualTo("2007-07-04 09:15:30.123+08:00"));
         }
 
-#endregion
+        [TestCase('a', "'a'")]
+        [TestCase('h', "'h'")]
+        [TestCase('z', "'z'")]
+        public static void FormatValue_CharTest(char c, string expected)
+        {
+            Assert.That(MsgUtils.FormatValue(c), Is.EqualTo(expected));
+        }
+
+        #endregion
 
 		#region EscapeControlChars
 
@@ -205,12 +213,6 @@ namespace NUnit.Framework.Constraints
         }
 
 #endregion
-
-        //[TestCase('\0')]
-        //[TestCase('\r')]
-        //public void CharacterArgumentTest(char c)
-        //{
-        //}
 
 #region ClipExpectedAndActual
 


### PR DESCRIPTION
Prior formatting of regular chars were only indirectly tested in `AllItemsAreInstancesOfTypeFailureMessage`.