### PR TITLE
Bugfix/issue2102

### DIFF
--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -229,9 +229,9 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Return a 
+        /// Implemented to use in place of Environment.OSVersion.ToString()
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A representation of the platform ID and version in an approximation of the format used by Environment.OSVersion.ToString()</returns>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -26,6 +26,7 @@ using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 
 namespace NUnit.Framework.Internal
 {
@@ -225,6 +226,37 @@ namespace NUnit.Framework.Internal
         public PlatformID Platform
         {
             get { return _platform; }
+        }
+
+        /// <summary>
+        /// Return a 
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            
+            switch (Platform)
+            {
+                case PlatformID.Win32NT:
+                    sb.Append("Microsoft Windows NT");
+                    break;
+                case PlatformID.Win32Windows:
+                    sb.Append("Microsoft Windows 95/98");
+                    break;
+                case PlatformID.Win32S:
+                    sb.Append("Microsoft Windows Win32s");
+                    break;
+                case PlatformID.WinCE:
+                    sb.Append("Microsoft Windows CE");
+                    break;
+                default:
+                    sb.Append(Platform);
+                    break;
+            }
+
+            sb.Append(" ").Append(Version);
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -174,7 +174,7 @@ namespace NUnitLite
             Writer.WriteLabelLine("   OS Version: ", RuntimeInformation.OSDescription);
             Writer.WriteLabelLine("  CLR Version: ", RuntimeInformation.FrameworkDescription);
 #else
-            Writer.WriteLabelLine("   OS Version: ", Environment.OSVersion);
+            Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);
             Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
 #endif
             Writer.WriteLine();


### PR DESCRIPTION
Corrects issue #2102 by implementing a ToString() in OSPlatform and substituting that for the existing Environment.OSVersion.ToString() used in TextUI.

Note that there are still two uses of Environment.OSVersion that could report the compatibility mode version instead of the true OS version.  One is in the FrameworkController at line 394, and one is in NUnit2XmlOutputWriter at line 143.  I left them as they're technically out of scope for this issue.