### PR TITLE
Prevent crash on invalid --result parsing in NUnitLite

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.6.0
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.6.1
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -413,9 +413,9 @@ namespace NUnitLite.Tests
         }
 #endif
 
-#endregion
+        #endregion
 
-#region EngineResult Option
+        #region EngineResult Option
 
         [Test]
         public void FileNameWithoutResultOptionLooksLikeParameter()
@@ -509,9 +509,9 @@ namespace NUnitLite.Tests
             Assert.That(options.ErrorMessages, Has.Exactly(1).Contains("invalid output spec").IgnoreCase);
         }
 
-    #endregion
+        #endregion
 
-    #region Explore Option
+        #region Explore Option
 
         [Test]
         public void ExploreOptionWithoutPath()

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -436,7 +436,6 @@ namespace NUnitLite.Tests
             OutputSpecification spec = options.ResultOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("nunit3", spec.Format);
-            Assert.Null(spec.Transform);
         }
 
         [Test]
@@ -448,19 +447,6 @@ namespace NUnitLite.Tests
             OutputSpecification spec = options.ResultOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("nunit2", spec.Format);
-            Assert.Null(spec.Transform);
-        }
-
-        [Test]
-        public void ResultOptionWithFilePathAndTransform()
-        {
-            var options = new NUnitLiteOptions("-result:results.xml;transform=transform.xslt");
-            Assert.True(options.Validate());
-
-            OutputSpecification spec = options.ResultOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("user", spec.Format);
-            Assert.AreEqual("transform.xslt", spec.Transform);
         }
 
         [Test]
@@ -474,26 +460,19 @@ namespace NUnitLite.Tests
         [Test]
         public void ResultOptionMayBeRepeated()
         {
-            var options = new NUnitLiteOptions("-result:results.xml", "-result:nunit2results.xml;format=nunit2", "-result:myresult.xml;transform=mytransform.xslt");
+            var options = new NUnitLiteOptions("-result:results.xml", "-result:nunit2results.xml;format=nunit2");
             Assert.True(options.Validate(), "Should be valid");
 
             var specs = options.ResultOutputSpecifications;
-            Assert.AreEqual(3, specs.Count);
+            Assert.That(specs, Has.Count.EqualTo(2));
 
             var spec1 = specs[0];
             Assert.AreEqual("results.xml", spec1.OutputPath);
             Assert.AreEqual("nunit3", spec1.Format);
-            Assert.Null(spec1.Transform);
 
             var spec2 = specs[1];
             Assert.AreEqual("nunit2results.xml", spec2.OutputPath);
             Assert.AreEqual("nunit2", spec2.Format);
-            Assert.Null(spec2.Transform);
-
-            var spec3 = specs[2];
-            Assert.AreEqual("myresult.xml", spec3.OutputPath);
-            Assert.AreEqual("user", spec3.Format);
-            Assert.AreEqual("mytransform.xslt", spec3.Transform);
         }
 
         [Test]
@@ -505,7 +484,6 @@ namespace NUnitLite.Tests
             var spec = options.ResultOutputSpecifications[0];
             Assert.AreEqual("TestResult.xml", spec.OutputPath);
             Assert.AreEqual("nunit3", spec.Format);
-            Assert.Null(spec.Transform);
         }
 
         [Test]
@@ -522,9 +500,18 @@ namespace NUnitLite.Tests
             Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
         }
 
-        #endregion
+        [Test]
+        public void InvalidResultSpecRecordsError()
+        {
+            var options = new NUnitLiteOptions("test.dll", "-result:userspecifed.xml;format=nunit2;format=nunit3");
+            Assert.That(options.ResultOutputSpecifications, Has.Exactly(1).Items
+                    .And.Exactly(1).Property(nameof(OutputSpecification.OutputPath)).EqualTo("TestResult.xml"));
+            Assert.That(options.ErrorMessages, Has.Exactly(1).Contains("invalid output spec").IgnoreCase);
+        }
 
-        #region Explore Option
+    #endregion
+
+    #region Explore Option
 
         [Test]
         public void ExploreOptionWithoutPath()
@@ -544,7 +531,6 @@ namespace NUnitLite.Tests
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("nunit3", spec.Format);
-            Assert.Null(spec.Transform);
         }
 
         [Test]
@@ -557,20 +543,6 @@ namespace NUnitLite.Tests
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("cases", spec.Format);
-            Assert.Null(spec.Transform);
-        }
-
-        [Test]
-        public void ExploreOptionWithFilePathAndTransform()
-        {
-            var options = new NUnitLiteOptions("-explore:results.xml;transform=myreport.xslt");
-            Assert.True(options.Validate());
-            Assert.True(options.Explore);
-
-            OutputSpecification spec = options.ExploreOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("user", spec.Format);
-            Assert.AreEqual("myreport.xslt", spec.Transform);
         }
 
         [Test]

--- a/src/NUnitFramework/nunitlite.tests/OutputSpecificationTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/OutputSpecificationTests.cs
@@ -32,7 +32,7 @@ namespace NUnit.Common.Tests
         {
             Assert.That(
                 () => new OutputSpecification(null),
-                Throws.TypeOf<NullReferenceException>());
+                Throws.TypeOf<ArgumentNullException>());
         }
 
 
@@ -58,7 +58,6 @@ namespace NUnit.Common.Tests
             var spec = new OutputSpecification("MyFile.xml");
             Assert.That(spec.OutputPath, Is.EqualTo("MyFile.xml"));
             Assert.That(spec.Format, Is.EqualTo("nunit3"));
-            Assert.Null(spec.Transform);
         }
 
         [Test]
@@ -67,34 +66,6 @@ namespace NUnit.Common.Tests
             var spec = new OutputSpecification("MyFile.xml;format=nunit2");
             Assert.That(spec.OutputPath, Is.EqualTo("MyFile.xml"));
             Assert.That(spec.Format, Is.EqualTo("nunit2"));
-            Assert.Null(spec.Transform);
-        }
-
-        [Test]
-        public void FileNamePlusTransform()
-        {
-            var spec = new OutputSpecification("MyFile.xml;transform=transform.xslt");
-            Assert.That(spec.OutputPath, Is.EqualTo("MyFile.xml"));
-            Assert.That(spec.Format, Is.EqualTo("user"));
-            Assert.That(spec.Transform, Is.EqualTo("transform.xslt"));
-        }
-
-        [Test]
-        public void UserFormatMayBeIndicatedExplicitlyAfterTransform()
-        {
-            var spec = new OutputSpecification("MyFile.xml;transform=transform.xslt;format=user");
-            Assert.That(spec.OutputPath, Is.EqualTo("MyFile.xml"));
-            Assert.That(spec.Format, Is.EqualTo("user"));
-            Assert.That(spec.Transform, Is.EqualTo("transform.xslt"));
-        }
-
-        [Test]
-        public void UserFormatMayBeIndicatedExplicitlyBeforeTransform()
-        {
-            var spec = new OutputSpecification("MyFile.xml;format=user;transform=transform.xslt");
-            Assert.That(spec.OutputPath, Is.EqualTo("MyFile.xml"));
-            Assert.That(spec.Format, Is.EqualTo("user"));
-            Assert.That(spec.Transform, Is.EqualTo("transform.xslt"));
         }
 
         [Test]
@@ -102,22 +73,6 @@ namespace NUnit.Common.Tests
         {
             Assert.That(
                 () => new OutputSpecification("MyFile.xml;format=nunit2;format=nunit3"),
-                Throws.TypeOf<ArgumentException>());
-        }
-
-        [Test]
-        public void MultipleTransformSpecifiersNotAllowed()
-        {
-            Assert.That(
-                () => new OutputSpecification("MyFile.xml;transform=transform1.xslt;transform=transform2.xslt"),
-                Throws.TypeOf<ArgumentException>());
-        }
-
-        [Test]
-        public void TransformWithNonUserFormatNotAllowed()
-        {
-            Assert.That(
-                () => new OutputSpecification("MyFile.xml;format=nunit2;transform=transform.xslt"),
                 Throws.TypeOf<ArgumentException>());
         }
     }

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -414,14 +414,13 @@ namespace NUnit.Common
             this.Add("err=", "File {PATH} to contain error output from the tests.",
                 v => ErrFile = RequiredValue(v, "--err"));
 
-            this.Add("result=", "An output {SPEC} for saving the test results.\nThis option may be repeated.",
-                v => resultOutputSpecifications.Add(new OutputSpecification(RequiredValue(v, "--resultxml"))));
+            this.Add("result=", "An output {SPEC} for saving the test results. This option may be repeated.",
+                v => ResolveOutputSpecification(RequiredValue(v, "--resultxml"), resultOutputSpecifications));
 
             this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
             {
                 Explore = true;
-                if (v != null)
-                    ExploreOutputSpecifications.Add(new OutputSpecification(v));
+                ResolveOutputSpecification(v, ExploreOutputSpecifications);
             });
 
             this.Add("noresult", "Don't save any test results.",
@@ -469,6 +468,22 @@ namespace NUnit.Common
         private bool LooksLikeAnOption(string v)
         {
             return v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/';
+        }
+
+        private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)
+        {
+            if (value == null)
+                return;
+
+            try
+            {
+                var spec = new OutputSpecification(value);
+                outputSpecifications.Add(spec);
+            }
+            catch (ArgumentException e)
+            {
+                ErrorMessages.Add(e.Message);
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/OutputManager.cs
+++ b/src/NUnitFramework/nunitlite/OutputManager.cs
@@ -72,12 +72,6 @@ namespace NUnitLite
                     outputWriter = new NUnit2XmlOutputWriter();
                     break;
 
-                //case "user":
-                //    Uri uri = new Uri(Assembly.GetExecutingAssembly().CodeBase);
-                //    string dir = Path.GetDirectoryName(uri.LocalPath);
-                //    outputWriter = new XmlTransformOutputWriter(Path.Combine(dir, spec.Transform));
-                //    break;
-
                 default:
                     throw new ArgumentException(
                         string.Format("Invalid XML output format '{0}'", spec.Format),
@@ -108,15 +102,9 @@ namespace NUnitLite
                     outputWriter = new TestCaseOutputWriter();
                     break;
 
-                //case "user":
-                //    Uri uri = new Uri(Assembly.GetExecutingAssembly().CodeBase);
-                //    string dir = Path.GetDirectoryName(uri.LocalPath);
-                //    outputWriter = new XmlTransformOutputWriter(Path.Combine(dir, spec.Transform));
-                //    break;
-
                 default:
                     throw new ArgumentException(
-                        string.Format("Invalid XML output format '{0}'", spec.Format),
+                        string.Format("Invalid output format '{0}'", spec.Format),
                         "spec");
             }
 

--- a/src/NUnitFramework/nunitlite/OutputSpecification.cs
+++ b/src/NUnitFramework/nunitlite/OutputSpecification.cs
@@ -40,49 +40,24 @@ namespace NUnit.Common
         public OutputSpecification(string spec)
         {
             if (spec == null)
-                throw new NullReferenceException("Output spec may not be null");
+                throw new ArgumentNullException(nameof(spec), "Output spec may not be null.");
 
             string[] parts = spec.Split(';');
+
+            if (parts.Length > 2)
+                throw new ArgumentException($"Invalid output spec: {spec}.");
+
             this.OutputPath = parts[0];
 
-            for (int i = 1; i < parts.Length; i++)
-            {
-                string[] opt = parts[i].Split('=');
+            if (parts.Length == 1)
+                return;
 
-                if (opt.Length != 2)
-                    throw new ArgumentException();
+            string[] opt = parts[1].Split('=');
 
-                switch (opt[0].Trim())
-                {
-                    case "format":
-                        string fmt = opt[1].Trim();
+            if (opt.Length != 2 || opt[0].Trim() != "format")
+                throw new ArgumentException($"Invalid output spec: {spec}.");
 
-                        if (this.Format != null && this.Format != fmt)
-                            throw new ArgumentException(
-                                string.Format("Conflicting format options: {0}", spec));
-
-                        this.Format = fmt;
-                        break;
-
-                    case "transform":
-                        string val = opt[1].Trim();
-
-                        if (this.Transform != null && this.Transform != val)
-                            throw new ArgumentException(
-                                string.Format("Conflicting transform options: {0}", spec));
-
-                        if (this.Format != null && this.Format != "user")
-                            throw new ArgumentException(
-                                string.Format("Conflicting format options: {0}", spec));
-
-                        this.Format = "user";
-                        this.Transform = opt[1].Trim();
-                        break;
-                }
-            }
-
-            if (Format == null)
-                Format = "nunit3";
+            this.Format = opt[1].Trim();
         }
 
         #endregion
@@ -92,17 +67,12 @@ namespace NUnit.Common
         /// <summary>
         /// Gets the path to which output will be written
         /// </summary>
-        public string OutputPath { get; private set; }
+        public string OutputPath { get; }
 
         /// <summary>
         /// Gets the name of the format to be used
         /// </summary>
-        public string Format { get; private set; }
-
-        /// <summary>
-        /// Gets the file name of a transform to be applied
-        /// </summary>
-        public string Transform { get; private set; }
+        public string Format { get; } = "nunit3";
 
         #endregion
     }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -147,7 +147,6 @@ namespace NUnitLite
             WriteHelpLine("      the following forms:");
             WriteHelpLine("          --OPTION:filename");
             WriteHelpLine("          --OPTION:filename;format=formatname");
-            WriteHelpLine("          --OPTION:filename;transform=xsltfile");
             Writer.WriteLine();
             WriteHelpLine("      The --result option may use any of the following formats:");
             WriteHelpLine("          nunit3 - the native XML format for NUnit 3");


### PR DESCRIPTION
This prevents a crash in the NUnitLite runner when an invalid `--result` command is specified. It essentially ports https://github.com/nunit/nunit-console/pull/257 to the NUnitLite runner.

The major difference is that NUnitLite would previously read the transform specifier, but made no use of it. In line with our vision of not having NUnitLite and the Console have exact matching functionality, I stripped the parsing logic for this out, so it a user specifies a transform, it will be seen as invalid.