### PR TITLE
TestCaseSource unable to pass one element byte array

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -189,48 +189,29 @@ namespace NUnit.Framework
 
                         if (parms == null)
                         {
+                            object[] args = null;
+
                             // 3. An array was passed, it may be an object[]
                             //    or possibly some other kind of array, which
                             //    TestCaseSource can accept.
-                            var args = item as object[];
-                            if (args == null && item is Array)
+                            var array = item as Array;
+                            if (array != null)
                             {
-                                Array array = item as Array;
-                                int numParameters = method.GetParameters().Length;
-                                if (array != null && array.Rank == 1 && array.Length == numParameters)
+                                // If array has the same number of elements as parameters
+                                // and it does not fit exactly into single existing parameter
+                                // we believe that this array contains arguments, not is a bare
+                                // argument itself.
+                                var parameters = method.GetParameters();
+                                var argsNeeded = parameters.Length;
+                                if (argsNeeded > 0 && argsNeeded == array.Length && parameters[0].ParameterType != array.GetType())
                                 {
-                                    // Array is something like int[] - convert it to
-                                    // an object[] for use as the argument array.
                                     args = new object[array.Length];
-                                    for (int i = 0; i < array.Length; i++)
+                                    for (var i = 0; i < array.Length; i++)
                                         args[i] = array.GetValue(i);
                                 }
                             }
 
-                            // Check again if we have an object[]
-                            if (args != null)
-                            {
-                                var parameters = method.GetParameters();
-                                var argsNeeded = parameters.Length;
-                                var argsProvided = args.Length;
-               
-                                // If only one argument is needed, our array may actually
-                                // be the bare argument. If it is, we should wrap it in
-                                // an outer object[] representing the list of arguments.
-                                if (argsNeeded == 1)
-                                {
-                                    var singleParmType = parameters[0].ParameterType;
-                                    
-                                    if (argsProvided == 0 || typeof(object[]).IsAssignableFrom(singleParmType))
-                                    {
-                                        if (argsProvided > 1 || singleParmType.IsAssignableFrom(args.GetType()))
-                                        {
-                                            args = new object[] { item };
-                                        }
-                                    }
-                                }
-                            }
-                            else // It may be a scalar or a multi-dimensioned array. Wrap it in object[]
+                            if (args == null)
                             {
                                 args = new object[] { item };
                             }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -142,6 +142,12 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(q, n / d);
         }
 
+        [Test, TestCaseSource("MyArrayData")]
+        public void SourceMayReturnArrayForArray(int[] array)
+        {
+            Assert.That(true);
+        }
+
         [Test, TestCaseSource("EvenNumbers")]
         public void SourceMayReturnSinglePrimitiveArgumentAlone(int n)
         {
@@ -330,6 +336,13 @@ namespace NUnit.Framework.Attributes
             new int[] { 12, 3, 4 },
             new int[] { 12, 4, 3 },
             new int[] { 12, 6, 2 } };
+
+        static object[] MyArrayData = new object[]
+        {
+            new int[] { 12 },
+            new int[] { 12, 4 },
+            new int[] { 12, 6, 2 }
+        };
 
         public static IEnumerable StaticMethodDataWithParameters(int inject1, int inject2, int inject3)
         {


### PR DESCRIPTION
While working on #2104 I have also optimized TestCaseSourceAttribute and additionally check it against this issue. Looks like it is fixed.

Fixes #1851 