### PR TITLE
Add more info to TestContext

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -172,9 +172,18 @@ namespace NUnit.Framework
             get { return _testExecutionContext.RandomGenerator; }
         }
 
-#endregion
+        /// <summary>
+        /// Gets the number of assertions executed
+        /// up to this point in the test.
+        /// </summary>
+        public int AssertCount
+        {
+            get { return _testExecutionContext.AssertCount; }
+        }
 
-#region Static Methods
+        #endregion
+
+        #region Static Methods
 
         /// <summary>Write the string representation of a boolean value to the current result</summary>
         public static void Write(bool value) { Out.Write(value); }
@@ -445,7 +454,8 @@ namespace NUnit.Framework
 #region Properties
 
             /// <summary>
-            /// Gets a ResultState representing the outcome of the test.
+            /// Gets a ResultState representing the outcome of the test
+            /// up to this point in its execution.
             /// </summary>
             public ResultState Outcome
             {

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -463,6 +463,15 @@ namespace NUnit.Framework
             }
 
             /// <summary>
+            /// Gets a list of the assertion results generated
+            /// up to this point in the test.
+            /// </summary>
+            public IEnumerable<AssertionResult> Assertions
+            {
+                get { return _result.AssertionResults; }
+            }
+
+            /// <summary>
             /// Gets the message associated with a test
             /// failure or with not running the test
             /// </summary>

--- a/src/NUnitFramework/testdata/TestContextData.cs
+++ b/src/NUnitFramework/testdata/TestContextData.cs
@@ -21,8 +21,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
+using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.TestData.TestContextData
 {
@@ -62,6 +63,36 @@ namespace NUnit.TestData.TestContextData
         public void TearDown()
         {
             stateList += "=>" + TestContext.CurrentContext.Result.Outcome;
+        }
+    }
+
+    public class AssertionResultFixture
+    {
+        public IEnumerable<AssertionResult> Assertions;
+
+        public void ThreeAsserts_TwoFailed()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+                Assert.That(2 + 2, Is.EqualTo(4));
+                Assert.That(2 + 2, Is.EqualTo(5));
+
+                Assertions = TestContext.CurrentContext.Result.Assertions;
+            });
+        }
+
+        public void WarningPlusFailedAssert()
+        {
+            Warn.Unless(2 + 2, Is.EqualTo(5));
+
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+
+                Assertions = TestContext.CurrentContext.Result.Assertions;
+            });
         }
     }
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -249,6 +249,25 @@ namespace NUnit.Framework.Tests
         #region Result
 
         [Test]
+        public void TestCanAccessAssertCount()
+        {
+            var context = TestExecutionContext.CurrentContext;
+
+            // These are counted as asserts
+            Assert.That(context.AssertCount, Is.EqualTo(0));
+            Assert.AreEqual(4, 2 + 2);
+            Warn.Unless(2 + 2, Is.EqualTo(4));
+
+            // This one is counted below
+            Assert.That(context.AssertCount, Is.EqualTo(3));
+
+            // Assumptions are not counted are not counted
+            Assume.That(2 + 2, Is.EqualTo(4));
+
+            Assert.That(TestContext.CurrentContext.AssertCount, Is.EqualTo(4));
+        }
+
+        [Test]
         public void TestCanAccessTestState_PassingTest()
         {
             TestStateRecordingFixture fixture = new TestStateRecordingFixture();

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -125,35 +126,35 @@ namespace NUnit.Framework.Tests
 
     #endregion
 
-    #region Test
+        #region Test
 
-    #region Name
-
-    [Test]
-        public void ConstructorCanAccessFixtureName()
-        {
-            Assert.That(_name, Is.EqualTo("TestContextTests"));
-        }
+        #region Name
 
         [Test]
-        public void TestCanAccessItsOwnName()
-        {
-            Assert.That(TestContext.CurrentContext.Test.Name, Is.EqualTo("TestCanAccessItsOwnName"));
-        }
+            public void ConstructorCanAccessFixtureName()
+            {
+                Assert.That(_name, Is.EqualTo("TestContextTests"));
+            }
 
-        [Test]
-        public void SetUpCanAccessTestName()
-        {
-            Assert.That(_setupContext.Test.Name, Is.EqualTo(TestContext.CurrentContext.Test.Name));
-        }
+            [Test]
+            public void TestCanAccessItsOwnName()
+            {
+                Assert.That(TestContext.CurrentContext.Test.Name, Is.EqualTo("TestCanAccessItsOwnName"));
+            }
 
-        [TestCase(5)]
-        public void TestCaseCanAccessItsOwnName(int x)
-        {
-            Assert.That(TestContext.CurrentContext.Test.Name, Is.EqualTo("TestCaseCanAccessItsOwnName(5)"));
-        }
+            [Test]
+            public void SetUpCanAccessTestName()
+            {
+                Assert.That(_setupContext.Test.Name, Is.EqualTo(TestContext.CurrentContext.Test.Name));
+            }
 
-        #endregion
+            [TestCase(5)]
+            public void TestCaseCanAccessItsOwnName(int x)
+            {
+                Assert.That(TestContext.CurrentContext.Test.Name, Is.EqualTo("TestCaseCanAccessItsOwnName(5)"));
+            }
+
+            #endregion
 
         #region FullName
 
@@ -265,6 +266,22 @@ namespace NUnit.Framework.Tests
             Assume.That(2 + 2, Is.EqualTo(4));
 
             Assert.That(TestContext.CurrentContext.AssertCount, Is.EqualTo(4));
+        }
+
+        [TestCase("ThreeAsserts_TwoFailed", AssertionStatus.Failed, AssertionStatus.Failed)]
+        [TestCase("WarningPlusFailedAssert", AssertionStatus.Warning, AssertionStatus.Failed)]
+        public void TestCanAccessAssertionResults(string testName, params AssertionStatus[] expectedStatus)
+        {
+            AssertionResultFixture fixture = new AssertionResultFixture();
+            TestBuilder.RunTestCase(fixture, testName);
+            var assertions = fixture.Assertions;
+
+            Assert.That(assertions.Select((o) => o.Status),
+                Is.EqualTo(expectedStatus));
+            Assert.That(assertions.Select((o) => o.Message),
+                Has.All.Contains("Expected: 5"));
+            Assert.That(assertions.Select((o) => o.StackTrace),
+                Has.All.Contains(testName));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #2353 

I added `TestContext.CurrentContext.AssertCount` and `TestContext.CurrentContext.Result.Assertions`.

Lets take a minute to make sure that is the syntax we want...

Under the covers, AssertCount is stored in the `TestExecutionContext` and doesn't actually get added to the result until the test is over. OTOH, the Assertion results are stored immediately in the current result itself. I presented this to the user just as it is internally. As an alternative, I could make AssertCount a property of the pseudo-Result that the user sees if that seems more natural. Tell me which you prefer, please.