### PR TITLE
Correct errors due to collection contains constraint

### DIFF
--- a/src/NUnitFramework/framework/AssertionHelper.cs
+++ b/src/NUnitFramework/framework/AssertionHelper.cs
@@ -686,21 +686,21 @@ namespace NUnit.Framework
         #region Member
 
         /// <summary>
-        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// Returns a new <see cref="SomeItemsConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public EqualConstraint Member(object expected)
+        public SomeItemsConstraint Member(object expected)
         {
-            return Has.Some.EqualTo(expected);
+            return new SomeItemsConstraint(new EqualConstraint(expected));
         }
 
         /// <summary>
-        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// Returns a new <see cref="SomeItemsConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public EqualConstraint Contains(object expected)
+        public SomeItemsConstraint Contains(object expected)
         {
-            return Has.Some.EqualTo(expected);
+            return new SomeItemsConstraint(new EqualConstraint(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class SomeItemsConstraint : PrefixConstraint
     {
-        private EqualConstraint equalConstraint = null;
+        private EqualConstraint _equalConstraint = null;
 
         /// <summary>
         /// Construct a SomeItemsConstraint on top of an existing constraint
@@ -42,9 +42,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint(IConstraint itemConstraint)
             : base(itemConstraint)
         {
-            var equalConstraint = itemConstraint as EqualConstraint;
-            if (equalConstraint != null)
-                this.equalConstraint = equalConstraint;
+            _equalConstraint = itemConstraint as EqualConstraint;
             DescriptionPrefix = "some item";
         }
 
@@ -84,7 +82,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
         {
             CheckPrecondition(nameof(comparison));
-            equalConstraint.Using(comparison);
+            _equalConstraint.Using(comparison);
             return this;
         }
 
@@ -96,7 +94,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using(IComparer comparer)
         {
             CheckPrecondition(nameof(comparer));
-            equalConstraint.Using(comparer);
+            _equalConstraint.Using(comparer);
             return this;
         }
 
@@ -108,7 +106,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using<T>(IComparer<T> comparer)
         {
             CheckPrecondition(nameof(comparer));
-            equalConstraint.Using(comparer);
+            _equalConstraint.Using(comparer);
             return this;
         }
 
@@ -120,7 +118,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using<T>(Comparison<T> comparer)
         {
             CheckPrecondition(nameof(comparer));
-            equalConstraint.Using(comparer);
+            _equalConstraint.Using(comparer);
             return this;
         }
 
@@ -132,7 +130,7 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using(IEqualityComparer comparer)
         {
             CheckPrecondition(nameof(comparer));
-            equalConstraint.Using(comparer);
+            _equalConstraint.Using(comparer);
             return this;
         }
 
@@ -144,16 +142,15 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint Using<T>(IEqualityComparer<T> comparer)
         {
             CheckPrecondition(nameof(comparer));
-            equalConstraint.Using(comparer);
+            _equalConstraint.Using(comparer);
             return this;
         }
 
         private void CheckPrecondition(string argument)
         {
-            if (equalConstraint == null)
+            if (_equalConstraint == null)
             {
-                var message =
-                    "Using can only be called when the underlying constraint is an instance of " + nameof(EqualConstraint);
+                var message = "Using may only be used with constraints that check the equality of the items";
                 throw new ArgumentException(message, argument);
             }
         }

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
@@ -32,6 +33,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class SomeItemsConstraint : PrefixConstraint
     {
+        private EqualConstraint equalConstraint = null;
+
         /// <summary>
         /// Construct a SomeItemsConstraint on top of an existing constraint
         /// </summary>
@@ -39,6 +42,9 @@ namespace NUnit.Framework.Constraints
         public SomeItemsConstraint(IConstraint itemConstraint)
             : base(itemConstraint)
         {
+            var equalConstraint = itemConstraint as EqualConstraint;
+            if (equalConstraint != null)
+                this.equalConstraint = equalConstraint;
             DescriptionPrefix = "some item";
         }
 
@@ -66,6 +72,90 @@ namespace NUnit.Framework.Constraints
                     return new ConstraintResult(this, actual, ConstraintStatus.Success);
 
             return new ConstraintResult(this, actual, ConstraintStatus.Failure);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="Func{TCollectionType, TMemberType, Boolean}"/> object.
+        /// </summary>
+        /// <typeparam name="TCollectionType">The type of the elements in the collection.</typeparam>
+        /// <typeparam name="TMemberType">The type of the member.</typeparam>
+        /// <param name="comparison">The comparison function to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
+        {
+            CheckPrecondition(nameof(comparison));
+            equalConstraint.Using(comparison);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="IComparer"/> object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using(IComparer comparer)
+        {
+            CheckPrecondition(nameof(comparer));
+            equalConstraint.Using(comparer);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="IComparer{T}"/> object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using<T>(IComparer<T> comparer)
+        {
+            CheckPrecondition(nameof(comparer));
+            equalConstraint.Using(comparer);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="Comparison{T}"/> object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using<T>(Comparison<T> comparer)
+        {
+            CheckPrecondition(nameof(comparer));
+            equalConstraint.Using(comparer);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="IEqualityComparer"/> object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using(IEqualityComparer comparer)
+        {
+            CheckPrecondition(nameof(comparer));
+            equalConstraint.Using(comparer);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied <see cref="IEqualityComparer{T}"/> object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public SomeItemsConstraint Using<T>(IEqualityComparer<T> comparer)
+        {
+            CheckPrecondition(nameof(comparer));
+            equalConstraint.Using(comparer);
+            return this;
+        }
+
+        private void CheckPrecondition(string argument)
+        {
+            if (equalConstraint == null)
+            {
+                var message =
+                    "Using can only be called when the underlying constraint is an instance of " + nameof(EqualConstraint);
+                throw new ArgumentException(message, argument);
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Has.cs
+++ b/src/NUnitFramework/framework/Has.cs
@@ -209,12 +209,12 @@ namespace NUnit.Framework
         #region Member
 
         /// <summary>
-        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// Returns a new <see cref="SomeItemsConstraint"/> checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static EqualConstraint Member(object expected)
+        public static SomeItemsConstraint Member(object expected)
         {
-            return Some.EqualTo(expected);
+            return new SomeItemsConstraint(new EqualConstraint(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -432,6 +432,46 @@ namespace NUnit.Framework.Syntax
             Expect(constraint.ToString(), EqualTo("<unresolved <equal 42>>"));
         }
 
+        [Test]
+        public void ContainsConstraintWithOr()
+        {
+            var constraint = Contains(5).Or.Contains(7);
+            var collection1 = new[] { 3, 5, 1, 8 };
+            var collection2 = new[] { 2, 7, 9, 2 };
+            Assert.That(collection1, constraint);
+            Assert.That(collection2, constraint);
+        }
+
+        [Test]
+        public void ContainsConstraintWithUsing()
+        {
+            Func<int, int, bool> myIntComparer = (x, y) => x == y;
+            var constraint = Contains(5).Using(myIntComparer);
+            var collection = new[] { 3, 5, 1, 8 };
+            Assert.That(collection, constraint);
+        }
+
+        #endregion
+
+        #region Member
+
+        [Test]
+        public void MemberConstraintWithAnd()
+        {
+            var constraint = Member(1).And.Member(7);
+            var collection = new[] { 2, 1, 7, 4 };
+            Assert.That(collection, constraint);
+        }
+
+        [Test]
+        public void MemberConstraintWithUsing()
+        {
+            Func<int, int, bool> myIntComparer = (x, y) => x == y;
+            var constraint = Member(1).Using(myIntComparer);
+            var collection = new[] { 2, 1, 7, 4 };
+            Assert.That(collection, constraint);
+        }
+
         #endregion
 
         #region SubsetOf

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -428,8 +428,8 @@ namespace NUnit.Framework.Syntax
         public void ContainsConstraint()
         {
             var constraint = Contains(42);
-            Expect(constraint, TypeOf<EqualConstraint>());
-            Expect(constraint.ToString(), EqualTo("<unresolved <equal 42>>"));
+            Expect(constraint, TypeOf<SomeItemsConstraint>());
+            Expect(constraint.ToString(), EqualTo("<some <equal 42>>"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/HasTests.cs
+++ b/src/NUnitFramework/tests/Assertions/HasTests.cs
@@ -1,0 +1,51 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.Framework.Assertions
+{
+    /// <summary>
+    /// Summary description for HasTests.
+    /// </summary>
+    [TestFixture]
+    public class HasTests
+    {
+        [Test]
+        public void HasMemberAnd()
+        {
+            var collection1 = new [] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Has.Member(7).And.Contain(1);
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void HasMemberUsing()
+        {
+            Func<int, int, bool> myIntComparer = (x, y) => x == y;
+            var collection1 = new [] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Has.Member(7).Using(myIntComparer);
+            Assert.That(collection1, constraint);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ArraySucceeds()
         {
-            Assert.Contains( "abc", testArray );
-            Assert.Contains( 123, testArray );
-            Assert.Contains( "xyz", testArray );
+            Assert.Contains("abc", testArray);
+            Assert.Contains(123, testArray);
+            Assert.Contains("xyz", testArray, "expected array containing '{0}'", "xyz");
         }
 
         [Test]
@@ -116,10 +116,44 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
+        public void DoesContainAnd()
+        {
+            var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Does.Contain(7).And.Member(2);
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void DoesContainUsing()
+        {
+            Func<int, int, bool> myIntComparer = (x, y) => x == y;
+            var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Does.Contain(7).Using(myIntComparer);
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
         public void ContainsMultipleItemsInt()
         {
             var collection = new[] { 1, 2, 3 };
             Assert.That(collection, Contains.Item(1).And.Contains(2).And.Contains(3));
+        }
+
+        [Test]
+        public void ContainsItemAnd()
+        {
+            var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Contains.Item(7).And.Member(3);
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ContainsItemUsing()
+        {
+            Func<int, int, bool> myIntComparer = (x, y) => x == y;
+            var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var constraint = Contains.Item(7).Using(myIntComparer);
+            Assert.That(collection1, constraint);
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
@@ -68,7 +68,6 @@ namespace NUnit.Framework.Constraints
         public void ConstraintExpressionContainsUsing()
         {
             var constraintExpression = new ConstraintExpression();
-            // DOES NOT COMPILE: There is no Using on SomeItemsConstraint
             var constraint = constraintExpression.Contains(4).Using(myIntComparer);
             var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
             Assert.That(collection1, constraint);

--- a/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
@@ -1,0 +1,104 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Summary description for ConstraintExpressionTests.
+    /// </summary>
+    [TestFixture]
+    public class ConstraintExpressionTests
+    {
+        static Func<int, int, bool> myIntComparer = (x, y) => x == y;
+
+        [Test]
+        public void ConstraintExpressionMemberAnd()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.Member(3).And.Contains(7);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ConstraintExpressionMemberUsing()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression
+                .Member("3")
+                .Using<int, string>((i, s) => i.ToString() == s)
+                .Using((IComparer<string>) Comparer<string>.Default);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ConstraintExpressionContainsAnd()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.Contains(4).And.Member(2);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ConstraintExpressionContainsUsing()
+        {
+            var constraintExpression = new ConstraintExpression();
+            // DOES NOT COMPILE: There is no Using on SomeItemsConstraint
+            var constraint = constraintExpression.Contains(4).Using(myIntComparer);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ConstraintExpressionContainAnd()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.Contain(8).And.Contain(7);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ConstraintExpressionContainUsing()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.Contain(8).Using(myIntComparer);
+            var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Assert.That(collection1, constraint);
+        }
+
+        [Test]
+        public void ContainsConstraintApplyTo()
+        {
+            var containsConstraint = new ContainsConstraint(6);
+            var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var result = containsConstraint.ApplyTo(collection1);
+            Assert.That(result.IsSuccess, Is.True);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/SomeItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/SomeItemsConstraintTests.cs
@@ -1,0 +1,49 @@
+// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
+
+namespace  NUnit.Framework.Tests.Constraints
+{
+    [TestFixture]
+    class SomeItemsConstraintTests
+    {
+        [Test]
+        public void EqualConstraintUsingDoesNotThrow()
+        {
+            var constraint = new SomeItemsConstraint(new EqualConstraint("42"));
+            Assert.DoesNotThrow(() => constraint.Using((IComparer<string>)Comparer<string>.Default));
+        }
+
+        [Test]
+        public void AnotherConstraintUsingThrows()
+        {
+            var constraint = new SomeItemsConstraint(new EmptyCollectionConstraint());
+            Assert.Throws<ArgumentException>(() => constraint.Using((IComparer<string>)Comparer<string>.Default));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -215,6 +216,7 @@
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />
     <Compile Include="Constraints\EndsWithConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -214,6 +215,7 @@
     <Compile Include="Constraints\CollectionOrderedConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />
     <Compile Include="Constraints\EndsWithConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -191,6 +192,7 @@
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -167,6 +168,7 @@
     <Compile Include="Constraints\CollectionSubsetConstraintTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\ConstraintTestBase.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -155,6 +156,7 @@
     <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Constraints\SameAsTest.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
     <Compile Include="Constraints\StringConstraintTest.cs" />
+    <Compile Include="Constraints\SomeItemsConstraintTests.cs" />
     <Compile Include="Constraints\SubstringConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsConstraintTests.cs" />
     <Compile Include="Constraints\ThrowsExceptionConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Assertions\FileAssertTests.cs" />
     <Compile Include="Assertions\GreaterEqualFixture.cs" />
     <Compile Include="Assertions\GreaterFixture.cs" />
+    <Compile Include="Assertions\HasTests.cs" />
     <Compile Include="Assertions\LessEqualFixture.cs" />
     <Compile Include="Assertions\LessFixture.cs" />
     <Compile Include="Assertions\ListContentsTests.cs" />
@@ -155,6 +156,7 @@
     <Compile Include="Constraints\CollectionEqualsTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\ComparisonConstraintTestBase.cs" />
+    <Compile Include="Constraints\ConstraintExpressionTests.cs" />
     <Compile Include="Constraints\DelayedConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsKeyConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />


### PR DESCRIPTION
Unfortunately I had to implement a lot of `Using`-overloads
in `SomeItemsConstraint` and add a dynamic check.

Fixes #2411 and fixes #2412