### PR TITLE
Fix show output labels when labels=All in runner

### DIFF
--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -248,11 +248,11 @@ namespace NUnitLite
 
         public void TestFinished(ITestResult result)
         {
+            if (_displayBeforeOutput)
+                WriteLabelLine(result.Test.FullName);
+                
             if (result.Output.Length > 0)
             {
-                if (_displayBeforeOutput)
-                    WriteLabelLine(result.Test.FullName);
-
                 WriteOutput(result.Output);
 
                 if (!result.Output.EndsWith("\n"))


### PR DESCRIPTION
Fixes Bug #2402
In console runner the result.Output has an empty values
in Passed statements. We want show _displayBeforeOutput
in every case.