### PR TITLE
Better links to the developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ To help new contributors get their feet wet, we have marked a number of issues w
 
 It is also a good idea to add a comment to an issue that you are working on to let everyone know. If you stop working on it, also please let us know.
 
-Please read through the developer section of the [NUnit documentation](https://github.com/nunit/docs/wiki/NUnit-Documentation) before contributing to understand our coding standards and contribution guidelines.
+Please read through the [developer docs](https://github.com/nunit/docs/wiki/Team-Practices#technical-practices) before contributing to understand our coding standards and contribution guidelines.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Documentation for all NUnit projects are hosted on GitHub at [https://github.com
 
 ## Contributing ##
 
-For more information on contributing to the NUnit project, please see [CONTRIBUTING.md](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) and the [Developer Docs](https://github.com/nunit/docs/wiki/Developer-FAQ).
+For more information on contributing to the NUnit project, please see [CONTRIBUTING.md](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) and the [Developer Docs](https://github.com/nunit/docs/wiki/Team-Practices#technical-practices).
 
 NUnit 3.0 was created by [Charlie Poole](https://github.com/CharliePoole), [Rob Prouse](https://github.com/rprouse), [Simone Busoli](https://github.com/simoneb), [Neil Colvin](https://github.con/oznetmaster) and numerous community contributors. A complete list of contributors since NUnit migrated to GitHub can be [found on GitHub](https://github.com/nunit/nunit/graphs/contributors).
 


### PR DESCRIPTION
We're decommissioning https://github.com/nunit/docs/wiki/Developer-FAQ and the most directly helpful place to send people is https://github.com/nunit/docs/wiki/Team-Practices#technical-practices.