### PR TITLE
Allowed ordering of test fixtures

### DIFF
--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
@@ -57,6 +58,28 @@ namespace NUnit.TestUtilities
             TestSuite suite = MakeFixture(fixture.GetType());
             suite.Fixture = fixture;
             return suite;
+        }
+
+        public static TestSuite MakeFixture(List<Type> types)
+        {
+            // following the pattern found in DefaultTestAssemblyBuilder
+            var fixtures = new List<Test>();
+            var defaultSuiteBuilder = new DefaultSuiteBuilder();
+            foreach (var type in types)
+            {
+                var typeInfo = new TypeWrapper(type);
+                var test = defaultSuiteBuilder.BuildFrom(typeInfo);
+                fixtures.Add(test);
+            }
+
+            var assembly = AssemblyHelper.Load("nunit.testdata");
+            var assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
+            TestSuite testSuite = new TestAssembly(assembly, assemblyPath);
+
+            var treeBuilder = new NamespaceTreeBuilder(testSuite);
+            treeBuilder.Add(fixtures);
+
+            return treeBuilder.RootSuite;
         }
 
         public static TestSuite MakeParameterizedMethodSuite(Type type, string methodName)

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Defines the order that the test will run in
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest
     {
           /// <summary>

--- a/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace NUnit.TestData
 {
     [TestFixture]
-    [Order(1)]
+    [Order(3)]
     public class TestCaseOrderAttributeFixture
     {
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
-    [Order(2)]
+    [Order(1)]
     public class AnotherTestCaseOrderAttributeFixture
     {
         [Test]
@@ -55,7 +55,7 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
-    [Order(3)]
+    [Order(2)]
     public class ThirdTestCaseOrderAttributeFixture
     {
         [Test]

--- a/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace NUnit.TestData
 {
     [TestFixture]
+    [Order(1)]
     public class TestCaseOrderAttributeFixture
     {
         [Test]
@@ -39,6 +40,28 @@ namespace NUnit.TestData
         public void A_NoOrderTestLowLetter()
         {
             Assert.Pass("A_NoOrderTestLowLetter");
+        }
+    }
+
+    [TestFixture]
+    [Order(2)]
+    public class AnotherTestCaseOrderAttributeFixture
+    {
+        [Test]
+        public void DummyTest()
+        {
+            Assert.Pass("DummyTest");
+        }
+    }
+
+    [TestFixture]
+    [Order(3)]
+    public class ThirdTestCaseOrderAttributeFixture
+    {
+        [Test]
+        public void DummyTest()
+        {
+            Assert.Pass("DummyTest");
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -31,8 +31,7 @@ namespace NUnit.Framework.Attributes
         {
             var testSuite = TestBuilder.MakeFixture(candidateTypes);
 
-            var work = TestBuilder.PrepareWorkItem(testSuite, null) 
-                as CompositeWorkItem;
+            var work = TestBuilder.PrepareWorkItem(testSuite, null) as CompositeWorkItem;
 
             var fixtureWorkItems = 
                 ((work.Children[0] as CompositeWorkItem)
@@ -42,13 +41,17 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(candidateTypes.Count, fixtureWorkItems.Count);
             for (var i = 1; i < fixtureWorkItems.Count; i++)
             {
-                var previousTestOrder = int.Parse(fixtureWorkItems[i - 1]
-                    .Test.Properties.Get(PropertyNames.Order).ToString());
-                var currentTestOrder = int.Parse(fixtureWorkItems[i]
-                    .Test.Properties.Get(PropertyNames.Order).ToString());
+                var previousTestOrder = GetOrderAttributeValue(fixtureWorkItems[i - 1]);
+                var currentTestOrder = GetOrderAttributeValue(fixtureWorkItems[i]);
 
                 Assert.IsTrue(previousTestOrder < currentTestOrder);
             }
+        }
+
+        private static int GetOrderAttributeValue(WorkItem item)
+        {
+            var order = item.Test.Properties.Get(PropertyNames.Order);
+            return int.Parse(order.ToString());
         }
 
         private static readonly object[] Cases =

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework.Internal;
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using NUnit.TestData;
 using NUnit.TestUtilities;
@@ -22,6 +24,51 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(work.Children[1].Test.Name, "Y_SecondTest");
             Assert.AreEqual(work.Children[2].Test.Name, "Z_ThirdTest");
         }
-        
+
+        [Test]
+        [TestCaseSource(nameof(Cases))]
+        public void CheckClassOrderIsCorrect(List<Type> candidateTypes)
+        {
+            var testSuite = TestBuilder.MakeFixture(candidateTypes);
+
+            var work = TestBuilder.PrepareWorkItem(testSuite, null) 
+                as CompositeWorkItem;
+
+            var fixtureWorkItems = 
+                ((work.Children[0] as CompositeWorkItem)
+                .Children[0] as CompositeWorkItem)
+                .Children;
+
+            Assert.AreEqual(candidateTypes.Count, fixtureWorkItems.Count);
+            for (var i = 1; i < fixtureWorkItems.Count; i++)
+            {
+                var previousTestOrder = int.Parse(fixtureWorkItems[i - 1]
+                    .Test.Properties.Get(PropertyNames.Order).ToString());
+                var currentTestOrder = int.Parse(fixtureWorkItems[i]
+                    .Test.Properties.Get(PropertyNames.Order).ToString());
+
+                Assert.IsTrue(previousTestOrder < currentTestOrder);
+            }
+        }
+
+        private static readonly object[] Cases =
+        {
+            new List<Type>
+            {
+                typeof(TestCaseOrderAttributeFixture),
+                typeof(ThirdTestCaseOrderAttributeFixture)
+            },
+            new List<Type>
+            {
+                typeof(TestCaseOrderAttributeFixture),
+                typeof(AnotherTestCaseOrderAttributeFixture)
+            },
+            new List<Type>
+            {
+                typeof(TestCaseOrderAttributeFixture),
+                typeof(AnotherTestCaseOrderAttributeFixture),
+                typeof(ThirdTestCaseOrderAttributeFixture)
+            }
+        };
     }
 }


### PR DESCRIPTION
Also added related unit test and a new TestBuilder method for creating a test hierarchy from a list of types.  This is per issue 345.  A couple of things I wanted to mention:

- I read that, generally speaking, one public type per class is the coding style to follow.  However, for the unit test data ("TestCaseOrderAttributeFixture.cs") I thought it made logical sense to include all of these related classes in the same file.  I hope that's alright, but I'm happy to change it if needed!
- I was going to use the existing TestBuilder.MakeFixture method like the current Order attribute tests do, but I wanted to verify that this worked with a real namespace-based test hierarchy, as close to the actual usage as possible

Fixes #345