### PR TITLE
Fix Mono 5.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ matrix:
     - os: linux
       mono: latest
     - os: osx
-      mono: 4.6.2
+      mono: latest
 script:
   - ./build.sh --target "Travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: csharp
 sudo: false
-mono:
-  - 4.6.2 # in most common distros
-  - latest
-os:
-  - linux
-  - osx
 matrix:
-  exclude:
-    - os: osx
+  include:
+    - os: linux
+      mono: 4.6.2
+    - os: linux
       mono: latest
-  allow_failures:
-    - mono: latest
-  fast_finish: true
+    - os: osx
+      mono: 4.6.2
 script:
   - ./build.sh --target "Travis"

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../src/NUnitFramework/framework/packages.config" />
+  <repository path="../src/NUnitFramework/nunitlite.tests/packages.config" />
+  <repository path="../src/NUnitFramework/nunitlite/packages.config" />
+  <repository path="../src/NUnitFramework/testdata/packages.config" />
+  <repository path="../src/NUnitFramework/tests/packages.config" />
   <repository path="..\src\NUnitFramework\testdata\packages.config" />
   <repository path="..\src\NUnitFramework\tests\packages.config" />
 </repositories>

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -111,7 +111,7 @@ namespace NUnit.Framework.Api
             catch (Exception ex)
             {
                 testAssembly = new TestAssembly(assemblyName);
-                testAssembly.MakeInvalid(ExceptionHelper.BuildFriendlyMessage(ex));
+                testAssembly.MakeInvalid(ExceptionHelper.BuildMessage(ex, true));
             }
 
             return testAssembly;
@@ -174,7 +174,7 @@ namespace NUnit.Framework.Api
             catch (Exception ex)
             {
                 testAssembly = new TestAssembly(assemblyPath);
-                testAssembly.MakeInvalid(ExceptionHelper.BuildFriendlyMessage(ex));
+                testAssembly.MakeInvalid(ExceptionHelper.BuildMessage(ex, true));
             }
 
             return testAssembly;

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -68,29 +68,31 @@ namespace NUnit.Framework.Internal
 #endif
         }
 
-        // TODO: Move to a utility class
         /// <summary>
         /// Builds up a message, using the Message field of the specified exception
-        /// as well as any InnerExceptions.
+        /// as well as any InnerExceptions. Optionally excludes exception names, 
+        /// creating a more readable message.
         /// </summary>
         /// <param name="exception">The exception.</param>
+        /// <param name="excludeExceptionNames">Flag indicating whether exception names should be excluded.</param>
         /// <returns>A combined message string.</returns>
-        public static string BuildMessage(Exception exception)
+        public static string BuildMessage(Exception exception, bool excludeExceptionNames=false)
         {
-            const bool isFriendlyMessage = false;
-            return BuildMessage(exception, isFriendlyMessage);
-        }
+            StringBuilder sb = new StringBuilder();
+            if (!excludeExceptionNames)
+                sb.AppendFormat("{0} : ", exception.GetType());
+            sb.Append(GetExceptionMessage(exception));
 
-        /// <summary>
-        /// Builds up a message, using the Message field of the specified exception
-        /// as well as any InnerExceptions. Excludes exception names, creating more readable message
-        /// </summary>
-        /// <param name="exception">The exception.</param>
-        /// <returns>A combined message string.</returns>
-        public static string BuildFriendlyMessage(Exception exception)
-        {
-            const bool isFriendlyMessage = true;
-            return BuildMessage(exception, isFriendlyMessage);
+            foreach (Exception inner in FlattenExceptionHierarchy(exception))
+            {
+                sb.Append(Environment.NewLine);
+                sb.Append("  ----> ");
+                if (!excludeExceptionNames)
+                    sb.AppendFormat("{0} : ", inner.GetType());
+                sb.Append(GetExceptionMessage(inner));
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace NUnit.Framework.Internal
         /// <returns>A combined stack trace.</returns>
         public static string BuildStackTrace(Exception exception)
         {
-            StringBuilder sb = new StringBuilder(GetStackTrace(exception));
+            StringBuilder sb = new StringBuilder(GetSafeStackTrace(exception));
 
             foreach (Exception inner in FlattenExceptionHierarchy(exception))
             {
@@ -109,18 +111,19 @@ namespace NUnit.Framework.Internal
                 sb.Append("--");
                 sb.Append(inner.GetType().Name);
                 sb.Append(Environment.NewLine);
-                sb.Append(GetStackTrace(inner));
+                sb.Append(GetSafeStackTrace(inner));
             }
 
             return sb.ToString();
         }
 
         /// <summary>
-        /// Gets the stack trace of the exception.
+        /// Gets the stack trace of the exception. If no stack trace
+        /// is provided, returns "No stack trace available".
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <returns>A string representation of the stack trace.</returns>
-        public static string GetStackTrace(Exception exception)
+        private static string GetSafeStackTrace(Exception exception)
         {
             try
             {
@@ -132,28 +135,18 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        private static string BuildMessage(Exception exception, bool isFriendlyMessage)
+        private static string GetExceptionMessage(Exception ex)
         {
-            StringBuilder sb = new StringBuilder();
-            WriteException(sb, exception, isFriendlyMessage);
-
-            foreach (Exception inner in FlattenExceptionHierarchy(exception))
+            if (string.IsNullOrEmpty(ex.Message))
             {
-                sb.Append(Environment.NewLine);
-                sb.Append("  ----> ");
-                WriteException(sb, inner, isFriendlyMessage);
+                // Special handling for Mono 5.0, which returns an empty message
+                var fnfEx = ex as System.IO.FileNotFoundException;
+                return fnfEx != null
+                    ? "Could not load assembly. File not found: " + fnfEx.FileName
+                    : "No message provided";
             }
 
-            return sb.ToString();
-        }
-
-        private static void WriteException(StringBuilder sb, Exception inner, bool isFriendlyMessage)
-        {
-            if (!isFriendlyMessage)
-            {
-                sb.AppendFormat(CultureInfo.CurrentCulture, "{0} : ", inner.GetType().ToString());
-            }
-            sb.Append(inner.Message);
+            return ex.Message;
         }
 
         private static List<Exception> FlattenExceptionHierarchy(Exception exception)

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner-4.5.csproj
@@ -25,7 +25,8 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <Externalconsole>true</Externalconsole>
+    <Commandlineparameters>nunit.framework.tests.dll</Commandlineparameters>
+    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -25,7 +25,7 @@ using System.IO;
 using System.Reflection;
 using NUnit.Compatibility;
 
-namespace NUnit.Framework.Internal.Tests
+namespace NUnit.Framework.Internal
 {
     [TestFixture]
     public class AssemblyHelperTests


### PR DESCRIPTION
Fixes #2358 

I compensated for the blank message field we are seeing in `FileNotFoundException` by creating a message. This is probably a bug in 5.0 and 5.2 beta, but we need to deal with it.

Once fixed, I made the linux mono latest build required, so we will check into problems that arise. I also rewrote .travis.yml to use matrix include rather than exclude. It seems a lot clearer that way.
