### PR TITLE
EqualConstraint.Using<T>() can be passed a delegate that returns bool

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -323,9 +323,9 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Flag the constraint to use the supplied (T, T) => bool object.
+        /// Flag the constraint to use the supplied boolean-returning delegate.
         /// </summary>
-        /// <param name="comparer">The (T, T) => bool object to use.</param>
+        /// <param name="comparer">The boolean-returning delegate to use.</param>
         /// <returns>Self.</returns>
         public EqualConstraint Using<T>(Func<T, T, bool> comparer)
         {

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -323,6 +323,17 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Flag the constraint to use the supplied (T, T) => bool object.
+        /// </summary>
+        /// <param name="comparer">The (T, T) => bool object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualConstraint Using<T>(Func<T, T, bool> comparer)
+        {
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            return this;
+        }
+
+        /// <summary>
         /// Flag the constraint to use the supplied Comparison object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -570,6 +570,14 @@ namespace NUnit.Framework.Constraints
             }
 
             [Test]
+            public void UsesProvidedGenericEqualityComparison()
+            {
+                var comparer = new GenericEqualityComparison<int>();
+                Assert.That(2 + 2, Is.EqualTo(4).Using<int>(comparer.Delegate));
+                Assert.That(comparer.WasCalled, "Comparer was not called");
+            }
+
+            [Test]
             public void UsesProvidedLambda_IntArgs()
             {
                 Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.CompareTo(y)));

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -578,6 +578,12 @@ namespace NUnit.Framework.Constraints
             }
 
             [Test]
+            public void UsesBooleanReturningDelegate()
+            {
+                Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.Equals(y)));
+            }
+
+            [Test]
             public void UsesProvidedLambda_IntArgs()
             {
                 Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.CompareTo(y)));

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/GenericEqualityComparison.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/GenericEqualityComparison.cs
@@ -1,0 +1,43 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    internal class GenericEqualityComparison<T>
+    {
+        public bool WasCalled = false;
+
+        public Func<T, T, bool> Delegate
+        {
+            get { return new Func<T, T, bool>(Compare); }
+        }
+
+        public bool Compare(T x, T y)
+        {
+            WasCalled = true;
+            return x.Equals(y);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -305,6 +305,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -304,6 +304,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -302,6 +302,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -308,6 +308,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -295,6 +295,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -295,6 +295,7 @@
     <Compile Include="TestUtilities\Comparers\GenericComparer.cs" />
     <Compile Include="TestUtilities\Comparers\GenericComparison.cs" />
     <Compile Include="TestUtilities\Comparers\GenericEqualityComparer.cs" />
+    <Compile Include="TestUtilities\Comparers\GenericEqualityComparison.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />


### PR DESCRIPTION
Addresses issue #2418.

The only difference from the direction that @jnm2 kindly provided on the issue page is that there is already a EqualityAdapter.For(Func<T, T, bool>) overload that returns a PredicateEqualityAdapter. What I have here is basically the filler needed to connect that function to a new EqualConstraint.Using<T>(Func<T, T, bool>) function.