### PR TITLE
Fix spurious kill failure

### DIFF
--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -34,7 +34,15 @@ namespace NUnit.Framework.Internal
                 else
                     ThreadUtility.Abort(thread, nativeId);
 
-                Assert.That(thread.Join(1000), "Native message pump was not able to be interrupted to enable a managed thread abort.");
+                // When not under CPU load, we expect the thread to take between 100 and 200 ms to abort.
+                // However we get spurious failures in CI if we only wait 1000 ms.
+                // Using AbortOrKillThreadWithMessagePump_StressTest (times: 1000, maxParallelism: 20),
+                // I measured timer callbacks to be firing around ten times later than the 100 ms requested.
+                // All this number does is manage how long we can tolerate waiting for a build if a bug
+                // is introduced and the thread never aborts.
+                const int waitTime = 15000;
+
+                Assert.That(thread.Join(waitTime), "Native message pump was not able to be interrupted to enable a managed thread abort.");
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -2,6 +2,7 @@
 
 using System.Runtime.InteropServices;
 using System.Threading;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Internal
 {
@@ -35,6 +36,16 @@ namespace NUnit.Framework.Internal
 
                 Assert.That(thread.Join(1000), "Native message pump was not able to be interrupted to enable a managed thread abort.");
             }
+        }
+
+        [Platform("Win")]
+        [Test, Explicit("For diagnostic purposes; slow")]
+        public void AbortOrKillThreadWithMessagePump_StressTest()
+        {
+            StressUtility.RunParallel(
+                () => AbortOrKillThreadWithMessagePump(kill: true),
+                times: 1000,
+                maxParallelism: 20);
         }
 
         [DllImport("user32.dll")]

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -1,4 +1,27 @@
-﻿#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
 
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
+++ b/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 using System.Threading;
 using NUnit.Framework.Internal;
 

--- a/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
+++ b/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading;
+using NUnit.Framework.Internal;
+
+#if NETSTANDARD1_3 || NETSTANDARD1_6
+using System.Threading.Tasks;
+#endif
+
+#if NETSTANDARD1_6
+using System.Reflection;
+#endif
+
+namespace NUnit.TestUtilities
+{
+    public static class StressUtility
+    {
+        public static void RunParallel(Action action, int times, int maxParallelism, bool useThreadPool = true)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+            if (times < 0) throw new ArgumentOutOfRangeException(nameof(times), times, "Number of times to run must be greater than or equal to 0.");
+            if (maxParallelism < 1) throw new ArgumentOutOfRangeException(nameof(maxParallelism), maxParallelism, "Max parallelism must be greater than or equal to 1.");
+
+            if (times == 0) return;
+
+            maxParallelism = Math.Min(times, maxParallelism);
+            var exception = (Exception)null;
+
+            var threadsToWaitFor = maxParallelism;
+            using (var noMoreThreadsEvent = new ManualResetEvent(false))
+            {
+                for (var i = 0; i < maxParallelism; i++)
+                {
+                    var work = new Action(() =>
+                    {
+                        try
+                        {
+                            while (Interlocked.Decrement(ref times) >= 0)
+                            {
+                                action.Invoke();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+#if NET_2_0 || NET_3_5 || NET_4_0
+                            exception = ex;
+                            times = 0;
+                            Thread.MemoryBarrier();
+#else
+                            Volatile.Write(ref exception, ex);
+                            Volatile.Write(ref times, 0);
+#endif
+                        }
+                        finally
+                        {
+                            if (Interlocked.Decrement(ref threadsToWaitFor) == 0)
+                                noMoreThreadsEvent.Set();
+                        }
+                    });
+
+                    if (useThreadPool)
+                    {
+#if NETSTANDARD1_3 || NETSTANDARD1_6
+                        Task.Run(work);
+#else
+                        ThreadPool.QueueUserWorkItem(_ => work.Invoke());
+#endif
+                    }
+                    else
+                    {
+#if NETSTANDARD1_3
+                        throw new PlatformNotSupportedException(".NET Standard 1.3 does not have access to System.Threading.Thread, so useThreadPool must be true.");
+#else
+#if NETSTANDARD1_6
+                        var actionMethod = action.GetMethodInfo();
+#else
+                        var actionMethod = action.Method;
+#endif
+
+                        new Thread(work.Invoke)
+                        {
+                            Name = $"{nameof(StressUtility)}.{nameof(RunParallel)} ({actionMethod.Name}) dedicated thread {maxParallelism + 1}"
+                        }.Start();
+#endif
+                    }
+                }
+
+                noMoreThreadsEvent.WaitOne();
+
+#if NET_2_0 || NET_3_5 || NET_4_0
+                Thread.MemoryBarrier();
+                if (exception != null)
+#else
+                if (Volatile.Read(ref exception) != null)
+#endif
+                {
+                    ExceptionHelper.Rethrow(exception);
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -307,6 +307,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -307,6 +307,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -304,6 +304,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -310,6 +310,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -297,6 +297,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -297,6 +297,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
+    <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />
     <Compile Include="TestUtilities\TestDelegates.cs" />
     <Compile Include="TestUtilities\TestDirectory.cs" />


### PR DESCRIPTION
Fixes #2398 

So what I'm measuring is that when the CPU is under load, timers get around ten times slower to execute callbacks. Can't think of any mitigations for CPU load except a sufficiently long timeout. When the CPU is under load, what else is there?
We don't ever expect failures from this test, so how long can you tolerate waiting for results from CI? I say we make this a 15 second timeout and reopen #2398 if it comes back. Sound good?