### PR TITLE
Initial fix for #2494

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -34,7 +34,10 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public abstract class CollectionItemsEqualConstraint : CollectionConstraint
     {
-        private readonly NUnitEqualityComparer comparer = NUnitEqualityComparer.Default;
+        /// <summary>
+        /// The NUnitEqualityComparer in use for this constraint
+        /// </summary>
+        private NUnitEqualityComparer _comparer = NUnitEqualityComparer.Default;
 
         /// <summary>
         /// Construct an empty CollectionConstraint
@@ -47,6 +50,26 @@ namespace NUnit.Framework.Constraints
         /// <param name="arg"></param>
         protected CollectionItemsEqualConstraint(object arg) : base(arg) { }
 
+        #region Protected Properties
+
+        /// <summary>
+        /// Get a flag indicating whether the user requested us to ignore case.
+        /// </summary>
+        protected bool IgnoringCase
+        {
+            get { return _comparer.IgnoreCase; }
+        }
+        
+        /// <summary>
+        /// Get a flag indicating whether any external comparers are in use.
+        /// </summary>
+        protected bool UsingExternalComparer
+        {
+            get { return _comparer.ExternalComparers.Count > 0; }
+        }
+
+        #endregion
+
         #region Modifiers
 
         /// <summary>
@@ -56,7 +79,7 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-                comparer.IgnoreCase = true;
+                _comparer.IgnoreCase = true;
                 return this;
             }
         }
@@ -68,7 +91,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using(IComparer comparer)
         {
-            this.comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
         }
 
@@ -79,7 +102,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using<T>(IComparer<T> comparer)
         {
-            this.comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
         }
 
@@ -90,7 +113,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using<T>(Comparison<T> comparer)
         {
-            this.comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
         }
 
@@ -101,7 +124,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using(IEqualityComparer comparer)
         {
-            this.comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
         }
 
@@ -112,13 +135,13 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using<T>(IEqualityComparer<T> comparer)
         {
-            this.comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
             return this;
         }
 
         internal CollectionItemsEqualConstraint Using(EqualityAdapter adapter)
         {
-            comparer.ExternalComparers.Add(adapter);
+            _comparer.ExternalComparers.Add(adapter);
             return this;
         }
 
@@ -130,7 +153,7 @@ namespace NUnit.Framework.Constraints
         protected bool ItemsEqual(object x, object y)
         {
             Tolerance tolerance = Tolerance.Default;
-            return comparer.AreEqual(x, y, ref tolerance);
+            return _comparer.AreEqual(x, y, ref tolerance);
         }
 
         /// <summary>
@@ -139,7 +162,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The collection to be included in the tally</param>
         protected CollectionTally Tally(IEnumerable c)
         {
-            return new CollectionTally(comparer, c);
+            return new CollectionTally(_comparer, c);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// The NUnitEqualityComparer in use for this constraint
         /// </summary>
-        private NUnitEqualityComparer _comparer = NUnitEqualityComparer.Default;
+        private readonly NUnitEqualityComparer _comparer = NUnitEqualityComparer.Default;
 
         /// <summary>
         /// Construct an empty CollectionConstraint

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -147,8 +147,8 @@ namespace NUnit.Framework.Constraints
 
             return type.IsArray
                 || typeof(IEnumerable).IsAssignableFrom(type) // Covers lists, collections, dictionaries as well
-                || type == typeof(System.IO.Stream)
-                || type == typeof(System.IO.DirectoryInfo)
+                || typeof(System.IO.Stream).IsAssignableFrom(type) // Covers all streams
+                || typeof(System.IO.DirectoryInfo).IsAssignableFrom(type) // Unlikely to be derived, but just in case
                 || type.FullName == "System.Tuple"
                 || type.FullName == "System.ValueTuple";
         }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Constraints
             // If IEnumerable<T> is not implemented exit,
             // Otherwise return value is the Type of T
             Type memberType = GetGenericTypeArgument(actual);
-            if (memberType == null)
+            if (memberType == null || IsHandledSpeciallyByNUnit(memberType))
                 return null;
 
             string methodName = nameof(ItemsUnique);
@@ -99,9 +99,9 @@ namespace NUnit.Framework.Constraints
                     methodName = nameof(CharsUniqueIgnoringCase);
                     makeGeneric = false;
                 }
-        }
+            }
 
-        MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
             if (method == null)
                 throw new InvalidOperationException("Internal error - Method not found: " + methodName);
             
@@ -156,6 +156,19 @@ namespace NUnit.Framework.Constraints
             }
 
             return true;
+        }
+
+        // Return true if NUnitEqualityHandler has special logic for Type
+        private static bool IsHandledSpeciallyByNUnit(Type type)
+        {
+            if (type == typeof(string)) return false; // even though it's IEnumerable
+
+            return type.IsArray
+                || type == typeof(IEnumerable) // Covers lists, collections, dictionaries as well
+                || type == typeof(System.IO.Stream)
+                || type == typeof(System.IO.DirectoryInfo)
+                || type.FullName == "System.Tuple"
+                || type.FullName == "System.ValueTuple";
         }
 
         private Type GetGenericTypeArgument(IEnumerable actual)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -48,6 +49,9 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
+            if (actual is IEnumerable<int>)
+                return Matches((IEnumerable<int>)actual);
+
             var list = new List<object>();
 
             foreach (object o1 in actual)
@@ -56,6 +60,28 @@ namespace NUnit.Framework.Constraints
                     if (ItemsEqual(o1, o2))
                         return false;
                 list.Add(o1);
+            }
+
+            return true;
+        }
+
+        private bool Matches<T>(IEnumerable<T> actual)
+        {
+            // This algorithm handles a range of 100000 ints,
+            // which previously took 105 seconds in 24 to 35
+            // milliseconds on my laptop (Debug). However,
+            // it does not use NUnit equality at all, so 
+            // may give different results if the members
+            // of the enumerable are handled specially by
+            // NUnitEqualityComparer.
+            var hash = new HashSet<T>();
+
+            foreach (T item in actual)
+            {
+                if (hash.Contains(item))
+                    return false;
+
+                hash.Add(item);
             }
 
             return true;

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -91,8 +91,6 @@ namespace NUnit.Framework.Constraints
                     return CharsUniqueIgnoringCase((IEnumerable<char>)actual);
             }
 
-            MethodInfo method = GetType().GetMethod(nameof(ItemsUnique), BindingFlags.Static | BindingFlags.NonPublic);
-
             return (bool)ItemsUniqueMethod.MakeGenericMethod(memberType).Invoke(null, new object[] { actual });
         }
 

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -24,17 +24,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
-
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-using System.Data;
-#endif
-
-#if !NET_2_0
-using System.Linq;
-#endif
 
 namespace NUnit.Framework.Assertions
 {
@@ -127,8 +120,7 @@ namespace NUnit.Framework.Assertions
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
         }
 
-#if !NET_2_0
-        static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
+        static readonly IEnumerable<int> RANGE = new RangeOfInt(0, 10000);
 
         static readonly IEnumerable[] PerformanceData =
         {
@@ -138,14 +130,12 @@ namespace NUnit.Framework.Assertions
             new List<string>(RANGE.Select(v => v.ToString()))
         };
 
-        // Using very short max time so it always fails and displays timing
-        [MaxTime(1), Explicit("Performance test")]
+        [MaxTime(100)]
         [TestCaseSource(nameof(PerformanceData))]
         public void PerformanceTests(IEnumerable values)
         {
             CollectionAssert.AllItemsAreUnique(values);
         }
-#endif
 
         #endregion
 

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
@@ -125,6 +126,23 @@ namespace NUnit.Framework.Assertions
             Assert.Throws<AssertionException>(
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
         }
+
+#if !NET_2_0
+        static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
+        static readonly IList<int> LIST = new List<int>(RANGE);
+
+        // Using very short max time so it always fails and displays timing
+        [Test, MaxTime(10), Explicit("Performance test")]
+        public void PerformanceTest1()
+        {
+            CollectionAssert.AllItemsAreUnique(RANGE);
+        }
+        [Test, MaxTime(1), Explicit("Performance test")]
+        public void PerformanceTest2()
+        {
+            CollectionAssert.AllItemsAreUnique(LIST);
+        }
+#endif
 
         #endregion
 

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -129,18 +129,21 @@ namespace NUnit.Framework.Assertions
 
 #if !NET_2_0
         static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
-        static readonly IList<int> LIST = new List<int>(RANGE);
+
+        static readonly IEnumerable[] PerformanceData =
+        {
+            RANGE,
+            new List<int>(RANGE),
+            new List<double>(RANGE.Select(v => (double)v)),
+            new List<string>(RANGE.Select(v => v.ToString()))
+        };
 
         // Using very short max time so it always fails and displays timing
-        [Test, MaxTime(10), Explicit("Performance test")]
-        public void PerformanceTest1()
+        [MaxTime(1), Explicit("Performance test")]
+        [TestCaseSource(nameof(PerformanceData))]
+        public void PerformanceTests(IEnumerable values)
         {
-            CollectionAssert.AllItemsAreUnique(RANGE);
-        }
-        [Test, MaxTime(1), Explicit("Performance test")]
-        public void PerformanceTest2()
-        {
-            CollectionAssert.AllItemsAreUnique(LIST);
+            CollectionAssert.AllItemsAreUnique(values);
         }
 #endif
 

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -22,6 +22,9 @@
 // ***********************************************************************
 
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 
 namespace NUnit.Framework.Constraints
@@ -53,5 +56,26 @@ namespace NUnit.Framework.Constraints
             new object[] {new[] {'A', 'B', 'C', 'c'}},
             new object[] {new[] {"a", "b", "c", "C"}}
         };
+
+        static readonly IEnumerable<int> RANGE = new RangeOfInt(0, 10000);
+
+        static readonly TestCaseData[] PerformanceData =
+        {
+            new TestCaseData(RANGE, false),
+            new TestCaseData(new List<int>(RANGE), false),
+            new TestCaseData(new List<double>(RANGE.Select(v => (double)v)), false),
+            new TestCaseData(new List<string>(RANGE.Select(v => v.ToString())), false),
+            new TestCaseData(new List<string>(RANGE.Select(v => v.ToString())), true)
+        };
+
+        [MaxTime(100)]
+        [TestCaseSource(nameof(PerformanceData))]
+        public void PerformanceTests(IEnumerable values, bool ignoreCase)
+        {
+            if (ignoreCase)
+                Assert.That(values, Is.Unique.IgnoreCase);
+            else
+                Assert.That(values, Is.Unique);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Constraints
         [TestCaseSource( "IgnoreCaseData" )]
         public void HonorsIgnoreCase( IEnumerable actual )
         {
-            Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should be unique ignoring case", actual );
+            Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should not be unique ignoring case", actual );
         }
 
         private static readonly object[] IgnoreCaseData =

--- a/src/NUnitFramework/tests/TestUtilities/RangeOfInt.cs
+++ b/src/NUnitFramework/tests/TestUtilities/RangeOfInt.cs
@@ -1,0 +1,55 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities
+{
+    // Class for use in place of Enumerable.Range,
+    // which isn't availble in .NET 2.0
+    public class RangeOfInt : IEnumerable<int>
+    {
+        private int _next;
+        private int _count;
+
+        public RangeOfInt(int start, int count)
+        {
+            _next = start;
+            _count = count;
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            while (_count-- > 0)
+            {
+                yield return _next++;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -313,6 +313,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -313,6 +313,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -311,6 +311,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -317,6 +317,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -304,6 +304,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -304,6 +304,7 @@
     <Compile Include="TestUtilities\Comparers\ObjectEqualityComparer.cs" />
     <Compile Include="TestUtilities\Comparers\ObjectToStringComparer.cs" />
     <Compile Include="TestUtilities\Comparers\TestComparer.cs" />
+    <Compile Include="TestUtilities\RangeOfInt.cs" />
     <Compile Include="TestUtilities\ResultSummary.cs" />
     <Compile Include="TestUtilities\StressUtility.cs" />
     <Compile Include="TestUtilities\TestAssert.cs" />


### PR DESCRIPTION
This goes towards fixing issue #2494. I wanted to try some things, but I'm happy for somebody else to continue. Here's what I did...

1. Created a test using `Enumerable.Range(0, 10000)`. Initially it took a105 seconds to complete.
2. Modified the code to make comparisons in place. This reduced the time to 97 seconds, which is not satisfactory. That modified code is still in the repository as `LegacyMatches`. It's the best time I acheived without changing any semantics.
3. Created a new `Matches` method using a `HashSet`. It completed my test in 24 __milliseconds__! Unfortunately, there were semantic changes. 
4. Fixed the most obvious problem, that of ignoring case. The fix is a hack for sure, but it works. Other more subtle semantic changes remain. This is the version that's currently in the code.

The key semantic difference is that my code no longer uses `NUnitEqualityComparer` in order to detect uniqueness, where the original code did. Thinking about it, I'm not sure that's what we want in a test of unique items. We might prefer object identity if we were doing this from scratch. We'll have to decide how to carry this forward.
