### PR TITLE
Some fixes for TestFixtureSource applied to generic classes

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Internal.Builders
             if (typeInfo.ContainsGenericParameters)
             {
                 Type[] typeArgs = testFixtureData.TypeArgs;
-                if (typeArgs.Length == 0)
+                if (typeArgs == null || typeArgs.Length == 0)
                 {
                     int cnt = 0;
                     foreach (object o in arguments)

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -24,6 +24,7 @@
 using System.Collections;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using System;
 
 namespace NUnit.TestData.TestFixtureSourceData
 {
@@ -304,6 +305,26 @@ namespace NUnit.TestData.TestFixtureSourceData
             yield return "Internet Explorer";
         }
     }
+
+    public class GenericFixtureSource
+    {
+        public static readonly Type[] Source = new Type[]
+        {
+            typeof(short),
+            typeof(int),
+            typeof(long)
+        };
+    }
+
+    [TestFixtureSource(typeof(GenericFixtureSource), "Source")]
+    public class GenericFixtureSourceWithProperArgsProvided<T>
+    {
+        [Test]
+        public void SomeTest()
+        {
+        }
+    }
+
 
     #region Source Data Classes
 

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -117,5 +117,14 @@ namespace NUnit.Framework.Attributes
             Assert.That(suite.Tests.Count, Is.EqualTo(1));
             Assert.That(suite.Tests[0], Is.TypeOf<TestMethod>());
         }
+
+        [Test]
+        public void CanRunGenericFixtureSourceWithProperArgsProvided()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithProperArgsProvided<>));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            Assert.That(suite is ParameterizedFixtureSuite);
+            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+        }
     }
 }


### PR DESCRIPTION
This is a simple solution when we pass generic type arguments directly to the TestFixture. Works fine.

```
public interface IValidEntity { }
public class EntityOne : IValidEntity { }
public class EntityTwo { }
public class EntityThree : IValidEntity { }

    [TestFixture(typeof(EntityOne))]
    [TestFixture(typeof(EntityTwo))]
    [TestFixture(typeof(EntityThree))]
    public class TestUsingSimpleCases<TEntity>
    {
        [Test]
        public void TestMethod()
        {
            Assert.That(typeof(IValidEntity).IsAssignableFrom(typeof(TEntity)));
        }
    }
```

The same, but we fetch the types array from the "Source" field with array of types.

```
[TestFixtureSource(typeof(RegistryType), nameof(RegistryType.Source))]
public class TestUsingTypeSource<TEntity>
{
	[Test]
	public void TestMethod()
	{
		Assert.That(typeof(IValidEntity).IsAssignableFrom(typeof(TEntity)));
	}
}

public class RegistryType
{
	public static readonly Type[] Source = new[]
	{
		typeof(EntityOne),
		typeof(EntityTwo),
		typeof(EntityThree)
	};
}
```

Firstly we get error in NUnitTestFixtureBuilder.cs:100, because TypeArgs is null. For TestFixtureAttribute it's set as an empty array by default, so things are ok. But when generated from source ITextFixtureData.TypeArgs contains null.

We can also create an empty array, but then we should do it in any ITestFixtureData implementation including some created by users. So I think it is better to apply a small fix to builder itself so it will have the same behaviour not only when TypeArgs.Length == 0, but also when it is null.

But when I tried to solve this problem without NUnit fixing, have found another issue. For example I've replaced types array with ITestFixtureData array that was looking as valid solution and I was able to initialize TypeArgs with an empty array as TestFixtureAttribute does (it is also ITestFixtureData).

```
[TestFixtureSource(typeof(RegistryData), nameof(RegistryData.Source))]
public class TestUsingDataSource<TEntity>
{
	[Test]
	public void TestMethod()
	{
		Assert.That(typeof(IValidEntity).IsAssignableFrom(typeof(TEntity)));
	}
}

public class CustomData : ITestFixtureData
{
	public Type[] TypeArgs { get; }
	public string TestName { get; }
	public RunState RunState { get; }
	public object[] Arguments { get; }
	public IPropertyBag Properties { get; }

	public CustomData(Type type)
	{
		Arguments = new object[] { type };
		TypeArgs = new Type[0];
		Properties = new PropertyBag();
		RunState = RunState.Runnable;
	}
}

public class RegistryData
{
	public static readonly ITestFixtureData[] Source = new ITestFixtureData[]
	{
		new CustomData(typeof(EntityOne)),
		new CustomData(typeof(EntityTwo)),
		new CustomData(typeof(EntityThree)),
	};
}
```

But now exception happens in in TestFixtureSourceAttribute.cs:100. It takes iterator through ITestFixtureData items and send each item from it to NUnitTestFixtureBuilder.BuildFrom that also accepts ITestFixtureData. But parameter in foreach defined as TestFixtureParameters, so we get two implicit castings and the first one fails for any other implementation of ITestFixtureData rather than TestFixtureParameters. I've applied a small fix here as well.

I believe this PR also closes #1346.

PS. This PR failed to build, but for the reason inherited from master branch. I can't build it as well with the same error.