### PR TITLE
Fix Assembly marked with ParallelScope.None hanging

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal.Execution
                             Result.SetResult(ResultState.Success);
 
                             if (Children.Count > 0)
-                            {
+                            {   
                                 InitializeSetUpAndTearDownCommands();
 
                                 PerformOneTimeSetUp();

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal.Execution
                             Result.SetResult(ResultState.Success);
 
                             if (Children.Count > 0)
-                            {   
+                            {
                                 InitializeSetUpAndTearDownCommands();
 
                                 PerformOneTimeSetUp();

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -82,6 +82,8 @@ namespace NUnit.Framework.Internal.Execution
 
         private void OnStartNonParallelWorkItem(TestWorker worker, WorkItem work)
         {
+            // This captures the startup of TestFixtures and SetUpFixtures,
+            // but not their teardown items, which are not composite items
             if (work is CompositeWorkItem && work.Test.TypeInfo != null)
                 IsolateQueues(work);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -304,8 +304,12 @@ namespace NUnit.Framework.Internal.Execution
                 work.Test is TestFixture && work.Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
                     return ExecutionStrategy.Parallel;
 
-            // If all else fails, run on same thread
-            return ExecutionStrategy.Direct;
+            // There is no scope specified either on the item itself or in the context.
+            // In that case, simple work items are test cases and just run on the same
+            // thread, while composite work items and teardowns are non-parallel.
+            return work is SimpleWorkItem
+                ? ExecutionStrategy.Direct
+                : ExecutionStrategy.NonParallel;
         }
 
 #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -82,8 +82,8 @@ namespace NUnit.Framework.Internal.Execution
 
         private void OnStartNonParallelWorkItem(TestWorker worker, WorkItem work)
         {
-            if (work is CompositeWorkItem)
-                SaveQueueState(work);
+            if (work is CompositeWorkItem && work.Test.TypeInfo != null)
+                IsolateQueues(work);
         }
 
         #endregion
@@ -197,12 +197,12 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         private object _queueLock = new object();
-        private int _savedQueueLevel = 0;
+        private int _isolationLevel = 0;
 
         /// <summary>
-        /// Save the state of the queues
+        /// Save the state of the queues and create a new isolated set
         /// </summary>
-        internal void SaveQueueState(WorkItem work)
+        internal void IsolateQueues(WorkItem work)
         {
             log.Info("Saving Queue State for {0}", work.Name);
             lock (_queueLock)
@@ -210,16 +210,16 @@ namespace NUnit.Framework.Internal.Execution
                 foreach (WorkItemQueue queue in Queues)
                     queue.Save();
 
-                _savedQueueLevel++;
+                _isolationLevel++;
             }
         }
 
         /// <summary>
-        /// Try to restore a saved queue state
-        /// </summary><returns>True if the state was restored, otherwise false</returns>
-        private void RestoreQueueState()
+        /// Remove isolated queues and restore old ones
+        /// </summary>
+        private void RestoreQueues()
         {
-            Guard.OperationValid(_savedQueueLevel > 0, "Internal Error: Called RestoreQueueState with no saved queues!");
+            Guard.OperationValid(_isolationLevel > 0, "Internal Error: Called RestoreQueueState with no saved queues!");
 
             // Keep lock until we can remove for both methods
             lock (_queueLock)
@@ -229,7 +229,7 @@ namespace NUnit.Framework.Internal.Execution
                 foreach (WorkItemQueue queue in Queues)
                     queue.Restore();
 
-                _savedQueueLevel--;
+                _isolationLevel--;
             }
         }
 
@@ -239,8 +239,8 @@ namespace NUnit.Framework.Internal.Execution
 
         private void OnEndOfShift(object sender, EventArgs ea)
         {
-            if (_savedQueueLevel > 0)
-                RestoreQueueState();
+            if (_isolationLevel > 0)
+                RestoreQueues();
 
             // Shift has ended but all work may not yet be done
             while (_topLevelWorkItem.State != WorkItemState.Complete)
@@ -283,8 +283,6 @@ namespace NUnit.Framework.Internal.Execution
             // If there is no fixture and so nothing to do but dispatch 
             // grandchildren we run directly. This saves time that would 
             // otherwise be spent enqueuing and dequeing items.
-            // TODO: It would be even better if we could avoid creating 
-            // these "do-nothing" work items in the first place.
             if (work.Test.TypeInfo == null)
                 return ExecutionStrategy.Direct;
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -90,6 +90,9 @@ namespace NUnit.Framework.Internal.Execution
             Result = wrappedItem.Result;
             Context = wrappedItem.Context;
             ParallelScope = wrappedItem.ParallelScope;
+#if PARALLEL
+            TestWorker = wrappedItem.TestWorker;
+#endif
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
             TargetApartment = wrappedItem.TargetApartment;
 #endif

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Internal.Execution
             Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo("Direct"));
         }
 
-        [TestCase(ParallelScope.Default, ParallelScope.Default, "Direct")]
+        [TestCase(ParallelScope.Default, ParallelScope.Default, "NonParallel")]
         [TestCase(ParallelScope.Self, ParallelScope.Default, "Parallel")]
         [TestCase(ParallelScope.None, ParallelScope.Default, "NonParallel")]
         [TestCase(ParallelScope.Default, ParallelScope.Children, "Parallel")]
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Internal.Execution
         [TestCase(ParallelScope.Default, ParallelScope.Fixtures, "Parallel")]
         [TestCase(ParallelScope.Self, ParallelScope.Fixtures, "Parallel")]
         [TestCase(ParallelScope.None, ParallelScope.Fixtures, "NonParallel")]
-        public void ParallelExeutionStrategy_TestFixture(ParallelScope testScope, ParallelScope contextScope, string expectedStrategy)
+        public void ParallelExecutionStrategy_TestFixture(ParallelScope testScope, ParallelScope contextScope, string expectedStrategy)
         {
             _testFixture.Properties.Set(PropertyNames.ParallelScope, testScope);
             _context.ParallelScope = contextScope;


### PR DESCRIPTION
Fixes #2261

Note: The branch is named real-2261 because I mistakenly used issue-2261 for a previous fix.

This fixes the problems we have seen and one that I anticipated. See my inline comments.

I have tested this extensively but manually, using simple assemblies with various mixes of fixtures. I'm working on an automated way to do this as a part of a set of integration tests for the framework. For now, this fix will help with two problems, so let's get it in.