### PR TITLE
Explicitly build release on CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ matrix:
     - os: osx
       mono: latest
 script:
-  - ./build.sh --target "Travis"
+  - ./build.sh --target "Travis" --configuration "Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ branches:
   except:
     - /travis-.*/
 
-build_script: 
-  - ps: .\build.ps1 -Target "Appveyor"
+build_script:
+  - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"
 
 # disable built-in tests.
 test: off

--- a/build.cake
+++ b/build.cake
@@ -122,7 +122,7 @@ Setup(context =>
         AppVeyor.UpdateBuildVersion(packageVersion);
     }
 
-    Information("Building version {0} of NUnit.", packageVersion);
+    Information("Building {0} version {1} of NUnit.", configuration, packageVersion);
 
     isDotNetCoreInstalled = CheckIfDotNetCoreInstalled();
 });


### PR DESCRIPTION
@CharliePoole noticed that newer versions of the Cake build scripts to not pass in release by default, so I am making it explicit for Travis and AppVeyor to ensure that our CI servers always build in release.