### PR TITLE
Honor --label option settings in nunitlite

### DIFF
--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -448,6 +448,8 @@ namespace NUnitLite
         {
             if (_teamCity != null)
                 _teamCity.TestStarted(test);
+
+            _textUI.TestStarted(test);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2402 

This is a small fix I included in my parallelism-issues branch, extracted here as a separate PR. It's important for anyone that wants to see labels on nunitlite output for debugging.