### PR TITLE
Compile RegEx to improve performance

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Interfaces
     /// <summary>
     /// TNode represents a single node in the XML representation
     /// of a Test or TestResult. It replaces System.Xml.XmlNode and
-    /// System.Xml.Linq.XElement, providing a minimal set of methods 
+    /// System.Xml.Linq.XElement, providing a minimal set of methods
     /// for operating on the XML in a platform-independent manner.
     /// </summary>
     public class TNode
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Interfaces
                 var stringWriter = new System.IO.StringWriter();
                 var settings = new XmlWriterSettings();
                 settings.ConformanceLevel = ConformanceLevel.Fragment;
-                
+
                 using (XmlWriter xmlWriter = XmlWriter.Create(stringWriter, settings))
                 {
                     WriteTo(xmlWriter);
@@ -230,7 +230,7 @@ namespace NUnit.Framework.Interfaces
 
             return ApplySelection(nodeList, xpath);
         }
-        
+
         /// <summary>
         /// Writes the XML representation of the node to an XmlWriter
         /// </summary>
@@ -318,7 +318,7 @@ namespace NUnit.Framework.Interfaces
                 : resultNodes;
         }
 
-        private static readonly Regex InvalidXmlCharactersRegex = new Regex("[^\u0009\u000a\u000d\u0020-\ufffd]|([\ud800-\udbff](?![\udc00-\udfff]))|((?<![\ud800-\udbff])[\udc00-\udfff])");
+        private static readonly Regex InvalidXmlCharactersRegex = new Regex("[^\u0009\u000a\u000d\u0020-\ufffd]|([\ud800-\udbff](?![\udc00-\udfff]))|((?<![\ud800-\udbff])[\udc00-\udfff])", RegexOptions.Compiled);
         private static string EscapeInvalidXmlCharacters(string str)
         {
             if (str == null) return null;
@@ -369,7 +369,7 @@ namespace NUnit.Framework.Interfaces
             public NodeFilter(string xpath)
             {
                 _nodeName = xpath;
-                
+
                 int lbrack = xpath.IndexOf('[');
                 if (lbrack >= 0)
                 {
@@ -392,10 +392,10 @@ namespace NUnit.Framework.Interfaces
             {
                 if (node.Name != _nodeName)
                     return false;
-                
+
                 if (_propName == null)
                     return true;
-                
+
                 return node.Attributes[_propName] == _propValue;
             }
         }

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -53,9 +53,9 @@ namespace NUnit.Framework.Internal
         public StackFilter(string topOfStackPattern, string bottomOfStackPattern)
         {
             if (topOfStackPattern != null)
-                _topOfStackRegex = new Regex(topOfStackPattern);
+                _topOfStackRegex = new Regex(topOfStackPattern, RegexOptions.Compiled);
             if (bottomOfStackPattern != null)
-                _bottomOfStackRegex = new Regex(bottomOfStackPattern);
+                _bottomOfStackRegex = new Regex(bottomOfStackPattern, RegexOptions.Compiled);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal
                         line = sr.ReadLine();
 
                 // Copy lines down to the line that invoked the failing method.
-                // This is actually only needed for the compact framework, but 
+                // This is actually only needed for the compact framework, but
                 // we do it on all platforms for simplicity. Desktop platforms
                 // won't have any System.Reflection lines.
                 while (line != null)


### PR DESCRIPTION
@OsirisTerje and I have been working with the Visual Studio test team looking at performance. Our XML serialization in TNode shows up as a bottleneck for performance which isn't really a surprise. One area in there that showed up fairly high was our use of `RegEx` to escape invalid XML characters. We create this `RegEx` as a static and use it many times. Adding the compiled option to the `RegEx` produced a small performance gain, so I did the same for our two other long lasting `RegEx`'s.

This was tested using a test project from the VSTest team with 10,000 empty test methods. Running those tests using the console, in-process, compiled release, took an average of 10.65 sec over 4 runs. With this fix, the average for 4 runs drops to 9.65 sec.

Even though this is nearly a 10% performance gain, it is only for trivial tests and the gain would be smaller if the tests were more complex. It is a minor fix though, so probably worth it.