### PR TITLE
Initial tests of parallel execution, shift changing, etc.

### DIFF
--- a/src/NUnitFramework/Fakes.cs
+++ b/src/NUnitFramework/Fakes.cs
@@ -113,6 +113,9 @@ namespace NUnit.TestUtilities
     {
         public event System.EventHandler Executed;
 
+        public FakeWorkItem(Test test)
+            : this(test, new TestExecutionContext()) { }
+
         public FakeWorkItem(Test test, TestExecutionContext context)
             : base(test, TestFilter.Empty)
         {

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -215,6 +215,8 @@ namespace NUnit.TestUtilities
         /// </summary>
         class SuperSimpleDispatcher : IWorkItemDispatcher
         {
+            public int LevelOfParallelism { get { return 0; } }
+
             public void Start(WorkItem topLevelWorkItem)
             {
                 topLevelWorkItem.Execute();

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -46,7 +46,8 @@ namespace NUnit.TestUtilities
     /// </summary>
     public static class TestBuilder
     {
-#region Build Tests
+        #region Build Tests
+
         public static TestSuite MakeSuite(string name)
         {
             return new TestSuite(name);
@@ -90,9 +91,48 @@ namespace NUnit.TestUtilities
             return new DefaultTestCaseBuilder().BuildFrom(new MethodWrapper(type, method));
         }
 
-#endregion
+        #endregion
 
-#region Run Tests
+        #region Create WorkItems
+
+        public static WorkItem CreateWorkItem(Type type)
+        {
+            return CreateWorkItem(MakeFixture(type));
+        }
+
+        public static WorkItem CreateWorkItem(Type type, string methodName)
+        {
+            return CreateWorkItem(MakeTestFromMethod(type, methodName));
+        }
+
+        public static WorkItem CreateWorkItem(Test test)
+        {
+            var context = new TestExecutionContext();
+            context.Dispatcher = new SuperSimpleDispatcher();
+
+            return CreateWorkItem(test, context);
+        }
+
+        public static WorkItem CreateWorkItem(Test test, object testObject)
+        {
+            var context = new TestExecutionContext();
+            context.TestObject = testObject;
+            context.Dispatcher = new SuperSimpleDispatcher();
+
+            return CreateWorkItem(test, context);
+        }
+
+        public static WorkItem CreateWorkItem(Test test, TestExecutionContext context)
+        {
+            var work = WorkItemBuilder.CreateWorkItem(test, TestFilter.Empty, true);
+            work.InitializeContext(context);
+
+            return work;
+        }
+
+        #endregion
+
+        #region Run Tests
 
         public static ITestResult RunTestFixture(Type type)
         {
@@ -141,41 +181,6 @@ namespace NUnit.TestUtilities
         public static ITestResult RunTest(Test test, object testObject)
         {
             return ExecuteWorkItem(CreateWorkItem(test, testObject));
-        }
-
-        public static CompositeWorkItem CreateWorkItem(Type type)
-        {
-            return CreateWorkItem(MakeFixture(type)) as CompositeWorkItem;
-        }
-
-        public static WorkItem CreateWorkItem(Type type, string methodName)
-        {
-            return CreateWorkItem(MakeTestFromMethod(type, methodName));
-        }
-
-        public static WorkItem CreateWorkItem(Test test)
-        {
-            var context = new TestExecutionContext();
-            context.Dispatcher = new SuperSimpleDispatcher();
-
-            return CreateWorkItem(test, context);
-        }
-
-        public static WorkItem CreateWorkItem(Test test, object testObject)
-        {
-            var context = new TestExecutionContext();
-            context.TestObject = testObject;
-            context.Dispatcher = new SuperSimpleDispatcher();
-
-            return CreateWorkItem(test, context);
-        }
-
-        public static WorkItem CreateWorkItem(Test test, TestExecutionContext context)
-        {
-            var work = WorkItemBuilder.CreateWorkItem(test, TestFilter.Empty, true);
-            work.InitializeContext(context);
-
-            return work;
         }
 
         public static ITestResult ExecuteWorkItem(WorkItem work)

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -47,6 +47,10 @@ namespace NUnit.TestUtilities
     public static class TestBuilder
     {
 #region Build Tests
+        public static TestSuite MakeSuite(string name)
+        {
+            return new TestSuite(name);
+        }
 
         public static TestSuite MakeFixture(Type type)
         {
@@ -60,28 +64,6 @@ namespace NUnit.TestUtilities
             return suite;
         }
 
-        public static TestSuite MakeFixture(List<Type> types)
-        {
-            // following the pattern found in DefaultTestAssemblyBuilder
-            var fixtures = new List<Test>();
-            var defaultSuiteBuilder = new DefaultSuiteBuilder();
-            foreach (var type in types)
-            {
-                var typeInfo = new TypeWrapper(type);
-                var test = defaultSuiteBuilder.BuildFrom(typeInfo);
-                fixtures.Add(test);
-            }
-
-            var assembly = AssemblyHelper.Load("nunit.testdata");
-            var assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
-            TestSuite testSuite = new TestAssembly(assembly, assemblyPath);
-
-            var treeBuilder = new NamespaceTreeBuilder(testSuite);
-            treeBuilder.Add(fixtures);
-
-            return treeBuilder.RootSuite;
-        }
-
         public static TestSuite MakeParameterizedMethodSuite(Type type, string methodName)
         {
             var suite = MakeTestFromMethod(type, methodName) as TestSuite;
@@ -89,22 +71,12 @@ namespace NUnit.TestUtilities
             return suite;
         }
 
-        public static TestSuite MakeParameterizedMethodSuite(object fixture, string methodName)
-        {
-            var test = MakeTestFromMethod(fixture.GetType(), methodName) as ParameterizedMethodSuite;
-            Assert.That(test, Is.TypeOf<ParameterizedMethodSuite>());
-
-            TestSuite suite = test as TestSuite;
-            suite.Fixture = fixture;
-            return suite;
-        }
-
         public static TestMethod MakeTestCase(Type type, string methodName)
         {
-            var test = MakeTestFromMethod(type, methodName);
-            Assert.That(test, Is.TypeOf<TestMethod>());
+            var test = MakeTestFromMethod(type, methodName) as TestMethod;
+            Assert.NotNull(test, "Unable to create TestMethod from {0}", methodName);
 
-            return (TestMethod)test;
+            return test;
         }
 
         // Will return either a ParameterizedMethodSuite or an NUnitTestMethod
@@ -161,15 +133,6 @@ namespace NUnit.TestUtilities
             return RunTest(testMethod, fixture);
         }
 
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-        public static ITestResult RunAsTestCase(Action action)
-        {
-            var method = action.Method;
-            var testMethod = MakeTestCase(method.DeclaringType, method.Name);
-            return RunTest(testMethod);
-        }
-#endif
-
         public static ITestResult RunTest(Test test)
         {
             return RunTest(test, null);
@@ -177,18 +140,38 @@ namespace NUnit.TestUtilities
 
         public static ITestResult RunTest(Test test, object testObject)
         {
-            return ExecuteWorkItem(PrepareWorkItem(test, testObject));
+            return ExecuteWorkItem(CreateWorkItem(test, testObject));
         }
 
-        // NOTE: The following two methods are separate in order to support
-        // tests that need to access the WorkItem before or after execution.
+        public static CompositeWorkItem CreateWorkItem(Type type)
+        {
+            return CreateWorkItem(MakeFixture(type)) as CompositeWorkItem;
+        }
 
-        public static WorkItem PrepareWorkItem(Test test, object testObject)
+        public static WorkItem CreateWorkItem(Type type, string methodName)
+        {
+            return CreateWorkItem(MakeTestFromMethod(type, methodName));
+        }
+
+        public static WorkItem CreateWorkItem(Test test)
+        {
+            var context = new TestExecutionContext();
+            context.Dispatcher = new SuperSimpleDispatcher();
+
+            return CreateWorkItem(test, context);
+        }
+
+        public static WorkItem CreateWorkItem(Test test, object testObject)
         {
             var context = new TestExecutionContext();
             context.TestObject = testObject;
             context.Dispatcher = new SuperSimpleDispatcher();
 
+            return CreateWorkItem(test, context);
+        }
+
+        public static WorkItem CreateWorkItem(Test test, TestExecutionContext context)
+        {
             var work = WorkItemBuilder.CreateWorkItem(test, TestFilter.Empty, true);
             work.InitializeContext(context);
 

--- a/src/NUnitFramework/TestSuiteExtensions.cs
+++ b/src/NUnitFramework/TestSuiteExtensions.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework;
 using NUnit.Framework.Internal;
 
 namespace NUnit.TestUtilities
@@ -45,6 +46,20 @@ namespace NUnit.TestUtilities
         {
             foreach (var test in tests)
                 theSuite.Add(test);
+
+            return theSuite;
+        }
+
+        public static TestSuite Parallelizable(this TestSuite theSuite)
+        {
+            theSuite.Properties.Set(PropertyNames.ParallelScope, ParallelScope.Self);
+
+            return theSuite;
+        }
+
+        public static TestSuite NonParallelizable(this TestSuite theSuite)
+        {
+            theSuite.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
 
             return theSuite;
         }

--- a/src/NUnitFramework/TestSuiteExtensions.cs
+++ b/src/NUnitFramework/TestSuiteExtensions.cs
@@ -1,0 +1,52 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Internal;
+
+namespace NUnit.TestUtilities
+{
+    internal static class TestSuiteExtensions
+    {
+        public static TestSuite Containing(this TestSuite theSuite, string name)
+        {
+            return theSuite.Containing(new TestSuite(name));
+        }
+
+        public static TestSuite Containing(this TestSuite theSuite, params Type[] types)
+        {
+            foreach (var type in types)
+                theSuite.Add(TestBuilder.MakeFixture(type));
+
+            return theSuite;
+        }
+
+        public static TestSuite Containing(this TestSuite theSuite, params Test[] tests)
+        {
+            foreach (var test in tests)
+                theSuite.Add(test);
+
+            return theSuite;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -71,10 +71,19 @@ namespace NUnit.Framework
                 return;
 
             if (Scope.HasFlag(ParallelScope.Self) && Scope.HasFlag(ParallelScope.None))
+            {
                 test.MakeInvalid("Test may not be both parallel and non-parallel");
-
-            if (test is TestMethod && Scope.HasFlag(ParallelScope.ContextMask))
-                test.MakeInvalid("ParallelScope of a test method may not specify Children or Fixtures");
+            }
+            else if (Scope.HasFlag(ParallelScope.Fixtures))
+            {
+                if (test is TestMethod || test is ParameterizedMethodSuite)
+                    test.MakeInvalid("May not specify ParallelScope.Fixtures on a test method");
+            }
+            else if (Scope.HasFlag(ParallelScope.Children))
+            {
+                if (test is TestMethod)
+                    test.MakeInvalid("May not specify ParallelScope.Children on a non-parameterized test method");
+            }
         }
 
         #region IApplyToContext Interface

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -23,6 +23,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Compatibility;
 
 namespace NUnit.Framework
 {
@@ -55,6 +57,8 @@ namespace NUnit.Framework
                 if (!IsValidFixtureType(typeInfo, ref reason))
                     fixture.MakeInvalid(reason);
             }
+
+            fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
 
             return new TestSuite[] { fixture };
         }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -127,13 +127,18 @@ namespace NUnit.Framework.Internal.Builders
 
             var fixture = new TestFixture(typeInfo, arguments);
 
-            if (arguments != null && arguments.Length > 0)
+            string name = fixture.Name;
+            if (testFixtureData.TestName != null)
+                fixture.Name = testFixtureData.TestName;
+            else if (arguments != null && arguments.Length > 0)
+                fixture.Name = typeInfo.GetDisplayName(arguments);
+
+            if (fixture.Name != name) // name was changed
             {
-                string name = fixture.Name = typeInfo.GetDisplayName(arguments);
                 string nspace = typeInfo.Namespace;
                 fixture.FullName = nspace != null && nspace != ""
-                    ? nspace + "." + name
-                    : name;
+                    ? nspace + "." + fixture.Name
+                    : fixture.Name;
             }
 
             if (fixture.RunState != RunState.NotRunnable)

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -50,6 +50,16 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public List<WorkItem> Children { get; } = new List<WorkItem>();
 
+#if PARALLEL
+        /// <summary>
+        /// Indicates whether this work item should use a separate dispatcher.
+        /// </summary>
+        public override bool IsolateChildTests
+        {
+            get { return ExecutionStrategy == ParallelExecutionStrategy.NonParallel && Context.Dispatcher.LevelOfParallelism > 0; }
+        }
+#endif
+
         private CountdownEvent _childTestCountdown;
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
@@ -29,6 +29,11 @@ namespace NUnit.Framework.Internal.Execution
     public interface IWorkItemDispatcher
     {
         /// <summary>
+        /// The level of parallelism supported. Zero if not supported.
+        /// </summary>
+        int LevelOfParallelism { get; }
+
+        /// <summary>
         /// Start execution, performing any initialization. Sets
         /// the top level work item and dispatches it.
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -284,41 +284,12 @@ namespace NUnit.Framework.Internal.Execution
 
             WorkShift nextShift = null;
 
-#if false
-            // Shift has ended but all work may not yet be done
-            while (_topLevelWorkItem.State != WorkItemState.Complete)
-            {
-                // This will return if all queues are empty.
-                nextShift = SelectNextShift();
-                if (nextShift != null)
-                    break;
-
-                // If the shift has ended for an isolated queue and there
-                // is no more work, we restore the queues and keep trying.
-                if (_isolationLevel > 0)
-                    RestoreQueues();
-
-                // We are at level zero - just continue to wait
-            }
-
-            // If we have a shift to start, do it
-            if (nextShift != null)
-            {
-                ShiftStarting?.Invoke(nextShift);
-                nextShift.Start();
-            }
-            else // otherwise, shutdown.
-            {
-                foreach (var shift in Shifts)
-                    shift.ShutDown();
-            }
-#else
             while (true)
             {
                 // Shift has ended but all work may not yet be done
                 while (_topLevelWorkItem.State != WorkItemState.Complete)
                 {
-                    // This will return if all queues are empty.
+                    // This will return null if all queues are empty.
                     nextShift = SelectNextShift();
                     if (nextShift != null)
                     {
@@ -339,7 +310,6 @@ namespace NUnit.Framework.Internal.Execution
             // All done - shutdown all shifts
             foreach (var shift in Shifts)
                 shift.ShutDown();
-#endif
         }
 
         private WorkShift SelectNextShift()

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -167,16 +167,22 @@ namespace NUnit.Framework.Internal.Execution
         {
             _topLevelWorkItem = topLevelWorkItem;
 
-            var strategy = topLevelWorkItem.ParallelScope.HasFlag(ParallelScope.None)
-                ? ParallelExecutionStrategy.NonParallel
-                : ParallelExecutionStrategy.Parallel;
-
-            Dispatch(topLevelWorkItem, strategy);
+            Dispatch(topLevelWorkItem, InitialExecutionStrategy(topLevelWorkItem));
 
             var shift = SelectNextShift();
 
             ShiftStarting?.Invoke(shift);
             shift.Start();
+        }
+
+        // Initial strategy for the top level item is solely determined
+        // by the ParallelScope of that item. While other approaches are
+        // possible, this one gives the user a predictable result.
+        private static ParallelExecutionStrategy InitialExecutionStrategy(WorkItem workItem)
+        {
+            return workItem.ParallelScope == ParallelScope.Default || workItem.ParallelScope == ParallelScope.None
+                ? ParallelExecutionStrategy.NonParallel
+                : ParallelExecutionStrategy.Parallel;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -43,12 +43,6 @@ namespace NUnit.Framework.Internal.Execution
         #region Events
         
         /// <summary>
-        /// Handler for ShiftChange events.
-        /// </summary>
-        /// <param name="shift">The shift that is starting or ending.</param>
-        public delegate void ShiftChangeEventHandler(WorkShift shift);
-
-        /// <summary>
         /// Event raised whenever a shift is starting.
         /// </summary>
         public event ShiftChangeEventHandler ShiftStarting;
@@ -274,9 +268,9 @@ namespace NUnit.Framework.Internal.Execution
 
         #region Helper Methods
 
-        private void OnEndOfShift(object sender, EventArgs ea)
+        private void OnEndOfShift(WorkShift endingShift)
         {
-            ShiftFinished?.Invoke(sender as WorkShift);
+            ShiftFinished?.Invoke(endingShift);
 
             WorkShift nextShift = null;
 

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -46,6 +46,11 @@ namespace NUnit.Framework.Internal.Execution
         #region IWorkItemDispatcher Members
 
         /// <summary>
+        ///  The level of parallelism supported
+        /// </summary>
+        public int LevelOfParallelism { get { return 0; } }
+
+        /// <summary>
         /// Start execution, creating the execution thread,
         /// setting the top level work  and dispatching it.
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -126,6 +126,9 @@ namespace NUnit.Framework.Internal.Execution
                     // This gives us a new set of queues, which are initially 
                     // empty. The intention is that only children of the current
                     // executing item should make use of the new set of queues.
+                    // TODO: If we had a separate NonParallelTestWOrker, it 
+                    // could simply create the isolated queue without  any
+                    // worrying about competing workers.
                     Busy(this, _currentWorkItem);
 
                     // Because we execute the current item AFTER the queue state

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -122,10 +122,19 @@ namespace NUnit.Framework.Internal.Execution
 
                     _currentWorkItem.TestWorker = this;
 
+                    // During this Busy call, the queue state may be saved.
+                    // This gives us a new set of queues, which are initially 
+                    // empty. The intention is that only children of the current
+                    // executing item should make use of the new set of queues.
                     Busy(this, _currentWorkItem);
 
+                    // Because we execute the current item AFTER the queue state
+                    // is saved, it's children end up in the new queue set.
                     _currentWorkItem.Execute();
 
+                    // This call may result in the queues being restored. There
+                    // is a potential race condition here. We should not restore
+                    // the queues unless all child items have finished.
                     Idle(this, _currentWorkItem);
 
                     ++_workItemCount;
@@ -138,15 +147,15 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         /// <summary>
-        /// Start processing work items.
+        /// Create thread and start processing work items.
         /// </summary>
         public void Start()
         {
-            log.Info("{0} starting ", Name);
-
             _workerThread = new Thread(new ThreadStart(TestWorkerThreadProc));
             _workerThread.Name = Name;
             _workerThread.SetApartmentState(WorkQueue.TargetApartment);
+
+            log.Info("{0} starting on thread [{1}]", Name, _workerThread.ManagedThreadId);
             _workerThread.Start();
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Internal.Execution
                     Busy(this, _currentWorkItem);
 
                     // Because we execute the current item AFTER the queue state
-                    // is saved, it's children end up in the new queue set.
+                    // is saved, its children end up in the new queue set.
                     _currentWorkItem.Execute();
 
                     // This call may result in the queues being restored. There

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -324,15 +324,6 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Standard Dispose implementation
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
             if (_completionEvent != null)
 #if NET_2_0 || NET_3_5
                 _completionEvent.Close();

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -339,6 +339,11 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         internal void Restore()
         {
+            // TODO: Originally, the following Guard statement was used. In theory, no queues should be running
+            // when we are doing a restore. It appears, however, that we end the shift, pausing queues, buy that
+            // a thread may then sneak in and restart some of them. My tests pass without the guard but I'm still
+            // concerned to understand what is happening and why. I'm leaving this commented out so that somebody
+            // else can take a look at it later on.
             //Guard.OperationValid(State != WorkItemQueueState.Running, $"Attempted to restore state of {Name} while queue was running.");
 
             var savedQueues = _savedState.Pop().InnerQueues;

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -339,14 +339,60 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         internal void Restore()
         {
-            Pause();
+            //Guard.OperationValid(State != WorkItemQueueState.Running, $"Attempted to restore state of {Name} while queue was running.");
 
-            _innerQueues = _savedState.Pop().InnerQueues;
+            var savedQueues = _savedState.Pop().InnerQueues;
 
-            Start();
+            // If there are any queued items, copy to the next lower level
+            for (int i = 0; i < PRIORITY_LEVELS; i++)
+            {
+                WorkItem work;
+                while (_innerQueues[i].TryDequeue(out work))
+                    savedQueues[i].Enqueue(work);
+            }
+
+            _innerQueues = savedQueues;
         }
 
-        #endregion
+#endregion
+
+#region Internal Methods for Testing
+
+        internal string DumpContents()
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"Contents of {Name} at isolation level {_savedState.Count}");
+
+            if (IsEmpty)
+                sb.AppendLine("  <empty>");
+            else
+                for (int priority = 0; priority < PRIORITY_LEVELS; priority++)
+                {
+                    foreach (WorkItem work in _innerQueues[priority])
+                        sb.AppendLine($"pri-{priority}: {work.Name}");
+                }
+
+            int level = 0;
+            foreach (var state in _savedState)
+            {
+                sb.AppendLine($"Saved State {level++}");
+                bool isEmpty = true;
+                for (int priority = 0; priority < PRIORITY_LEVELS; priority++)
+                {
+                    foreach (WorkItem work in state.InnerQueues[priority])
+                    {
+                        sb.AppendLine($"pri-{priority}: {work.Name}");
+                        isEmpty = false;
+                    }
+                }
+                if (isEmpty)
+                    sb.AppendLine("  <empty>");
+            }
+
+            return sb.ToString();
+        }
+
+#endregion
     }
 
 #if NET_2_0 || NET_3_5

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -161,11 +161,11 @@ namespace NUnit.Framework.Internal.Execution
                 worker.Idle += (s, ea) =>
                 {
                     // Quick check first using Interlocked.Decrement
-                    if (Interlocked.Decrement(ref _busyCount) == 0)
+                    if (Interlocked.Decrement(ref _busyCount) == 0 && !HasWork)
                         lock (_syncRoot)
                         {
-                            // Check busy count again under the lock. If there is no work
-                            // try to restore any saved queues and end the shift.
+                            // Check again under the lock. If there is no work
+                            // we can end the shift.
                             if (_busyCount == 0 && !HasWork)
                             {
                                 EndShift();

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -57,8 +57,6 @@ namespace NUnit.Framework.Internal.Execution
         {
             Name = name;
             IsActive = false;
-            Queues = new List<WorkItemQueue>();
-            Workers = new List<TestWorker>();
         }
 
         #region Public Events and Properties
@@ -78,16 +76,21 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public bool IsActive { get; private set; }
 
+        #endregion
+
+        #region Internal Properties
+
         /// <summary>
         /// Gets a list of the queues associated with this shift.
         /// </summary>
-        /// <remarks>Used for testing</remarks>
-        public IList<WorkItemQueue> Queues { get; }
+        /// <remarks>Internal for testing - immutable once initialized</remarks>
+        internal IList<WorkItemQueue> Queues { get; } = new List<WorkItemQueue>();
 
         /// <summary>
         /// Gets the list of workers associated with this shift.
         /// </summary>
-        public IList<TestWorker> Workers { get; }
+        /// <remarks>Internal for testing - immutable once initialized</remarks>
+        internal IList<TestWorker> Workers { get; } = new List<TestWorker>();
 
         /// <summary>
         /// Gets a bool indicating whether this shift has any work to do

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -162,6 +162,7 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     // Quick check first using Interlocked.Decrement
                     if (Interlocked.Decrement(ref _busyCount) == 0 && !HasWork)
+                    {
                         lock (_syncRoot)
                         {
                             // Check again under the lock. If there is no work
@@ -171,6 +172,7 @@ namespace NUnit.Framework.Internal.Execution
                                 EndShift();
                             }
                         }
+                    }
                 };
 
                 worker.Start();

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -82,10 +82,20 @@ namespace NUnit.Framework
         #region Fluent Instance Modifiers
 
         /// <summary>
+        /// Sets the name of the test fixture
+        /// </summary>
+        /// <returns>The modified TestFixtureData instance</returns>
+        public TestFixtureData SetName(string name)
+        {
+            TestName = name;
+            return this;
+        }
+
+        /// <summary>
         /// Marks the test fixture as explicit.
         /// </summary>
         public TestFixtureData Explicit()	{
-            this.RunState = RunState.Explicit;
+            RunState = RunState.Explicit;
             return this;
         }
 
@@ -94,8 +104,8 @@ namespace NUnit.Framework
         /// </summary>
         public TestFixtureData Explicit(string reason)
         {
-            this.RunState = RunState.Explicit;
-            this.Properties.Set(PropertyNames.SkipReason, reason);
+            RunState = RunState.Explicit;
+            Properties.Set(PropertyNames.SkipReason, reason);
             return this;
         }
 
@@ -106,8 +116,8 @@ namespace NUnit.Framework
         /// <returns></returns>
         public TestFixtureData Ignore(string reason)
         {
-            this.RunState = RunState.Ignored;
-            this.Properties.Set(PropertyNames.SkipReason, reason);
+            RunState = RunState.Ignored;
+            Properties.Set(PropertyNames.SkipReason, reason);
             return this;
         }
 

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -1,0 +1,79 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if PARALLEL
+using System.Threading;
+using NUnit.Framework;
+
+namespace NUnit.TestData.ParallelExecutionData
+{
+    [SetUpFixture, Parallelizable]
+    public class TestSetUpFixture
+    {
+        [OneTimeSetUpAttribute]
+        public void RunOneTimeSetUp()
+        {
+            TestContext.Progress.Write("OneTimeSetUp running on " + TestContext.CurrentContext.WorkerId);
+        }
+
+        [OneTimeTearDown]
+        public void RunOneTimeTearDown()
+        {
+            TestContext.Progress.Write("OneTimeTearDown running on " + TestContext.CurrentContext.WorkerId);
+        }
+    }
+
+    [Parallelizable]
+    public class TestFixture1
+    {
+        [Test]
+        public void TestFixture1_Test()
+        {
+            TestContext.Progress.WriteLine("Test1 running on " + TestContext.CurrentContext.WorkerId);
+            Thread.Sleep(1000);
+        }
+    }
+
+    [NonParallelizable]
+    public class TestFixture2
+    {
+        [Test]
+        public void TestFixture2_Test()
+        {
+            TestContext.Progress.WriteLine("Test2 running on " + TestContext.CurrentContext.WorkerId);
+            Thread.Sleep(1000);
+        }
+    }
+
+    [Parallelizable]
+    public class TestFixture3
+    {
+        [Test]
+        public void TestFixture3_Test()
+        {
+            TestContext.Progress.WriteLine("Test3 running on " + TestContext.CurrentContext.WorkerId);
+            Thread.Sleep(1000);
+        }
+    }
+}
+#endif

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -33,14 +33,12 @@ namespace NUnit.TestData.ParallelExecutionData
         [OneTimeSetUpAttribute]
         public void RunOneTimeSetUp()
         {
-            TestContext.Progress.Write("OneTimeSetUp running on " + TestContext.CurrentContext.WorkerId);
             Thread.Sleep(1000);
         }
 
         [OneTimeTearDown]
         public void RunOneTimeTearDown()
         {
-            TestContext.Progress.Write("OneTimeTearDown running on " + TestContext.CurrentContext.WorkerId);
             Thread.Sleep(1000);
         }
     }
@@ -50,7 +48,6 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture1_Test()
         {
-            TestContext.Progress.WriteLine("Test1 running on " + TestContext.CurrentContext.WorkerId);
             Thread.Sleep(1000);
         }
     }
@@ -60,7 +57,6 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture2_Test()
         {
-            TestContext.Progress.WriteLine("Test2 running on " + TestContext.CurrentContext.WorkerId);
             Thread.Sleep(1000);
         }
     }
@@ -70,7 +66,6 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture3_Test()
         {
-            TestContext.Progress.WriteLine("Test3 running on " + TestContext.CurrentContext.WorkerId);
             Thread.Sleep(1000);
         }
     }

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -34,12 +34,14 @@ namespace NUnit.TestData.ParallelExecutionData
         public void RunOneTimeSetUp()
         {
             TestContext.Progress.Write("OneTimeSetUp running on " + TestContext.CurrentContext.WorkerId);
+            Thread.Sleep(1000);
         }
 
         [OneTimeTearDown]
         public void RunOneTimeTearDown()
         {
             TestContext.Progress.Write("OneTimeTearDown running on " + TestContext.CurrentContext.WorkerId);
+            Thread.Sleep(1000);
         }
     }
 

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -28,18 +28,34 @@ using NUnit.Framework;
 namespace NUnit.TestData.ParallelExecutionData
 {
     [SetUpFixture]
-    public class TestSetUpFixture
+    public class SetUpFixture1
     {
         [OneTimeSetUpAttribute]
         public void RunOneTimeSetUp()
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(100);
         }
 
         [OneTimeTearDown]
         public void RunOneTimeTearDown()
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(100);
+        }
+    }
+
+    [SetUpFixture]
+    public class SetUpFixture2
+    {
+        [OneTimeSetUpAttribute]
+        public void RunOneTimeSetUp()
+        {
+            Thread.Sleep(100);
+        }
+
+        [OneTimeTearDown]
+        public void RunOneTimeTearDown()
+        {
+            Thread.Sleep(100);
         }
     }
 
@@ -48,7 +64,7 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture1_Test()
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(100);
         }
     }
 
@@ -57,7 +73,7 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture2_Test()
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(100);
         }
     }
 
@@ -66,7 +82,19 @@ namespace NUnit.TestData.ParallelExecutionData
         [Test]
         public void TestFixture3_Test()
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(100);
+        }
+    }
+
+    public class TestFixtureWithParallelParameterizedTest
+    {
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [Parallelizable(ParallelScope.Children)]
+        public void ParameterizedTest(int i)
+        {
+            Thread.Sleep(100);
         }
     }
 }

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -86,6 +86,16 @@ namespace NUnit.TestData.ParallelExecutionData
         }
     }
 
+    [Apartment(ApartmentState.STA)]
+    public class STAFixture
+    {
+        [Test]
+        public void STAFixture_Test()
+        {
+            Thread.Sleep(100);
+        }
+    }
+
     public class TestFixtureWithParallelParameterizedTest
     {
         [TestCase(1)]

--- a/src/NUnitFramework/testdata/ParallelExecutionData.cs
+++ b/src/NUnitFramework/testdata/ParallelExecutionData.cs
@@ -27,7 +27,7 @@ using NUnit.Framework;
 
 namespace NUnit.TestData.ParallelExecutionData
 {
-    [SetUpFixture, Parallelizable]
+    [SetUpFixture]
     public class TestSetUpFixture
     {
         [OneTimeSetUpAttribute]
@@ -45,7 +45,6 @@ namespace NUnit.TestData.ParallelExecutionData
         }
     }
 
-    [Parallelizable]
     public class TestFixture1
     {
         [Test]
@@ -56,7 +55,6 @@ namespace NUnit.TestData.ParallelExecutionData
         }
     }
 
-    [NonParallelizable]
     public class TestFixture2
     {
         [Test]
@@ -67,7 +65,6 @@ namespace NUnit.TestData.ParallelExecutionData
         }
     }
 
-    [Parallelizable]
     public class TestFixture3
     {
         [Test]

--- a/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-2.0.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-2.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-2.0\</OutputPath>
-    <DefineConstants>TRACE;NET_2_0</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -56,6 +56,7 @@
     </Compile>
     <Compile Include="ActionAttributeFixture.cs" />
     <Compile Include="AssertMultipleData.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="TestAttachmentsTests.cs" />
     <Compile Include="WarningFixture.cs" />
     <Compile Include="AsyncDummyFixture.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-3.5.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -58,6 +58,7 @@
     <Compile Include="AssertMultipleData.cs" />
     <Compile Include="AsyncDummyFixture.cs" />
     <Compile Include="AsyncRealFixture.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="RepeatingTestsFixtureBase.cs" />
     <Compile Include="RetryFixture.cs" />
     <Compile Include="GenericTestMethodData.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.0.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0;ASYNC;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0;ASYNC;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -92,6 +92,7 @@
     <Compile Include="MaxTimeFixture.cs" />
     <Compile Include="OneTimeSetUpTearDownData.cs" />
     <Compile Include="OptionalTestParametersFixture.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="ParameterizedTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyAttributeTests.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-4.5.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5;ASYNC;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5;ASYNC;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -75,6 +75,7 @@
     <Compile Include="MaxTimeFixture.cs" />
     <Compile Include="OneTimeSetUpTearDownData.cs" />
     <Compile Include="OptionalTestParametersFixture.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="ParameterizedTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyAttributeTests.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard13.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard13.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MaxTimeFixture.cs" />
     <Compile Include="OneTimeSetUpTearDownData.cs" />
     <Compile Include="OptionalTestParametersFixture.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="ParameterizedTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyAttributeTests.cs" />

--- a/src/NUnitFramework/testdata/nunit.testdata-netstandard16.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata-netstandard16.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MaxTimeFixture.cs" />
     <Compile Include="OneTimeSetUpTearDownData.cs" />
     <Compile Include="OptionalTestParametersFixture.cs" />
+    <Compile Include="ParallelExecutionData.cs" />
     <Compile Include="ParameterizedTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyAttributeTests.cs" />

--- a/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
@@ -21,7 +21,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
@@ -89,6 +91,56 @@ namespace NUnit.Framework.Attributes
             ParallelScope.Self | ParallelScope.Fixtures
         };
 
+        [Test]
+        public void MayNotCombineParallelScopeSelfAndParallelScopeNone()
+        {
+            var fixture = new TestFixture(new TypeWrapper(typeof(FixtureClass)));
+            var attr = new ParallelizableAttribute(ParallelScope.Self | ParallelScope.None);
+            attr.ApplyToTest(fixture);
+            Assert.That(fixture.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public void MayNotUseParallelScopeFixturesOnTestMethod()
+        {
+            var test = TestBuilder.MakeTestCase(GetType(), "DummyMethod");
+            var attr = new ParallelizableAttribute(ParallelScope.Fixtures);
+            attr.ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public void MayNotUseParallelScopeFixturesOnParameterizedTestMethod()
+        {
+            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "DummyTestCase");
+            var attr = new ParallelizableAttribute(ParallelScope.Fixtures);
+            attr.ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public void MayNotUseParallelScopeChildrenOnTestMethod()
+        {
+            var test = TestBuilder.MakeTestCase(GetType(), "DummyMethod");
+            var attr = new ParallelizableAttribute(ParallelScope.Children);
+            attr.ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public void OkTotUseParallelScopeChildrenOnParameterizedTestMethod()
+        {
+            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "DummyTestCase");
+            var attr = new ParallelizableAttribute(ParallelScope.Children);
+            attr.ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
         public class FixtureClass { }
+
+        public void DummyMethod() { }
+
+        [TestCase(1)]
+        public void DummyTestCase(int i) { }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleIntRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleIntRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -166,7 +166,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UnsignedIntRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleUnsignedIntRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleUnsignedIntRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -244,7 +244,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleLongRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleLongRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -306,7 +306,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UnsignedLongRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleUnsignedLongRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleUnsignedLongRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -360,7 +360,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleDoubleRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleDoubleRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -414,7 +414,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(this, "MethodWithMultipleFloatRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleFloatRange");
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -31,6 +31,32 @@ namespace NUnit.Framework.Attributes
 {
     public class SetUpFixtureAttributeTests
     {
+        [Test]
+        public void SetUpFixtureCanBeIgnored()
+        {
+            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeWrapper(typeof(IgnoredSetUpFixture)));
+            foreach (var fixture in fixtures)
+                Assert.That(fixture.RunState, Is.EqualTo(RunState.Ignored));
+        }
+
+        [Ignore("Just Because")]
+        private class IgnoredSetUpFixture
+        {
+        }
+
+        [Test]
+        public void SetUpFixtureMayBeParallelizable()
+        {
+            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeWrapper(typeof(ParallelizableSetUpFixture)));
+            foreach (var fixture in fixtures)
+                Assert.That(fixture.Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.Self));
+        }
+
+        [Parallelizable]
+        private class ParallelizableSetUpFixture
+        {
+        }
+
         [TestCase(typeof(TestSetupClass))]
         [TestCase(typeof(TestTearDownClass))]
         public void CertainAttributesAreNotAllowed(Type type)

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CheckOrderIsCorrect()
         {
-            var work = TestBuilder.CreateWorkItem(typeof(TestCaseOrderAttributeFixture));
+            var work = (CompositeWorkItem)TestBuilder.CreateWorkItem(typeof(TestCaseOrderAttributeFixture));
 
             // This triggers sorting
             TestBuilder.ExecuteWorkItem(work);

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -13,8 +13,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CheckOrderIsCorrect()
         {
-            var fixture = TestBuilder.MakeFixture(typeof (TestCaseOrderAttributeFixture));
-            var work = TestBuilder.PrepareWorkItem(fixture, null) as CompositeWorkItem;
+            var work = TestBuilder.CreateWorkItem(typeof(TestCaseOrderAttributeFixture));
 
             // This triggers sorting
             TestBuilder.ExecuteWorkItem(work);
@@ -27,18 +26,15 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         [TestCaseSource(nameof(Cases))]
-        public void CheckClassOrderIsCorrect(List<Type> candidateTypes)
+        public void CheckClassOrderIsCorrect(Type[] candidateTypes)
         {
-            var testSuite = TestBuilder.MakeFixture(candidateTypes);
+            var testSuite = new TestSuite("dummy").Containing(candidateTypes);
 
-            var work = TestBuilder.PrepareWorkItem(testSuite, null) as CompositeWorkItem;
+            var work = TestBuilder.CreateWorkItem(testSuite) as CompositeWorkItem;
 
-            var fixtureWorkItems = 
-                ((work.Children[0] as CompositeWorkItem)
-                .Children[0] as CompositeWorkItem)
-                .Children;
+            var fixtureWorkItems = work.Children;
 
-            Assert.AreEqual(candidateTypes.Count, fixtureWorkItems.Count);
+            Assert.AreEqual(candidateTypes.Length, fixtureWorkItems.Count);
             for (var i = 1; i < fixtureWorkItems.Count; i++)
             {
                 var previousTestOrder = GetOrderAttributeValue(fixtureWorkItems[i - 1]);
@@ -56,17 +52,17 @@ namespace NUnit.Framework.Attributes
 
         private static readonly object[] Cases =
         {
-            new List<Type>
+            new Type[]
             {
                 typeof(TestCaseOrderAttributeFixture),
                 typeof(ThirdTestCaseOrderAttributeFixture)
             },
-            new List<Type>
+            new Type[]
             {
                 typeof(TestCaseOrderAttributeFixture),
                 typeof(AnotherTestCaseOrderAttributeFixture)
             },
-            new List<Type>
+            new Type[]
             {
                 typeof(TestCaseOrderAttributeFixture),
                 typeof(AnotherTestCaseOrderAttributeFixture),

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -167,7 +167,6 @@ namespace NUnit.Framework.Attributes
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Is.EqualTo("Test exceeded Timeout value of 500ms"));
-            Assert.That(result.Duration, Is.EqualTo(0.5).Within(0.2));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -71,11 +71,8 @@ namespace NUnit.Framework.Internal.Execution
 
             var workItem = TestBuilder.CreateWorkItem(_testSuite, context);
 
-            var run_complete = new ManualResetEvent(false);
-            workItem.Completed += (s, e) => { run_complete.Set(); };
-
             dispatcher.Start(workItem);
-            run_complete.WaitOne(Timeout.Infinite);
+            workItem.WaitForCompletion();
 
             _result = workItem.Result;
         }
@@ -129,6 +126,11 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
+        [Test]
+        public void ListEvents()
+        {
+            Console.WriteLine(DumpEvents("Events Received:"));
+        }
         #region Test Data
 
         static IEnumerable<TestFixtureData> GetParallelSuites()

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -403,6 +403,24 @@ namespace NUnit.Framework.Internal.Execution
                     That("TestFixture3").RunsOn("ParallelWorker"),
                     That("TestFixture3_Test").RunsOn("ParallelWorker")))
                 .SetName("ThreeFixtures_TwoSetUpFixturesInSameNamespace_SecondOneParallelizable");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("SomeNamespace")
+                        .Containing(Fixture(typeof(SetUpFixture1)))
+                            .Containing(Fixture(typeof(TestFixture1))))
+                    .Containing(Suite("OtherNamespace")
+                        .Containing(Fixture(typeof(TestFixture2)))),
+                Expecting(
+                    That("fake-assembly.dll").RunsOn("NonParallelWorker"),
+                    That("SomeNamespace").RunsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("NonParallelWorker"), // SetUpFixture1
+                    That("TestFixture1").RunsOn("NonParallelWorker"),
+                    That("TestFixture1_Test").RunsOn("NonParallelWorker"),
+                    That("OtherNamespace").RunsOn("NonParallelWorker"),
+                    That("TestFixture2").RunsOn("NonParallelWorker"),
+                    That("TestFixture2_Test").RunsOn("NonParallelWorker")))
+                .SetName("Issue-2464");
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -421,6 +421,15 @@ namespace NUnit.Framework.Internal.Execution
                     That("TestFixture2").RunsOn("NonParallelWorker"),
                     That("TestFixture2_Test").RunsOn("NonParallelWorker")))
                 .SetName("Issue-2464");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll").Parallelizable()
+                    .Containing(Fixture(typeof(STAFixture)).Parallelizable()),
+                Expecting(
+                    That("fake-assembly.dll").StartsOn("ParallelWorker"),
+                    That("STAFixture").RunsOn("ParallelSTAWorker"),
+                    That("STAFixture_Test").RunsOn("ParallelSTAWorker")))
+                .SetName("Issue-2467");
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -233,8 +233,24 @@ namespace NUnit.Framework.Internal.Execution
             yield return new TestFixtureData(
                 Suite("fake-assembly.dll")
                     .Containing(Suite("NUnit")
+                        .Containing(Suite("Tests")
+                            .Containing(Fixture(typeof(TestFixtureWithParallelParameterizedTest))))),
+                Expecting(
+                    That("fake-assembly.dll").RunsOn("NonParallelWorker"),
+                    That("NUnit").RunsOn("NonParallelWorker"),
+                    That("Tests").RunsOn("NonParallelWorker"),
+                    That("TestFixtureWithParallelParameterizedTest").RunsOn("NonParallelWorker"),
+                    That("ParameterizedTest").StartsOn("NonParallelWorker").FinishesOn("ParallelWorker"),
+                    That("ParameterizedTest(1)").RunsOn("ParallelWorker"),
+                    That("ParameterizedTest(2)").RunsOn("ParallelWorker"),
+                    That("ParameterizedTest(3)").RunsOn("ParallelWorker")))
+                .SetName("SingleFixture_ParameterizedTest");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("NUnit")
                         .Containing(Suite("TestData")
-                            .Containing(Fixture(typeof(TestSetUpFixture))
+                            .Containing(Fixture(typeof(SetUpFixture1))
                                 .Containing(
                                     Fixture(typeof(TestFixture1)),
                                     Fixture(typeof(TestFixture2)),
@@ -243,7 +259,7 @@ namespace NUnit.Framework.Internal.Execution
                     That("fake-assembly.dll").RunsOn("NonParallelWorker"),
                     That("NUnit").RunsOn("NonParallelWorker"),
                     That("TestData").RunsOn("NonParallelWorker"),
-                    That("ParallelExecutionData").RunsOn("NonParallelWorker"), // TestSetUpFixture
+                    That("ParallelExecutionData").RunsOn("NonParallelWorker"), // SetUpFixture1
                     That("TestFixture1").RunsOn("NonParallelWorker"),
                     That("TestFixture1_Test").RunsOn("NonParallelWorker"),
                     That("TestFixture2").RunsOn("NonParallelWorker"),
@@ -256,7 +272,7 @@ namespace NUnit.Framework.Internal.Execution
                 Suite("fake-assembly.dll")
                     .Containing(Suite("NUnit")
                         .Containing(Suite("TestData")
-                            .Containing(Fixture(typeof(TestSetUpFixture))
+                            .Containing(Fixture(typeof(SetUpFixture1))
                                 .Containing(
                                     Fixture(typeof(TestFixture1)).Parallelizable(),
                                     Fixture(typeof(TestFixture2)),
@@ -265,7 +281,7 @@ namespace NUnit.Framework.Internal.Execution
                     That("fake-assembly.dll").RunsOn("NonParallelWorker"),
                     That("NUnit").RunsOn("NonParallelWorker"),
                     That("TestData").RunsOn("NonParallelWorker"),
-                    That("ParallelExecutionData").RunsOn("NonParallelWorker"), // TestSetUpFixture
+                    That("ParallelExecutionData").RunsOn("NonParallelWorker"), // SetUpFixture1
                     That("TestFixture1").RunsOn("ParallelWorker"),
                     That("TestFixture1_Test").RunsOn("ParallelWorker"),
                     That("TestFixture2").RunsOn("NonParallelWorker"),
@@ -278,16 +294,16 @@ namespace NUnit.Framework.Internal.Execution
                 Suite("fake-assembly.dll")
                     .Containing(Suite("NUnit")
                         .Containing(Suite("TestData")
-                            .Containing(Fixture(typeof(TestSetUpFixture)).Parallelizable()
+                            .Containing(Fixture(typeof(SetUpFixture1)).Parallelizable()
                                 .Containing(
                                     Fixture(typeof(TestFixture1)).Parallelizable(),
                                     Fixture(typeof(TestFixture2)),
                                     Fixture(typeof(TestFixture3)).Parallelizable())))),
                 Expecting(
-                    That("fake-assembly.dll").StartsOn("NonParallelWorker").FinishesOn("ParallelWorker"),
-                    That("NUnit").StartsOn("NonParallelWorker").FinishesOn("ParallelWorker"),
-                    That("TestData").StartsOn("NonParallelWorker").FinishesOn("ParallelWorker"),
-                    That("ParallelExecutionData").RunsOn("ParallelWorker"), // TestSetUpFixture
+                    That("fake-assembly.dll").StartsOn("NonParallelWorker"),
+                    That("NUnit").StartsOn("NonParallelWorker"),
+                    That("TestData").StartsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("ParallelWorker"), // SetUpFixture1
                     That("TestFixture1").RunsOn("ParallelWorker"),
                     That("TestFixture1_Test").RunsOn("ParallelWorker"),
                     That("TestFixture2").RunsOn("NonParallelWorker"),
@@ -295,6 +311,98 @@ namespace NUnit.Framework.Internal.Execution
                     That("TestFixture3").RunsOn("ParallelWorker"),
                     That("TestFixture3_Test").RunsOn("ParallelWorker")))
                 .SetName("ThreeFixtures_TwoParallelizable_ParallelizableSetUpFixture");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("NUnit")
+                        .Containing(Suite("TestData")
+                            .Containing(Fixture(typeof(SetUpFixture1)).Parallelizable()
+                                .Containing(Fixture(typeof(SetUpFixture2)).Parallelizable()
+                                    .Containing(
+                                        Fixture(typeof(TestFixture1)).Parallelizable(),
+                                        Fixture(typeof(TestFixture2)),
+                                        Fixture(typeof(TestFixture3)).Parallelizable()))))),
+                Expecting(
+                    That("fake-assembly.dll").StartsOn("NonParallelWorker"),
+                    That("NUnit").StartsOn("NonParallelWorker"),
+                    That("TestData").StartsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("ParallelWorker"), // SetUpFixture1 && SetUpFixture2
+                    That("TestFixture1").RunsOn("ParallelWorker"),
+                    That("TestFixture1_Test").RunsOn("ParallelWorker"),
+                    That("TestFixture2").RunsOn("NonParallelWorker"),
+                    That("TestFixture2_Test").RunsOn("NonParallelWorker"),
+                    That("TestFixture3").RunsOn("ParallelWorker"),
+                    That("TestFixture3_Test").RunsOn("ParallelWorker")))
+                .SetName("ThreeFixtures_TwoSetUpFixturesInSameNamespace_BothParallelizable");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("NUnit")
+                        .Containing(Suite("TestData")
+                            .Containing(Fixture(typeof(SetUpFixture1))
+                                .Containing(Fixture(typeof(SetUpFixture2))
+                                    .Containing(
+                                        Fixture(typeof(TestFixture1)).Parallelizable(),
+                                        Fixture(typeof(TestFixture2)),
+                                        Fixture(typeof(TestFixture3)).Parallelizable()))))),
+                Expecting(
+                    That("fake-assembly.dll").RunsOn("NonParallelWorker"),
+                    That("NUnit").RunsOn("NonParallelWorker"),
+                    That("TestData").RunsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("*"), // SetUpFixture1 && SetUpFixture2
+                    That("TestFixture1").RunsOn("ParallelWorker"),
+                    That("TestFixture1_Test").RunsOn("ParallelWorker"),
+                    That("TestFixture2").RunsOn("NonParallelWorker"),
+                    That("TestFixture2_Test").RunsOn("NonParallelWorker"),
+                    That("TestFixture3").RunsOn("ParallelWorker"),
+                    That("TestFixture3_Test").RunsOn("ParallelWorker")))
+                .SetName("ThreeFixtures_TwoSetUpFixturesInSameNamespace_NeitherParallelizable");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("NUnit")
+                        .Containing(Suite("TestData")
+                            .Containing(Fixture(typeof(SetUpFixture1)).Parallelizable()
+                                .Containing(Fixture(typeof(SetUpFixture2))
+                                    .Containing(
+                                        Fixture(typeof(TestFixture1)).Parallelizable(),
+                                        Fixture(typeof(TestFixture2)),
+                                        Fixture(typeof(TestFixture3)).Parallelizable()))))),
+                Expecting(
+                    That("fake-assembly.dll").StartsOn("NonParallelWorker"),
+                    That("NUnit").StartsOn("NonParallelWorker"),
+                    That("TestData").StartsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("*"), // SetUpFixture1 && SetUpFixture2 (we can't distinguish the two)
+                    That("TestFixture1").RunsOn("ParallelWorker"),
+                    That("TestFixture1_Test").RunsOn("ParallelWorker"),
+                    That("TestFixture2").RunsOn("NonParallelWorker"),
+                    That("TestFixture2_Test").RunsOn("NonParallelWorker"),
+                    That("TestFixture3").RunsOn("ParallelWorker"),
+                    That("TestFixture3_Test").RunsOn("ParallelWorker")))
+                .SetName("ThreeFixtures_TwoSetUpFixturesInSameNamespace_FirstOneParallelizable");
+
+            yield return new TestFixtureData(
+                Suite("fake-assembly.dll")
+                    .Containing(Suite("NUnit")
+                        .Containing(Suite("TestData")
+                            .Containing(Fixture(typeof(SetUpFixture1))
+                                .Containing(Fixture(typeof(SetUpFixture2)).Parallelizable()
+                                    .Containing(
+                                        Fixture(typeof(TestFixture1)).Parallelizable(),
+                                        Fixture(typeof(TestFixture2)),
+                                        Fixture(typeof(TestFixture3)).Parallelizable()))))),
+                Expecting(
+                    That("fake-assembly.dll").StartsOn("NonParallelWorker"),
+                    That("NUnit").StartsOn("NonParallelWorker"),
+                    That("TestData").StartsOn("NonParallelWorker"),
+                    That("ParallelExecutionData").RunsOn("*"), // SetUpFixture1 && SetUpFixture2 (we can't distinguish the two)
+                    That("TestFixture1").RunsOn("ParallelWorker"),
+                    That("TestFixture1_Test").RunsOn("ParallelWorker"),
+                    That("TestFixture2").RunsOn("NonParallelWorker"),
+                    That("TestFixture2_Test").RunsOn("NonParallelWorker"),
+                    That("TestFixture3").RunsOn("ParallelWorker"),
+                    That("TestFixture3_Test").RunsOn("ParallelWorker")))
+                .SetName("ThreeFixtures_TwoSetUpFixturesInSameNamespace_SecondOneParallelizable");
         }
 
         #endregion
@@ -346,9 +454,9 @@ namespace NUnit.Framework.Internal.Execution
             return new Expectations(expectations);
         }
 
-        private static Expectation That(string TestName)
+        private static Expectation That(string testName)
         {
-            return new Expectation(TestName, null);
+            return new Expectation(testName);
         }
 
         private string DumpEvents(string message)
@@ -404,34 +512,48 @@ namespace NUnit.Framework.Internal.Execution
             public string StartWorker { get; private set; }
             public string FinishWorker { get; private set; }
 
-            public Expectation(string testName, string workerType)
+            public Expectation(string testName)
             {
                 TestName = testName;
-                StartWorker = workerType;
+                StartWorker = FinishWorker = "*";
             }
 
+            // THe RunsOn method specifies that the work item will
+            // run entirely on a particular worker. In the case of
+            // a composite work item, this doesn't include its
+            // children, which may run on a different thread.
             public Expectation RunsOn(string worker)
             {
                 StartWorker = FinishWorker = worker;
                 return this;
             }
 
+            // Sometimes, the thread used to complete a composite work item
+            // is unimportant because there is no actual user code to run.
+            // In that case, we can just specify which worker is used to
+            // initially run the item using StartsOn
             public Expectation StartsOn(string worker)
             {
                 StartWorker = worker;
                 return this;
             }
 
+            // FinishesOn may be used if we know that the work item
+            // starts and finishes on different threads and we want
+            // to specify both of them. In most cases, this amounts
+            // to over-specification since we usually don't care.
             public Expectation FinishesOn(string worker)
             {
                 FinishWorker = worker;
                 return this;
             }
 
+            // Verify that a particular TestEvent meets all expectations
             public void Verify(TestEvent e)
             {
                 var worker = e.Action == TestAction.TestStarting ? StartWorker : FinishWorker;
-                Assert.That(e.ThreadName, Does.StartWith(worker), $"{e.Action} {e.TestName} running on wrong type of worker thread.");
+                if (worker != "*")
+                    Assert.That(e.ThreadName, Does.StartWith(worker), $"{e.Action} {e.TestName} running on wrong type of worker thread.");
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -1,0 +1,194 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if PARALLEL
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using NUnit.Framework.Interfaces;
+using NUnit.TestData.ParallelExecutionData;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Internal.Execution
+{
+    [TestFixtureSource(nameof(GetParallelSuites))]
+    public class ParallelExecutionTests : ITestListener
+    {
+        private TestSuite _testSuite;
+        private int _numCases;
+
+        private List<string> _events;
+        private TestResult _result;
+
+        private static readonly string NL = Environment.NewLine;
+
+        public ParallelExecutionTests(TestSuite testSuite, int numCases)
+        {
+            _testSuite = testSuite;
+            _numCases = numCases;
+        }
+
+        [OneTimeSetUp]
+        public void RunTestSuite()
+        {
+            _events = new List<string>();
+
+            var dispatcher = new ParallelWorkItemDispatcher(4);
+            var context = new TestExecutionContext();
+            context.Dispatcher = dispatcher;
+            context.Listener = this;
+
+            dispatcher.ShiftStarting += (shift) =>
+            {
+                AddEvent("ShiftStarted " + shift.Name);
+            };
+
+            dispatcher.ShiftFinished += (shift) =>
+            {
+                AddEvent("ShiftFinished " + shift.Name);
+            };
+
+            var workItem = TestBuilder.CreateWorkItem(_testSuite, context);
+
+            var run_complete = new ManualResetEvent(false);
+            workItem.Completed += (s, e) => { run_complete.Set(); };
+
+            dispatcher.Start(workItem);
+            run_complete.WaitOne(Timeout.Infinite);
+
+            _result = workItem.Result;
+        }
+
+        // NOTE: The following tests use Assert.Fail under control of an
+        // if statement to avoid evaluating DumpEvents unnecessarily.
+        // Unfortunately, we can't use the form of Assert that takes
+        // a Func for a message because it's not present in .NET 2.0
+
+        [Test]
+        public void AllTestsPassed()
+        {
+            if (_result.ResultState != ResultState.Success)
+                Assert.Fail(DumpEvents("Not all tests passed"));
+        }
+
+        [Test]
+        public void AllTestsRan()
+        {
+            if(_result.PassCount != _numCases)
+                Assert.Fail(DumpEvents("Incorrect number of test cases"));
+        }
+
+        [Test]
+        public void OnlyOneShiftMayBeActive()
+        {
+            int count = 0;
+            foreach (var @event in _events)
+            {
+                if (@event.StartsWith("ShiftStarted") && ++count > 1)
+                    Assert.Fail(DumpEvents("Shift started while another shift was active"));
+
+                if (@event.StartsWith("ShiftFinished"))
+                    --count;               
+            }
+        }
+
+        [Test]
+        public void AllTestsAreWithinShifts()
+        {
+            bool inShift = false;
+            foreach (var @event in _events)
+            {
+                if (@event.StartsWith("ShiftStarted"))
+                    inShift = true;
+                else if (@event.StartsWith("ShiftFinished"))
+                    inShift = false;
+                else
+                    if(!inShift)
+                        Assert.Fail(DumpEvents("Test event received outside of any shift"));
+            }
+        }
+
+        #region Test Data
+
+        static IEnumerable<TestFixtureData> GetParallelSuites()
+        {
+            yield return new TestFixtureData(
+                TestBuilder.MakeSuite("NUnit.TestData.ParallelExecutionData")
+                    .Containing(TestBuilder.MakeFixture(typeof(TestSetUpFixture))
+                        .Containing(typeof(TestFixture1), typeof(TestFixture2), typeof(TestFixture3))),
+                3);
+
+            yield return new TestFixtureData(
+                TestBuilder.MakeSuite("NUnit")
+                    .Containing(TestBuilder.MakeSuite("TestData")
+                        .Containing(TestBuilder.MakeSuite("ParallelExecutionData")
+                            .Containing(TestBuilder.MakeFixture(typeof(TestSetUpFixture))
+                                .Containing(typeof(TestFixture1), typeof(TestFixture2), typeof(TestFixture3))))),
+                3);
+        }
+
+        #endregion
+
+        #region ITestListener implementation
+
+        public void TestStarted(ITest test)
+        {
+            AddEvent("TestStarted " + test.FullName);
+        }
+
+        public void TestFinished(ITestResult result)
+        {
+            AddEvent("TestFinished " + result.FullName + " " + result.ResultState);
+        }
+
+        public void TestOutput(TestOutput output)
+        {
+            AddEvent(output.Stream + " " + output.Text.TrimEnd('\r', '\n'));
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private void AddEvent(string @event)
+        {
+            lock (_events)
+                _events.Add(@event);
+        }
+
+        private string DumpEvents(string message)
+        {
+            var sb = new StringBuilder(message + NL);
+            foreach (string @event in _events)
+            {
+                sb.Append(@event);
+                sb.Append(NL);
+            }
+            return sb.ToString();
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelExecutionTests.cs
@@ -35,13 +35,11 @@ namespace NUnit.Framework.Internal.Execution
     [TestFixtureSource(nameof(GetParallelSuites))]
     public class ParallelExecutionTests : ITestListener
     {
-        private TestSuite _testSuite;
-        private int _numCases;
+        private readonly TestSuite _testSuite;
+        private readonly int _numCases;
 
         private List<string> _events;
         private TestResult _result;
-
-        private static readonly string NL = Environment.NewLine;
 
         public ParallelExecutionTests(TestSuite testSuite, int numCases)
         {
@@ -92,7 +90,7 @@ namespace NUnit.Framework.Internal.Execution
         [Test]
         public void AllTestsRan()
         {
-            if(_result.PassCount != _numCases)
+            if (_result.PassCount != _numCases)
                 Assert.Fail(DumpEvents("Incorrect number of test cases"));
         }
 
@@ -131,22 +129,26 @@ namespace NUnit.Framework.Internal.Execution
         {
             Console.WriteLine(DumpEvents("Events Received:"));
         }
+
         #region Test Data
 
         static IEnumerable<TestFixtureData> GetParallelSuites()
         {
             yield return new TestFixtureData(
-                TestBuilder.MakeSuite("NUnit.TestData.ParallelExecutionData")
-                    .Containing(TestBuilder.MakeFixture(typeof(TestSetUpFixture))
-                        .Containing(typeof(TestFixture1), typeof(TestFixture2), typeof(TestFixture3))),
-                3);
-
-            yield return new TestFixtureData(
-                TestBuilder.MakeSuite("NUnit")
-                    .Containing(TestBuilder.MakeSuite("TestData")
-                        .Containing(TestBuilder.MakeSuite("ParallelExecutionData")
-                            .Containing(TestBuilder.MakeFixture(typeof(TestSetUpFixture))
-                                .Containing(typeof(TestFixture1), typeof(TestFixture2), typeof(TestFixture3))))),
+                TestBuilder.MakeSuite("fake-assembly.dll")
+                    .Containing(TestBuilder.MakeSuite("NUnit")
+                        .Containing(TestBuilder.MakeSuite("TestData")
+                            .Containing(TestBuilder.MakeSuite("ParallelExecutionData")
+                                .Containing(TestBuilder.MakeFixture(typeof(TestSetUpFixture)).Parallelizable()
+                                    .Containing(
+                                        TestBuilder.MakeFixture(typeof(TestFixture1)).Parallelizable(), 
+                                        TestBuilder.MakeFixture(typeof(TestFixture2)), 
+                                        TestBuilder.MakeFixture(typeof(TestFixture3)).Parallelizable()
+                                    )
+                                )
+                            )
+                        )
+                    ),
                 3);
         }
 
@@ -181,12 +183,11 @@ namespace NUnit.Framework.Internal.Execution
 
         private string DumpEvents(string message)
         {
-            var sb = new StringBuilder(message + NL);
+            var sb = new StringBuilder().AppendLine(message);
+
             foreach (string @event in _events)
-            {
-                sb.Append(@event);
-                sb.Append(NL);
-            }
+                sb.AppendLine(@event);
+
             return sb.ToString();
         }
 

--- a/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
@@ -50,8 +50,7 @@ namespace NUnit.Framework.Internal.Tests
 		[Test]
 		public void TestStarted_FixtureEmitsStartSuiteElement()
 		{
-			var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestFixtureAttribute));
-			var work = TestBuilder.PrepareWorkItem(fixture, null);
+			var work = TestBuilder.CreateWorkItem(typeof(FixtureWithTestFixtureAttribute));
 			work.Context.Listener = _reporter;
 
 			TestBuilder.ExecuteWorkItem(work);
@@ -64,8 +63,7 @@ namespace NUnit.Framework.Internal.Tests
 		[Test]
 		public void TestStarted_TestMethodEmitsStartTestElement()
 		{
-			var test = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
-			var work = TestBuilder.PrepareWorkItem(test, null);
+			var work = TestBuilder.CreateWorkItem(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
 			work.Context.Listener = _reporter;
 
 			TestBuilder.ExecuteWorkItem(work);
@@ -78,8 +76,7 @@ namespace NUnit.Framework.Internal.Tests
 		[Test]
 		public void TestStarted_ReportAttributes()
 		{
-			var fixture = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
-			var work = TestBuilder.PrepareWorkItem(fixture, null);
+			var work = TestBuilder.CreateWorkItem(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
 			work.Context.Listener = _reporter;
 
 			TestBuilder.ExecuteWorkItem(work);
@@ -97,8 +94,7 @@ namespace NUnit.Framework.Internal.Tests
 		[Test]
 		public void TestFinished_AdditionalReportAttributes()
 		{
-			var test = TestBuilder.MakeTestCase(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
-			var work = TestBuilder.PrepareWorkItem(test, null);
+			var work = TestBuilder.CreateWorkItem(typeof(FixtureWithTestFixtureAttribute), "SomeTest");
 			work.Context.Listener = _reporter;
 
 			TestBuilder.ExecuteWorkItem(work);

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests
         public void ConsoleErrorWrite_WritesToListener()
         {
             var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWrite");
-            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
 
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Tests
         public void ConsoleErrorWriteLine_WritesToListener()
         {
             var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWriteLine");
-            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
 
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Tests
         public void TestContextError_WritesToListener()
         {
             var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextErrorWriteLine");
-            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
 
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Tests
         public void TestContextProgress_WritesToListener()
         {
             var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextProgressWriteLine");
-            var work = TestBuilder.PrepareWorkItem(test, new TextOutputFixture());
+            var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
 

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -100,6 +103,7 @@
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -99,6 +102,7 @@
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -144,6 +147,7 @@
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />
     <Compile Include="Internal\NamespaceTreeBuilderTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -221,6 +224,7 @@
     <Compile Include="Internal\DeduceTypeArgsFromArgs.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\EventQueueTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
     <Compile Include="Internal\Filters\MockTestFilter.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -202,6 +205,7 @@
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\TestFile.cs">
       <Link>TestUtilities\TestFile.cs</Link>
     </Compile>
+    <Compile Include="..\TestSuiteExtensions.cs">
+      <Link>TestUtilities\TestSuiteExtensions.cs</Link>
+    </Compile>
     <Compile Include="Api\FrameworkControllerTests.cs" />
     <Compile Include="Api\ResultStateTests.cs" />
     <Compile Include="Api\TestAssemblyRunnerTests.cs" />
@@ -202,6 +205,7 @@
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />
     <Compile Include="Internal\Execution\ParallelExecutionStrategyTests.cs" />
+    <Compile Include="Internal\Execution\ParallelExecutionTests.cs" />
     <Compile Include="Internal\Execution\ParallelWorkItemDispatcherTests.cs" />
     <Compile Include="Internal\Filters\AndFilterTests.cs" />
     <Compile Include="Internal\Filters\CategoryFilterTests.cs" />


### PR DESCRIPTION
This PR is intended to collect fixes for a number of parallelism issues, particularly around use of SetUpFixtures but also with the handling of parallel and non-parallel TestFixtures and the smooth changing of shifts within the dispatcher.

The initial commit sets up some infrastructure and adds a few unit tests of the parallel dispatcher. Those tests are known to fail intermittently, just as user runs are failing intermittently in some cases.

The issues I hope to address in this PR include #1239, ~~#1905~~, #2364, #2388, #2467 and #2471. I'll add "Fixes" notations when I think any of them is fixed.

I'd like it if @nunit/framework-team members followed along and commented.

Fixes #1239 (needs review)
Fixes #2364
Fixes #2395
Fixes #2467
Fixes #2471
Fixes #2478 
