### PR TITLE
Issue1678 allow special chars in category

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -82,9 +82,6 @@ namespace NUnit.Framework
         public void ApplyToTest(Test test)
         {
             test.Properties.Add(PropertyNames.Category, this.Name);
-
-            if (this.Name.IndexOfAny(new char[] { '!', '+' }) >= 0)
-                test.MakeInvalid("Category name must not contain '!' or '+'");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -83,8 +83,8 @@ namespace NUnit.Framework
         {
             test.Properties.Add(PropertyNames.Category, this.Name);
 
-            if (this.Name.IndexOfAny(new char[] { ',', '!', '+', '-' }) >= 0)
-                test.MakeInvalid("Category name must not contain ',', '!', '+' or '-'");
+            if (this.Name.IndexOfAny(new char[] { '!', '+' }) >= 0)
+                test.MakeInvalid("Category name must not contain '!' or '+'");
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite.tests/TestSelectionParserTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TestSelectionParserTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -41,9 +41,17 @@ namespace NUnit.Common.Tests
 
         [TestCase("cat=Urgent", "<cat>Urgent</cat>")]
         [TestCase("cat==Urgent", "<cat>Urgent</cat>")]
+        [TestCase("cat=='Urgent,+-!'", "<cat>Urgent,+-!</cat>")]
         [TestCase("cat!=Urgent", "<not><cat>Urgent</cat></not>")]
+        [TestCase("cat!='Urgent,+-!'", "<not><cat>Urgent,+-!</cat></not>")]
         [TestCase("cat =~ Urgent", "<cat re='1'>Urgent</cat>")]
+        [TestCase("cat =~ 'Urgent,+-!'", "<cat re='1'>Urgent,+-!</cat>")]
+        [TestCase("cat =~ 'Urgent,\\+-!'", "<cat re='1'>Urgent,+-!</cat>")]
+        [TestCase("cat =~ 'Urgent,\\\\+-!'", "<cat re='1'>Urgent,\\+-!</cat>")]
         [TestCase("cat !~ Urgent", "<not><cat re='1'>Urgent</cat></not>")]
+        [TestCase("cat !~ 'Urgent,+-!'", "<not><cat re='1'>Urgent,+-!</cat></not>")]
+        [TestCase("cat !~ 'Urgent,\\+-!'", "<not><cat re='1'>Urgent,+-!</cat></not>")]
+        [TestCase("cat !~ 'Urgent,\\\\+-!'", "<not><cat re='1'>Urgent,\\+-!</cat></not>")]
         [TestCase("cat = Urgent || cat = High", "<or><cat>Urgent</cat><cat>High</cat></or>")]
         [TestCase("Priority == High", "<prop name='Priority'>High</prop>")]
         [TestCase("Priority != Urgent", "<not><prop name='Priority'>Urgent</prop></not>")]

--- a/src/NUnitFramework/testdata/CategoryAttributeData.cs
+++ b/src/NUnitFramework/testdata/CategoryAttributeData.cs
@@ -42,11 +42,8 @@ namespace NUnit.TestData.CategoryAttributeData
         [TestCaseSource("Test3Data")]
         public void Test3(int x) { }
 
-        [Test, Category("A-B"), Category("A,B")]
+        [Test, Category("A-B"), Category("A,B"), Category("A!B"), Category("A+B")]
         public void TestValidSpecialChars() { }
-        
-        [Test, Category("A!B"), Category("A+B")]
-        public void TestInvalidSpecialChars() { }
 
 #pragma warning disable 414
         private static TestCaseData[] Test3Data = new TestCaseData[] {

--- a/src/NUnitFramework/testdata/CategoryAttributeData.cs
+++ b/src/NUnitFramework/testdata/CategoryAttributeData.cs
@@ -42,8 +42,11 @@ namespace NUnit.TestData.CategoryAttributeData
         [TestCaseSource("Test3Data")]
         public void Test3(int x) { }
 
-        [Test, Category("A-B")]
-        public void Test4() { }
+        [Test, Category("A-B"), Category("A,B")]
+        public void TestValidSpecialChars() { }
+        
+        [Test, Category("A!B"), Category("A+B")]
+        public void TestInvalidSpecialChars() { }
 
 #pragma warning disable 414
         private static TestCaseData[] Test3Data = new TestCaseData[] {

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -42,16 +42,23 @@ namespace NUnit.Framework.Attributes
 
         #region CategoryAttribute
 
-        [TestCase(',')]
         [TestCase('!')]
         [TestCase('+')]
-        [TestCase('-')]
         public void CategoryAttributeFailsOnSpecialCharacters(char specialCharacter)
         {
             var categoryName = new string(specialCharacter, 5);
             new CategoryAttribute(categoryName).ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Category name must not contain ',', '!', '+' or '-'"));
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Category name must not contain '!' or '+'"));
+        }
+
+        [TestCase(',')]
+        [TestCase('-')]
+        public void CategoryAttributePassesOnSpecialCharacters(char specialCharacter)
+        {
+            var categoryName = new string(specialCharacter, 5);
+            new CategoryAttribute(categoryName).ApplyToTest(test);
+            Assert.That(test.Properties.Get(PropertyNames.Category), Is.EqualTo(categoryName));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -42,6 +42,18 @@ namespace NUnit.Framework.Attributes
 
         #region CategoryAttribute
 
+        [TestCase(',')]
+        [TestCase('!')]
+        [TestCase('+')]
+        [TestCase('-')]
+        public void CategoryAttributeFailsOnSpecialCharacters(char specialCharacter)
+        {
+            var categoryName = new string(specialCharacter, 5);
+            new CategoryAttribute(categoryName).ApplyToTest(test);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Category name must not contain ',', '!', '+' or '-'"));
+        }
+
         [Test]
         public void CategoryAttributeSetsCategory()
         {

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -41,17 +41,9 @@ namespace NUnit.Framework.Attributes
         }
 
         #region CategoryAttribute
-
+        
         [TestCase('!')]
         [TestCase('+')]
-        public void CategoryAttributeFailsOnSpecialCharacters(char specialCharacter)
-        {
-            var categoryName = new string(specialCharacter, 5);
-            new CategoryAttribute(categoryName).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Category name must not contain '!' or '+'"));
-        }
-
         [TestCase(',')]
         [TestCase('-')]
         public void CategoryAttributePassesOnSpecialCharacters(char specialCharacter)

--- a/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void TestWithVvalidCategoryNameIsNotRunnable()
+        public void TestWithValidCategoryNameIsNotRunnable()
         {
             Test testValidSpecialChars = (Test)fixture.Tests[3];
             Assert.That(testValidSpecialChars.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
@@ -89,12 +89,5 @@ namespace NUnit.Framework.Attributes
             Test testValidSpecialChars = (Test)fixture.Tests[3];
             Assert.That(testValidSpecialChars.RunState, Is.EqualTo(RunState.Runnable));
         }
-
-        [Test]
-        public void TestWithInvalidCategoryNameIsNotRunnable()
-        {
-            Test testInvalidSpecialChars = (Test)fixture.Tests[4];
-            Assert.That(testInvalidSpecialChars.RunState, Is.EqualTo(RunState.NotRunnable));
-        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
@@ -84,10 +84,17 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void TestWithVvalidCategoryNameIsNotRunnable()
+        {
+            Test testValidSpecialChars = (Test)fixture.Tests[3];
+            Assert.That(testValidSpecialChars.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
+        [Test]
         public void TestWithInvalidCategoryNameIsNotRunnable()
         {
-            Test test4 = (Test)fixture.Tests[3];
-            Assert.That(test4.RunState, Is.EqualTo(RunState.NotRunnable));
+            Test testInvalidSpecialChars = (Test)fixture.Tests[4];
+            Assert.That(testInvalidSpecialChars.RunState, Is.EqualTo(RunState.NotRunnable));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -73,6 +73,7 @@ namespace NUnit.Framework.Internal.Filters
         protected readonly TestSuite _emptyNestedFixture = TestBuilder.MakeFixture(typeof(NestingFixture.EmptyNestedFixture));
         protected readonly TestSuite _topLevelSuite = new TestSuite("MySuite");
         protected readonly TestSuite _explicitFixture = TestBuilder.MakeFixture(typeof(ExplicitFixture));
+        protected readonly TestSuite _specialFixture = TestBuilder.MakeFixture(typeof(SpecialCharactersFixture));
 
         [OneTimeSetUp]
         public void SetUpSuite()
@@ -91,6 +92,15 @@ namespace NUnit.Framework.Internal.Filters
 
         [Category("Dummy"), Property("Priority", "High"), Author("Charlie Poole")]
         private class DummyFixture
+        {
+            [Test]
+            public void Test() { }
+
+        }
+
+
+        [Category("Special,Character-Fixture")]
+        private class SpecialCharactersFixture
         {
             [Test]
             public void Test() { }

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
@@ -99,12 +99,11 @@ namespace NUnit.Framework.Internal.Filters
         }
 
 
-        [Category("Special,Character-Fixture")]
+        [Category("Special,Character-Fixture+!")]
         private class SpecialCharactersFixture
         {
             [Test]
             public void Test() { }
-
         }
 
         [Category("Another"), Property("Priority", "Low"), Author("Fred Smith")]

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Internal.Filters
         public void CategoryFilterWithSpecialCharacters_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
-                "<filter><cat>Special,Character-Fixture</cat></filter>");
+                "<filter><cat>Special,Character-Fixture+!</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_specialFixture));
@@ -236,7 +236,7 @@ namespace NUnit.Framework.Internal.Filters
         public void CategoryFilterWithSpecialCharacters_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
-                "<filter><cat re='1'>Special,Character-Fixture</cat></filter>");
+                @"<filter><cat re='1'>Special,Character-Fixture\+!</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_specialFixture));

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -222,6 +222,13 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
+        public void CategoryFilterWithSpecialCharacters_ToXml()
+        {
+            TestFilter filter = new CategoryFilter("Special,Character-Fixture+!");
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<cat>Special,Character-Fixture+!</cat>"));
+        }
+
+        [Test]
         public void CategoryFilter_FromXml_Regex()
         {
             TestFilter filter = TestFilter.FromXml(
@@ -248,6 +255,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             TestFilter filter = new CategoryFilter("CATEGORY") { IsRegex = true };
             Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<cat re=\"1\">CATEGORY</cat>"));
+        }
+
+        [Test]
+        public void CategoryFilterWithSpecialCharacters_ToXml_Regex()
+        {
+            TestFilter filter = new CategoryFilter("Special,Character-Fixture+!") { IsRegex = true };
+            Assert.That(filter.ToXml(false).OuterXml, Is.EqualTo("<cat re=\"1\">Special,Character-Fixture+!</cat>"));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -204,6 +204,17 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
+        public void CategoryFilterWithSpecialCharacters_FromXml()
+        {
+            TestFilter filter = TestFilter.FromXml(
+                "<filter><cat>Special,Character-Fixture</cat></filter>");
+
+            Assert.That(filter, Is.TypeOf<CategoryFilter>());
+            Assert.That(filter.Match(_specialFixture));
+            Assert.False(filter.Match(_anotherFixture));
+        }
+
+        [Test]
         public void CategoryFilter_ToXml()
         {
             TestFilter filter = new CategoryFilter("CATEGORY");
@@ -218,6 +229,17 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_dummyFixture));
+            Assert.False(filter.Match(_anotherFixture));
+        }
+
+        [Test]
+        public void CategoryFilterWithSpecialCharacters_FromXml_Regex()
+        {
+            TestFilter filter = TestFilter.FromXml(
+                "<filter><cat re='1'>Special,Character-Fixture</cat></filter>");
+
+            Assert.That(filter, Is.TypeOf<CategoryFilter>());
+            Assert.That(filter.Match(_specialFixture));
             Assert.False(filter.Match(_anotherFixture));
         }
 


### PR DESCRIPTION
Fixes #1678 

This is a bit of an intermediate point in my proposed fix for #1678 . It removes the check for special characters `","` and `"-"` in category names, along with adding some tests in various places that we use Category names. Based on what I can see in the console runner (and per [this comment](https://github.com/nunit/nunit/issues/1678#issuecomment-334960196) ) the other two special characters of `"!"` and `"+"` should also be OK. I'll be investigating that next.

This is my first real feature change to the NUnit internals, so I'm trying to take it slow and careful. I'd appreciate a review to see if I'm on the right track.