### PR TITLE
Min-fix to make WorkItemQueue.Save() threadsafe

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Internal.Execution
 
             ParallelShift.Assign(new TestWorker(ParallelSTAQueue, "Worker#STA"));
 
-            var worker = new TestWorker(NonParallelQueue, "Worker#STA_NP");
+            var worker = new TestWorker(NonParallelQueue, "Worker#NP");
             worker.Busy += OnStartNonParallelWorkItem;
             NonParallelShift.Assign(worker);
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -85,6 +85,7 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         private Stack<SavedState> _savedState = new Stack<SavedState>();
+        private object saveLock = new object();
 
         /* This event is used solely for the purpose of having an optimized sleep cycle when
          * we have to wait on an external event (Add or Remove for instance)
@@ -322,13 +323,14 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         internal void Save()
         {
-            Pause();
+            lock (saveLock)
+            {
+                Pause();
+                _savedState.Push(new SavedState(this));
 
-            _savedState.Push(new SavedState(this));
-
-            InitializeQueues();
-
-            Start();
+                InitializeQueues();
+                Start();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2428

This is intended as the minimal necessary fix to make this method thread-safe, and prevent the exceptions which are currently being thrown. @garuma has proposed a more wide-scale re-write in https://github.com/nunit/nunit/issues/2417. This commit is intended for a hotfix, meaning we can fix the issue at hand with minimal changes, and look at a better solution for the next full release.

I'm believe this is all that's strictly necessary - @garuma, @CharliePoole - would you both mind checking you agree?