### PR TITLE
[Proposal] Hide indirect-only test assemblies from autodiscovery

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -69,10 +69,25 @@ namespace NUnit.Framework.Api
         /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary settings)
+            : this(assemblyNameOrPath, idPrefix, settings, indirectMode: false)
+        {
+        }
+
+        /// <summary>
+        /// Construct a FrameworkController using the default builder and runner.
+        /// </summary>
+        /// <param name="assemblyNameOrPath">The AssemblyName or path to the test assembly</param>
+        /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
+        /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
+        /// <param name="indirectMode">
+        /// Whether to run only tests intended to be run indirectly, or tests intended to be run directly.
+        /// See <see cref="IndirectTestAssemblyAttribute"/>.
+        /// </param>
+        public FrameworkController(string assemblyNameOrPath, string idPrefix, IDictionary settings, bool indirectMode)
         {
             Initialize(assemblyNameOrPath, settings);
 
-            this.Builder = new DefaultTestAssemblyBuilder();
+            this.Builder = indirectMode ? DefaultTestAssemblyBuilder.IndirectMode : DefaultTestAssemblyBuilder.Default;
             this.Runner = new NUnitTestAssemblyRunner(this.Builder);
 
             Test.IdPrefix = idPrefix;
@@ -86,6 +101,22 @@ namespace NUnit.Framework.Api
         /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
         public FrameworkController(Assembly assembly, string idPrefix, IDictionary settings)
             : this(assembly.FullName, idPrefix, settings)
+        {
+            _testAssembly = assembly;
+        }
+
+        /// <summary>
+        /// Construct a FrameworkController using the default builder and runner.
+        /// </summary>
+        /// <param name="assembly">The test assembly</param>
+        /// <param name="idPrefix">A prefix used for all test ids created under this controller.</param>
+        /// <param name="settings">A Dictionary of settings to use in loading and running the tests</param>
+        /// <param name="indirectMode">
+        /// Whether to run only tests intended to be run indirectly, or tests intended to be run directly.
+        /// See <see cref="IndirectTestAssemblyAttribute"/>.
+        /// </param>
+        public FrameworkController(Assembly assembly, string idPrefix, IDictionary settings, bool indirectMode)
+            : this(assembly.FullName, idPrefix, settings, indirectMode)
         {
             _testAssembly = assembly;
         }

--- a/src/NUnitFramework/framework/Internal/IndirectTestAssemblyAttribute.cs
+++ b/src/NUnitFramework/framework/Internal/IndirectTestAssemblyAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// Causes the assembly to be skipped when autodiscovering tests.
+    /// Useful for tests-on-tests scenarios so that tools that run all tests in the solution do not execute the indirect tests directly.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class IndirectTestAssemblyAttribute : Attribute
+    {
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Interfaces\TestAttachment.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Warn.cs" />
     <Compile Include="Assume.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
@@ -368,6 +368,7 @@
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
@@ -368,6 +368,7 @@
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IndirectTestAssemblyAttribute.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />

--- a/src/NUnitFramework/mock-assembly/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/mock-assembly/Properties/AssemblyInfo.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
@@ -29,3 +30,5 @@ using System.Reflection;
 [assembly: AssemblyTitle("mock-assembly")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
+
+[assembly: IndirectTestAssembly]

--- a/src/NUnitFramework/slow-tests/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/slow-tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using NUnit.Framework.Internal;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,3 +13,5 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: IndirectTestAssembly]

--- a/src/NUnitFramework/testdata/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/testdata/Properties/AssemblyInfo.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
@@ -30,3 +31,5 @@ using System.Reflection;
 
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
+
+[assembly: IndirectTestAssembly]

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -84,9 +84,9 @@ namespace NUnit.Framework.Api
         public void CreateController()
         {
 #if NETSTANDARD1_3 || NETSTANDARD1_6
-            _controller = new FrameworkController(typeof(MockAssembly).GetTypeInfo().Assembly, "ID", _settings);
+            _controller = new FrameworkController(typeof(MockAssembly).GetTypeInfo().Assembly, "ID", _settings, indirectMode: true);
 #else
-            _controller = new FrameworkController(MOCK_ASSEMBLY_PATH, "ID", _settings);
+            _controller = new FrameworkController(MOCK_ASSEMBLY_PATH, "ID", _settings, indirectMode: true);
 #endif
             _handler = new CallbackEventHandler();
         }
@@ -125,7 +125,7 @@ namespace NUnit.Framework.Api
         [Test]
         public void LoadTestsAction_Assembly_ReturnsRunnableSuite()
         {
-            _controller = new FrameworkController(typeof(MockAssembly).GetTypeInfo().Assembly, "ID", _settings);
+            _controller = new FrameworkController(typeof(MockAssembly).GetTypeInfo().Assembly, "ID", _settings, indirectMode: true);
             new FrameworkController.LoadTestsAction(_controller, _handler);
             var result = TNode.FromXml(_handler.GetCallbackResult());
 

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Api
         [SetUp]
         public void CreateRunner()
         {
-            _runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
+            _runner = new NUnitTestAssemblyRunner(DefaultTestAssemblyBuilder.IndirectMode);
 
             _testStartedCount = 0;
             _testFinishedCount = 0;

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Tests
         [OneTimeSetUp]
         public void Setup()
         {
-            var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
+            var runner = new NUnitTestAssemblyRunner(DefaultTestAssemblyBuilder.IndirectMode);
 
             ActionAttributeFixture.ClearResults();
 

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal
         {
             TestUtilities.SimpleEventRecorder.Clear();
 
-            builder = new DefaultTestAssemblyBuilder();
+            builder = DefaultTestAssemblyBuilder.IndirectMode;
             runner = new NUnitTestAssemblyRunner(builder);
         }
         #endregion SetUp


### PR DESCRIPTION
[Proposal: please do not merge]

Autodiscovery of tests that aren't intended to be directly run has been a more or less constant irritation for me going back to my first PR. It is apparently also a source of confusion for new contributors. At the very least it's an unnecessary distraction every time you run tests in a tool such as an IDE which autodetects test assemblies.

This will benefit not just the NUnit project itself but any project which extends or integrates with NUnit.
Now it will even make sense for me to unit test custom constraints in personal projects and at work which require an indirect test assembly.

It seemed worthwhile to see how straightforward the implementation would be so that we have a concrete idea to discuss. I put it in the Internal namespace to give us more freedom of expression in the future.

/cc @OmicronPersei

