### PR TITLE
Allow null values in CollectionOrderedConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -192,13 +192,13 @@ namespace NUnit.Framework.Constraints
             int index = 0;
             foreach (object current in actual)
             {
-                if (current == null)
-                    throw new ArgumentNullException(nameof(actual), "Null value at index " + index.ToString());
-
                 if (previous != null)
                 {
                     if (_steps[0].PropertyName != null)
                     {
+                        if (current == null)
+                            throw new ArgumentNullException(nameof(actual), "Null value at index " + index.ToString());
+
                         foreach (var step in _steps)
                         {
                             string propertyName = step.PropertyName;

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -628,10 +628,9 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IsOrdered_Handles_null()
         {
-            var list = new SimpleObjectList("x", null, "z");
+            var list = new SimpleObjectList(null, "x", "z");
 
-            var ex = Assert.Throws<ArgumentNullException>(() => CollectionAssert.IsOrdered(list));
-            Assert.That(ex.Message, Does.Contain("index 1"));
+            Assert.That(list, Is.Ordered);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -67,6 +67,15 @@ namespace NUnit.Framework.Constraints
             new TestCaseData(
                 new[] { "x", "x", "z" },
                 Is.Ordered),
+            new TestCaseData(
+                new[] { null, "x", "y" },
+                Is.Ordered),
+            new TestCaseData(
+                new[] {"y", "x", null},
+                Is.Ordered.Descending),
+            new TestCaseData(
+                new[] { "x", null, "y" },
+                Is.Not.Ordered),
             // Ordered By Single Property
             new TestCaseData(
                 new[] { new TestClass1(1), new TestClass1(2), new TestClass1(3) },
@@ -237,9 +246,9 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
-        public void IsOrdered_ThrowsOnNull()
+        public void IsOrderedByProperty_ThrowsOnNull()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(new[] { "x", null, "z" }, Is.Ordered));
+            var ex = Assert.Throws<ArgumentNullException>(() => Assert.That(new[] { new TestClass4("x"), null, new TestClass4("z") }, Is.Ordered.By("Value")));
             Assert.That(ex.Message, Does.Contain("index 1"));
         }
 


### PR DESCRIPTION
Allows null values for simple ordering in `CollectionOrderedConstraint`. Null sorts less than everything else. An `ArgumentNullException` will still be thrown if ordering by a property.

This is a potentially breaking change. If the previous behavior of throwing an exception if a collection contains null items is desired, it can be achieved using `Has.None.Null.And.Ordered`.

Fixes #1473