### PR TITLE
Add explicit NUnit package dependencies for all target frameworks

### DIFF
--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -27,18 +27,25 @@ How to use this package:
     <tags>test unit testing tdd framework fluent assert device phone embedded</tags>
     <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
     <dependencies>
-      <group>
+      <group targetFramework="net20">
         <dependency id="NUnit" version="[$version$]" />
       </group>
-      <group targetFramework="net20" />
-      <group targetFramework="net35" />
-      <group targetFramework="net40" />
-      <group targetFramework="net45" />
+      <group targetFramework="net35">
+        <dependency id="NUnit" version="[$version$]" />
+      </group>
+      <group targetFramework="net40">
+        <dependency id="NUnit" version="[$version$]" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="NUnit" version="[$version$]" />
+      </group>
       <group targetFramework="netstandard1.3">
+        <dependency id="NUnit" version="[$version$]" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Threading.Thread" version="4.3.0" />
       </group>
       <group targetFramework="netstandard1.6">
+        <dependency id="NUnit" version="[$version$]" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Runtime.Loader" version="4.3.0" />
         <dependency id="System.Threading.Thread" version="4.3.0" />


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2299

I've tested this under VS 2015/NuGet 3.5/packages.config. I haven't tried any other versions of anything, but it seems logical given our current understanding.