### PR TITLE
Allows to override load-time/execution-time interfaces in built-in tests attributes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework
         /// Modifies a test by adding a category to it.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             test.Properties.Add(PropertyNames.Category, this.Name);
 

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -77,7 +77,7 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+        public virtual IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             List<TestMethod> tests = new List<TestMethod>();
             
@@ -117,7 +117,7 @@ namespace NUnit.Framework
         /// to the properties.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             var joinType = _strategy.GetType().Name;
             if (joinType.EndsWith("Strategy"))

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework
         /// Causes a test to be skipped if this CultureAttribute is not satisfied.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (test.RunState != RunState.NotRunnable && !IsCultureSupported())
             {

--- a/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework
         /// Apply changes to the TestExecutionContext
         /// </summary>
         /// <param name="context">The TestExecutionContext</param>
-        public void ApplyToContext(TestExecutionContext context)
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             context.DefaultFloatingPointTolerance = _tolerance;
         }

--- a/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework
         /// Modifies a test by marking it as explicit.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (test.RunState != RunState.NotRunnable && test.RunState != RunState.Ignored)
             {

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -76,7 +76,7 @@ namespace NUnit.Framework
         /// Modifies a test by marking it as Ignored.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (test.RunState != RunState.NotRunnable)
             {

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework
     /// Specifies the maximum time (in milliseconds) for a test case to succeed.
     /// </summary>
     [AttributeUsage( AttributeTargets.Method, AllowMultiple=false, Inherited=false )]
-    public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown
+    public class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown
     {
         private int _milliseconds;
         /// <summary>
@@ -47,7 +47,8 @@ namespace NUnit.Framework
 
         #region ICommandWrapper Members
 
-        TestCommand ICommandWrapper.Wrap(TestCommand command)
+        /// <inheritdoc />
+        public virtual TestCommand Wrap(TestCommand command)
         {
             return new MaxTimeCommand(command, _milliseconds);
         }

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework
          /// Modifies a test as defined for the specific attribute.
          /// </summary>
          /// <param name="test">The test to modify</param>
-         public void ApplyToTest(Test test)
+         public virtual void ApplyToTest(Test test)
         {
             if (!test.Properties.ContainsKey(PropertyNames.Order))
                 test.Properties.Set(PropertyNames.Order, Order);

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -83,7 +83,7 @@ namespace NUnit.Framework
         /// Modify the context to be used for child tests
         /// </summary>
         /// <param name="context">The current TestExecutionContext</param>
-        public void ApplyToContext(TestExecutionContext context)
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             // Don't reflect Self in the context, since it will be
             // used for descendant tests.

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework
         /// Causes a test to be skipped if this PlatformAttribute is not satisfied.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -151,7 +151,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of values to be used as arguments.
         /// </summary>
-        public IEnumerable GetData(IParameterInfo parameter)
+        public virtual IEnumerable GetData(IParameterInfo parameter)
         {
             // Since a separate Randomizer is used for each parameter,
             // we can't fill in the data in the constructor of the

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="command">The command to be wrapped</param>
         /// <returns>The wrapped command</returns>
-        public TestCommand Wrap(TestCommand command)
+        public virtual TestCommand Wrap(TestCommand command)
         {
             return new RepeatedTestCommand(command, _count);
         }

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -50,7 +50,8 @@ namespace NUnit.Framework
             this.Properties.Add(PropertyNames.ApartmentState, apartment);
         }
 
-        void IApplyToTest.ApplyToTest(Test test)
+        /// <inheritdoc />
+        public override void ApplyToTest(Test test)
         {
             test.RequiresThread = true;
             base.ApplyToTest(test);

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="command">The command to be wrapped</param>
         /// <returns>The wrapped command</returns>
-        public TestCommand Wrap(TestCommand command)
+        public virtual TestCommand Wrap(TestCommand command)
         {
             return new RetryCommand(command, _tryCount);
         }

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -52,7 +52,8 @@ namespace NUnit.Framework
 
         #region IApplyToContext Members
 
-        void IApplyToContext.ApplyToContext(TestExecutionContext context)
+        /// <inheritdoc />
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             context.CurrentCulture = new System.Globalization.CultureInfo(_culture, false);
         }

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -52,7 +52,8 @@ namespace NUnit.Framework
 
         #region IApplyToContext Members
 
-        void IApplyToContext.ApplyToContext(TestExecutionContext context)
+        /// <inheritdoc />
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             context.CurrentUICulture = new System.Globalization.CultureInfo(_culture, false);
         }

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="typeInfo">The type info of the fixture to be used.</param>
         /// <returns>A SetUpFixture object as a TestSuite.</returns>
-        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
+        public virtual IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
             SetUpFixture fixture = new SetUpFixture(typeInfo);
 

--- a/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework
         /// Apply changes to the TestExecutionContext
         /// </summary>
         /// <param name="context">The TestExecutionContext</param>
-        public void ApplyToContext(TestExecutionContext context)
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             context.IsSingleThreaded = true;
         }

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework
         /// Modifies a test by adding a description, if not already set.
         /// </summary>
         /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (!test.Properties.ContainsKey(PropertyNames.Description) && Description != null)
                 test.Properties.Set(PropertyNames.Description, Description);
@@ -124,7 +124,7 @@ namespace NUnit.Framework
         /// <param name="method">The method for which a test is to be constructed.</param>
         /// <param name="suite">The suite to which the test will be added.</param>
         /// <returns>A TestMethod</returns>
-        public TestMethod BuildFrom(IMethodInfo method, Test suite)
+        public virtual TestMethod BuildFrom(IMethodInfo method, Test suite)
         {
             TestCaseParameters parms = null;
 

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -420,7 +420,7 @@ namespace NUnit.Framework
         /// <param name="method">The MethodInfo for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+        public virtual IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
 

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -132,7 +132,7 @@ namespace NUnit.Framework
         /// <param name="method">The IMethod for which tests are to be constructed.</param>
         /// <param name="suite">The suite to which the tests will be added.</param>
         /// <returns>One or more TestMethods</returns>
-        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+        public virtual IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             int count = 0;
 

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -222,7 +222,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="typeInfo">The type info of the fixture to be used.</param>
         /// <returns>A an IEnumerable holding one TestFixture object.</returns>
-        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
+        public virtual IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
             yield return _builder.BuildFrom(typeInfo, this);
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -107,7 +107,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="typeInfo">The TypeInfo for which fixtures are to be constructed.</param>
         /// <returns>One or more TestFixtures as TestSuite</returns>
-        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
+        public virtual IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
             Type sourceType = SourceType ?? typeInfo.Type;
 
@@ -125,7 +125,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="sourceType">The type for which data is needed.</param>
         /// <returns></returns>
-        public IEnumerable<ITestFixtureData> GetParametersFor(Type sourceType)
+        public virtual IEnumerable<ITestFixtureData> GetParametersFor(Type sourceType)
         {
             List<ITestFixtureData> data = new List<ITestFixtureData>();
 

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -52,7 +52,8 @@ namespace NUnit.Framework
 
         #region IApplyToContext Members
 
-        void IApplyToContext.ApplyToContext(TestExecutionContext context)
+        /// <inheritdoc />
+        public virtual void ApplyToContext(TestExecutionContext context)
         {
             context.TestCaseTimeout = _timeout;
         }

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework
         /// <returns>
         /// An enumeration containing individual data items
         /// </returns>
-        public IEnumerable GetData(IParameterInfo parameter)
+        public virtual IEnumerable GetData(IParameterInfo parameter)
         {
             return GetDataSource(parameter);
         }

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -98,7 +98,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Get the collection of values to be used as arguments
         /// </summary>
-        public IEnumerable GetData(IParameterInfo parameter)
+        public virtual IEnumerable GetData(IParameterInfo parameter)
         {
             Type targetType = parameter.ParameterType;
 

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Internal
         /// Applies ParameterSet values to the test itself.
         /// </summary>
         /// <param name="test">A test.</param>
-        public void ApplyToTest(Test test)
+        public virtual void ApplyToTest(Test test)
         {
             if (this.RunState != RunState.Runnable)
                 test.RunState = this.RunState;


### PR DESCRIPTION
Hey,

This PR allows to override the load-time/execution-time interfaces implemented by the various attributes in NUnit (e.g `ISimpleTestBuilder`, `ITestBuilder`, `IApplyToTest`...). It is a relatively very small change, only adding `virtual` qualifiers to the current implemented methods...

I hit an issue where I wanted to use a standard attribute but slightly change the behavior of the builder method but couldn't do it without rebuilding the whole logic, which is a bit frustrating, considering that these extension points in NUnit are so convenient!

Let me know if there are any issues!
Thanks
