### PR TITLE
Execute OneTimeTearDown as early as possible

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,8 @@
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.7.0
+
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.7.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -435,6 +435,16 @@ namespace NUnit.Framework.Internal.Execution
                 get { return string.Format("{0} OneTimeTearDown", base.Name); }
             }
 
+#if PARALLEL
+            /// <summary>
+            /// The ExecutionStrategy for use in running this work item
+            /// </summary>
+            public override ParallelExecutionStrategy ExecutionStrategy
+            {
+                get { return _originalWorkItem.ExecutionStrategy; }
+            }
+#endif
+
             /// <summary>
             ///
             /// </summary>

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelExecutionStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelExecutionStrategy.cs
@@ -1,0 +1,49 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if PARALLEL
+namespace NUnit.Framework.Internal.Execution
+{
+    /// <summary>
+    /// Enumeration representing the strategy to follow in executing a work item.
+    /// The value is only relevant when running under the parallel dispatcher.
+    /// </summary>
+    public enum ParallelExecutionStrategy
+    {
+        /// <summary>
+        /// Run directly on same thread
+        /// </summary>
+        Direct,
+
+        /// <summary>
+        /// Enqueue for parallel execution
+        /// </summary>
+        Parallel,
+
+        /// <summary>
+        /// Enqueue for non-parallel execution
+        /// </summary>
+        NonParallel,
+    }
+}
+#endif

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="work">The item to dispatch</param>
         public void Dispatch(WorkItem work)
         {
-            Dispatch(work, work.GetExecutionStrategy());
+            Dispatch(work, work.ExecutionStrategy);
         }
 
         // Separate method so it can be used by Start

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -284,7 +284,47 @@ namespace NUnit.Framework.Internal.Execution
 #endif
         }
 
-        #endregion
+#if PARALLEL
+        /// <summary>
+        /// Return the ParallelExecutionStrategy to be used for this work item
+        /// </summary>
+        /// <returns></returns>
+        public ParallelExecutionStrategy GetExecutionStrategy()
+        {
+            // If there is no fixture and so nothing to do but dispatch 
+            // grandchildren we run directly. This saves time that would 
+            // otherwise be spent enqueuing and dequeing items.
+            if (Test.TypeInfo == null)
+                return ParallelExecutionStrategy.Direct;
+
+            // If the context is single-threaded we are required to run
+            // the tests one by one on the same thread as the fixture.
+            if (Context.IsSingleThreaded)
+                return ParallelExecutionStrategy.Direct;
+
+            // Check if item is explicitly marked as non-parallel
+            if (ParallelScope.HasFlag(ParallelScope.None))
+                return ParallelExecutionStrategy.NonParallel;
+
+            // Check if item is explicitly marked as parallel
+            if (ParallelScope.HasFlag(ParallelScope.Self))
+                return ParallelExecutionStrategy.Parallel;
+
+            // Item is not explicitly marked, so check the inherited context
+            if (Context.ParallelScope.HasFlag(ParallelScope.Children) ||
+                Test is TestFixture && Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
+                return ParallelExecutionStrategy.Parallel;
+
+            // There is no scope specified either on the item itself or in the context.
+            // In that case, simple work items are test cases and just run on the same
+            // thread, while composite work items and teardowns are non-parallel.
+            return this is SimpleWorkItem
+                ? ParallelExecutionStrategy.Direct
+                : ParallelExecutionStrategy.NonParallel;
+        }
+#endif
+
+#endregion
 
         #region Protected Methods
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -161,6 +161,22 @@ namespace NUnit.Framework.Internal.Execution
         /// The worker executing this item.
         /// </summary>
         public TestWorker TestWorker { get; internal set; }
+
+        private ParallelExecutionStrategy? _executionStrategy;
+
+        /// <summary>
+        /// The ParallelExecutionStrategy to use for this work item
+        /// </summary>
+        public virtual ParallelExecutionStrategy ExecutionStrategy
+        {
+            get
+            {
+                if (!_executionStrategy.HasValue)
+                    _executionStrategy = GetExecutionStrategy();
+
+                return _executionStrategy.Value;
+            }
+        }
 #endif
 
         /// <summary>
@@ -283,46 +299,6 @@ namespace NUnit.Framework.Internal.Execution
             }
 #endif
         }
-
-#if PARALLEL
-        /// <summary>
-        /// Return the ParallelExecutionStrategy to be used for this work item
-        /// </summary>
-        /// <returns></returns>
-        public ParallelExecutionStrategy GetExecutionStrategy()
-        {
-            // If there is no fixture and so nothing to do but dispatch 
-            // grandchildren we run directly. This saves time that would 
-            // otherwise be spent enqueuing and dequeing items.
-            if (Test.TypeInfo == null)
-                return ParallelExecutionStrategy.Direct;
-
-            // If the context is single-threaded we are required to run
-            // the tests one by one on the same thread as the fixture.
-            if (Context.IsSingleThreaded)
-                return ParallelExecutionStrategy.Direct;
-
-            // Check if item is explicitly marked as non-parallel
-            if (ParallelScope.HasFlag(ParallelScope.None))
-                return ParallelExecutionStrategy.NonParallel;
-
-            // Check if item is explicitly marked as parallel
-            if (ParallelScope.HasFlag(ParallelScope.Self))
-                return ParallelExecutionStrategy.Parallel;
-
-            // Item is not explicitly marked, so check the inherited context
-            if (Context.ParallelScope.HasFlag(ParallelScope.Children) ||
-                Test is TestFixture && Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
-                return ParallelExecutionStrategy.Parallel;
-
-            // There is no scope specified either on the item itself or in the context.
-            // In that case, simple work items are test cases and just run on the same
-            // thread, while composite work items and teardowns are non-parallel.
-            return this is SimpleWorkItem
-                ? ParallelExecutionStrategy.Direct
-                : ParallelExecutionStrategy.NonParallel;
-        }
-#endif
 
 #endregion
 
@@ -484,6 +460,43 @@ namespace NUnit.Framework.Internal.Execution
 
             PerformWork();
         }
+
+#if PARALLEL
+        private ParallelExecutionStrategy GetExecutionStrategy()
+        {
+            // If there is no fixture and so nothing to do but dispatch 
+            // grandchildren we run directly. This saves time that would 
+            // otherwise be spent enqueuing and dequeing items.
+            if (Test.TypeInfo == null)
+                return ParallelExecutionStrategy.Direct;
+
+            // If the context is single-threaded we are required to run
+            // the tests one by one on the same thread as the fixture.
+            if (Context.IsSingleThreaded)
+                return ParallelExecutionStrategy.Direct;
+
+            // Check if item is explicitly marked as non-parallel
+            if (ParallelScope.HasFlag(ParallelScope.None))
+                return ParallelExecutionStrategy.NonParallel;
+
+            // Check if item is explicitly marked as parallel
+            if (ParallelScope.HasFlag(ParallelScope.Self))
+                return ParallelExecutionStrategy.Parallel;
+
+            // Item is not explicitly marked, so check the inherited context
+            if (Context.ParallelScope.HasFlag(ParallelScope.Children) ||
+                Test is TestFixture && Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
+                return ParallelExecutionStrategy.Parallel;
+
+            // There is no scope specified either on the item itself or in the context.
+            // In that case, simple work items are test cases and just run on the same
+            // thread, while composite work items and teardowns are non-parallel.
+            return this is SimpleWorkItem
+                ? ParallelExecutionStrategy.Direct
+                : ParallelExecutionStrategy.NonParallel;
+        }
+#endif
+
         #endregion
     }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -60,19 +60,27 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class WorkItemQueue
     {
-        private const int spinCount = 5;
+        private const int SPIN_COUNT = 5;
+
+        // Although the code makes the number of levels relatively
+        // easy to change, it is still baked in as a constant at
+        // this time. If we wanted to make it variable, that would
+        // be a bit more work, which does not now seem necessary.
+        private const int HIGH_PRIORITY = 0;
+        private const int NORMAL_PRIORITY = 1;
+        private const int PRIORITY_LEVELS = 2;
 
         private Logger log = InternalTrace.GetLogger("WorkItemQueue");
 
-        private ConcurrentQueue<WorkItem> _innerQueue = new ConcurrentQueue<WorkItem>();
+        private ConcurrentQueue<WorkItem>[] _innerQueues;
 
         private class SavedState
         {
-            public ConcurrentQueue<WorkItem> InnerQueue;
+            public ConcurrentQueue<WorkItem>[] InnerQueues;
 
             public SavedState(WorkItemQueue queue)
             {
-                InnerQueue = queue._innerQueue;
+                InnerQueues = queue._innerQueues;
             }
         }
 
@@ -98,15 +106,24 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         /// <param name="name">The name of the queue.</param>
         /// <param name="isParallel">Flag indicating whether this is a parallel queue</param>
-        /// "<param name="apartment">ApartmentState to use for items on this queue</param>
+        /// <param name="apartment">ApartmentState to use for items on this queue</param>
         public WorkItemQueue(string name, bool isParallel, ApartmentState apartment)
         {
             Name = name;
             IsParallelQueue = isParallel;
             TargetApartment = apartment;
             State = WorkItemQueueState.Paused;
-            MaxCount = 0;
             ItemsProcessed = 0;
+
+            InitializeQueues();
+        }
+
+        private void InitializeQueues()
+        {
+            _innerQueues = new ConcurrentQueue<WorkItem>[PRIORITY_LEVELS];
+
+            for (int i = 0; i < PRIORITY_LEVELS; i++)
+                _innerQueues[i] = new ConcurrentQueue<WorkItem>();
         }
 
         #region Properties
@@ -136,17 +153,6 @@ namespace NUnit.Framework.Internal.Execution
             private set { _itemsProcessed = value; }
         }
 
-        private int _maxCount;
-
-        /// <summary>
-        /// Gets the maximum number of work items.
-        /// </summary>
-        public int MaxCount
-        {
-            get { return _maxCount; }
-            private set { _maxCount = value; }
-        }
-
         private int _state;
         /// <summary>
         /// Gets the current state of the queue
@@ -162,12 +168,21 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public bool IsEmpty
         {
-            get { return _innerQueue.IsEmpty; }
+            get
+            {
+                foreach (var q in _innerQueues)
+                    if (!q.IsEmpty)
+                        return false;
+
+                return true;
+            }
         }
 
         #endregion
 
         #region Public Methods
+
+        private Random _random = new Random();
 
         /// <summary>
         /// Enqueue a WorkItem to be processed
@@ -175,6 +190,19 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="work">The WorkItem to process</param>
         public void Enqueue(WorkItem work)
         {
+            Enqueue(work, work is CompositeWorkItem.OneTimeTearDownWorkItem ? HIGH_PRIORITY : NORMAL_PRIORITY);
+        }
+
+        /// <summary>
+        /// Enqueue a WorkItem to be processed - internal for testing
+        /// </summary>
+        /// <param name="work">The WorkItem to process</param>
+        /// <param name="priority">The priority at which to process the item</param>
+        internal void Enqueue(WorkItem work, int priority)
+        {
+            Guard.ArgumentInRange(priority >= 0 && priority < PRIORITY_LEVELS,
+                "Invalid priority specified", "priority");
+
             do
             {
                 int cachedAddId = _addId;
@@ -184,16 +212,7 @@ namespace NUnit.Framework.Internal.Execution
                     continue;
 
                 // Add to the collection
-                _innerQueue.Enqueue(work);
-
-                // Set MaxCount using CAS
-                int i, j = _maxCount;
-                do
-                {
-                    i = j;
-                    j = Interlocked.CompareExchange(ref _maxCount, Math.Max(i, _innerQueue.Count), i);
-                }
-                while (i != j);
+                _innerQueues[priority].Enqueue(work);
 
                 // Wake up threads that may have been sleeping
                 _mreAdd.Set();
@@ -224,7 +243,7 @@ namespace NUnit.Framework.Internal.Execution
                 if (cachedRemoveId == cachedAddId || cachedState == WorkItemQueueState.Paused)
                 {
                     // Spin a few times to see if something changes
-                    if (sw.Count <= spinCount)
+                    if (sw.Count <= SPIN_COUNT)
                     {
                         sw.SpinOnce();
                     }
@@ -254,8 +273,11 @@ namespace NUnit.Framework.Internal.Execution
 
 
                 // Dequeue our work item
-                WorkItem work;
-                while (!_innerQueue.TryDequeue(out work)) { };
+                WorkItem work = null;
+                while (work == null)
+                    foreach (var q in _innerQueues)
+                        if (q.TryDequeue(out work))
+                            break;
 
                 // Add to items processed using CAS
                 Interlocked.Increment(ref _itemsProcessed);
@@ -280,7 +302,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Stop()
         {
-            log.Info("{0}.{1} stopping - {2} WorkItems processed, max size {3}", Name, _savedState.Count, ItemsProcessed, MaxCount);
+            log.Info("{0}.{1} stopping - {2} WorkItems processed", Name, _savedState.Count, ItemsProcessed);
 
             if (Interlocked.Exchange(ref _state, (int)WorkItemQueueState.Stopped) != (int)WorkItemQueueState.Stopped)
                 _mreAdd.Set();
@@ -305,7 +327,8 @@ namespace NUnit.Framework.Internal.Execution
             Pause();
 
             _savedState.Push(new SavedState(this));
-            _innerQueue = new ConcurrentQueue<WorkItem>();
+
+            InitializeQueues();
 
             Start();
         }
@@ -317,7 +340,7 @@ namespace NUnit.Framework.Internal.Execution
         {
             Pause();
 
-            _innerQueue = _savedState.Pop().InnerQueue;
+            _innerQueues = _savedState.Pop().InnerQueues;
 
             Start();
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -182,8 +182,6 @@ namespace NUnit.Framework.Internal.Execution
 
         #region Public Methods
 
-        private Random _random = new Random();
-
         /// <summary>
         /// Enqueue a WorkItem to be processed
         /// </summary>

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Internal\Commands\DisposeFixtureCommand.cs" />
     <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Internal\Commands\EmptyTestCommand.cs" />
     <Compile Include="Internal\Commands\TimeoutCommand.cs" />
     <Compile Include="Internal\Execution\EventListenerTextWriter.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Internal\Filters\CompositeFilter.cs" />
     <Compile Include="Internal\Filters\PropertyFilter.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcher.cs" />
     <Compile Include="Internal\Execution\QueuingEventListener.cs" />
     <Compile Include="Internal\Execution\SimpleWorkItem.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Internal\Commands\BeforeAndAfterTestCommand.cs" />
     <Compile Include="Internal\Commands\ConstructFixtureCommand.cs" />
     <Compile Include="Internal\Commands\TimeoutCommand.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Interfaces\TestAttachment.cs" />
     <Compile Include="Internal\TestCaseTimeoutException.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcher.cs" />
     <Compile Include="Internal\Execution\QueuingEventListener.cs" />
     <Compile Include="Internal\Execution\SimpleWorkItem.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Internal\Execution\EventPump.cs" />
     <Compile Include="Internal\Execution\EventQueue.cs" />
     <Compile Include="Internal\Execution\IWorkItemDispatcher.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcher.cs" />
     <Compile Include="Internal\Execution\QueuingEventListener.cs" />
     <Compile Include="Internal\Execution\SimpleWorkItem.cs" />

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionStrategyTests.cs
@@ -59,11 +59,11 @@ namespace NUnit.Framework.Internal.Execution
             work.InitializeContext(_context);
 
             // We use a string for expected because the ExecutionStrategy enum is internal and can't be an arg to a public method
-            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo(expectedStrategy));
+            Assert.That(work.GetExecutionStrategy().ToString(), Is.EqualTo(expectedStrategy));
             
             // Make context single threaded - should always be direct
             _context.IsSingleThreaded = true;
-            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo("Direct"));
+            Assert.That(work.GetExecutionStrategy().ToString(), Is.EqualTo("Direct"));
         }
 
         [TestCase(ParallelScope.Default, ParallelScope.Default, "NonParallel")]
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Internal.Execution
             work.InitializeContext(_context);
 
             // We use a string for expected because the ExecutionStrategy enum is internal and can't be an arg to a public method
-            Assert.That(ParallelWorkItemDispatcher.GetExecutionStrategy(work).ToString(), Is.EqualTo(expectedStrategy));
+            Assert.That(work.GetExecutionStrategy().ToString(), Is.EqualTo(expectedStrategy));
         }
 
         private void TestMethod() { }


### PR DESCRIPTION
Fixes #2335 

This seems to fix it but requires some review since it's an area where we do not have tests. It's really not unit-testable and we have not set up an infrastructure for running integrated tests, especially where parallelis is involved. That said, I've tested a fair bit to ensure it does no harm. I ran with five levels of priority and generated random priorities for every work item, with only two test failures, which depended on the order of execution.

We now have a priority queue embedded in WorkItemQueue, implemented as an array of individual queues. There is no public access to this feature and the implementation is strictly limited to what we need for two levels of priority, one for OneTimeTearDown and one for everything else. I think we should be conservative in extending this and do it in very very small steps if we do.

I also did some refactoring to make it easier to implement the change. Notably, WorkItem is now responsible for calculating and remembering its own ExecutionStrategy.

I'd like to get this merged into a dev build and recruit some of the users who have reported the issue to try it out.