### PR TITLE
Return also protected and internal properties

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -346,7 +346,7 @@ namespace NUnit.Compatibility
             if (pub && !priv)
                 infos = infos.Where(p => (p.GetMethod != null && p.GetMethod.IsPublic) || (p.SetMethod != null && p.SetMethod.IsPublic));
             if (priv && !pub)
-                infos = infos.Where(p => (p.GetMethod == null || p.GetMethod.IsPrivate) && (p.SetMethod == null || p.SetMethod.IsPrivate));
+                infos = infos.Where(p => (p.GetMethod == null || !(p.GetMethod.IsPublic)) && (p.SetMethod == null || !(p.SetMethod.IsPublic)));
 
             bool stat = flags.HasFlag(BindingFlags.Static);
             bool inst = flags.HasFlag(BindingFlags.Instance);

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -250,7 +250,9 @@ namespace NUnit.Compatibility
         /// <returns></returns>
         public static PropertyInfo GetProperty(this Type type, string name, BindingFlags flags)
         {
+            bool declaredOnly = flags.HasFlag(BindingFlags.DeclaredOnly);
             return type.GetRuntimeProperties()
+                .Where(prop => declaredOnly ? prop.DeclaringType.Equals(type) : true)
                 .ApplyBindingFlags(flags)
                 .Where(p => p.Name == name)
                 .FirstOrDefault();

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -193,6 +193,11 @@ namespace NUnit.Framework.Tests.Compatibility
         [TestCase(typeof(DerivedTestClass), "PubPriv", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance, true)]
         [TestCase(typeof(BaseTestClass), "PubPriv", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
         [TestCase(typeof(DerivedTestClass), "PubPriv", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, false)]
+
+        [TestCase(typeof(DerivedTestClass), "Protected", BindingFlags.NonPublic | BindingFlags.Instance, true)]
+        [TestCase(typeof(DerivedTestClass), "Internal", BindingFlags.NonPublic | BindingFlags.Instance, true)]
+        [TestCase(typeof(BaseTestClass), "Protected", BindingFlags.NonPublic | BindingFlags.Instance, true)]
+        [TestCase(typeof(BaseTestClass), "Internal", BindingFlags.NonPublic | BindingFlags.Instance, true)]
         public void CanGetPropertyWithBindingFlags(Type type, string name, BindingFlags flags, bool shouldFind)
         {
             var result = type.GetProperty(name, flags);
@@ -353,6 +358,8 @@ namespace NUnit.Framework.Tests.Compatibility
         public static string StaticString { get; set; }
 
         protected string Protected { get; set; }
+
+        internal string Internal { get; set; }
 
         public string Name { get; set; }
 


### PR DESCRIPTION
As the documentation states "Specify BindingFlags.NonPublic
to include non-public properties (that is, private, internal,
and protected properties) in the search.

Fixes #2465