### PR TITLE
CI fixes for new warning tests

### DIFF
--- a/src/NUnitFramework/testdata/WarningFixture.cs
+++ b/src/NUnitFramework/testdata/WarningFixture.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -634,9 +634,22 @@ namespace NUnit.TestData
         [Test]
         public static void WarningInBeginInvoke()
         {
-            new Action(() => Assert.Warn("(Warning message)"))
-                .BeginInvoke(null, null)
-                .AsyncWaitHandle.WaitOne();
+            using (var finished = new ManualResetEvent(false))
+            {
+                new Action(() =>
+                {
+                    try
+                    {
+                        Assert.Warn("(Warning message)");
+                    }
+                    finally
+                    {
+                        finished.Set();
+                    }
+                }).BeginInvoke(ar => { }, null);
+
+                finished.WaitOne();
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/testdata/WarningFixture.cs
+++ b/src/NUnitFramework/testdata/WarningFixture.cs
@@ -660,7 +660,6 @@ namespace NUnit.TestData
             }
         }
 
-#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
         [Test]
         public static void WarningInThreadPoolQueueUserWorkItem()
         {
@@ -681,7 +680,6 @@ namespace NUnit.TestData
                 finished.WaitOne();
             }
         }
-#endif
 
 #if ASYNC
         [Test]

--- a/src/NUnitFramework/testdata/WarningFixture.cs
+++ b/src/NUnitFramework/testdata/WarningFixture.cs
@@ -648,7 +648,7 @@ namespace NUnit.TestData
                     }
                 }).BeginInvoke(ar => { }, null);
 
-                finished.WaitOne();
+                if (!finished.WaitOne(10000)) Assert.Fail("Timeout while waiting for BeginInvoke to execute.");
             }
         }
 
@@ -669,7 +669,8 @@ namespace NUnit.TestData
                     }
                 }).Start();
 
-                finished.WaitOne();
+                if (!finished.WaitOne(10000))
+                    Assert.Fail("Timeout while waiting for threadstart to execute.");
             }
         }
 
@@ -690,7 +691,8 @@ namespace NUnit.TestData
                     }
                 });
 
-                finished.WaitOne();
+                if (!finished.WaitOne(10000))
+                    Assert.Fail("Timeout while waiting for Threadpool.QueueUserWorkItem to execute.");
             }
         }
 
@@ -698,7 +700,8 @@ namespace NUnit.TestData
         [Test]
         public static void WarningInTaskRun()
         {
-            Task.Run(() => Assert.Warn("(Warning message)")).Wait();
+            if (!Task.Run(() => Assert.Warn("(Warning message)")).Wait(10000))
+                Assert.Fail("Timeout while waiting for Task.Run to execute.");
         }
 
         [Test]

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard13.project.json
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard13.project.json
@@ -1,7 +1,9 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.0",
+    "System.Threading.Thread": "4.3.0",
+    "System.Threading.ThreadPool": "4.3.0"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard16.project.json
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard16.project.json
@@ -1,8 +1,9 @@
-{
+﻿{
   "supports": {},
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "System.Threading.Thread": "4.3.0"
+    "System.Threading.Thread": "4.3.0",
+    "System.Threading.ThreadPool": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -259,7 +259,11 @@ namespace NUnit.Framework.Assertions
         // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
         [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
         [TestCase(nameof(WarningFixture.WarningInThreadStart), 2)]
+#if NETSTANDARD1_3 || NETSTANDARD1_6
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4)]
+#else
+        [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4, ExcludePlatform = "mono", Reason = "Warning has no effect inside BeginInvoke on Mono")]
+#endif
         [TestCase(nameof(WarningFixture.WarningInThreadPoolQueueUserWorkItem), 2)]
 #if ASYNC
         [TestCase(nameof(WarningFixture.WarningInTaskRun), 4)]

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -273,6 +273,11 @@ namespace NUnit.Framework.Assertions
                 return; // BeginInvoke causes PlatformNotSupportedException on .NET Core
             }
 
+            if (result.AssertionResults.Count != 1 || result.AssertionResults[0].Status != AssertionStatus.Warning)
+            {
+                Assert.Fail("Expected a single warning assertion. Message: " + result.Message);
+            }
+
             var warningStackTrace = result.AssertionResults[0].StackTrace;
             var lineCount = warningStackTrace.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Length;
 

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -259,10 +259,8 @@ namespace NUnit.Framework.Assertions
         // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
         [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
         [TestCase(nameof(WarningFixture.WarningInThreadStart), 2)]
-#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4)]
         [TestCase(nameof(WarningFixture.WarningInThreadPoolQueueUserWorkItem), 2)]
-#endif
 #if ASYNC
         [TestCase(nameof(WarningFixture.WarningInTaskRun), 4)]
         [TestCase(nameof(WarningFixture.WarningAfterAwaitTaskDelay), 3)]

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -258,21 +258,21 @@ namespace NUnit.Framework.Assertions
         // and makes it hard to read build logs.
         // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
         [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
-        [TestCase(nameof(WarningFixture.WarningInThreadStart), 1)]
+        [TestCase(nameof(WarningFixture.WarningInThreadStart), 2)]
 #if !(NETSTANDARD1_3 || NETSTANDARD1_6)
-        [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 3)]
-        [TestCase(nameof(WarningFixture.WarningInThreadPoolQueueUserWorkItem), 1)]
+        [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4)]
+        [TestCase(nameof(WarningFixture.WarningInThreadPoolQueueUserWorkItem), 2)]
 #endif
 #if ASYNC
-        [TestCase(nameof(WarningFixture.WarningInTaskRun), 2)]
-        [TestCase(nameof(WarningFixture.WarningAfterAwaitTaskDelay), 1)]
+        [TestCase(nameof(WarningFixture.WarningInTaskRun), 4)]
+        [TestCase(nameof(WarningFixture.WarningAfterAwaitTaskDelay), 3)]
 #endif
         public static void StackTracesAreFiltered(string methodName, int maxLineCount)
         {
             var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
             if (result.FailCount != 0 && result.Message.StartsWith(typeof(PlatformNotSupportedException).FullName))
             {
-                return; // BeginInvoke causes PlatformNotSupportedException on .NET Core 
+                return; // BeginInvoke causes PlatformNotSupportedException on .NET Core
             }
 
             var warningStackTrace = result.AssertionResults[0].StackTrace;


### PR DESCRIPTION
Quick fix. Spotted all four CI builds failing after my tests were pushed in https://github.com/nunit/nunit/pull/2431.

