### PR TITLE
Null guard in BuildMessage

### DIFF
--- a/src/NUnitFramework/framework/Guard.cs
+++ b/src/NUnitFramework/framework/Guard.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -39,7 +39,7 @@ namespace NUnit.Framework
         public static void ArgumentNotNull(object value, string name)
         {
             if (value == null)
-                throw new ArgumentNullException("Argument " + name + " must not be null", name);
+                throw new ArgumentNullException(name, "Argument " + name + " must not be null");
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -78,6 +78,8 @@ namespace NUnit.Framework.Internal
         /// <returns>A combined message string.</returns>
         public static string BuildMessage(Exception exception, bool excludeExceptionNames=false)
         {
+            Guard.ArgumentNotNull(exception, "exception");
+
             StringBuilder sb = new StringBuilder();
             if (!excludeExceptionNames)
                 sb.AppendFormat("{0} : ", exception.GetType());

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
         /// <returns>A combined message string.</returns>
         public static string BuildMessage(Exception exception, bool excludeExceptionNames=false)
         {
-            Guard.ArgumentNotNull(exception, "exception");
+            Guard.ArgumentNotNull(exception, nameof(exception));
 
             StringBuilder sb = new StringBuilder();
             if (!excludeExceptionNames)

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         public ITest Test { get; }
 
         /// <summary>
-        /// Gets the ResultState of the test result, which 
+        /// Gets the ResultState of the test result, which
         /// indicates the success or failure of the test.
         /// </summary>
         public ResultState ResultState
@@ -493,15 +493,12 @@ namespace NUnit.Framework.Internal
         /// <param name="ex">The exception that was thrown</param>
         public void RecordException(Exception ex)
         {
-            Guard.ArgumentNotNull(ex, nameof(ex));
-
-            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException != null)
-                ex = ex.InnerException;
+            ex = ValidateAndUnwrap(ex);
 
             if (ex is ResultStateException)
                 SetResult(
                     ((ResultStateException)ex).ResultState,
-                    ex.Message, 
+                    ex.Message,
                     StackFilter.DefaultFilter.Filter(ex.StackTrace));
 #if !NETSTANDARD1_6
             else if (ex is System.Threading.ThreadAbortException)
@@ -534,10 +531,7 @@ namespace NUnit.Framework.Internal
         /// <param name="site">The FailureSite to use in the result</param>
         public void RecordException(Exception ex, FailureSite site)
         {
-            Guard.ArgumentNotNull(ex, nameof(ex));
-
-            if (ex is NUnitException)
-                ex = ex.InnerException;
+            ex = ValidateAndUnwrap(ex);
 
             if (ex is ResultStateException)
                 SetResult(((ResultStateException)ex).ResultState.WithSite(site),
@@ -568,8 +562,7 @@ namespace NUnit.Framework.Internal
         /// <param name="ex">The Exception to be recorded</param>
         public void RecordTearDownException(Exception ex)
         {
-            if (ex is NUnitException)
-                ex = ex.InnerException;
+            ex = ValidateAndUnwrap(ex);
 
             ResultState resultState = ResultState == ResultState.Cancelled
                 ? ResultState.Cancelled
@@ -586,6 +579,16 @@ namespace NUnit.Framework.Internal
                 stackTrace = StackTrace + Environment.NewLine + stackTrace;
 
             SetResult(resultState, message, stackTrace);
+        }
+
+        private static Exception ValidateAndUnwrap(Exception ex)
+        {
+            Guard.ArgumentNotNull(ex, nameof(ex));
+
+            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException != null)
+                return ex.InnerException;
+
+            return ex;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -493,7 +493,7 @@ namespace NUnit.Framework.Internal
         /// <param name="ex">The exception that was thrown</param>
         public void RecordException(Exception ex)
         {
-            Guard.ArgumentNotNull(ex, "ex");
+            Guard.ArgumentNotNull(ex, nameof(ex));
 
             if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException != null)
                 ex = ex.InnerException;

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -493,7 +493,7 @@ namespace NUnit.Framework.Internal
         /// <param name="ex">The exception that was thrown</param>
         public void RecordException(Exception ex)
         {
-            if (ex is NUnitException || ex is TargetInvocationException)
+            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException != null)
                 ex = ex.InnerException;
 
             if (ex is ResultStateException)

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -493,6 +493,8 @@ namespace NUnit.Framework.Internal
         /// <param name="ex">The exception that was thrown</param>
         public void RecordException(Exception ex)
         {
+            Guard.ArgumentNotNull(ex, "ex");
+
             if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException != null)
                 ex = ex.InnerException;
 
@@ -532,6 +534,8 @@ namespace NUnit.Framework.Internal
         /// <param name="site">The FailureSite to use in the result</param>
         public void RecordException(Exception ex, FailureSite site)
         {
+            Guard.ArgumentNotNull(ex, nameof(ex));
+
             if (ex is NUnitException)
                 ex = ex.InnerException;
 

--- a/src/NUnitFramework/tests/Internal/ExceptionHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/ExceptionHelperTests.cs
@@ -1,0 +1,34 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework.Internal
+{
+    public static class ExceptionHelperTests
+    {
+        [Test]
+        public static void BuildMessageThrowsForNullException()
+        {
+            Assert.That(() => ExceptionHelper.BuildMessage(null), Throws.ArgumentNullException.With.Property("ParamName").EqualTo("exception"));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
@@ -1,0 +1,79 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Results
+{
+    public sealed class TestResultApiTests : TestResultTests
+    {
+        private IEnumerable<TestResult> TestResults => new[]
+        {
+            _testResult,
+            _suiteResult
+        };
+
+        private static IEnumerable<Action<TestResult, Exception>> RecordExceptionMethods => new Action<TestResult, Exception>[]
+        {
+            (result, exception) => result.RecordException(exception),
+            (result, exception) => result.RecordException(exception, FailureSite.Test),
+            (result, exception) => result.RecordTearDownException(exception)
+        };
+
+        [Test]
+        public void ThrowsForNullException()
+        {
+            foreach (var method in RecordExceptionMethods)
+            foreach (var result in TestResults)
+            {
+                Assert.That(
+                    () => method.Invoke(result, null),
+                    Throws.ArgumentNullException.With.Property("ParamName").EqualTo("ex"));
+            }
+        }
+
+
+        [Test]
+        public void DoesNotThrowForMissingInnerException()
+        {
+            var exceptions = new Exception[]
+            {
+                new NUnitException(),
+                new TargetInvocationException(null),
+#if ASYNC
+                new AggregateException()
+#endif
+            };
+
+            foreach (var method in RecordExceptionMethods)
+            foreach (var result in TestResults)
+            foreach (var exception in exceptions)
+            {
+                method.Invoke(result, exception);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `null` guards in `ExceptionHelper.BuildMessage()` and `TestResult.RecordException()` and avoids using `InnerException` if it is null.

This fixes #2450, or at least makes an honest attempt to fix it, although there's no unit test here proving the problem described in that issue as I'm unable to reproduce it as of yet. If you have any great ideas on how to reproduce the problem, please let me know and I'll add a unit test to the PR.