### PR TITLE
GetMethods return all non-private methods if specified

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -332,7 +332,7 @@ namespace NUnit.Compatibility
             if (type != null)
             {
                 var baseMethods = type.GetAllMethods(includeBaseStatic)
-                    .Where(b => b.IsPublic && (includeBaseStatic || !b.IsStatic) && !methods.Any(m => m.GetRuntimeBaseDefinition() == b));
+                    .Where(b => !b.IsPrivate && (includeBaseStatic || !b.IsStatic) && !methods.Any(m => m.GetRuntimeBaseDefinition() == b));
                 methods.AddRange(baseMethods);
             }
 
@@ -363,7 +363,7 @@ namespace NUnit.Compatibility
             bool pub = flags.HasFlag(BindingFlags.Public);
             bool priv = flags.HasFlag(BindingFlags.NonPublic);
             if (priv && !pub)
-                infos = infos.Where(m => m.IsPrivate);
+                infos = infos.Where(m => !m.IsPublic);
             else if (pub && !priv)
                 infos = infos.Where(m => m.IsPublic);
 


### PR DESCRIPTION
We now return all non-private methods from base classes instead of only all public-methods. Furthermore, when filtering with `BindingFlags.NonPublic` we return all non-public methods instead of all private methods.

Tests have been added to ensure the behaviour is the same between regular .NET reflection and our own reflection methods.

Also the test `CanGetStaticMethodsOnBase()` has been corrected and enabled.

Fixes #2448