### PR TITLE
Removed incorrect information about slow-nunit-tests

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,6 @@ The solutions all place their output in a common bin directory under the solutio
 The tests that should be run in the solution are grouped by project name:
  * `nunit.framework.tests-*`
  * `nunitlite.tests-*`
- * `slow-nunit-tests-*`
 
 Other test projects contain tests designed to fail purposely for integration tests.
 


### PR DESCRIPTION
Via https://github.com/nunit/nunit/issues/2021#issuecomment-338502861

They aren't actually intended to be run directly.

/cc @CharliePoole 