### PR TITLE
Fix package for supported iOS/Android/UWP platforms

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -28,9 +28,17 @@ Supported platforms:
       <group targetFramework="net35" />
       <group targetFramework="net40" />
       <group targetFramework="net45" />
+      <group targetFramework="Xamarin.iOS">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+      </group>
+      <group targetFramework="MonoAndroid">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+      </group>
+      <group targetFramework="uap">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+      </group>
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="System.Threading.Thread" version="4.3.0" />
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />
@@ -52,6 +60,12 @@ Supported platforms:
     <file src="bin/net-4.0/nunit.framework.xml" target="lib\net40" />
     <file src="bin/net-4.5/nunit.framework.dll" target="lib\net45" />
     <file src="bin/net-4.5/nunit.framework.xml" target="lib\net45" />
+    <file src="bin/netstandard13/nunit.framework.dll" target="lib\xamarin.ios" />
+    <file src="bin/netstandard13/nunit.framework.xml" target="lib\xamarin.ios" />
+    <file src="bin/netstandard13/nunit.framework.dll" target="lib\monoandroid" />
+    <file src="bin/netstandard13/nunit.framework.xml" target="lib\monoandroid" />
+    <file src="bin/netstandard13/nunit.framework.dll" target="lib\uap" />
+    <file src="bin/netstandard13/nunit.framework.xml" target="lib\uap" />
     <file src="bin/netstandard13/nunit.framework.dll" target="lib\netstandard1.3" />
     <file src="bin/netstandard13/nunit.framework.xml" target="lib\netstandard1.3" />
     <file src="bin/netstandard16/nunit.framework.dll" target="lib\netstandard1.6" />

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -202,7 +202,11 @@ namespace NUnit.TestUtilities
             // TODO: Replace with an event - but not while method is static
             while (work.State != WorkItemState.Complete)
             {
+#if NETSTANDARD1_3
+                System.Threading.Tasks.Task.Delay(1);
+#else
                 Thread.Sleep(1);
+#endif
             }
 
             return work.Result;

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -288,6 +288,8 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
+#if !NETSTANDARD1_3
+
         #region After Modifier
 
         /// <summary>
@@ -319,7 +321,9 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
-        #region IResolveConstraint Members
+#endif
+
+#region IResolveConstraint Members
 
         /// <summary>
         /// Resolves any pending operators and returns the resolved constraint.
@@ -329,6 +333,6 @@ namespace NUnit.Framework.Constraints
             return Builder == null ? this : Builder.Resolve();
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_3
+
 using System;
 using System.Diagnostics;
 using System.Threading;
@@ -387,3 +389,4 @@ namespace NUnit.Framework.Constraints
         }
     }
 }
+#endif

--- a/src/NUnitFramework/framework/nunit.framework-netstandard13.project.json
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard13.project.json
@@ -1,8 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Threading.Thread": "4.3.0"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -61,7 +61,11 @@ namespace NUnit.Tests
 
         private static void Delay()
         {
+#if NETSTANDARD1_3
+            System.Threading.Tasks.Task.Delay(DELAY);
+#else
             System.Threading.Thread.Sleep(DELAY);
+#endif
         }
     }
 }

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard13.project.json
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests-netstandard13.project.json
@@ -1,8 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Threading.Thread": "4.3.0"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/NUnitFramework/testdata/MaxTimeFixture.cs
+++ b/src/NUnitFramework/testdata/MaxTimeFixture.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-
+#if !NETSTANDARD1_3
 using System;
 using System.Threading;
 
@@ -70,3 +70,4 @@ namespace NUnit.TestData
         }
     }
 }
+#endif

--- a/src/NUnitFramework/testdata/UnhandledExceptions.cs
+++ b/src/NUnitFramework/testdata/UnhandledExceptions.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_3
+
 using System;
 using System.Collections;
 using System.Text;
@@ -84,3 +86,4 @@ namespace NUnit.TestData.UnhandledExceptionData
         #endregion
     }
 }
+#endif

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard13.project.json
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard13.project.json
@@ -1,8 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Threading.Thread": "4.3.0"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if (NET_4_0 || NET_4_5 || NETSTANDARD1_3 || NETSTANDARD1_6)
+#if (NET_4_0 || NET_4_5 || NETSTANDARD1_6)
 using System;
 using System.Threading.Tasks;
 

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_3
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -277,3 +278,4 @@ namespace NUnit.Framework.Constraints
         }
     }
 }
+#endif

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_3
+
 using System;
 using System.Threading;
 using System.Collections.Generic;
@@ -74,6 +76,7 @@ namespace NUnit.Framework.Syntax
             builderSyntax = Builder().EqualTo(10).After(500).MilliSeconds;
         }
     }
+
 
     public class AfterTest_PropertyTest : SyntaxTest
     {
@@ -225,3 +228,5 @@ namespace NUnit.Framework.Syntax
         }
     }
 }
+
+#endif

--- a/src/NUnitFramework/tests/WorkItemTests.cs
+++ b/src/NUnitFramework/tests/WorkItemTests.cs
@@ -85,6 +85,7 @@ namespace NUnit.Framework.Internal.Execution
         }
 #endif
 
+
         // Use static for simplicity
         static class DummyFixture
         {
@@ -92,9 +93,13 @@ namespace NUnit.Framework.Internal.Execution
 
             public static void DummyTest()
             {
+#if !NETSTANDARD1_3
                 if (Delay > 0)
                     Thread.Sleep(Delay);
+#else
+                System.Threading.Tasks.Task.Delay(Delay);
+#endif
             }
-        }
+}
     }
 }

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.project.json
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.project.json
@@ -1,8 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Threading.Thread": "4.3.0"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
Fixes #2237 

Unfortunately, I think we've been a bit liberal regarding adding new functionality to the .NET Standard builds, and assuming it will be available on all platforms. (Until I started looking in to this issue, I thought that was the POINT of .NET Standard - turns out it's not quite there yet.)

This PR includes a various changes to allow the package to be used on latest Android/iOS/UWP. I've upgraded and tested both the nunit.xamarin Android and UWP projects as a test. iOS I'm not set up to test, however NUnit 3.7.1 wasn't restoring in the same manner as the Android platform, so I assume the same fix applies. (NuGet now restores the package successfully, which it didn't previously.)

The first part of the issue, is that System.Runtime.Loader is available for .NET Standard 1.6, but not available on Android/iOS. To combat this, I altered the NuGet package to use the .NET Standard 1.3 build for these platforms, which doesn't have the System.Runtime.Loader dependency.

The next issue was that UWP doesn't support the System.Threading.Thread API, which was a dependency of NUnit's .NET Standard 1.3 build. Rather than create an entirely new build solely for UWP - I just removed the System.Threading.Thread dependency from .NET Standard 1.3. This is technically a breaking change - however given the build already wasn't working on the main platform we expect people to use the .NET Standard 1.3 build on - I don't think that's too much of a concern.

It would be good if we could test this stuff in CI. I had a quick experiment with the project.json, but couldn't get the build to fail - I don't have much more time to look in to that before the 3.8 release, so wanted to push this as is.