### PR TITLE
Only restore isolated queues when current queues are completed

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -221,7 +221,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Remove isolated queues and restore old ones
         /// </summary>
-        private void RestoreQueues()
+        internal void RestoreQueues()
         {
             Guard.OperationValid(_isolationLevel > 0, $"Internal Error: Called {nameof(RestoreQueues)} with no saved queues.");
             Guard.OperationValid(Queues.All(q => q.IsEmpty), $"Internal Error: Called {nameof(RestoreQueues)} with non-empty queues.");

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace NUnit.Framework.Internal.Execution
@@ -71,7 +72,7 @@ namespace NUnit.Framework.Internal.Execution
 
             ParallelShift.Assign(new TestWorker(ParallelSTAQueue, "Worker#STA"));
 
-            var worker = new TestWorker(NonParallelQueue, "Worker#STA_NP");
+            var worker = new TestWorker(NonParallelQueue, "Worker#NP");
             worker.Busy += OnStartNonParallelWorkItem;
             NonParallelShift.Assign(worker);
 
@@ -222,7 +223,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         private void RestoreQueues()
         {
-            Guard.OperationValid(_isolationLevel > 0, $"Internal Error: Called {nameof(RestoreQueues)} with no saved queues!");
+            Guard.OperationValid(_isolationLevel > 0, $"Internal Error: Called {nameof(RestoreQueues)} with no saved queues.");
+            Guard.OperationValid(Queues.All(q => q.IsEmpty), $"Internal Error: Called {nameof(RestoreQueues)} with non-empty queues.");
 
             // Keep lock until we can remove for both methods
             lock (_queueLock)
@@ -242,7 +244,7 @@ namespace NUnit.Framework.Internal.Execution
 
         private void OnEndOfShift(object sender, EventArgs ea)
         {
-            if (_isolationLevel > 0)
+            if (_isolationLevel > 0 && Shifts.All(q => !q.HasWork))
                 RestoreQueues();
 
             // Shift has ended but all work may not yet be done

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelWorkItemDispatcherTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelWorkItemDispatcherTests.cs
@@ -24,6 +24,7 @@
 #if PARALLEL
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Internal.Execution
 {
@@ -71,6 +72,19 @@ namespace NUnit.Framework.Internal.Execution
             Assert.That(shifts[2].Queues.Count, Is.EqualTo(1));
             Assert.That(shifts[2].Queues[0].Name, Is.EqualTo("NonParallelSTAQueue"));
             Assert.That(shifts[2].Workers.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void QueuesCannotBeRestoredWhenContainWork()
+        {
+            var workItem = Fakes.GetWorkItem(this, nameof(FakeMethod));
+            _dispatcher.IsolateQueues(workItem);
+            _dispatcher.Dispatch(workItem);
+            Assert.That(() => _dispatcher.RestoreQueues(), Throws.InvalidOperationException.With.Message.Contains("non-empty queues"));
+        }
+
+        private void FakeMethod()
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes #2438.

What I believe was happening - RestoreQueues was being called while the OneTimeTearDown was waiting to be executed. RestoreQueues was then removing the current queues, and the as-yet-unexecuted OneTimeTearDown was being lost.

I added a Guard to `RestoreQueues()` - as I can't think of any situation where we would want to restore the queues while the existing queues still contain work. Hopefully in future that would give us a crash, rather than a hang. I then added the check to `OnEndOfShift()`, so the queues are only popped from the save-state-stack if all current work has been completed.

This is a new area to me - would appreciate someone checking this is all following what's expected here!