### PR TITLE
Add MaxTime constrain property to has.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MaxTimeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/MaxTimeConstraint.cs
@@ -1,0 +1,102 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+using System.Diagnostics;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// MaxTimeConstraint is used to test if a delegate
+    /// executes within the specified maximum time by
+    /// applying a constraint to it.
+    /// </summary>
+    public class MaxTimeConstraint : Constraint
+    {
+        private readonly TimeSpan _maxTime;
+
+        /// <summary>
+        /// Constructs MaxTimeConstraint with the specified timeout.
+        /// </summary>
+        public MaxTimeConstraint(TimeSpan maxTime) : base(maxTime)
+        {
+            _maxTime = maxTime;
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description => $"Maximum time {_maxTime}";
+
+        private static Stopwatch InvokeTestDelegate(object testDelegate)
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            var invocationDescriptor = InvocationDescriptorExtensions.GetInvocationDescriptor(testDelegate);
+
+#if ASYNC
+            if (AsyncInvocationRegion.IsAsyncOperation(invocationDescriptor.Delegate))
+            {
+                using (var region = AsyncInvocationRegion.Create(invocationDescriptor.Delegate))
+                {
+                    stopwatch.Start();
+                    object result = invocationDescriptor.Invoke();
+                    region.WaitForPendingOperationsToComplete(result);
+                    stopwatch.Stop();
+                }
+            }
+            else
+#endif
+            {
+                using (new TestExecutionContext.IsolatedContext())
+                {
+                    stopwatch.Start();
+                    invocationDescriptor.Invoke();
+                    stopwatch.Stop();
+                }
+            }
+
+            return stopwatch;
+        }
+
+        /// <summary>
+        /// Executes the code of the passed delegate, measures the duration of
+        /// the execution and applies the constraint, that the operation should
+        /// finish within the specified maximum time.
+        /// </summary>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            Stopwatch stopwatch = InvokeTestDelegate(actual);
+            return new ConstraintResult(this, stopwatch.Elapsed, stopwatch.Elapsed <= _maxTime);
+        }
+
+        /// <summary>
+        /// Retrieves the value to be tested from an ActualValueDelegate
+        /// wrapped in into <see cref="NUnit.Framework.TestDelegate"/>.
+        /// </summary>
+        protected override object GetTestObject<TActual>(ActualValueDelegate<TActual> actualValueDelegate)
+        {
+            return (TestDelegate)(() => actualValueDelegate());
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Operators/MaxTimeOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/MaxTimeOperator.cs
@@ -1,0 +1,55 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Operator that tests if executed code terminated within
+    /// specified maximum time.
+    /// </summary>
+    public class MaxTimeOperator : SelfResolvingOperator
+    {
+        private readonly TimeSpan _maxTime;
+
+        /// <summary>
+        /// Constructs MaxTimeOperator with specified timeout.
+        /// </summary>
+        public MaxTimeOperator(TimeSpan maxTime)
+        {
+            this._maxTime = maxTime;
+            left_precedence = 1;
+            right_precedence = 100;
+        }
+
+        /// <summary>
+        /// Reduce produces a constraint from the operator and 
+        /// any arguments. It takes the arguments from the constraint 
+        /// stack and pushes the resulting constraint on it.
+        /// </summary>
+        public override void Reduce(ConstraintBuilder.ConstraintStack stack)
+        {
+            stack.Push(new MaxTimeConstraint(_maxTime));
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Constraints
 
             internal static Exception Intercept(object invocation)
             {
-                var invocationDescriptor = GetInvocationDescriptor(invocation);
+                var invocationDescriptor = InvocationDescriptorExtensions.GetInvocationDescriptor(invocation);
 
 #if ASYNC
                 if (AsyncInvocationRegion.IsAsyncOperation(invocationDescriptor.Delegate))
@@ -191,92 +191,9 @@ namespace NUnit.Framework.Constraints
                 }
             }
 
-            private static IInvocationDescriptor GetInvocationDescriptor(object actual)
-            {
-                var invocationDescriptor = actual as IInvocationDescriptor;
-
-                if (invocationDescriptor == null)
-                {
-                    var testDelegate = actual as TestDelegate;
-
-                    if (testDelegate != null)
-                    {
-                        invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
-                    }
-
-#if ASYNC
-                    else
-                    {
-                        var asyncTestDelegate = actual as AsyncTestDelegate;
-                        if (asyncTestDelegate != null)
-                        {
-                            invocationDescriptor = new GenericInvocationDescriptor<System.Threading.Tasks.Task>(() => asyncTestDelegate());
-                        }
-                    }
-#endif
-                }
-                if (invocationDescriptor == null)
-                    throw new ArgumentException(
-                        String.Format(
-                            "The actual value must be a TestDelegate or AsyncTestDelegate but was {0}",
-                            actual.GetType().Name),
-                        "actual");
-
-                return invocationDescriptor;
-            }
         }
 
 #endregion
 
-#region InvocationDescriptor
-
-        internal class GenericInvocationDescriptor<T> : IInvocationDescriptor
-        {
-            private readonly ActualValueDelegate<T> _del;
-
-            public GenericInvocationDescriptor(ActualValueDelegate<T> del)
-            {
-                _del = del;
-            }
-
-            public object Invoke()
-            {
-                return _del();
-            }
-
-            public Delegate Delegate
-            {
-                get { return _del; }
-            }
-        }
-
-        private interface IInvocationDescriptor
-        {
-            Delegate Delegate { get; }
-            object Invoke();
-        }
-
-        private class VoidInvocationDescriptor : IInvocationDescriptor
-        {
-            private readonly TestDelegate _del;
-
-            public VoidInvocationDescriptor(TestDelegate del)
-            {
-                _del = del;
-            }
-
-            public object Invoke()
-            {
-                _del();
-                return null;
-            }
-
-            public Delegate Delegate
-            {
-                get { return _del; }
-            }
-        }
-
-#endregion
     }
 }

--- a/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsNothingConstraint.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -63,7 +64,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         public override ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
-            return ApplyTo(new ThrowsConstraint.GenericInvocationDescriptor<TActual>(del));
+            return ApplyTo(new GenericInvocationDescriptor<TActual>(del));
         }
     }
 }

--- a/src/NUnitFramework/framework/Has.cs
+++ b/src/NUnitFramework/framework/Has.cs
@@ -219,5 +219,20 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region MaxTime
+
+        /// <summary>
+        /// Returns a ConstraintExpression, which will test if the
+        /// operation is terminated within the specified time.
+        /// </summary>
+        public static ResolvableConstraintExpression MaxTime(int milliseconds) => MaxTime(TimeSpan.FromMilliseconds(milliseconds));
+
+        /// <summary>
+        /// Returns a ConstraintExpression, which will test if the
+        /// operation is terminated within the specified time.
+        /// </summary>
+        public static ResolvableConstraintExpression MaxTime(TimeSpan maxTime) => new ConstraintExpression().Append(new MaxTimeOperator(maxTime));
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/GenericInvocationDescriptor.cs
+++ b/src/NUnitFramework/framework/Internal/GenericInvocationDescriptor.cs
@@ -1,0 +1,48 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Internal
+{
+    internal class GenericInvocationDescriptor<T> : IInvocationDescriptor
+    {
+        private readonly ActualValueDelegate<T> _actualValueDelegate;
+
+        public GenericInvocationDescriptor(ActualValueDelegate<T> actualValueDelegate)
+        {
+            _actualValueDelegate = actualValueDelegate;
+        }
+
+        public object Invoke()
+        {
+            return _actualValueDelegate();
+        }
+
+        public Delegate Delegate
+        {
+            get { return _actualValueDelegate; }
+        }
+    }
+
+}

--- a/src/NUnitFramework/framework/Internal/IInvocationDescriptor.cs
+++ b/src/NUnitFramework/framework/Internal/IInvocationDescriptor.cs
@@ -1,0 +1,69 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+
+namespace NUnit.Framework.Internal
+{
+    internal interface IInvocationDescriptor
+    {
+        Delegate Delegate { get; }
+        object Invoke();
+    }
+
+    internal class InvocationDescriptorExtensions
+    {
+        public static IInvocationDescriptor GetInvocationDescriptor(object actual)
+        {
+            var invocationDescriptor = actual as IInvocationDescriptor;
+
+            if (invocationDescriptor == null)
+            {
+                var testDelegate = actual as TestDelegate;
+
+                if (testDelegate != null)
+                {
+                    invocationDescriptor = new VoidInvocationDescriptor(testDelegate);
+                }
+
+#if ASYNC
+                else
+                {
+                    var asyncTestDelegate = actual as AsyncTestDelegate;
+                    if (asyncTestDelegate != null)
+                    {
+                        invocationDescriptor = new GenericInvocationDescriptor<System.Threading.Tasks.Task>(() => asyncTestDelegate());
+                    }
+                }
+#endif
+            }
+            if (invocationDescriptor == null)
+                throw new ArgumentException(
+                    string.Format(
+                        "The actual value must be a TestDelegate or AsyncTestDelegate but was {0}",
+                        actual.GetType().Name),
+                    "actual");
+
+            return invocationDescriptor;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/VoidInvocationDescriptor.cs
+++ b/src/NUnitFramework/framework/Internal/VoidInvocationDescriptor.cs
@@ -1,0 +1,47 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+
+namespace NUnit.Framework.Internal
+{
+    internal class VoidInvocationDescriptor : IInvocationDescriptor
+    {
+        private readonly TestDelegate _testDelegate;
+
+        public VoidInvocationDescriptor(TestDelegate testDelegate)
+        {
+            _testDelegate = testDelegate;
+        }
+
+        public object Invoke()
+        {
+            _testDelegate();
+            return null;
+        }
+
+        public Delegate Delegate
+        {
+            get { return _testDelegate; }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework-2.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-2.0.csproj
@@ -114,7 +114,9 @@
     <Compile Include="Constraints\IConstraint.cs" />
     <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\Interval.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
     <Compile Include="Constraints\Operators\AllOperator.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />
     <Compile Include="Constraints\Operators\SomeOperator.cs" />
     <Compile Include="Constraints\SubPathConstraint.cs" />
@@ -171,6 +173,8 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
@@ -186,6 +190,7 @@
     <Compile Include="Internal\TestNameGenerator.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="TestFixtureData.cs" />
     <Compile Include="DirectoryAssert.cs" />
     <Compile Include="Does.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-3.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-3.5.csproj
@@ -113,7 +113,9 @@
     <Compile Include="Constraints\IConstraint.cs" />
     <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\Interval.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
     <Compile Include="Constraints\Operators\AllOperator.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />
     <Compile Include="Constraints\Operators\SomeOperator.cs" />
     <Compile Include="Constraints\SubPathConstraint.cs" />
@@ -170,6 +172,8 @@
     <Compile Include="Internal\Filters\ClassNameFilter.cs" />
     <Compile Include="Internal\Filters\MethodNameFilter.cs" />
     <Compile Include="Internal\Filters\NamespaceFilter.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\Logging\ILogger.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
@@ -185,6 +189,7 @@
     <Compile Include="Internal\TestNameGenerator.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="TestFixtureData.cs" />
     <Compile Include="DirectoryAssert.cs" />
     <Compile Include="Does.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.0.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.0.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />
     <Compile Include="Constraints\MsgUtils.cs" />
     <Compile Include="Constraints\NaNConstraint.cs" />
@@ -222,6 +223,7 @@
     <Compile Include="Constraints\Operators\BinaryOperator.cs" />
     <Compile Include="Constraints\Operators\CollectionOperator.cs" />
     <Compile Include="Constraints\Operators\ConstraintOperator.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />
     <Compile Include="Constraints\Operators\NotOperator.cs" />
     <Compile Include="Constraints\Operators\OrOperator.cs" />
@@ -375,7 +377,9 @@
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
@@ -421,6 +425,7 @@
     <Compile Include="Internal\TypeHelper.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-4.5.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-4.5.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Attributes\NonTestAssemblyAttribute.cs" />
     <Compile Include="Attributes\NonParallelizableAttribute.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintResult.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Internal\Commands\AfterTestCommand.cs" />
     <Compile Include="Internal\Commands\BeforeTestCommand.cs" />
     <Compile Include="Internal\Commands\DisposeFixtureCommand.cs" />
@@ -104,10 +106,13 @@
     <Compile Include="Internal\Execution\ParallelExecutionStrategy.cs" />
     <Compile Include="Internal\Execution\WorkItemBuilder.cs" />
     <Compile Include="Interfaces\TestAttachment.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\ParamAttributeTypeConversions.cs" />
     <Compile Include="Internal\TestCaseTimeoutException.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="Warn.cs" />
     <Compile Include="Assume.cs" />
     <Compile Include="Attributes\ApartmentAttribute.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard13.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />
     <Compile Include="Constraints\MsgUtils.cs" />
     <Compile Include="Constraints\NaNConstraint.cs" />
@@ -231,6 +232,7 @@
     <Compile Include="Constraints\Operators\CollectionOperator.cs" />
     <Compile Include="Constraints\Operators\ConstraintOperator.cs" />
     <Compile Include="Constraints\Operators\ExactCountOperator.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />
     <Compile Include="Constraints\Operators\NotOperator.cs" />
     <Compile Include="Constraints\Operators\OrOperator.cs" />
@@ -382,7 +384,9 @@
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
@@ -430,6 +434,7 @@
     <Compile Include="Internal\TypeHelper.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
+++ b/src/NUnitFramework/framework/nunit.framework-netstandard16.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Constraints\ItemsConstraintExpression.cs" />
     <Compile Include="Constraints\LessThanConstraint.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraint.cs" />
+    <Compile Include="Constraints\MaxTimeConstraint.cs" />
     <Compile Include="Constraints\MessageWriter.cs" />
     <Compile Include="Constraints\MsgUtils.cs" />
     <Compile Include="Constraints\NaNConstraint.cs" />
@@ -231,6 +232,7 @@
     <Compile Include="Constraints\Operators\CollectionOperator.cs" />
     <Compile Include="Constraints\Operators\ConstraintOperator.cs" />
     <Compile Include="Constraints\Operators\ExactCountOperator.cs" />
+    <Compile Include="Constraints\Operators\MaxTimeOperator.cs" />
     <Compile Include="Constraints\Operators\NoneOperator.cs" />
     <Compile Include="Constraints\Operators\NotOperator.cs" />
     <Compile Include="Constraints\Operators\OrOperator.cs" />
@@ -382,7 +384,9 @@
     <Compile Include="Internal\Filters\PropertyFilter.cs" />
     <Compile Include="Internal\Filters\TestNameFilter.cs" />
     <Compile Include="Internal\Filters\ValueMatchFilter.cs" />
+    <Compile Include="Internal\GenericInvocationDescriptor.cs" />
     <Compile Include="Internal\GenericMethodHelper.cs" />
+    <Compile Include="Internal\IInvocationDescriptor.cs" />
     <Compile Include="Internal\InvalidDataSourceException.cs" />
     <Compile Include="Internal\InvalidPlatformException.cs" />
     <Compile Include="Internal\InvalidTestFixtureException.cs" />
@@ -430,6 +434,7 @@
     <Compile Include="Internal\TypeHelper.cs" />
     <Compile Include="Internal\TypeNameDifferenceResolver.cs" />
     <Compile Include="Internal\TypeWrapper.cs" />
+    <Compile Include="Internal\VoidInvocationDescriptor.cs" />
     <Compile Include="Is.cs" />
     <Compile Include="ITestAction.cs" />
     <Compile Include="Iz.cs" />

--- a/src/NUnitFramework/tests/Constraints/MaxTimeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MaxTimeConstraintTests.cs
@@ -1,0 +1,104 @@
+// *****************************************************************************
+//Copyright(c) 2017 Charlie Poole, Rob Prouse
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+// ****************************************************************************
+
+using System;
+using System.Threading;
+#if ASYNC
+using System.Threading.Tasks;
+#endif
+using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Tests.Constraints
+{
+    [TestFixture]
+    public class MaxTimeConstraintTests : ConstraintTestBaseNoData
+    {
+        private const int TimeOut = 500;
+
+        static object[] SuccessData = new object[]
+        {
+            new TestDelegate(() => Thread.Sleep(100)),
+            new TestDelegate(() => Thread.Sleep(200)),
+#if ASYNC
+#if NET_4_0
+            new AsyncTestDelegate(() => Task.Factory.StartNew(() => Thread.Sleep(100))),
+            new AsyncTestDelegate(() => Task.Factory.StartNew(() => Thread.Sleep(200))),
+#else
+            new AsyncTestDelegate(() => Task.Delay(100)),
+            new AsyncTestDelegate(() => Task.Delay(200)),
+#endif
+#endif
+        };
+
+        static object[] FailureData = new object[]
+        {
+            new TestCaseData(new TestDelegate(() => Thread.Sleep(800))),
+            new TestCaseData(new TestDelegate(() => Thread.Sleep(1000))),
+#if ASYNC
+#if NET_4_0
+            new TestCaseData(new AsyncTestDelegate(() => Task.Factory.StartNew(() => Thread.Sleep(800)))),
+            new TestCaseData(new AsyncTestDelegate(() => Task.Factory.StartNew(() => Thread.Sleep(1000)))),
+#else
+            new TestCaseData(new AsyncTestDelegate(() => Task.Delay(1500))),
+            new TestCaseData(new AsyncTestDelegate(() => Task.Delay(2000))),
+#endif
+#endif
+        };
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeSpan timeOut = TimeSpan.FromMilliseconds(TimeOut);
+            theConstraint = new MaxTimeConstraint(timeOut);
+            expectedDescription = $"Maximum time {timeOut}";
+            stringRepresentation = $"<maxtime {timeOut}>";
+        }
+
+        [Test, TestCaseSource("SuccessData")]
+        public void SucceedsWithGoodValues(object value)
+        {
+            var constraintResult = theConstraint.ApplyTo(value);
+            if (!constraintResult.IsSuccess)
+            {
+                MessageWriter writer = new TextMessageWriter();
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
+            }
+        }
+
+        [Test, TestCaseSource("FailureData")]
+        public void FailsWithBadValues(object badValue)
+        {
+            string NL = Environment.NewLine;
+
+            var constraintResult = theConstraint.ApplyTo(badValue);
+            Assert.IsFalse(constraintResult.IsSuccess);
+
+            TextMessageWriter writer = new TextMessageWriter();
+            constraintResult.WriteMessageTo(writer);
+            Assert.That(writer.ToString(), Does.StartWith(
+                TextMessageWriter.Pfx_Expected + expectedDescription + NL +
+                TextMessageWriter.Pfx_Actual + constraintResult.ActualValue.ToString()));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-2.0.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
     <Compile Include="Constraints\IntervalTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
     <Compile Include="Constraints\CollectionSupersetConstraintTests.cs" />
     <Compile Include="Constraints\DictionaryContainsValueConstraintTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\AsyncSetupTeardownTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.0.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Attributes\TestExpectedResult.cs" />
     <Compile Include="Attributes\TestOrderAttributeTests.cs" />
     <Compile Include="Constraints\CollectionEquivalentConstraintResultTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\CollectionTallyTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-4.5.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Constraints\InstanceOfTypeConstraintTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\MsgUtilTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NotConstraintTests.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard13.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />
     <Compile Include="Constraints\ConstraintTestBase.cs" />

--- a/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-netstandard16.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Constraints\IntervalTests.cs" />
     <Compile Include="Constraints\LessThanConstraintTests.cs" />
     <Compile Include="Constraints\LessThanOrEqualConstraintTests.cs" />
+    <Compile Include="Constraints\MaxTimeConstraintTests.cs" />
     <Compile Include="Constraints\NoItemConstraintTests.cs" />
     <Compile Include="Constraints\NUnitComparerTests.cs" />
     <Compile Include="Constraints\ConstraintTestBase.cs" />


### PR DESCRIPTION
This change adds the feature of Has.MaxTime constraint for assertions: #2021

The implementation is based on https://gist.github.com/jnm2/f5c4e2224114d23e566467dbf1467128, however I rather organized out InvocationDescriptor from ThrowConstraint an resued that.

Please comment on the timeout values use in that test, whether they should be less or just fine with this timeout.