### PR TITLE
Editorconfig charset and coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,7 @@ root = true
 indent_style = space
 indent_size = 4
 insert_final_newline = true
-# VS 15.0–15.2 misinterpret as utf-8-bom https://developercommunity.visualstudio.com/content/problem/22922
-# charset = utf-8
+charset = utf-8
 
 [*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,28 +10,77 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
+insert_final_newline = true
+# VS 15.0–15.2 misinterpret as utf-8-bom https://developercommunity.visualstudio.com/content/problem/22922
+# charset = utf-8
 
-[*.proj]
+[*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
 indent_size = 2
 
-[*.csproj]
-indent_size = 2
 
-[*.vcxproj]
-indent_size = 2
 
-[*.xproj]
-indent_size = 2
+[*]
+# https://github.com/nunit/docs/wiki/Coding-Standards#namespace-class-structure-interface-enumeration-and-method-definitions
+csharp_indent_braces = false
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
 
-[*.json]
-indent_size = 2
+# https://github.com/nunit/docs/wiki/Coding-Standards#spaces
+csharp_space_after_cast = false
+csharp_space_after_comma = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = none
+csharp_space_between_square_brackets = false
 
-[*.config]
-indent_size = 2
+# https://github.com/nunit/docs/wiki/Coding-Standards#indentation
+csharp_indent_block_contents = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
 
-[*.nuspec]
-indent_size = 2
+# https://github.com/nunit/docs/wiki/Coding-Standards#naming
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
 
-[*.xml]
-indent_size = 2
+# The first matching rule wins, more specific rules at the top
+
+# dotnet_naming_rule.*.symbols does not yet support a comma-separated list https://github.com/dotnet/roslyn/issues/20891
+# dotnet_naming_symbols.*.applicable_kinds does not yet support namespace, type_parameter or local https://github.com/dotnet/roslyn/issues/18121
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
+dotnet_naming_rule.namespaces_types_and_non_field_members.severity = error
+dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
+dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
+
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public
+dotnet_naming_rule.public_fields.severity = error
+dotnet_naming_rule.public_fields.symbols = public_fields
+dotnet_naming_rule.public_fields.style = pascal_case
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+dotnet_naming_rule.parameters_and_locals.severity = error
+dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals.style = camel_case
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#file-organization
+dotnet_sort_system_directives_first = true
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#use-of-the-var-keyword
+# Would be true:error, except that that so much existing code is not consistent with the coding standard.
+csharp_style_var_when_type_is_apparent = true:suggestion


### PR DESCRIPTION
Fixes #2319

Removed `end_of_line = crlf` because git already normalizes everything to `lf` internally and some people are on different platforms where `crlf` doesn't make sense. If certain files like the .sh files need to be `lf`-only, we do that in `.gitattributes`.

Added `insert_final_newline = true` because otherwise GitHub and git complain every time you view files and I figured it was a nice default, but if you see a problem with it we can remove it.

#### Coding standard

Most of these rules are already defaults in VS and are just useful in case anyone has customized VS to do things differently for them.
I made everything that goes against the coding standard show as an error. It doesn't prevent any activities like building, but as we discussed, things in the coding standard are things we're prepared to request changes on at review time. If we don't like certain rules annotating code this way, we should start by revising the coding standard and afterwards update the .editorconfig.

I did not see any reason to add non-coding-standard warnings, suggestions, and silent preferences (which affect autocomplete and code generation). If we ever see a reason to add things like that, it should be kept in a separate section from the coding standard.