### PR TITLE
Ensure global setup fixtures do not overwrite assembly-level suite

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
@@ -38,12 +38,12 @@ namespace NUnit.Framework.Internal.Builders
         /// NamespaceDictionary of all test suites we have created to represent 
         /// namespaces. Used to locate namespace parent suites for fixtures.
         /// </summary>
-        Dictionary<string, TestSuite> namespaceSuites  = new Dictionary<string, TestSuite>();
+        Dictionary<string, TestSuite> _namespaceIndex  = new Dictionary<string, TestSuite>();
 
         /// <summary>
-        /// The root of the test suite being created by this builder.
+        /// Point in the tree where items in the global namespace are added
         /// </summary>
-        TestSuite rootSuite;
+        private TestSuite _globalInsertionPoint;
 
         #endregion
 
@@ -55,7 +55,8 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="rootSuite">The root suite.</param>
         public NamespaceTreeBuilder( TestSuite rootSuite )
         {
-            this.rootSuite = rootSuite;
+            Guard.ArgumentNotNull(rootSuite, nameof(rootSuite));
+            RootSuite = _globalInsertionPoint = rootSuite;
         }
 
         #endregion
@@ -66,10 +67,7 @@ namespace NUnit.Framework.Internal.Builders
         /// Gets the root entry in the tree created by the NamespaceTreeBuilder.
         /// </summary>
         /// <value>The root suite.</value>
-        public TestSuite RootSuite
-        {
-            get { return rootSuite; }
-        }
+        public TestSuite RootSuite { get; private set; }
 
         #endregion
 
@@ -82,10 +80,7 @@ namespace NUnit.Framework.Internal.Builders
         public void Add( IList<Test> fixtures )
         {
             foreach (TestSuite fixture in fixtures)
-                //if (fixture is SetUpFixture)
-                //    Add(fixture as SetUpFixture);
-                //else
-                    Add( fixture );
+                Add( fixture );
         }
 
         /// <summary>
@@ -95,7 +90,7 @@ namespace NUnit.Framework.Internal.Builders
         public void Add( TestSuite fixture )
         {
             string ns = GetNamespaceForFixture(fixture);
-            TestSuite containingSuite = BuildFromNameSpace( ns );
+            TestSuite containingSuite = GetNamespaceSuite( ns );
 
             if (fixture is SetUpFixture)
                 AddSetUpFixture(fixture, containingSuite, ns);
@@ -117,36 +112,33 @@ namespace NUnit.Framework.Internal.Builders
             return ns;
         }
 
-        private TestSuite BuildFromNameSpace( string ns )
+        private TestSuite GetNamespaceSuite( string ns )
         {
-            if( ns == null || ns  == "" ) return rootSuite;
+            Guard.ArgumentNotNull(ns, nameof(ns));
 
-            TestSuite suite = namespaceSuites.ContainsKey(ns)
-                ? namespaceSuites[ns]
-                : null;
-            
-            if (suite != null)
-                return suite;
+            if( ns  == "" ) return _globalInsertionPoint;
 
+            if (_namespaceIndex.ContainsKey(ns))
+                return _namespaceIndex[ns];
+
+            TestSuite suite = null;
             int index = ns.LastIndexOf(".");
+
             if( index == -1 )
             {
                 suite = new TestSuite( ns );
-                if ( rootSuite == null )
-                    rootSuite = suite;
-                else
-                    rootSuite.Add(suite);
+                _globalInsertionPoint.Add(suite);
             }
             else
             {
                 string parentNamespace = ns.Substring( 0,index );
-                TestSuite parent = BuildFromNameSpace( parentNamespace );
+                TestSuite parent = GetNamespaceSuite( parentNamespace );
                 string suiteName = ns.Substring( index+1 );
                 suite = new TestSuite( parentNamespace, suiteName );
                 parent.Add( suite );
             }
 
-            namespaceSuites[ns] = suite;
+            _namespaceIndex[ns] = suite;
             return suite;
         }
 
@@ -155,20 +147,19 @@ namespace NUnit.Framework.Internal.Builders
             // The SetUpFixture must replace the namespace suite
             // in which it is "contained". 
             //
-            // First, add the old suite's children
+            // First, add the old suite's children to the new
+            // SetUpFixture and clear them from the old suite.
             foreach (TestSuite child in containingSuite.Tests)
                 newSetupFixture.Add(child);
 
-            if (containingSuite is SetUpFixture)
+            containingSuite.Tests.Clear();
+
+            if (containingSuite is SetUpFixture || containingSuite is TestAssembly)
             {
-                // The parent suite is also a SetupFixture. The new
-                // SetupFixture is nested below the parent SetupFixture.
-                // TODO: Avoid nesting of SetupFixtures somehow?
-                //
-                // Note: The tests have already been copied to the new
-                //       SetupFixture. Thus the tests collection of
-                //       the parent SetupFixture can be cleared.
-                containingSuite.Tests.Clear();
+                // If the parent suite is another SetUpFixture or a TestAssembly,
+                // it must be retained, because it may have properties set, which
+                // are needed for proper execution. In both cases, the new
+                // SetupFixture is nested below the parent suite.
                 containingSuite.Add(newSetupFixture);
             }
             else
@@ -179,8 +170,8 @@ namespace NUnit.Framework.Internal.Builders
                 TestSuite parent = (TestSuite)containingSuite.Parent;
                 if (parent == null)
                 {
-                    newSetupFixture.Name = rootSuite.Name;
-                    rootSuite = newSetupFixture;
+                    newSetupFixture.Name = RootSuite.Name;
+                    RootSuite = newSetupFixture;
                 }
                 else
                 {
@@ -190,7 +181,11 @@ namespace NUnit.Framework.Internal.Builders
             }
 
             // Update the dictionary
-            namespaceSuites[ns] = newSetupFixture;
+            _namespaceIndex[ns] = newSetupFixture;
+
+            // Update global insertion point for global setup fixtures
+            if (ns == "")
+                _globalInsertionPoint = newSetupFixture;
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
@@ -1,0 +1,207 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Text;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Builders
+{
+    public class NamespaceTreeBuilderTests
+    {
+        private TestAssembly _testAssembly;
+        private NamespaceTreeBuilder _builder;
+
+
+        [SetUp]
+        public void CreateTreeBuilder()
+        {
+            _testAssembly = new TestAssembly("mytest.dll");
+            _builder = new NamespaceTreeBuilder(_testAssembly);
+        }
+
+        [Test]
+        public void InitialTreeState()
+        {
+            Assert.That(_builder.RootSuite, Is.SameAs(_testAssembly));
+            Assert.That(_builder.RootSuite.Tests.Count, Is.Zero);
+        }
+
+        [Test]
+        public void AddSingleFixture()
+        {
+            _builder.Add( new TestSuite(typeof(NUnit.TestData.TestFixtureTests.RegularFixtureWithOneTest)));
+
+            CheckTree("NUnit", "TestData", "TestFixtureTests", "RegularFixtureWithOneTest");
+        }
+
+        [Test]
+        public void AddMultipleFixtures_SameNamespace()
+        {
+            _builder.Add(new[]
+            {
+                new TestSuite(typeof(NUnit.TestData.TestFixtureTests.RegularFixtureWithOneTest)),
+                new TestSuite(typeof(NUnit.TestData.TestFixtureTests.FixtureWithTestFixtureAttribute)),
+                new TestSuite(typeof(NUnit.TestData.TestFixtureTests.FixtureWithoutTestFixtureAttributeContainingTestCase))
+            });
+
+            CheckTree("NUnit", "TestData", "TestFixtureTests", "RegularFixtureWithOneTest");
+            CheckTree("NUnit", "TestData", "TestFixtureTests", "FixtureWithTestFixtureAttribute");
+            CheckTree("NUnit", "TestData", "TestFixtureTests", "FixtureWithoutTestFixtureAttributeContainingTestCase");
+        }
+
+        [Test]
+        public void AddMultipleFixtures_DifferentNamespaces()
+        {
+            _builder.Add(new[]
+            {
+                new TestSuite(typeof(NUnit.TestData.TestFixtureTests.RegularFixtureWithOneTest)),
+                new TestSuite(typeof(NUnit.TestData.SetUpData.SetUpAndTearDownFixture)),
+                new TestSuite(typeof(NUnit.TestData.TheoryFixture.TheoryFixture))
+            });
+
+            CheckTree("NUnit", "TestData", "TestFixtureTests", "RegularFixtureWithOneTest");
+            CheckTree("NUnit", "TestData", "SetUpData", "SetUpAndTearDownFixture");
+            CheckTree("NUnit", "TestData", "TheoryFixture", "TheoryFixture");
+        }
+
+        [Test]
+        public void AddMultipleFixtures_DifferentTopLevelNamespaces()
+        {
+            _builder.Add(new[]
+            {
+                new TestSuite(typeof(One.Fixture1)),
+                new TestSuite(typeof(Two.Fixture2)),
+                new TestSuite(typeof(Three.Fixture3)),
+            });
+
+            CheckTree("One", "Fixture1");
+            CheckTree("Two", "Fixture2");
+            CheckTree("Three", "Fixture3");
+        }
+
+        [Test]
+        public void AddSetUpFixture_BottomUp()
+        {
+            _builder.Add(new TestSuite(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture)));
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NUnit.TestData.SetupFixture.Namespace1.NUnitNamespaceSetUpFixture1))));
+
+            CheckTree("NUnit", "TestData", "SetupFixture", "Namespace1", "SomeFixture");
+            Assert.That(_builder.RootSuite.Tests[0].Tests[0].Tests[0].Tests[0], Is.TypeOf<SetUpFixture>());
+        }
+
+        [Test]
+        public void AddSetUpFixture_TopDown()
+        {
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NUnit.TestData.SetupFixture.Namespace1.NUnitNamespaceSetUpFixture1))));
+            _builder.Add(new TestSuite(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture)));
+
+            CheckTree("NUnit", "TestData", "SetupFixture", "Namespace1", "SomeFixture");
+            Assert.That(_builder.RootSuite.Tests[0].Tests[0].Tests[0].Tests[0], Is.TypeOf<SetUpFixture>());
+        }
+
+        [Test]
+        public void AddGlobalSetUpFixture_BottomUp()
+        {
+            _builder.Add(new TestSuite(typeof(SomeFixture)));
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+
+            CheckTree("[default namespace]", "SomeFixture");
+        }
+
+        [Test]
+        public void AddGlobalSetUpFixture_TopDown()
+        {
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+            _builder.Add(new TestSuite(typeof(SomeFixture)));
+
+            CheckTree("[default namespace]", "SomeFixture");
+        }
+
+        [Test]
+        public void AddTwoGlobalSetupFixtures_BottomUp()
+        {
+            _builder.Add(new TestSuite(typeof(SomeFixture)));
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+
+            CheckTree("[default namespace]", "[default namespace]", "SomeFixture");
+        }
+
+        [Test]
+        public void AddTwoGlobalSetUpFixture_TopDown()
+        {
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+            _builder.Add(new SetUpFixture(new TypeWrapper(typeof(NoNamespaceSetupFixture))));
+            _builder.Add(new TestSuite(typeof(SomeFixture)));
+
+            CheckTree("[default namespace]", "[default namespace]", "SomeFixture");
+        }
+
+        private void CheckTree(params string[] names)
+        {
+            ITest suite = _builder.RootSuite;
+            Assert.That(suite.Name, Is.EqualTo("mytest.dll"));
+
+            foreach (var name in names)
+            {
+                foreach (var child in suite.Tests)
+                    if (child.Name == name)
+                    {
+                        suite = child;
+                        break;
+                    }
+
+                if (suite.Name != name)
+                {
+                    var dump = DumpTree(_builder.RootSuite, "   ");
+                    Assert.Fail("Did not find {0} in tree under {1}\nTree Contains:\n{2}", name, suite.Name, dump);
+                }
+            }
+        }
+
+        private string DumpTree(ITest suite, string indent)
+        {
+            var sb = new StringBuilder(indent + suite.Name + Environment.NewLine);
+            foreach (var child in suite.Tests)
+                sb.Append(DumpTree(child, indent + "  "));
+
+            return sb.ToString();
+        }
+    }
+}
+
+namespace One
+{
+    public class Fixture1 { }
+}
+
+namespace Two
+{
+    public class Fixture2 { }
+}
+
+namespace Three
+{
+    public class Fixture3 { }
+}

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -93,14 +93,17 @@ namespace NUnit.Framework.Internal
         /// Tests that the TestSuiteBuilder correctly interprets a SetupFixture class with no parent namespace
         /// as a 'virtual assembly' into which all it's sibling fixtures are inserted.
         /// </summary>
-        [NUnit.Framework.Test]
-        public void AssemblySetUpFixtureReplacesAssemblyNodeInTree()
+        [Test]
+        public void AssemblySetUpFixtureFollowsAssemblyNodeInTree()
         {
             IDictionary<string, object> options = new Dictionary<string, object>();
-            var setupFixture = builder.Build(testAssembly, options) as SetUpFixture;
-            Assert.IsNotNull(setupFixture);
+            var rootSuite = builder.Build(testAssembly, options);
+            Assert.That(rootSuite, Is.TypeOf<TestAssembly>());
+            var setupFixture = rootSuite.Tests[0];
+            Assert.That(setupFixture, Is.TypeOf<SetUpFixture>());
 
-            var testFixture = TestFinder.Find("SomeFixture", setupFixture, false);
+            var testFixture = TestFinder.Find("SomeFixture", (SetUpFixture)setupFixture, false);
+            Assert.NotNull(testFixture);
             Assert.AreEqual(1, testFixture.Tests.Count);
         }
 

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
     <Compile Include="Internal\GenericMethodHelperTests.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\Results\TestAttachmentTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
     <Compile Include="Internal\GenericMethodHelperTests.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\Results\AssertionResultTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\Results\AssertionResultTests.cs" />
     <Compile Include="Internal\Results\TestAttachmentTests.cs" />
     <Compile Include="Internal\Results\TestAttachmentXmlTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Internal\GenericMethodHelperTests.cs" />
     <Compile Include="Internal\GenericTestFixtureTests.cs" />
     <Compile Include="Internal\GenericTestMethodTests.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\NUnitTestCaseBuilderTests.cs" />
     <Compile Include="Internal\PlatformDetectionTests.cs" />
     <Compile Include="Internal\PropertyBagTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Internal\Filters\TestFilterTests.cs" />
     <Compile Include="Internal\Filters\TestFilterXmlTests.cs" />
     <Compile Include="Internal\Filters\TestNameFilterTests.cs" />
+    <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />
     <Compile Include="Internal\RealAsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />


### PR DESCRIPTION
Fixes #2361 

The reason that the `ParallelizableAttribute` on the assembly was being ignored was that the global `SetUpFixture` was replacing the assembly-level suite in the tree. Basically, this caused all NUnit assembly-level attributes to be ignored in running the tests. It also had the side-effect that multiple global `SetUpFixtures` (a little-used feature) would not work, because the second one found would overwrite the first. This was not happening anyplace except at the global level.

This fix preserves all global information by not overwriting it. Since we don't have integration tests for parallel execution, I created tests of the `NamespaceTreeBuilder` that verify the proper shape of the tree. Global info is now added to rather than being overwritten.
