### PR TITLE
Fix stack trace filtering of async methods

### DIFF
--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal
     public class StackFilter
     {
         private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.(Assert|Assume|Warn|CollectionAssert|StringAssert|FileAssert|DirectoryAssert)\.";
-        private const string DEFAULT_BOTTOM_OF_STACK_PATTERN = @" System\.R(eflection|untimeMethodHandle)\.";
+        private const string DEFAULT_BOTTOM_OF_STACK_PATTERN = @" System\.(Reflection|RuntimeMethodHandle|Threading\.ExecutionContext)\.";
 
         /// <summary>
         /// Single instance of our default filter

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -163,6 +163,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(result.Message, Contains.Substring(result.AssertionResults[0].Message), "Result message should contain assertion message");
 #if !NETSTANDARD1_3
             Assert.That(result.AssertionResults[0].StackTrace, Does.Contain("WarningFixture"));
+            Assert.That(result.AssertionResults[0].StackTrace.Split(new char[] { '\n' }).Length, Is.LessThan(3));
 #endif
 
             if (expectedMessage != null)
@@ -170,7 +171,6 @@ namespace NUnit.Framework.Assertions
                 Assert.That(result.Message, Does.Contain(expectedMessage));
                 Assert.That(result.AssertionResults[0].Message, Does.Contain(expectedMessage));
             }
-
         }
 
 #if !NET_2_0
@@ -227,6 +227,15 @@ namespace NUnit.Framework.Assertions
             Assert.That(exception.StackTrace, Does.Contain("ThrowExceptionGenericTask"));
 #endif
         }
+
+#if NET_4_5
+        [Test]
+        public async Task DisplayWarning()
+        {
+            await Task.Delay(100);
+            Assert.Warn("This is your last warning!");
+        }
+#endif
 
         [Test]
         public void WarnIf_Async_Error()

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -253,5 +253,32 @@ namespace NUnit.Framework.Assertions
             throw new InvalidOperationException();
         }
 #endif
+
+        // We decided to trim ExecutionContext and below because ten lines per warning adds up
+        // and makes it hard to read build logs.
+        // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
+        [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
+        [TestCase(nameof(WarningFixture.WarningInThreadStart), 1)]
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
+        [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 3)]
+        [TestCase(nameof(WarningFixture.WarningInThreadPoolQueueUserWorkItem), 1)]
+#endif
+#if ASYNC
+        [TestCase(nameof(WarningFixture.WarningInTaskRun), 2)]
+        [TestCase(nameof(WarningFixture.WarningAfterAwaitTaskDelay), 1)]
+#endif
+        public static void StackTracesAreFiltered(string methodName, int maxLineCount)
+        {
+            var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
+            if (result.FailCount != 0 && result.Message.StartsWith(typeof(PlatformNotSupportedException).FullName))
+            {
+                return; // BeginInvoke causes PlatformNotSupportedException on .NET Core 
+            }
+
+            var warningStackTrace = result.AssertionResults[0].StackTrace;
+            var lineCount = warningStackTrace.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Length;
+
+            Assert.That(lineCount, Is.LessThanOrEqualTo(maxLineCount));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -228,15 +228,6 @@ namespace NUnit.Framework.Assertions
 #endif
         }
 
-#if NET_4_5
-        [Test]
-        public async Task DisplayWarning()
-        {
-            await Task.Delay(100);
-            Assert.Warn("This is your last warning!");
-        }
-#endif
-
         [Test]
         public void WarnIf_Async_Error()
         {


### PR DESCRIPTION
Fixes #2429 

@jnm2 This fixes it for me. You might find you need to add more in your environment. As I'm leaving in the morning for a two-week family trip, feel free add yourself to the issue to take the branch and PR over if you think more should be done.