### PR TITLE
Write TestParametersDictionary to xml result file in readable format (#2298)

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -437,7 +437,25 @@ namespace NUnit.Framework.Api
         {
             TNode setting = new TNode("setting");
             setting.AddAttribute("name", name);
-            setting.AddAttribute("value", value.ToString());
+
+            if (value is IDictionary)
+            {
+                var values = value as IDictionary;
+
+                var valueEntries = new List<string>();
+                foreach (var key in values.Keys)
+                {
+                    var settingValue = values[key];
+                    valueEntries.Add($"[{key}, {values[key]}]");
+                }
+
+                var valueString = string.Join(", ", valueEntries.ToArray());
+                setting.AddAttribute("value", valueString);
+            }
+            else
+            {
+                setting.AddAttribute("value", value.ToString());
+            }
 
             settingsNode.ChildNodes.Add(setting);
         }

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -440,17 +440,7 @@ namespace NUnit.Framework.Api
 
             if (value is IDictionary)
             {
-                var values = value as IDictionary;
-
-                var valueEntries = new List<string>();
-                foreach (var key in values.Keys)
-                {
-                    var settingValue = values[key];
-                    valueEntries.Add($"[{key}, {values[key]}]");
-                }
-
-                var valueString = string.Join(", ", valueEntries.ToArray());
-                setting.AddAttribute("value", valueString);
+                AddDictionaryEntries(setting, value as IDictionary);
             }
             else
             {
@@ -458,6 +448,18 @@ namespace NUnit.Framework.Api
             }
 
             settingsNode.ChildNodes.Add(setting);
+        }
+
+        private static void AddDictionaryEntries(TNode settingNode, IDictionary entries)
+        {
+            foreach(var key in entries.Keys)
+            {
+                var value = entries[key];
+                var entryNode = new TNode("entry");
+                entryNode.AddAttribute("name", key.ToString());
+                entryNode.AddAttribute("value", value?.ToString() ?? "");
+                settingNode.ChildNodes.Add(entryNode);
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -455,8 +455,8 @@ namespace NUnit.Framework.Api
             foreach(var key in entries.Keys)
             {
                 var value = entries[key];
-                var entryNode = new TNode("entry");
-                entryNode.AddAttribute("name", key.ToString());
+                var entryNode = new TNode("item");
+                entryNode.AddAttribute("key", key.ToString());
                 entryNode.AddAttribute("value", value?.ToString() ?? "");
                 settingNode.ChildNodes.Add(entryNode);
             }

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -107,17 +107,16 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // in parallel, an additional node is added with number of test workers
-            Assert.AreEqual(3, inserted.ChildNodes.Count);
+            Assert.That(3, Is.EqualTo(inserted.ChildNodes.Count));
 #else
-            Assert.AreEqual(2, inserted.ChildNodes.Count);
+            Assert.That(2, Is.EqualTo(inserted.ChildNodes.Count));
 #endif
-            Assert.AreEqual("key1", inserted.ChildNodes[0].Attributes["name"]);
-            Assert.AreEqual("value1", inserted.ChildNodes[0].Attributes["value"]);
+            Assert.That("key1", Is.EqualTo(inserted.ChildNodes[0].Attributes["name"]));
+            Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
 
-            Assert.AreEqual(1, inserted.ChildNodes[1].ChildNodes.Count);
             var innerNode = inserted.ChildNodes[1].FirstChild;
-            Assert.AreEqual("innerkey", innerNode.Attributes["name"]);
-            Assert.AreEqual("innervalue", innerNode.Attributes["value"]);
+            Assert.That("innerkey", Is.EqualTo(innerNode.Attributes["name"]));
+            Assert.That("innervalue", Is.EqualTo(innerNode.Attributes["value"]));
         }
 
         [Test]
@@ -134,9 +133,9 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // in parallel, an additional node is added with number of test workers
-            Assert.AreEqual(3, inserted.ChildNodes.Count);
+            Assert.That(3, Is.EqualTo(inserted.ChildNodes.Count));
 #else
-            Assert.AreEqual(2, inserted.ChildNodes.Count);
+            Assert.That(2, Is.EqualTo(inserted.ChildNodes.Count));
 #endif
         }
 
@@ -151,11 +150,12 @@ namespace NUnit.Framework.Api
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
+            
+            Assert.That("key1", Is.EqualTo(inserted.ChildNodes[0].Attributes["name"]));
+            Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
 
-            Assert.AreEqual("key1", inserted.ChildNodes[0].Attributes["name"]);
-            Assert.AreEqual("value1", inserted.ChildNodes[0].Attributes["value"]);
-            Assert.AreEqual("key2", inserted.ChildNodes[1].Attributes["name"]);
-            Assert.AreEqual("value2", inserted.ChildNodes[1].Attributes["value"]);
+            Assert.That("key2", Is.EqualTo(inserted.ChildNodes[1].Attributes["name"]));
+            Assert.That("value2", Is.EqualTo(inserted.ChildNodes[1].Attributes["value"]));
         }
 
         [Test]
@@ -169,8 +169,8 @@ namespace NUnit.Framework.Api
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             var settingNode = inserted.FirstChild;
-
-            Assert.AreEqual(2, settingNode.ChildNodes.Count);
+            
+            Assert.That(2, Is.EqualTo(settingNode.ChildNodes.Count));
         }
 
         [Test]
@@ -184,12 +184,12 @@ namespace NUnit.Framework.Api
             var settingNode = inserted.FirstChild;
 
             var key1Node = settingNode.ChildNodes[0];
-            Assert.AreEqual("key1", key1Node.Attributes["name"]);
-            Assert.AreEqual("value1", key1Node.Attributes["value"]);
+            Assert.That("key1", Is.EqualTo(key1Node.Attributes["name"]));
+            Assert.That("value1", Is.EqualTo(key1Node.Attributes["value"]));
 
             var key2Node = settingNode.ChildNodes[1];
-            Assert.AreEqual("key2", key2Node.Attributes["name"]);
-            Assert.AreEqual("value2", key2Node.Attributes["value"]);
+            Assert.That("key2", Is.EqualTo(key2Node.Attributes["name"]));
+            Assert.That("value2", Is.EqualTo(key2Node.Attributes["value"]));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -104,7 +104,6 @@ namespace NUnit.Framework.Api
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
-
 #if PARALLEL
             // in parallel, an additional node is added with number of test workers
             Assert.That(3, Is.EqualTo(inserted.ChildNodes.Count));
@@ -115,7 +114,7 @@ namespace NUnit.Framework.Api
             Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
 
             var innerNode = inserted.ChildNodes[1].FirstChild;
-            Assert.That("innerkey", Is.EqualTo(innerNode.Attributes["name"]));
+            Assert.That("innerkey", Is.EqualTo(innerNode.Attributes["key"]));
             Assert.That("innervalue", Is.EqualTo(innerNode.Attributes["value"]));
         }
 
@@ -150,7 +149,7 @@ namespace NUnit.Framework.Api
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
-            
+
             Assert.That("key1", Is.EqualTo(inserted.ChildNodes[0].Attributes["name"]));
             Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
 
@@ -184,11 +183,11 @@ namespace NUnit.Framework.Api
             var settingNode = inserted.FirstChild;
 
             var key1Node = settingNode.ChildNodes[0];
-            Assert.That("key1", Is.EqualTo(key1Node.Attributes["name"]));
+            Assert.That("key1", Is.EqualTo(key1Node.Attributes["key"]));
             Assert.That("value1", Is.EqualTo(key1Node.Attributes["value"]));
 
             var key2Node = settingNode.ChildNodes[1];
-            Assert.That("key2", Is.EqualTo(key2Node.Attributes["name"]));
+            Assert.That("key2", Is.EqualTo(key2Node.Attributes["key"]));
             Assert.That("value2", Is.EqualTo(key2Node.Attributes["value"]));
         }
 

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -91,6 +91,42 @@ namespace NUnit.Framework.Api
             _handler = new CallbackEventHandler();
         }
 
+        #region SettingsElement Tests
+
+        [Test]
+        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesForDictionaryElements()
+        {
+            var outerNode = new TNode("test");
+            var testSettings = new Dictionary<string, object>();
+            testSettings.Add("outerkey", new Dictionary<string, object> { { "key1", "value1" }, { "key2", "value2" } });
+
+            var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
+            var settingNode = inserted.FirstChild;
+
+            Assert.AreEqual(2, settingNode.ChildNodes.Count);
+        }
+
+        [Test]
+        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesWithKeysAndValuesFromDictionary()
+        {
+            var outerNode = new TNode("test");
+            var testSettings = new Dictionary<string, object>();
+            testSettings.Add("outerkey", new Dictionary<string, object> { { "key1", "value1" }, { "key2", "value2" } });
+
+            var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
+            var settingNode = inserted.FirstChild;
+
+            var key1Node = settingNode.ChildNodes[0];
+            Assert.AreEqual("key1", key1Node.Attributes["name"]);
+            Assert.AreEqual("value1", key1Node.Attributes["value"]);
+
+            var key2Node = settingNode.ChildNodes[1];
+            Assert.AreEqual("key2", key2Node.Attributes["name"]);
+            Assert.AreEqual("value2", key2Node.Attributes["value"]);
+        }
+
+        #endregion
+
         #region Construction Test
         [Test]
         public void ConstructController()


### PR DESCRIPTION
Fixes #2298

This writes dictionary parameters as extra nodes below the setting element.