### PR TITLE
Make TestContext.AddFormatter more generic

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -329,9 +329,9 @@ namespace NUnit.Framework
         /// </summary>
         /// <typeparam name="TSUPPORTED">The type supported by this formatter</typeparam>
         /// <param name="formatter">The ValueFormatter delegate</param>
-        public static void AddFormatter<TSUPPORTED>(ValueFormatter formatter)
+        public static void AddFormatter<TSUPPORTED>(Func<TSUPPORTED, string> formatter)
         {
-            AddFormatter(next => val => (val is TSUPPORTED) ? formatter(val) : next(val));
+            AddFormatter(next => val => (val is TSUPPORTED) ? formatter((TSUPPORTED) val) : next(val));
         }
 
 #endregion

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -33,7 +33,10 @@ namespace NUnit.Framework.Constraints
     public static class MsgUtilTests
     {
         #region FormatValue
-        class CustomFormattableType { }
+        class CustomFormattableType
+        {
+            public string Value => "value";
+        }
 
         [Test]
         public static void FormatValue_ContextualCustomFormatterInvoked_FactoryArg()
@@ -55,9 +58,9 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_ContextualCustomFormatterInvoked_FormatterArg()
         {
-            TestContext.AddFormatter<CustomFormattableType>(val => "custom_formatted_using_type");
+            TestContext.AddFormatter<CustomFormattableType>(val => "custom_formatted_using_type : " + val.Value);
 
-            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type"));
+            Assert.That(MsgUtils.FormatValue(new CustomFormattableType()), Is.EqualTo("custom_formatted_using_type : value"));
         }
 
         [Test]


### PR DESCRIPTION
This is a proposal to fix issue #2245

Tell me if we should make ValueFormatter delegate generic, and get rid of the associated "object" parameters. It would be more invasive while looking the same to callers.