### PR TITLE
Correct divergence from shadowed Is / Has members.

### DIFF
--- a/src/NUnitFramework/framework/AssertionHelper.cs
+++ b/src/NUnitFramework/framework/AssertionHelper.cs
@@ -217,7 +217,7 @@ namespace NUnit.Framework
         /// the following constraint to all members of a collection,
         /// succeeding only if a specified number of them succeed.
         /// </summary>
-        public static ConstraintExpression Exactly(int expectedCount)
+        public static ItemsConstraintExpression Exactly(int expectedCount)
         {
             return Has.Exactly(expectedCount);
         }
@@ -943,7 +943,7 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual value falls
         /// within a specified range.
         /// </summary>
-        public RangeConstraint InRange(IComparable from, IComparable to)
+        public RangeConstraint InRange(object from, object to)
         {
             return new RangeConstraint(from, to);
         }


### PR DESCRIPTION
`InRange()` and `Exactly()` in `AssertionHelper` mimic (in fact facade in the case of `Exactly()`) members of the `Is` and `Has` classes, respectively. These members have recently had their signatures altered in `Is` and `Has` but the corresponding signatures in `AssertionHelper` were not amended. This change fixes that. `AH` is being deprecated, but I'm assuming this will count as maintenance.

Impetus: this change is referenced in #1212. As `AssertionHelper` is obsolete and is likely to be removed, `NUnit.StaticExpect` has been produced to help users migrate away from it with minimal changes (remove inheritance from `AssertionHelper`, add `using static NUnit.StaticExpect`). Tests in the `StaticExpect` project attempt to guarantee complete coverage of the original `AssertionHelper` classes by reflecting on `AH`. These tests have highlighted this discrepancy and fixing it should provide correctness within NUnit and will also allow the `StaticExpect` tests to pass without special-casing.

I should point out that I haven't compiled or tested these changes because I wasn't able to easily compile NUnit (#2331). That said, the proposed change merely replicates the underlying behaviour (`AssertionHelper.Exactly()` calls `Has.Exactly()` which already returns an `ItemsConstraintExpression`; `AssertionHelper.InRange()` returns a new `RangeConstraint` whose ctor already takes a pair of `object`s rather than `IComparable`s).