### PR TITLE
Mark fixtures with ParallelizableAttribute on non-test methods invalid

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -38,12 +38,13 @@ namespace NUnit.Framework.Internal.Builders
     /// </summary>
     public class NUnitTestFixtureBuilder
     {
-        #region Static Fields
+        #region Messages
 
-        static readonly string NO_TYPE_ARGS_MSG =
-            "Fixture type contains generic parameters. You must either provide " +
-            "Type arguments or specify constructor arguments that allow NUnit " +
-            "to deduce the Type arguments.";
+        const string NO_TYPE_ARGS_MSG =
+            "Fixture type contains generic parameters. You must either provide Type arguments or specify constructor arguments that allow NUnit to deduce the Type arguments.";
+
+        const string PARALLEL_NOT_ALLOWED_MSG =
+            "ParallelizableAttribute is only allowed on test methods and fixtures";
 
         #endregion
 
@@ -177,9 +178,10 @@ namespace NUnit.Framework.Internal.Builders
                 Test test = BuildTestCase(method, fixture);
 
                 if (test != null)
-                {
                     fixture.Add(test);
-                }
+                else // it's not a test, check for disallowed attributes
+                    if (method.IsDefined<ParallelizableAttribute>(false))
+                        fixture.MakeInvalid(PARALLEL_NOT_ALLOWED_MSG);
             }
         }
 

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -49,10 +49,10 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         }
 
         [Test]
-        public void Success(){}
+        public void Success() { }
 
         [Test]
-        public void EvenMoreSuccess(){}
+        public void EvenMoreSuccess() { }
     }
 
     [TestFixture]
@@ -122,7 +122,7 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         }
     }
 
-    [TestFixture,Explicit]
+    [TestFixture, Explicit]
     public class ExplicitSetUpAndTearDownFixture
     {
         public int setUpCount = 0;
@@ -141,20 +141,20 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         }
 
         [Test]
-        public void Success(){}
+        public void Success() { }
 
         [Test]
-        public void EvenMoreSuccess(){}
+        public void EvenMoreSuccess() { }
     }
 
     [TestFixture]
     public class InheritSetUpAndTearDown : SetUpAndTearDownFixture
     {
         [Test]
-        public void AnotherTest(){}
+        public void AnotherTest() { }
 
         [Test]
-        public void YetAnotherTest(){}
+        public void YetAnotherTest() { }
     }
 
     [TestFixture]
@@ -282,6 +282,17 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
 
         [Test]
         public static void MyTest() { }
+    }
+
+    [TestFixture]
+    public class FixtureWithParallelizableOnOneTimeSetUp
+    {
+        [OneTimeSetUp]
+        [Parallelizable]
+        public void BadOneTimeSetup() { }
+
+        [Test]
+        public void Test() { }
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -184,11 +184,20 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
         }
 
-//		[Test]
-//		public void CannotRunAbstractFixture()
-//		{
-//            TestAssert.IsNotRunnable(typeof(AbstractTestFixture));
-//		}
+        [Test]
+        public void FixtureWithParallelizableOnOneTimeSetUpIsInvalid()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureWithParallelizableOnOneTimeSetUp));
+            Assert.AreEqual(RunState.NotRunnable, suite.RunState);
+            Assert.AreEqual("ParallelizableAttribute is only allowed on test methods and fixtures", 
+                suite.Properties.Get(PropertyNames.SkipReason));
+        }
+
+        //		[Test]
+        //		public void CannotRunAbstractFixture()
+        //		{
+        //            TestAssert.IsNotRunnable(typeof(AbstractTestFixture));
+        //		}
 
         [Test]
         public void CanRunFixtureDerivedFromAbstractTestFixture()


### PR DESCRIPTION
Fixes #2269 
