### PR TITLE
TestCaseAttribute can convert int to nullable long

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -381,7 +381,7 @@ namespace NUnit.Framework
 #endif
                 bool convert = false;
 
-                if (targetType == typeof(short) || targetType == typeof(byte) || targetType == typeof(sbyte) ||
+                if (targetType == typeof(short) || targetType == typeof(byte) || targetType == typeof(sbyte) || targetType == typeof(long?) ||
                     targetType == typeof(short?) || targetType == typeof(byte?) || targetType == typeof(sbyte?) || targetType == typeof(double?))
                 {
                     convert = arg is int;

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -421,6 +421,13 @@ namespace NUnit.Framework.Attributes
             Assert.That(x.Value, Is.EqualTo(1));
         }
 
+        [TestCase(1)]
+        public void CanConvertIntToNullableLong(long? x)
+        {
+            Assert.That(x.HasValue);
+            Assert.That(x.Value, Is.EqualTo(1));
+        }
+
         [TestCase("2.2", "3.3", ExpectedResult = 5.5)]
         public decimal? CanConvertStringToNullableDecimal(decimal? x, decimal? y)
         {


### PR DESCRIPTION
In this PR I fixed #2370.
Now `TestCaseAttribute` can convert `int` to `long?`.