### PR TITLE
Tests with invalid platform names are marked Not Runnable

### DIFF
--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -56,12 +56,20 @@ namespace NUnit.Framework
         /// <param name="test">The test to modify</param>
         public void ApplyToTest(Test test)
         {
-            if (test.RunState != RunState.NotRunnable && 
-                test.RunState != RunState.Ignored && 
-                !platformHelper.IsPlatformSupported(this))
+            try
             {
-                test.RunState = RunState.Skipped;
-                test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+                if (test.RunState != RunState.NotRunnable &&
+                    test.RunState != RunState.Ignored &&
+                    !platformHelper.IsPlatformSupported(this))
+                {
+                    test.RunState = RunState.Skipped;
+                    test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+                }
+            }
+            catch (Exception ex)
+            {
+                test.RunState = RunState.NotRunnable;
+                test.Properties.Add(PropertyNames.SkipReason, ex.Message);
             }
         }
 

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -56,27 +56,23 @@ namespace NUnit.Framework
         /// <param name="test">The test to modify</param>
         public void ApplyToTest(Test test)
         {
-            if (!IsPlatformSupportedAndValid(test) &&
-                test.RunState != RunState.NotRunnable &&
+            if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)
             {
-                test.RunState = RunState.Skipped;
-                test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+                try
+                {
+                    if (!platformHelper.IsPlatformSupported(this))
+                    {
+                        test.RunState = RunState.Skipped;
+                        test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+                    }
+                }
+                catch (InvalidPlatformException ex)
+                {
+                    test.RunState = RunState.NotRunnable;
+                    test.Properties.Add(PropertyNames.SkipReason, ex.Message);
+                }
             }
-        }
-
-        private bool IsPlatformSupportedAndValid(Test test)
-        {
-            try
-            {
-                return platformHelper.IsPlatformSupported(this);
-            }
-            catch (InvalidPlatformException ex)
-            {
-                test.RunState = RunState.NotRunnable;
-                test.Properties.Add(PropertyNames.SkipReason, ex.Message);
-            }
-            return false;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -56,21 +56,27 @@ namespace NUnit.Framework
         /// <param name="test">The test to modify</param>
         public void ApplyToTest(Test test)
         {
+            if (!IsPlatformSupportedAndValid(test) &&
+                test.RunState != RunState.NotRunnable &&
+                test.RunState != RunState.Ignored)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+            }
+        }
+
+        private bool IsPlatformSupportedAndValid(Test test)
+        {
             try
             {
-                if (test.RunState != RunState.NotRunnable &&
-                    test.RunState != RunState.Ignored &&
-                    !platformHelper.IsPlatformSupported(this))
-                {
-                    test.RunState = RunState.Skipped;
-                    test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
-                }
+                return platformHelper.IsPlatformSupported(this);
             }
-            catch (Exception ex)
+            catch (InvalidPlatformException ex)
             {
                 test.RunState = RunState.NotRunnable;
                 test.Properties.Add(PropertyNames.SkipReason, ex.Message);
             }
+            return false;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -59,18 +59,22 @@ namespace NUnit.Framework
             if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)
             {
+                bool platformIsSupported = false;
                 try
                 {
-                    if (!platformHelper.IsPlatformSupported(this))
-                    {
-                        test.RunState = RunState.Skipped;
-                        test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
-                    }
+                    platformIsSupported = platformHelper.IsPlatformSupported(this);
                 }
                 catch (InvalidPlatformException ex)
                 {
                     test.RunState = RunState.NotRunnable;
                     test.Properties.Add(PropertyNames.SkipReason, ex.Message);
+                    return;
+                }
+
+                if (!platformIsSupported)
+                {
+                    test.RunState = RunState.Skipped;
+                    test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
@@ -1,0 +1,67 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+using System.Runtime.Serialization;
+#endif
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// InvalidPlatformException is thrown when the platform name supplied
+    /// to a test is not recognized.
+    /// </summary>
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+    [Serializable]
+#endif
+    class InvalidPlatformException : ArgumentException
+    {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="InvalidPlatformException"/> class.
+        /// </summary>
+        public InvalidPlatformException() : base() { }
+        
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="InvalidPlatformException"/> class
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public InvalidPlatformException(string message) : base(message) { }
+
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="InvalidPlatformException"/> class
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public InvalidPlatformException(string message, Exception inner) : base(message, inner) { }
+
+# if !NETSTANDARD_3 && !NETSTANDARD1_6
+        /// <summary>
+        /// Serialization constructor for the <see cref="InvalidPlatformException"/> class
+        /// </summary>
+        protected InvalidPlatformException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        { }
+    }
+# endif
+}

--- a/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2017 Charlie Poole
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -134,8 +134,7 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Test to determine if the a particular platform or comma-
-        /// delimited set of platforms is in use.
+        /// Test to determine if a particular platform or comma-delimited set of platforms is in use.
         /// </summary>
         /// <param name="platform">Name of the platform or comma-separated list of platform ids</param>
         /// <returns>True if the platform is in use on the system</returns>
@@ -146,15 +145,6 @@ namespace NUnit.Framework.Internal
 
             string platformName = platform.Trim();
             bool isSupported;
-
-//			string versionSpecification = null;
-//
-//			string[] parts = platformName.Split( new char[] { '-' } );
-//			if ( parts.Length == 2 )
-//			{
-//				platformName = parts[0];
-//				versionSpecification = parts[1];
-//			}
 
             switch( platformName.ToUpper() )
             {
@@ -314,7 +304,7 @@ namespace NUnit.Framework.Internal
                     return IsRuntimeSupported(RuntimeType.MonoTouch, versionSpecification);
 
                 default:
-                    throw new ArgumentException("Invalid platform name", platformName);
+                    throw new InvalidPlatformException("Invalid platform name: " + platformName);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -118,23 +118,15 @@ namespace NUnit.Framework.Internal
 
         private bool IsPlatformSupported(string include, string exclude)
         {
-            try
+            if (include != null && !IsPlatformSupported(include))
             {
-                if (include != null && !IsPlatformSupported(include))
-                {
-                    _reason = string.Format("Only supported on {0}", include);
-                    return false;
-                }
-
-                if (exclude != null && IsPlatformSupported(exclude))
-                {
-                    _reason = string.Format("Not supported on {0}", exclude);
-                    return false;
-                }
+                _reason = string.Format("Only supported on {0}", include);
+                return false;
             }
-            catch (Exception ex)
+
+            if (exclude != null && IsPlatformSupported(exclude))
             {
-                _reason = ex.Message;
+                _reason = string.Format("Not supported on {0}", exclude);
                 return false;
             }
 

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceLevel.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
+    <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Interfaces\TestAttachment.cs" />
     <Compile Include="Internal\TestCaseTimeoutException.cs" />
+    <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Warn.cs" />
     <Compile Include="Assume.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -386,6 +386,8 @@ namespace NUnit.Framework.Attributes
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
             Assert.That(test.Properties.Get(PropertyNames.SkipReason),
                 Does.StartWith("Invalid platform name"));
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
+                Does.Contain(invalidPlatform));
         }
 
         string GetMyPlatform()

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -378,6 +378,16 @@ namespace NUnit.Framework.Attributes
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
+        [Test]
+        public void InvalidPlatformAttributeIsNotRunnable()
+        {
+            var invalidPlatform = "FakePlatform";
+            new PlatformAttribute(invalidPlatform).ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
+                Does.StartWith("Invalid platform name"));
+        }
+
         string GetMyPlatform()
         {
             if (System.IO.Path.DirectorySeparatorChar == '/')

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -429,7 +429,7 @@ namespace NUnit.Framework.Internal
         public void PlatformAttribute_InvalidPlatform()
         {
             PlatformAttribute attr = new PlatformAttribute( "Net-1.0,Net11,Mono" );
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<InvalidPlatformException>(
                 () => winXPHelper.IsPlatformSupported(attr), 
                 "Invalid platform name Net11");
         }

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -429,9 +429,9 @@ namespace NUnit.Framework.Internal
         public void PlatformAttribute_InvalidPlatform()
         {
             PlatformAttribute attr = new PlatformAttribute( "Net-1.0,Net11,Mono" );
-            Assert.IsFalse( winXPHelper.IsPlatformSupported( attr ) );
-            Assert.That( winXPHelper.Reason, Does.StartWith("Invalid platform name"));
-            Assert.That( winXPHelper.Reason, Does.Contain("Net11"));
+            Assert.Throws<ArgumentException>(
+                () => winXPHelper.IsPlatformSupported(attr), 
+                "Invalid platform name Net11");
         }
 
         [Test]


### PR DESCRIPTION
Resolves issue #2201: Invalid platform name passed to PlatformAttribute should mark test NotRunnable.

Based on Chris Maddock's suggestion in the comments on that issue. Previously, passing an invalid platform name to a PlatformAttribute would cause the test to be skipped. This change alters where the exception generated in this case is handled, allowing the test to be marked NotRunnable instead.