### PR TITLE
Write test parameters dictionary out to the legacy XML value attribute

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -438,9 +438,11 @@ namespace NUnit.Framework.Api
             TNode setting = new TNode("setting");
             setting.AddAttribute("name", name);
 
-            if (value is IDictionary)
+            var dict = value as IDictionary;
+            if (dict != null)
             {
-                AddDictionaryEntries(setting, value as IDictionary);
+                AddDictionaryEntries(setting, dict);
+                AddBackwardsCompatibleDictionaryEntries(setting, dict);
             }
             else
             {
@@ -448,6 +450,16 @@ namespace NUnit.Framework.Api
             }
 
             settingsNode.ChildNodes.Add(setting);
+        }
+
+        private static void AddBackwardsCompatibleDictionaryEntries(TNode settingsNode, IDictionary entries)
+        {
+            var pairs = new List<string>(entries.Count);
+            foreach (var key in entries.Keys)
+            {
+                pairs.Add($"[{key}, {entries[key]}]");
+            }
+            settingsNode.AddAttribute("value", string.Join(", ", pairs.ToArray()));
         }
 
         private static void AddDictionaryEntries(TNode settingNode, IDictionary entries)

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -92,30 +92,30 @@ namespace NUnit.Framework.Api
         }
 
         #region SettingsElement Tests
-        
-        [Test]
-        public void InsertSettingsElement_MixedSettings_CreatesCorrectSubNodes()
+
+        [TestCaseSource(nameof(SettingsData))]
+        public void InsertSettingsElement_MixedSettings_CreatesCorrectSubNodes(string value)
         {
             var outerNode = new TNode("test");
             var testSettings = new Dictionary<string, object>
             {
                 ["key1"] = "value1",
-                ["key2"] = new Dictionary<string, object> { ["innerkey"] = "innervalue" }
+                ["key2"] = new Dictionary<string, object> { ["innerkey"] = value }
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
 #if PARALLEL
             // in parallel, an additional node is added with number of test workers
-            Assert.That(3, Is.EqualTo(inserted.ChildNodes.Count));
+            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(3));
 #else
-            Assert.That(2, Is.EqualTo(inserted.ChildNodes.Count));
+            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(2));
 #endif
-            Assert.That("key1", Is.EqualTo(inserted.ChildNodes[0].Attributes["name"]));
-            Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
+            Assert.That(inserted.ChildNodes[0].Attributes["name"], Is.EqualTo("key1"));
+            Assert.That(inserted.ChildNodes[0].Attributes["value"], Is.EqualTo("value1"));
 
             var innerNode = inserted.ChildNodes[1].FirstChild;
-            Assert.That("innerkey", Is.EqualTo(innerNode.Attributes["key"]));
-            Assert.That("innervalue", Is.EqualTo(innerNode.Attributes["value"]));
+            Assert.That(innerNode.Attributes["key"], Is.EqualTo("innerkey"));
+            Assert.That(innerNode.Attributes["value"], Is.EqualTo(value));
         }
 
         [Test]
@@ -132,63 +132,89 @@ namespace NUnit.Framework.Api
 
 #if PARALLEL
             // in parallel, an additional node is added with number of test workers
-            Assert.That(3, Is.EqualTo(inserted.ChildNodes.Count));
+            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(3));
 #else
-            Assert.That(2, Is.EqualTo(inserted.ChildNodes.Count));
+            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(2));
 #endif
         }
 
-        [Test]
-        public void InsertSettingsElement_SettingIsValue_SetsKeyAndValueAsAttributes()
+        [TestCaseSource(nameof(SettingsData))]
+        public void InsertSettingsElement_SettingIsValue_SetsKeyAndValueAsAttributes(string value)
         {
             var outerNode = new TNode("test");
             var testSettings = new Dictionary<string, object>
             {
                 ["key1"] = "value1",
-                ["key2"] = "value2"
+                ["key2"] = value
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
 
-            Assert.That("key1", Is.EqualTo(inserted.ChildNodes[0].Attributes["name"]));
-            Assert.That("value1", Is.EqualTo(inserted.ChildNodes[0].Attributes["value"]));
+            Assert.That(inserted.ChildNodes[0].Attributes["name"], Is.EqualTo("key1"));
+            Assert.That(inserted.ChildNodes[0].Attributes["value"], Is.EqualTo("value1"));
 
-            Assert.That("key2", Is.EqualTo(inserted.ChildNodes[1].Attributes["name"]));
-            Assert.That("value2", Is.EqualTo(inserted.ChildNodes[1].Attributes["value"]));
+            Assert.That(inserted.ChildNodes[1].Attributes["name"], Is.EqualTo("key2"));
+            Assert.That(inserted.ChildNodes[1].Attributes["value"], Is.EqualTo(value));
         }
 
-        [Test]
-        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesForDictionaryElements()
+        [TestCaseSource(nameof(SettingsData))]
+        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesForDictionaryElements(string value)
         {
             var outerNode = new TNode("test");
             var testSettings = new Dictionary<string, object>
             {
-                ["outerkey"] = new Dictionary<string, object> { { "key1", "value1" }, { "key2", "value2" } } 
+                ["outerkey"] = new Dictionary<string, object> { { "key1", "value1" }, { "key2", value } }
             };
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             var settingNode = inserted.FirstChild;
-            
-            Assert.That(2, Is.EqualTo(settingNode.ChildNodes.Count));
+
+            Assert.That(settingNode.ChildNodes.Count, Is.EqualTo(2));
         }
 
-        [Test]
-        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesWithKeysAndValuesFromDictionary()
+        [TestCaseSource(nameof(SettingsData))]
+        public void InsertSettingsElement_SettingIsDictionary_CreatesValueAttributeForDictionaryElements(string value)
+        {
+            var outerNode = new TNode("test");
+            var testSettings = new Dictionary<string, object>
+            {
+                ["outerkey"] = new Dictionary<string, object> { { "key1", "value1" }, { "key2", value } }
+            };
+
+            var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
+            var settingNode = inserted.FirstChild;
+
+            Assert.That(settingNode.ChildNodes.Count, Is.EqualTo(2));
+            Assert.That(settingNode.Attributes["value"], Is.EqualTo($"[key1, value1], [key2, {value}]"));
+        }
+
+        [TestCaseSource(nameof(SettingsData))]
+        public void InsertSettingsElement_SettingIsDictionary_CreatesEntriesWithKeysAndValuesFromDictionary(string value)
         {
             var outerNode = new TNode("test");
             var testSettings = new Dictionary<string, object>();
-            testSettings.Add("outerkey", new Dictionary<string, object> { { "key1", "value1" }, { "key2", "value2" } });
+            testSettings.Add("outerkey", new Dictionary<string, object> { { "key1", "value1" }, { "key2", value } });
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             var settingNode = inserted.FirstChild;
 
             var key1Node = settingNode.ChildNodes[0];
-            Assert.That("key1", Is.EqualTo(key1Node.Attributes["key"]));
-            Assert.That("value1", Is.EqualTo(key1Node.Attributes["value"]));
+            Assert.That(key1Node.Attributes["key"], Is.EqualTo("key1"));
+            Assert.That(key1Node.Attributes["value"], Is.EqualTo("value1"));
 
             var key2Node = settingNode.ChildNodes[1];
-            Assert.That("key2", Is.EqualTo(key2Node.Attributes["key"]));
-            Assert.That("value2", Is.EqualTo(key2Node.Attributes["value"]));
+            Assert.That(key2Node.Attributes["key"], Is.EqualTo("key2"));
+            Assert.That(key2Node.Attributes["value"], Is.EqualTo(value));
+        }
+
+        public static IEnumerable SettingsData()
+        {
+            yield return new TestCaseData("value");
+            yield return new TestCaseData("");
+            yield return new TestCaseData("<value>");
+            yield return new TestCaseData("\"value\"");
+            yield return new TestCaseData("'value'");
+            yield return new TestCaseData("value1;value2");
         }
 
         #endregion


### PR DESCRIPTION
This writes the dictionary settings out to a value attribute in addition to the child elements. This allows legacy runners (like the console) to continue to work if they expect a value attribute.

The XML now looks like this,

```xml
<setting name="TestParametersDictionary" value="[1, d], [2, e]">
  <item key="1" value="d" />
  <item key="2" value="e" />
</setting>
<setting name="TestParameters" value="1=d;2=e" />
```

And the console output looks like,

```
Run Settings
    DisposeRunners: True
    WorkDirectory: C:\src\NUnit\nunit
    TestParametersDictionary: [1, d], [2, e]
    TestParameters: 1=d;2=e
    ImageRuntimeVersion: 4.0.30319
    ImageTargetFrameworkName: .NETFramework,Version=v4.5
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 8
```

This merge targets the release branch in preparation for a hotfix. I will create a PR to merge the hotfix into master once the hotfix is released.

Fixes #2390 