### PR TITLE
Use unique names for each TestAttachments Fixture

### DIFF
--- a/src/NUnitFramework/testdata/TestAttachmentsTests.cs
+++ b/src/NUnitFramework/testdata/TestAttachmentsTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.TestData
     [TestFixture]
     public class TestAttachmentsTests
     {
-        public const string TempFileName = "NUnitTests.tmp";
+        public const string TempFileName = "TestAttachmentsTests.tmp";
         public const string Description = "Description for attachment";
 
         [Test]

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Tests
 
         private string _tempFilePath;
 
-        private const string TempFileName = "NUnitTests.tmp";
+        private const string TempFileName = "TestContextTests.tmp";
 
         public TestContextTests()
         {


### PR DESCRIPTION
Fixes #2276 - by not using the same name for temporary files across two independent test fixtures.

I used hardcoded file names rather than `Path.GetTempFileName()` as I wanted solely a file name for relative-path tests, rather than a fully rooted path.

Thanks @CharliePoole for tracking down the problem there. 🙂 