### PR TITLE
Throw argument exception if property not found in Is.Ordered.By()

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
             CreateNextStep(null);
         }
 
-        /// <summary> 
+        /// <summary>
         /// The display name of this Constraint for use by ToString().
         /// The default value is the name of the constraint with
         /// trailing "Constraint" removed. Derived classes may set
@@ -161,7 +161,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override string Description
         {
-            get 
+            get
             {
                 string description = "collection ordered";
 
@@ -193,7 +193,7 @@ namespace NUnit.Framework.Constraints
             foreach (object current in actual)
             {
                 if (current == null)
-                    throw new ArgumentNullException("actual", "Null value at index " + index.ToString());
+                    throw new ArgumentNullException(nameof(actual), "Null value at index " + index.ToString());
 
                 if (previous != null)
                 {
@@ -202,13 +202,16 @@ namespace NUnit.Framework.Constraints
                         foreach (var step in _steps)
                         {
                             string propertyName = step.PropertyName;
-                            PropertyInfo previousProp = previous.GetType().GetProperty(propertyName);
-                            PropertyInfo prop = current.GetType().GetProperty(propertyName);
-                            var previousValue = previousProp.GetValue(previous, null);
-                            var currentValue = prop.GetValue(current, null);
 
-                            if (currentValue == null)
-                                throw new ArgumentException("actual", "Null property value at index " + index.ToString());
+                            PropertyInfo previousProp = previous.GetType().GetProperty(propertyName);
+                            if (previousProp == null)
+                                throw new ArgumentException($"Property {propertyName} not found at index {index - 1}", nameof(actual));
+                            var previousValue = previousProp.GetValue(previous, null);
+
+                            PropertyInfo prop = current.GetType().GetProperty(propertyName);
+                            if (prop == null)
+                                throw new ArgumentException($"Property {propertyName} not found at index {index}", nameof(actual));
+                            var currentValue = prop.GetValue(current, null);
 
                             int comparisonResult = step.Comparer.Compare(previousValue, currentValue);
 

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -125,7 +125,11 @@ namespace NUnit.Framework.Constraints
                 Is.Ordered.By("A").Descending.Then.By("B").Descending ),
             new TestCaseData(
                 new[] { new TestClass3("XYZ", 2), new TestClass3("ABC", 42), new TestClass3("ABC", 1) },
-                Is.Ordered.Descending.By("A").Then.Descending.By("B") )
+                Is.Ordered.Descending.By("A").Then.Descending.By("B") ),
+            // Ordered by a field
+            new TestCaseData(
+                new[] { new TestClass4("aaa"), new TestClass4("bbb"), new TestClass4("ccc") },
+                Is.Ordered.By("Name") ),
         };
 
         #endregion
@@ -303,6 +307,21 @@ namespace NUnit.Framework.Constraints
             public override string ToString()
             {
                 return A.ToString() + "," + B.ToString();
+            }
+        }
+
+        public class TestClass4
+        {
+            public readonly string Name;
+
+            public TestClass4(string name)
+            {
+                Name = name;
+            }
+
+            public override string ToString()
+            {
+                return Name;
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -125,11 +125,7 @@ namespace NUnit.Framework.Constraints
                 Is.Ordered.By("A").Descending.Then.By("B").Descending ),
             new TestCaseData(
                 new[] { new TestClass3("XYZ", 2), new TestClass3("ABC", 42), new TestClass3("ABC", 1) },
-                Is.Ordered.Descending.By("A").Then.Descending.By("B") ),
-            // Ordered by a field
-            new TestCaseData(
-                new[] { new TestClass4("aaa"), new TestClass4("bbb"), new TestClass4("ccc") },
-                Is.Ordered.By("Name") ),
+                Is.Ordered.Descending.By("A").Then.Descending.By("B") )
         };
 
         #endregion
@@ -259,6 +255,28 @@ namespace NUnit.Framework.Constraints
             Assert.Throws<ArgumentException>(() => Assert.That(new [] { new object(), new object() }, Is.Ordered));
         }
 
+        [TestCaseSource(nameof(InvalidOrderedByData))]
+        public void IsOrdered_ThrowsOnMissingProperty(object[] collection, string property, string expectedIndex)
+        {
+            Assert.That(() => Assert.That(collection, Is.Ordered.By(property)), Throws.ArgumentException.With.Message.Contain(expectedIndex));
+        }
+
+        static readonly object[] InvalidOrderedByData = new[]
+        {
+            new TestCaseData(
+                new object [] { "a", "b" },
+                "A",
+                "index 0"),
+            new TestCaseData(
+                new object [] { new TestClass3("a", 1), "b" },
+                "A",
+                "index 1"),
+            new TestCaseData(
+                new object [] { new TestClass3("a", 1), new TestClass3("b", 1), new TestClass4("c") },
+                "A",
+                "index 2"),
+        };
+
         #endregion
 
         #region Test Classes
@@ -312,16 +330,16 @@ namespace NUnit.Framework.Constraints
 
         public class TestClass4
         {
-            public readonly string Name;
+            public readonly string A;
 
-            public TestClass4(string name)
+            public TestClass4(string a)
             {
-                Name = name;
+                A = a;
             }
 
             public override string ToString()
             {
-                return Name;
+                return A;
             }
         }
 


### PR DESCRIPTION
Fixes #2292 