### PR TITLE
Include differences in output for Is.EquivalentTo

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -75,8 +75,9 @@ namespace NUnit.Framework.Constraints
         {
             //Store the tally so the collection is only iterated over once.
             _lastPerformedTally = Tally(_expected);
+            _lastPerformedTally.TryRemove(actual);
 
-            return _lastPerformedTally.TryRemove(actual) && _lastPerformedTally.MissingItems.Count == 0;
+            return ((_lastPerformedTally.Result.ExtraItems.Count == 0) && (_lastPerformedTally.Result.MissingItems.Count == 0));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Constraints
             bool matchesResult = Matches(enumerable);
 
             return new CollectionEquivalentConstraintResult(
-                this, _lastPerformedTally, actual, matchesResult);
+                this, _lastPerformedTally.Result, actual, matchesResult);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -33,16 +33,12 @@ namespace NUnit.Framework.Constraints
     {
         private readonly IEnumerable _expected;
 
-        /// <summary>
-        /// The <see cref="CollectionTally"/> of the last performed collection equivalence
-        /// comparison.
-        /// </summary>
-        private CollectionTally _lastPerformedTally;
+        /// <summary>The result of the <see cref="CollectionTally"/> from the collections
+        /// under comparison.</summary>
+        private CollectionTally.CollectionTallyResult _tallyResult;
 
-        /// <summary>
-        /// Construct a CollectionEquivalentConstraint
-        /// </summary>
-        /// <param name="expected"></param>
+        /// <summary>Construct a CollectionEquivalentConstraint</summary>
+        /// <param name="expected">Expected collection.</param>
         public CollectionEquivalentConstraint(IEnumerable expected)
             : base(expected)
         {
@@ -73,11 +69,14 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
-            //Store the tally so the collection is only iterated over once.
-            _lastPerformedTally = Tally(_expected);
-            _lastPerformedTally.TryRemove(actual);
+            CollectionTally ct = Tally(_expected);
+            ct.TryRemove(actual);
 
-            return ((_lastPerformedTally.Result.ExtraItems.Count == 0) && (_lastPerformedTally.Result.MissingItems.Count == 0));
+            //Store the CollectionTallyResult so the comparison between the two collections
+            //is only performed once.
+            _tallyResult = ct.Result;
+
+            return ((_tallyResult.ExtraItems.Count == 0) && (_tallyResult.MissingItems.Count == 0));
         }
 
         /// <summary>
@@ -103,7 +102,7 @@ namespace NUnit.Framework.Constraints
             bool matchesResult = Matches(enumerable);
 
             return new CollectionEquivalentConstraintResult(
-                this, _lastPerformedTally.Result, actual, matchesResult);
+                this, _tallyResult, actual, matchesResult);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -89,22 +89,22 @@ namespace NUnit.Framework.Constraints
             //Write the expected/actual message first.
             base.WriteMessageTo(writer);
             
-            if (_tally.MissingItems.Count > 0)
+            if (_tally.Result.MissingItems.Count > 0)
             {
-                int missingItemsCount = _tally.MissingItems.Count;
+                int missingItemsCount = _tally.Result.MissingItems.Count;
 
                 string missingStr = $"Missing ({missingItemsCount}): ";
-                missingStr += MsgUtils.FormatCollection(_tally.MissingItems, 0, MaxDifferingElemsToWrite);
+                missingStr += MsgUtils.FormatCollection(_tally.Result.MissingItems, 0, MaxDifferingElemsToWrite);
 
                 writer.WriteMessageLine(missingStr);
             }
 
-            if (_tally.ExtraItems.Count > 0)
+            if (_tally.Result.ExtraItems.Count > 0)
             {
-                int extraItemsCount = _tally.ExtraItems.Count;
+                int extraItemsCount = _tally.Result.ExtraItems.Count;
 
                 string extraStr = $"Extra ({extraItemsCount}): ";
-                extraStr += MsgUtils.FormatCollection(_tally.ExtraItems, 0, MaxDifferingElemsToWrite);
+                extraStr += MsgUtils.FormatCollection(_tally.Result.ExtraItems, 0, MaxDifferingElemsToWrite);
 
                 writer.WriteMessageLine(extraStr);
             }

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -24,87 +24,59 @@
 
 namespace NUnit.Framework.Constraints
 {
-    /// <summary>
-    /// Provides a <see cref="ConstraintResult"/> for the <see cref="CollectionEquivalentConstraint"/>.
-    /// </summary>
-    /// <remarks>
-    /// Assumes that a <see cref="CollectionTally"/> has been created and used to compare the expected
-    /// equivalent collections.
-    /// </remarks>
+    /// <summary>Provides a <see cref="ConstraintResult"/> for the <see cref="CollectionEquivalentConstraint"/>.</summary>
     public class CollectionEquivalentConstraintResult : ConstraintResult
     {
-        /// <summary>
-        /// Preprocessed <see cref="CollectionTally"/> of the collections to compare for equivalence.
-        /// </summary>
-        private CollectionTally _tally;
+        /// <summary>Result of a <see cref="CollectionTally"/> of the collections to compare for equivalence.</summary>
+        private CollectionTally.CollectionTallyResult _tallyResult;
 
-        /// <summary>
-        /// Maximum amount of elements to write to the <see cref="MessageWriter"/> if there are
-        /// extra/missing elements from the collection.
-        /// </summary>
+        /// <summary>Maximum amount of elements to write to the <see cref="MessageWriter"/> if there are
+        /// extra/missing elements from the collection.</summary>
         private const int MaxDifferingElemsToWrite = 10;
         
-        /// <summary>
-        /// Construct a <see cref="CollectionEquivalentConstraintResult"/> with a <see cref="CollectionTally"/>
-        /// already applied to the actual collection.
-        /// </summary>
-        /// <param name="Constraint">
-        /// Source <see cref="CollectionEquivalentConstraint"/>.
-        /// </param>
-        /// <param name="Tally">
-        /// Preprocessed <see cref="CollectionTally"/> for the collections to compare.
-        /// </param>
-        /// <param name="actual">
-        /// Collection to compare to the expected one.
-        /// </param>
-        /// <param name="isSuccess">
-        /// Whether or not the <see cref="CollectionEquivalentConstraint"/> succeeded.
-        /// </param>
-        /// <remarks>
-        /// The already processed <see cref="CollectionTally"/> is provided to reduce
-        /// unnecessary iterations over the collections to determine equivalence.
-        /// </remarks>
+        /// <summary>Construct a <see cref="CollectionEquivalentConstraintResult"/> using a <see cref="CollectionTally.CollectionTallyResult"/>.</summary>
+        /// <param name="constraint">Source <see cref="CollectionEquivalentConstraint"/>.</param>
+        /// <param name="tallyResult">Result of the collection comparison.</param>
+        /// <param name="actual">Actual collection to compare.</param>
+        /// <param name="isSuccess">Whether or not the <see cref="CollectionEquivalentConstraint"/> succeeded.</param>
         public CollectionEquivalentConstraintResult(
-            CollectionEquivalentConstraint Constraint,
-            CollectionTally Tally,
+            CollectionEquivalentConstraint constraint,
+            CollectionTally.CollectionTallyResult tallyResult,
             object actual,
             bool isSuccess)
-            : base(Constraint, actual, isSuccess)
+            : base(constraint, actual, isSuccess)
         {
-            if (Tally == null)
+            if (tallyResult == null)
             {
                 throw new System.ArgumentNullException("Tally was null.");
             }
 
-            _tally = Tally;
+            _tallyResult = tallyResult;
         }
 
-        /// <summary>
-        /// Write the custom failure message for this object's 
-        /// <see cref="CollectionEquivalentConstraint"/>.
-        /// </summary>
+        /// <summary>Write the custom failure message for this object's <see cref="CollectionEquivalentConstraint"/>.</summary>
         /// <param name="writer"></param>
         public override void WriteMessageTo(MessageWriter writer)
         {
             //Write the expected/actual message first.
             base.WriteMessageTo(writer);
             
-            if (_tally.Result.MissingItems.Count > 0)
+            if (_tallyResult.MissingItems.Count > 0)
             {
-                int missingItemsCount = _tally.Result.MissingItems.Count;
+                int missingItemsCount = _tallyResult.MissingItems.Count;
 
                 string missingStr = $"Missing ({missingItemsCount}): ";
-                missingStr += MsgUtils.FormatCollection(_tally.Result.MissingItems, 0, MaxDifferingElemsToWrite);
+                missingStr += MsgUtils.FormatCollection(_tallyResult.MissingItems, 0, MaxDifferingElemsToWrite);
 
                 writer.WriteMessageLine(missingStr);
             }
 
-            if (_tally.Result.ExtraItems.Count > 0)
+            if (_tallyResult.ExtraItems.Count > 0)
             {
-                int extraItemsCount = _tally.Result.ExtraItems.Count;
+                int extraItemsCount = _tallyResult.ExtraItems.Count;
 
                 string extraStr = $"Extra ({extraItemsCount}): ";
-                extraStr += MsgUtils.FormatCollection(_tally.Result.ExtraItems, 0, MaxDifferingElemsToWrite);
+                extraStr += MsgUtils.FormatCollection(_tallyResult.ExtraItems, 0, MaxDifferingElemsToWrite);
 
                 writer.WriteMessageLine(extraStr);
             }

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>Write the custom failure message for this object's <see cref="CollectionEquivalentConstraint"/>.</summary>
-        /// <param name="writer">The object to write the failure message to.</param>
+        /// <param name="writer">The <see cref="MessageWriter"/> to write the failure message to.</param>
         public override void WriteMessageTo(MessageWriter writer)
         {
             //Write the expected/actual message first.

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -46,16 +46,13 @@ namespace NUnit.Framework.Constraints
             bool isSuccess)
             : base(constraint, actual, isSuccess)
         {
-            if (tallyResult == null)
-            {
-                throw new System.ArgumentNullException("Tally was null.");
-            }
+            Guard.ArgumentNotNull(tallyResult, "tallyResult");
 
             _tallyResult = tallyResult;
         }
 
         /// <summary>Write the custom failure message for this object's <see cref="CollectionEquivalentConstraint"/>.</summary>
-        /// <param name="writer"></param>
+        /// <param name="writer">The object to write the failure message to.</param>
         public override void WriteMessageTo(MessageWriter writer)
         {
             //Write the expected/actual message first.

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -1,0 +1,113 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Provides a <see cref="ConstraintResult"/> for the <see cref="CollectionEquivalentConstraint"/>.
+    /// </summary>
+    /// <remarks>
+    /// Assumes that a <see cref="CollectionTally"/> has been created and used to compare the expected
+    /// equivalent collections.
+    /// </remarks>
+    public class CollectionEquivalentConstraintResult : ConstraintResult
+    {
+        /// <summary>
+        /// Preprocessed <see cref="CollectionTally"/> of the collections to compare for equivalence.
+        /// </summary>
+        private CollectionTally _tally;
+
+        /// <summary>
+        /// Maximum amount of elements to write to the <see cref="MessageWriter"/> if there are
+        /// extra/missing elements from the collection.
+        /// </summary>
+        private const int MaxDifferingElemsToWrite = 10;
+        
+        /// <summary>
+        /// Construct a <see cref="CollectionEquivalentConstraintResult"/> with a <see cref="CollectionTally"/>
+        /// already applied to the actual collection.
+        /// </summary>
+        /// <param name="Constraint">
+        /// Source <see cref="CollectionEquivalentConstraint"/>.
+        /// </param>
+        /// <param name="Tally">
+        /// Preprocessed <see cref="CollectionTally"/> for the collections to compare.
+        /// </param>
+        /// <param name="actual">
+        /// Collection to compare to the expected one.
+        /// </param>
+        /// <param name="isSuccess">
+        /// Whether or not the <see cref="CollectionEquivalentConstraint"/> succeeded.
+        /// </param>
+        /// <remarks>
+        /// The already processed <see cref="CollectionTally"/> is provided to reduce
+        /// unnecessary iterations over the collections to determine equivalence.
+        /// </remarks>
+        public CollectionEquivalentConstraintResult(
+            CollectionEquivalentConstraint Constraint,
+            CollectionTally Tally,
+            object actual,
+            bool isSuccess)
+            : base(Constraint, actual, isSuccess)
+        {
+            if (Tally == null)
+            {
+                throw new System.ArgumentNullException("Tally was null.");
+            }
+
+            _tally = Tally;
+        }
+
+        /// <summary>
+        /// Write the custom failure message for this object's 
+        /// <see cref="CollectionEquivalentConstraint"/>.
+        /// </summary>
+        /// <param name="writer"></param>
+        public override void WriteMessageTo(MessageWriter writer)
+        {
+            //Write the expected/actual message first.
+            base.WriteMessageTo(writer);
+            
+            if (_tally.MissingItems.Count > 0)
+            {
+                int missingItemsCount = _tally.MissingItems.Count;
+
+                string missingStr = $"Missing ({missingItemsCount}): ";
+                missingStr += MsgUtils.FormatCollection(_tally.MissingItems, 0, MaxDifferingElemsToWrite);
+
+                writer.WriteMessageLine(missingStr);
+            }
+
+            if (_tally.ExtraItems.Count > 0)
+            {
+                int extraItemsCount = _tally.ExtraItems.Count;
+
+                string extraStr = $"Extra ({extraItemsCount}): ";
+                extraStr += MsgUtils.FormatCollection(_tally.ExtraItems, 0, MaxDifferingElemsToWrite);
+
+                writer.WriteMessageLine(extraStr);
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
@@ -67,7 +67,10 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
-            return Tally(_expected).TryRemove( actual );
+            CollectionTally tally = Tally(_expected);
+            tally.TryRemove(actual);
+
+            return tally.Result.ExtraItems.Count == 0;
         }
 
 

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -69,7 +69,10 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
-            return Tally(actual).TryRemove(_expected);
+            CollectionTally tally = Tally(actual);
+            tally.TryRemove(_expected);
+
+            return tally.Result.ExtraItems.Count == 0;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -26,31 +26,20 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
-    /// <summary>
-    /// CollectionTally counts (tallies) the number of
-    /// occurrences of each object in one or more enumerations.
-    /// </summary>
+    /// <summary><see cref="CollectionTally"/> counts (tallies) the number of occurrences 
+    /// of each object in one or more enumerations.</summary>
     public class CollectionTally
     {
-        /// <summary>
-        /// Provides the result of a <see cref="CollectionTally"/>.
-        /// </summary>
+        /// <summary>The result of a <see cref="CollectionTally"/>.</summary>
         public class CollectionTallyResult
         {
-            /// <summary>
-            /// Items that were not in the expected collection.
-            /// </summary>
+            /// <summary>Items that were not in the expected collection.</summary>
             public List<object> ExtraItems { get; set; }
 
-            /// <summary>
-            /// Items that were not accounted for in the expected collection.
-            /// </summary>
+            /// <summary>Items that were not accounted for in the expected collection.</summary>
             public List<object> MissingItems { get; set; }
 
-            /// <summary>
-            /// Construct a <see cref="CollectionTallyResult"/> to describe the comparison
-            /// results from a <see cref="CollectionTally"/>
-            /// </summary>
+            /// <summary>Constructs an empty <see cref="CollectionTallyResult"/>.</summary>
             public CollectionTallyResult()
             {
                 ExtraItems = new List<object>();
@@ -60,9 +49,7 @@ namespace NUnit.Framework.Constraints
 
         private readonly NUnitEqualityComparer comparer;
 
-        /// <summary>
-        /// The result of the comparision between the two collections.
-        /// </summary>
+        /// <summary>The result of the comparision between the two collections.</summary>
         public CollectionTallyResult Result
         {
             get
@@ -79,23 +66,15 @@ namespace NUnit.Framework.Constraints
 
         private List<object> _extraItems = new List<object>();
 
-        /// <summary>
-        /// Construct a CollectionTally object from a comparer and a collection
-        /// </summary>
-        /// <param name="comparer">
-        /// The comparer to use for equality.
-        /// </param>
-        /// <param name="c">
-        /// The expected collection to compare against.
-        /// </param>
+        /// <summary>Construct a CollectionTally object from a comparer and a collection.</summary>
+        /// <param name="comparer">The comparer to use for equality.</param>
+        /// <param name="c">The expected collection to compare against.</param>
         public CollectionTally(NUnitEqualityComparer comparer, IEnumerable c)
         {
             this.comparer = comparer;
 
             foreach (object o in c)
-            {
                 _missingItems.Add(o);
-            }
         }
 
         private bool ItemsEqual(object expected, object actual)
@@ -104,10 +83,8 @@ namespace NUnit.Framework.Constraints
             return comparer.AreEqual(expected, actual, ref tolerance);
         }
 
-        /// <summary>
-        /// Try to remove an object from the tally
-        /// </summary>
-        /// <param name="o">The object to remove</param>
+        /// <summary>Try to remove an object from the tally.</summary>
+        /// <param name="o">The object to remove.</param>
         public void TryRemove(object o)
         {
             for (int index = 0; index < _missingItems.Count; index++)
@@ -120,10 +97,8 @@ namespace NUnit.Framework.Constraints
             _extraItems.Add(o);
         }
 
-        /// <summary>
-        /// Try to remove a set of objects from the tally
-        /// </summary>
-        /// <param name="c">The objects to remove</param>
+        /// <summary>Try to remove a set of objects from the tally.</summary>
+        /// <param name="c">The objects to remove.</param>
         public void TryRemove(IEnumerable c)
         {
             foreach (object o in c)

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -61,9 +61,23 @@ namespace NUnit.Framework.Constraints
         private readonly NUnitEqualityComparer comparer;
 
         /// <summary>
-        /// The result of the comparision between two collections.
+        /// The result of the comparision between the two collections.
         /// </summary>
-        public CollectionTallyResult Result { get; private set; } = new CollectionTallyResult();
+        public CollectionTallyResult Result
+        {
+            get
+            {
+                return new CollectionTallyResult()
+                {
+                    MissingItems = new List<object>(_missingItems),
+                    ExtraItems = new List<object>(_extraItems)
+                };
+            }
+        }
+
+        private List<object> _missingItems = new List<object>();
+
+        private List<object> _extraItems = new List<object>();
 
         /// <summary>
         /// Construct a CollectionTally object from a comparer and a collection
@@ -80,9 +94,8 @@ namespace NUnit.Framework.Constraints
 
             foreach (object o in c)
             {
-                Result.MissingItems.Add(o);
+                _missingItems.Add(o);
             }
-                
         }
 
         private bool ItemsEqual(object expected, object actual)
@@ -97,14 +110,14 @@ namespace NUnit.Framework.Constraints
         /// <param name="o">The object to remove</param>
         public void TryRemove(object o)
         {
-            for (int index = 0; index < Result.MissingItems.Count; index++)
-                if (ItemsEqual(Result.MissingItems[index], o))
+            for (int index = 0; index < _missingItems.Count; index++)
+                if (ItemsEqual(_missingItems[index], o))
                 {
-                    Result.MissingItems.RemoveAt(index);
+                    _missingItems.RemoveAt(index);
                     return;
                 }
 
-            Result.ExtraItems.Add(o);
+            _extraItems.Add(o);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -49,7 +49,8 @@ namespace NUnit.Framework.Constraints.Comparers
                 return false;
 
             CollectionTally tally = new CollectionTally(_equalityComparer, xDictionary.Keys);
-            if (!tally.TryRemove(yDictionary.Keys) || tally.MissingItems.Count > 0)
+            tally.TryRemove(yDictionary.Keys);
+            if ((tally.Result.MissingItems.Count > 0) || (tally.Result.ExtraItems.Count > 0))
                 return false;
 
             foreach (object key in xDictionary.Keys)

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Constraints.Comparers
                 return false;
 
             CollectionTally tally = new CollectionTally(_equalityComparer, xDictionary.Keys);
-            if (!tally.TryRemove(yDictionary.Keys) || tally.Count > 0)
+            if (!tally.TryRemove(yDictionary.Keys) || tally.MissingItems.Count > 0)
                 return false;
 
             foreach (object key in xDictionary.Keys)

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Compatibility\System.Threading\LazyThreadSafetyMode.cs" />
     <Compile Include="Compatibility\System.Threading\SpinWait.cs" />
     <Compile Include="Compatibility\System\Lazy.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />
     <Compile Include="Constraints\Comparers\ArraysComparer.cs" />
     <Compile Include="Constraints\Comparers\CharsComparer.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Compatibility\System.Threading\LazyThreadSafetyMode.cs" />
     <Compile Include="Compatibility\System.Threading\SpinWait.cs" />
     <Compile Include="Compatibility\System\Lazy.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />
     <Compile Include="Constraints\Comparers\ArraysComparer.cs" />
     <Compile Include="Constraints\Comparers\CharsComparer.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Constraints\CollectionConstraint.cs" />
     <Compile Include="Constraints\CollectionContainsConstraint.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraint.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Constraints\CollectionItemsEqualConstraint.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraint.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Attributes\DefaultFloatingPointToleranceAttribute.cs" />
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\NonParallelizableAttribute.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Internal\Commands\AfterTestCommand.cs" />
     <Compile Include="Internal\Commands\BeforeTestCommand.cs" />
     <Compile Include="Internal\Commands\DisposeFixtureCommand.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Constraints\CollectionConstraint.cs" />
     <Compile Include="Constraints\CollectionContainsConstraint.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraint.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Constraints\CollectionItemsEqualConstraint.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraint.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraint.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Constraints\CollectionConstraint.cs" />
     <Compile Include="Constraints\CollectionContainsConstraint.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraint.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
     <Compile Include="Constraints\CollectionItemsEqualConstraint.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraint.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraint.cs" />

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -288,7 +288,9 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: equivalent to < \"x\", \"y\", \"z\" >" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", \"x\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", \"x\" >" + Environment.NewLine +
+                "  Missing (1): < \"z\" >" + Environment.NewLine +
+                "  Extra (1): < \"x\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AreEquivalent(set1,set2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
@@ -302,7 +304,9 @@ namespace NUnit.Framework.Assertions
             
             var expectedMessage =
                 "  Expected: equivalent to < \"x\", \"y\", \"x\" >" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine +
+                "  Missing (1): < \"x\" >" + Environment.NewLine +
+                "  Extra (1): < \"z\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AreEquivalent(set1,set2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
@@ -73,6 +73,20 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void TestTwoExtraValues()
+        {
+            List<object> actualList = new List<object>() { "one", "two", "three", "four" };
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg =
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"one\", \"two\", \"three\", \"four\" >" + Environment.NewLine +
+                "  Extra (2): < \"three\", \"four\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
         public void TestOneExtraValue()
         {
             List<object> actualList = new List<object>() { "three", "one", "two" };

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
@@ -1,0 +1,125 @@
+﻿using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Constraints
+{
+    [TestFixture]
+    public class CollectionEquivalentConstraintResultTests
+    {
+        private List<string> _expected = new List<string>() { "one", "two" };
+
+        private CollectionEquivalentConstraint _constraint;
+        private TextMessageWriter _writer;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            _constraint = new CollectionEquivalentConstraint(_expected);
+            _writer = new TextMessageWriter();
+        }
+
+        [Test]
+        public void TestOneMissingValue()
+        {
+            List<object> actualList = new List<object>() { "one" };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"one\" >" + Environment.NewLine +
+                "  Missing (1): < \"two\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestTwoMissingValues()
+        {
+            List<object> actualList = new List<object>() { };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  <empty>" + Environment.NewLine +
+                "  Missing (2): < \"one\", \"two\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestOneExtraValue()
+        {
+            List<object> actualList = new List<object>() { "three", "one", "two" };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"three\", \"one\", \"two\" >" + Environment.NewLine +
+                "  Extra (1): < \"three\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestOneExtraOneMissing()
+        {
+            List<object> actualList = new List<object>() { "three", "one", };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"three\", \"one\" >" + Environment.NewLine +
+                "  Missing (1): < \"two\" >" + Environment.NewLine +
+                "  Extra (1): < \"three\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestOneExtraValueDueToUnexpectedRepeatedValue()
+        {
+            List<object> actualList = new List<object>() { "one", "two", "two" };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"one\", \"two\", \"two\" >" + Environment.NewLine +
+                "  Extra (1): < \"two\" >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestOnlyDisplaysUpToTenDifferences()
+        {
+            List<object> actualList = new List<object>() { "one", "two", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven" };
+
+            ConstraintResult cr = _constraint.ApplyTo(actualList);
+            cr.WriteMessageTo(_writer);
+
+            string expectedMsg = 
+                "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
+                "  But was:  < \"one\", \"two\", \"one\", \"two\", \"three\", \"four\", \"five\", \"six\", \"seven\", \"eight\"... >" + Environment.NewLine +
+                "  Extra (11): < \"one\", \"two\", \"three\", \"four\", \"five\", \"six\", \"seven\", \"eight\", \"nine\", \"ten\"... >" + Environment.NewLine;
+            Assert.AreEqual(expectedMsg, _writer.ToString());
+        }
+
+        [Test]
+        public void TestExceptionThrownWhenCollectionTallyNull()
+        {
+            List<object> actualList = new List<object>() { "one", "two", "two" };
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                #pragma warning disable CS0219
+                CollectionEquivalentConstraintResult cr = new CollectionEquivalentConstraintResult(_constraint, null, actualList, false);
+            });
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
@@ -1,4 +1,27 @@
-﻿using NUnit.Framework.Internal;
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
 

--- a/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
+++ b/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
@@ -1,0 +1,81 @@
+﻿using NUnit.Framework.Internal;
+using System.Collections.Generic;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class CollectionTallyTests
+    {
+        private List<string> _testStrings = new List<string>() { "one", "two", "three" };
+
+        private CollectionTally _collectionTally;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            _collectionTally = new CollectionTally(new NUnitEqualityComparer(), _testStrings);
+        }
+
+        [Test]
+        public void TestSingularTryRemove()
+        {
+            List<string> strings = new List<string>(_testStrings);
+
+            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
+
+            Assert.IsTrue(_collectionTally.TryRemove((object)strings[0]));
+            Assert.AreEqual(2, _collectionTally.MissingItems.Count);
+
+            Assert.IsTrue(_collectionTally.TryRemove((object)strings[1]));
+            Assert.AreEqual(1, _collectionTally.MissingItems.Count);
+
+            Assert.IsTrue(_collectionTally.TryRemove((object)strings[2]));
+            Assert.AreEqual(0, _collectionTally.MissingItems.Count);
+        }
+
+        [Test]
+        public void TestRemoveEntireCollection()
+        {
+            List<string> strings = new List<string>(_testStrings);
+
+            Assert.IsTrue(_collectionTally.TryRemove(strings));
+            Assert.AreEqual(0, _collectionTally.MissingItems.Count);
+        }
+
+        [Test]
+        public void TestRemoveNonExistingSingularElement()
+        {
+            Assert.IsFalse(_collectionTally.TryRemove((object)"notFound"));
+
+            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
+            Assert.AreEqual(1, _collectionTally.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound"));
+        }
+
+        [Test]
+        public void TestRemoveMultipleNonExistingElements()
+        {
+            List<string> nonExistingElems = new List<string>() { "notFound", "notFound2" };
+
+            Assert.IsFalse(_collectionTally.TryRemove(nonExistingElems));
+
+            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
+            Assert.AreEqual(2, _collectionTally.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound"));
+            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound2"));
+        }
+
+        [Test]
+        public void TestRemoveSomeExistingElements()
+        {
+            List<string> someExistingElems = new List<string>() { "one", "notFound2" };
+
+            Assert.IsFalse(_collectionTally.TryRemove(someExistingElems));
+
+            Assert.AreEqual(2, _collectionTally.MissingItems.Count);
+            Assert.AreEqual(1, _collectionTally.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound2"));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
+++ b/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
@@ -1,4 +1,26 @@
-﻿using NUnit.Framework.Internal;
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 

--- a/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
+++ b/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
@@ -22,16 +22,20 @@ namespace NUnit.Framework.Internal
         {
             List<string> strings = new List<string>(_testStrings);
 
-            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
+            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
 
-            Assert.IsTrue(_collectionTally.TryRemove((object)strings[0]));
-            Assert.AreEqual(2, _collectionTally.MissingItems.Count);
+            _collectionTally.TryRemove((object)strings[0]);
+            Assert.AreEqual(2, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
 
-            Assert.IsTrue(_collectionTally.TryRemove((object)strings[1]));
-            Assert.AreEqual(1, _collectionTally.MissingItems.Count);
+            _collectionTally.TryRemove((object)strings[1]);
+            Assert.AreEqual(1, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
 
-            Assert.IsTrue(_collectionTally.TryRemove((object)strings[2]));
-            Assert.AreEqual(0, _collectionTally.MissingItems.Count);
+            _collectionTally.TryRemove((object)strings[2]);
+            Assert.AreEqual(0, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
         }
 
         [Test]
@@ -39,18 +43,19 @@ namespace NUnit.Framework.Internal
         {
             List<string> strings = new List<string>(_testStrings);
 
-            Assert.IsTrue(_collectionTally.TryRemove(strings));
-            Assert.AreEqual(0, _collectionTally.MissingItems.Count);
+            _collectionTally.TryRemove(strings);
+            Assert.AreEqual(0, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
         }
 
         [Test]
         public void TestRemoveNonExistingSingularElement()
         {
-            Assert.IsFalse(_collectionTally.TryRemove((object)"notFound"));
+            _collectionTally.TryRemove((object)"notFound");
 
-            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
-            Assert.AreEqual(1, _collectionTally.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound"));
+            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(1, _collectionTally.Result.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound"));
         }
 
         [Test]
@@ -58,12 +63,12 @@ namespace NUnit.Framework.Internal
         {
             List<string> nonExistingElems = new List<string>() { "notFound", "notFound2" };
 
-            Assert.IsFalse(_collectionTally.TryRemove(nonExistingElems));
+            _collectionTally.TryRemove(nonExistingElems);
 
-            Assert.AreEqual(3, _collectionTally.MissingItems.Count);
-            Assert.AreEqual(2, _collectionTally.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound"));
-            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound2"));
+            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(2, _collectionTally.Result.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound"));
+            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound2"));
         }
 
         [Test]
@@ -71,11 +76,11 @@ namespace NUnit.Framework.Internal
         {
             List<string> someExistingElems = new List<string>() { "one", "notFound2" };
 
-            Assert.IsFalse(_collectionTally.TryRemove(someExistingElems));
+            _collectionTally.TryRemove(someExistingElems);
 
-            Assert.AreEqual(2, _collectionTally.MissingItems.Count);
-            Assert.AreEqual(1, _collectionTally.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.ExtraItems.Contains("notFound2"));
+            Assert.AreEqual(2, _collectionTally.Result.MissingItems.Count);
+            Assert.AreEqual(1, _collectionTally.Result.ExtraItems.Count);
+            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound2"));
         }
     }
 }

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -90,12 +90,14 @@
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Compatibility\ReflectionExtensionsTests.cs" />
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
     <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -90,11 +90,13 @@
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Compatibility\ReflectionExtensionsTests.cs" />
     <Compile Include="Constraints\AsyncDelayedConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -138,7 +138,9 @@
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
     <Compile Include="Constraints\CollectionEqualsTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -212,6 +213,7 @@
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />
     <Compile Include="Internal\CallContextTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\CultureSettingAndDetectionTests.cs" />
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\AssignableFromConstraintTests.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -195,6 +196,7 @@
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Constraints\BinarySerializableTest.cs" />
     <Compile Include="Constraints\AssignableFromConstraintTests.cs" />
     <Compile Include="Constraints\CollectionContainsConstraintTests.cs" />
+    <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintTests.cs" />
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
@@ -195,6 +196,7 @@
     <Compile Include="Constraints\UniqueItemsConstraintTests.cs" />
     <Compile Include="Constraints\XmlSerializableTest.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
+    <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />


### PR DESCRIPTION
Fixes issue #1151 .

Allows the returned `ConstraintResult` from `CollectionEquivalentConstraint` description message to show collection differences (up to 10) of either extra or missing items when attempting to compare the actual collection to the expected.

For example,
```
List<string> expectedCollection = new List<string>() { "one", "two" }; 
List<string> actualCollection = new List<string>() { "three", "one" }; 
 
ConstraintResult cr = new CollectionEquivalentConstraint(expectedCollection)
    .ApplyTo(actualCollection); 
```

would yield a test failure message of:

```
  Expected: equivalent to < "one", "two" >
  But was:  < "three", "one" >
  Missing (1): < "two" >
  Extra (1): < "three" >
```
