### PR TITLE
Fixes Contains.Item().And.Contains()

### DIFF
--- a/src/NUnitFramework/framework/Contains.cs
+++ b/src/NUnitFramework/framework/Contains.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,10 +37,8 @@ namespace NUnit.Framework
         /// Returns a new <see cref="EqualConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static EqualConstraint Item(object expected)
-        {
-            return Has.Some.EqualTo(expected);
-        }
+        public static ContainsConstraint Item(object expected) =>
+            new ContainsConstraint(expected);
 
         #endregion
 

--- a/src/NUnitFramework/framework/Contains.cs
+++ b/src/NUnitFramework/framework/Contains.cs
@@ -34,11 +34,11 @@ namespace NUnit.Framework
         #region Item
 
         /// <summary>
-        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// Returns a new <see cref="SomeItemsConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static ContainsConstraint Item(object expected) =>
-            new ContainsConstraint(expected);
+        public static SomeItemsConstraint Item(object expected) =>
+            new SomeItemsConstraint(new EqualConstraint(expected));
 
         #endregion
 

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -1,6 +1,6 @@
 ﻿// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -63,20 +63,7 @@ namespace NUnit.Framework
         /// Returns a new <see cref="EqualConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static EqualConstraint Contain(object expected)
-        {
-            return new ConstraintExpression().Some.EqualTo(expected);
-        }
-
-        /// <summary>
-        /// Returns a new ContainsConstraint. This constraint
-        /// will, in turn, make use of the appropriate second-level
-        /// constraint, depending on the type of the actual argument. 
-        /// This overload is only used if the item sought is a string,
-        /// since any other type implies that we are looking for a 
-        /// collection member.
-        /// </summary>
-        public static ContainsConstraint Contain(string expected)
+        public static ContainsConstraint Contain(object expected)
         {
             return new ContainsConstraint(expected);
         }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -60,21 +60,32 @@ namespace NUnit.Framework
         #region Contain
 
         /// <summary>
-        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// Returns a new <see cref="SomeItemsConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static ContainsConstraint Contain(object expected) =>
+        public static SomeItemsConstraint Contain(object expected) =>
+            new SomeItemsConstraint(new EqualConstraint(expected));
+
+        /// <summary>
+        /// Returns a new <see cref="ContainsConstraint"/>. This constraint
+        /// will, in turn, make use of the appropriate second-level
+        /// constraint, depending on the type of the actual argument.
+        /// This overload is only used if the item sought is a string,
+        /// since any other type implies that we are looking for a
+        /// collection member.
+        /// </summary>
+        public static ContainsConstraint Contain(string expected) =>
             new ContainsConstraint(expected);
 
-        #endregion
+    #endregion
 
-        #region DictionaryContain
-        /// <summary>
-        /// Returns a new DictionaryContainsKeyConstraint checking for the
-        /// presence of a particular key in the Dictionary key collection.
-        /// </summary>
-        /// <param name="expected">The key to be matched in the Dictionary key collection</param>
-        public static DictionaryContainsKeyConstraint ContainKey(object expected)
+    #region DictionaryContain
+    /// <summary>
+    /// Returns a new DictionaryContainsKeyConstraint checking for the
+    /// presence of a particular key in the Dictionary key collection.
+    /// </summary>
+    /// <param name="expected">The key to be matched in the Dictionary key collection</param>
+    public static DictionaryContainsKeyConstraint ContainKey(object expected)
         {
             return Contains.Key(expected);
         }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -63,10 +63,8 @@ namespace NUnit.Framework
         /// Returns a new <see cref="EqualConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static ContainsConstraint Contain(object expected)
-        {
-            return new ContainsConstraint(expected);
-        }
+        public static ContainsConstraint Contain(object expected) =>
+            new ContainsConstraint(expected);
 
         #endregion
 

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -77,15 +77,15 @@ namespace NUnit.Framework
         public static ContainsConstraint Contain(string expected) =>
             new ContainsConstraint(expected);
 
-    #endregion
+        #endregion
 
-    #region DictionaryContain
-    /// <summary>
-    /// Returns a new DictionaryContainsKeyConstraint checking for the
-    /// presence of a particular key in the Dictionary key collection.
-    /// </summary>
-    /// <param name="expected">The key to be matched in the Dictionary key collection</param>
-    public static DictionaryContainsKeyConstraint ContainKey(object expected)
+        #region DictionaryContain
+        /// <summary>
+        /// Returns a new DictionaryContainsKeyConstraint checking for the
+        /// presence of a particular key in the Dictionary key collection.
+        /// </summary>
+        /// <param name="expected">The key to be matched in the Dictionary key collection</param>
+        public static DictionaryContainsKeyConstraint ContainKey(object expected)
         {
             return Contains.Key(expected);
         }

--- a/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
-                "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;	
+                "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.Contains("def", testArray));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
-                "  But was:  <empty>" + Environment.NewLine;	
+                "  But was:  <empty>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.Contains( "def", new object[0] ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -92,6 +92,34 @@ namespace NUnit.Framework.Assertions
         public void DifferentTypesMayBeEqual()
         {
             Assert.Contains( 123.0, new SimpleObjectList( testArray ) );
+        }
+
+        [Test]
+        public void DoesContainMultipleItemsString()
+        {
+            var collection = new[] { "test1", "test2", "test3" };
+            Assert.That(collection, Does.Contain("test1").And.Contains("test2").And.Contains("test3"));
+        }
+
+        [Test]
+        public void ContainsMultipleItemsString()
+        {
+            var collection = new[] { "test1", "test2", "test3" };
+            Assert.That(collection, Contains.Item("test1").And.Contains("test2").And.Contains("test3"));
+        }
+
+        [Test]
+        public void DoesContainMultipleItemsInt()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Assert.That(collection, Does.Contain(1).And.Contains(2).And.Contains(3));
+        }
+
+        [Test]
+        public void ContainsMultipleItemsInt()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Assert.That(collection, Contains.Item(1).And.Contains(2).And.Contains(3));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -25,9 +25,13 @@ namespace NUnit.Framework.Constraints
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        [Test]
         public void CanMatchTwoLists()
         {
-            //IList expected = new List<int>();
+            IList expected = new List<int> { 1, 2, 3 };
+            IList actual = new List<int> { 1, 2, 3 };
+
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -54,7 +58,6 @@ namespace NUnit.Framework.Constraints
                 TextMessageWriter.Pfx_Actual + "5" + Environment.NewLine));
         }
 
-        [Test]
         [TestCaseSource( "IgnoreCaseData" )]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
@@ -72,5 +75,32 @@ namespace NUnit.Framework.Constraints
             new object[] {new List<string> {"a", "b", "c"}, new List<string> {"A", "B", "C"}},
         };
 
+        [Test]
+        public void DoesContainMultipleItemsString()
+        {
+            var collection = new[] { "test1", "test2", "test3" };
+            Assert.That(collection, Does.Contain("test1").And.Contains("test2").And.Contains("test3"));
+        }
+
+        [Test]
+        public void ContainsMultipleItemsString()
+        {
+            var collection = new[] { "test1", "test2", "test3" };
+            Assert.That(collection, Contains.Item("test1").And.Contains("test2").And.Contains("test3"));
+        }
+
+        [Test]
+        public void DoesContainMultipleItemsInt()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Assert.That(collection, Does.Contain(1).And.Contains(2).And.Contains(3));
+        }
+
+        [Test]
+        public void ContainsMultipleItemsInt()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Assert.That(collection, Contains.Item(1).And.Contains(2).And.Contains(3));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -74,33 +74,5 @@ namespace NUnit.Framework.Constraints
             new object[] {new List<char> {'A', 'B', 'C'}, new List<char> {'a', 'b', 'c'}},
             new object[] {new List<string> {"a", "b", "c"}, new List<string> {"A", "B", "C"}},
         };
-
-        [Test]
-        public void DoesContainMultipleItemsString()
-        {
-            var collection = new[] { "test1", "test2", "test3" };
-            Assert.That(collection, Does.Contain("test1").And.Contains("test2").And.Contains("test3"));
-        }
-
-        [Test]
-        public void ContainsMultipleItemsString()
-        {
-            var collection = new[] { "test1", "test2", "test3" };
-            Assert.That(collection, Contains.Item("test1").And.Contains("test2").And.Contains("test3"));
-        }
-
-        [Test]
-        public void DoesContainMultipleItemsInt()
-        {
-            var collection = new[] { 1, 2, 3 };
-            Assert.That(collection, Does.Contain(1).And.Contains(2).And.Contains(3));
-        }
-
-        [Test]
-        public void ContainsMultipleItemsInt()
-        {
-            var collection = new[] { 1, 2, 3 };
-            Assert.That(collection, Contains.Item(1).And.Contains(2).And.Contains(3));
-        }
     }
 }


### PR DESCRIPTION
Fixes #2386 

This PR is being merged into release in preparation for a 3.8.1 hotfix release. I will create a separate PR to merge all changes from the hotfix back into master.