### PR TITLE
Handling of native exceptions, to attempt to catch C++ errors …

### DIFF
--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -26,7 +26,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+#if !NET_2_0 && !NET_3_5 && !NETSTANDARD1_3 && !NETSTANDARD1_6
 using System.Runtime.ExceptionServices;
+#endif
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
@@ -199,7 +201,9 @@ namespace NUnit.Framework.Internal
         /// <param name="fixture">The object on which to invoke the method</param>
         /// <param name="args">The argument list for the method</param>
         /// <returns>The return value from the invoked method</returns>
+#if !NET_2_0 && !NET_3_5 && !NETSTANDARD1_3 && !NETSTANDARD1_6
         [HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions. 
+#endif
         public static object InvokeMethod( MethodInfo method, object fixture, params object[] args )
         {
             if(method != null)

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -223,10 +223,6 @@ namespace NUnit.Framework.Internal
                 {
                     throw new NUnitException("Rethrown", e);
                 }
-                catch
-                {
-                    throw new NUnitException("Rethrown", new Exception("Unknown Native exception thrown."));
-                }
             }
 
             return null;

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -24,7 +24,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
@@ -197,6 +199,7 @@ namespace NUnit.Framework.Internal
         /// <param name="fixture">The object on which to invoke the method</param>
         /// <param name="args">The argument list for the method</param>
         /// <returns>The return value from the invoked method</returns>
+        [HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions. 
         public static object InvokeMethod( MethodInfo method, object fixture, params object[] args )
         {
             if(method != null)
@@ -219,6 +222,10 @@ namespace NUnit.Framework.Internal
                 catch (Exception e)
                 {
                     throw new NUnitException("Rethrown", e);
+                }
+                catch
+                {
+                    throw new NUnitException("Rethrown", new Exception("Unknown Native exception thrown."));
                 }
             }
 


### PR DESCRIPTION
Fixes #2091 . It is useful for cases when people are using NUnit in C++/CLI projects and a native exception of corrupt state occurs that crashes the testing thread. When the testing thread crashes, NUnit hangs as a result. 

