### PR TITLE
Fix Has.Property causing AmbiguousMatchException for shadowing properties

### DIFF
--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -52,7 +52,6 @@ namespace NUnit.Framework.Constraints
         /// Test whether the constraint is satisfied by a given value
         /// </summary>
         /// <param name="actual">The value to be tested</param>
-        /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             // TODO: Use an error result for null
@@ -77,7 +76,6 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns the string representation of the constraint.
         /// </summary>
-        /// <returns></returns>
         protected override string GetStringRepresentation()
         {
             return string.Format("<property {0} {1}>", name, BaseConstraint);

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -23,7 +23,11 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
+
+#if NETSTANDARD1_3
 using NUnit.Compatibility;
+#endif
 
 namespace NUnit.Framework.Constraints
 {
@@ -61,7 +65,7 @@ namespace NUnit.Framework.Constraints
             if (actualType == null)
                 actualType = actual.GetType();
 
-            PropertyInfo property = actualType.GetProperty(name,
+            PropertyInfo property = Reflect.GetUltimateShadowingProperty(actualType, name,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
             // TODO: Use an error result here

--- a/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
@@ -23,7 +23,11 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
+
+#if NETSTANDARD1_3
 using NUnit.Compatibility;
+#endif
 
 namespace NUnit.Framework.Constraints
 {
@@ -73,7 +77,7 @@ namespace NUnit.Framework.Constraints
             if (actualType == null)
                 actualType = actual.GetType();
 
-            PropertyInfo property = actualType.GetProperty(name,
+            PropertyInfo property = Reflect.GetUltimateShadowingProperty(actualType, name,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             return new ConstraintResult(this, actualType, property != null);
         }

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -21,10 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-// TODO: Remove conditional code
 using System;
 using System.Collections.Generic;
-using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -26,6 +26,46 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
+    public static class PropertyConstraintTests
+    {
+        [TestCase("PublicProperty")]
+        [TestCase("PrivateProperty")]
+        [TestCase("PublicPropertyPrivateShadow")]
+        public static void PropertyExists_ShadowingPropertyOfDifferentType(string propertyName)
+        {
+            var instance = new DerivedClassWithoutProperty();
+            Assert.That(instance, Has.Property(propertyName));
+        }
+
+        [TestCase("PublicProperty", true)]
+        [TestCase("PrivateProperty", true)]
+        [TestCase("PublicPropertyPrivateShadow", false)]
+        public static void PropertyValue_ShadowingPropertyOfDifferentType(string propertyName, bool shouldUseShadowingProperty)
+        {
+            var instance = new DerivedClassWithoutProperty();
+            Assert.That(instance, Has.Property(propertyName).EqualTo(shouldUseShadowingProperty ? 2 : 1));
+        }
+
+        public class BaseClass
+        {
+            public object PublicProperty => 1;
+            // Private members can't be shadowed
+            protected object PrivateProperty => 1;
+            public object PublicPropertyPrivateShadow => 1;
+        }
+
+        public class ClassWithShadowingProperty : BaseClass
+        {
+            public new int PublicProperty => 2;
+            private new int PrivateProperty => 2;
+            private new int PublicPropertyPrivateShadow => 2;
+        }
+
+        public class DerivedClassWithoutProperty : ClassWithShadowingProperty
+        {
+        }
+    }
+
     public class PropertyExistsTests : ConstraintTestBase
     {
         [SetUp]


### PR DESCRIPTION
Fixes #2422 

