### PR TITLE
Use ConstraintUtils.RequireActual

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -58,10 +59,9 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (!(actual is IEnumerable))
-                throw new ArgumentException("The actual value must be an IEnumerable", "actual");
+            var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
-            foreach (object item in (IEnumerable)actual)
+            foreach (object item in enumerable)
                 if (!BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Failure);
 

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -69,10 +70,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override bool Matches(IEnumerable actual)
         {
-            IDictionary dictionary = actual as IDictionary;
-
-            if (dictionary == null)
-                throw new ArgumentException("The actual value must be an IDictionary", "actual");
+            var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
 
             foreach (object obj in dictionary.Keys)
                 if (ItemsEqual(obj, Expected))

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -69,10 +70,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override bool Matches(IEnumerable actual)
         {
-            IDictionary dictionary = actual as IDictionary;
-
-            if (dictionary == null)
-                throw new ArgumentException("The actual value must be an IDictionary", "actual");
+            var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
 
             foreach (object obj in dictionary.Values)
                 if (ItemsEqual(obj, Expected))

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -67,18 +68,17 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (!(actual is IEnumerable))
-                throw new ArgumentException("The actual value must be an IEnumerable", "actual");
+            var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
             int count = 0;
             if (_itemConstraint == null)
             {
-                foreach (object item in (IEnumerable)actual)
+                foreach (object item in enumerable)
                     count++;
             }
             else
             {
-                foreach (object item in (IEnumerable)actual)
+                foreach (object item in enumerable)
                     if (_itemConstraint.ApplyTo(item).IsSuccess)
                         count++;
             }

--- a/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -58,10 +59,9 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (!(actual is IEnumerable))
-                throw new ArgumentException("The actual value must be an IEnumerable", "actual");
+            var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
-            foreach (object item in (IEnumerable)actual)
+            foreach (object item in enumerable)
                 if (BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Failure);
 

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -62,10 +63,9 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (!(actual is IEnumerable))
-                throw new ArgumentException("The actual value must be an IEnumerable", "actual");
+            var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
-            foreach (object item in (IEnumerable)actual)
+            foreach (object item in enumerable)
                 if (BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Success);
 

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Comparers;
 
@@ -114,10 +113,19 @@ namespace NUnit.Framework.Constraints
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
+        [Test]
         public void WorksOnICollection()
         {
             var c = new NUnit.TestUtilities.Collections.SimpleObjectCollection(1, 2, 3);
             Assert.That(c, Is.All.Not.Null);
+        }
+        
+        [Test]
+        public void FailsWhenNotUsedAgainstAnEnumerable()
+        {
+            var notEnumerable = 42;
+            TestDelegate act = () => Assert.That(notEnumerable, new AllItemsConstraint(new RangeConstraint(10, 100)));
+            Assert.That(act, Throws.ArgumentException.With.Message.Contains("IEnumerable"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -22,10 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
-using NUnit.Framework.Assertions;
 using NUnit.Framework.Internal;
-using NUnit.TestUtilities.Collections;
 
 namespace NUnit.Framework.Constraints
 {
@@ -130,6 +127,14 @@ namespace NUnit.Framework.Constraints
         public void ExactlyTwoItemsNoopMatch()
         {
             Assert.That(names, Has.Exactly(2).Items.EqualTo("Charlie"));
+        }
+        
+        [Test]
+        public void FailsWhenNotUsedAgainstAnEnumerable()
+        {
+            var notEnumerable = 42;
+            TestDelegate act = () => Assert.That(notEnumerable, new ExactCountConstraint(1));
+            Assert.That(act, Throws.ArgumentException.With.Message.Contains("IEnumerable"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
@@ -1,5 +1,5 @@
-// ***********************************************************************
-// Copyright (c) 2017 Charlie Poole, Rob Prouse
+﻿// ***********************************************************************
+// Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,28 +22,31 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
-
-using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
-namespace  NUnit.Framework.Tests.Constraints
+namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    class SomeItemsConstraintTests
-    {
+    public class NoItemConstraintTests
+    {   
+        private readonly string NL = Environment.NewLine;
+        
         [Test]
-        public void EqualConstraintUsingDoesNotThrow()
+        public void NoItemsAreNotNull()
         {
-            var constraint = new SomeItemsConstraint(new EqualConstraint("42"));
-            Assert.DoesNotThrow(() => constraint.Using((IComparer<string>)Comparer<string>.Default));
+            object[] c = new object[] { 1, "hello", 3, Environment.NewLine };
+            Assert.That(c, new NoItemConstraint(Is.Null));
         }
 
         [Test]
-        public void AnotherConstraintUsingThrows()
+        public void NoItemsAreNotNullFails()
         {
-            var constraint = new SomeItemsConstraint(new EmptyCollectionConstraint());
-            Assert.Throws<ArgumentException>(() => constraint.Using((IComparer<string>)Comparer<string>.Default));
+            object[] c = new object[] { 1, "hello", null, 3 };
+            var expectedMessage =
+                TextMessageWriter.Pfx_Expected + "no item null" + NL +
+                TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL;
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new NoItemConstraint(Is.Null)));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
         
         [Test]

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
     <Compile Include="Constraints\IntervalTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />
     <Compile Include="Internal\AsyncTestMethodTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\CollectionTallyTests.cs" />
     <Compile Include="Internal\EventListenerTextWriterTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
     <Compile Include="Constraints\MsgUtilTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NotConstraintTests.cs" />
     <Compile Include="Constraints\NumericsTest.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />
     <Compile Include="Constraints\ConstraintTestBase.cs" />
     <Compile Include="Constraints\EmptyConstraintTest.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
+    <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />
     <Compile Include="Constraints\ConstraintTestBase.cs" />
     <Compile Include="Constraints\EmptyConstraintTest.cs" />


### PR DESCRIPTION
This is a fix for the issue #2497
I'm adding the RequireActual call on the specified classes, adding tests when calling constraints with a incompatible type, and creating NoItemConstraintTests. I'm also adding a missing Test attribute in AllItemsConstraintTests.
Please let me know if I need to update this PR.
