### PR TITLE
Stop using [Timeout] so that there should be no thread abort on the t…

### DIFF
--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -9,7 +9,6 @@ namespace NUnit.Framework.Internal
     public class ThreadUtilityTests
     {
         [Platform("Win")]
-        [Timeout(1000)]
         [TestCase(false, TestName = "Abort")]
         [TestCase(true, TestName = "Kill")]
         public void AbortOrKillThreadWithMessagePump(bool kill)
@@ -34,9 +33,8 @@ namespace NUnit.Framework.Internal
                 else
                     ThreadUtility.Abort(thread, nativeId);
 
-                thread.Join();
+                Assert.That(thread.Join(1000), "Native message pump was not able to be interrupted to enable a managed thread abort.");
             }
-
         }
 
         [DllImport("user32.dll")]


### PR DESCRIPTION
Possibly fixes https://github.com/nunit/nunit/issues/2288, at least closes it for now.

This attempts to simplify the situation so that a thread abort exception will never happen on the test execution thread.

I would have originally picked `Assert.That(thread.Join(1000), ...` over `[Timeout(1000)]` if it had crossed my mind when I first wrote it because it's less wasteful.
