### PR TITLE
Issue #2426 - ApartmentState at assemblyinfo level not being honored by the tests

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -1,4 +1,4 @@
-// ***********************************************************************
+﻿// ***********************************************************************
 // Copyright (c) 2012-2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -67,15 +67,9 @@ namespace NUnit.Framework.Internal.Execution
                 : ParallelScope.Default;
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
-            /*
-            if ((ApartmentState) (Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) == ApartmentState.Unknown &&
-                (ApartmentState) (Test.Parent?.Properties?.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) != ApartmentState.Unknown)
-            {
-                Test.Properties.Set(PropertyNames.ApartmentState, 
-                    Test.Parent?.Properties?.Get(PropertyNames.ApartmentState));
-            }
-            */
-            TargetApartment = (ApartmentState)(Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown);
+            TargetApartment = Test.Properties.ContainsKey(PropertyNames.ApartmentState)
+                ? (ApartmentState)Test.Properties.Get(PropertyNames.ApartmentState)
+                : ApartmentState.Unknown;
 #endif
 
             State = WorkItemState.Ready;
@@ -96,11 +90,11 @@ namespace NUnit.Framework.Internal.Execution
             Result = wrappedItem.Result;
             Context = wrappedItem.Context;
             ParallelScope = wrappedItem.ParallelScope;
-/*
+
 #if PARALLEL
             TestWorker = wrappedItem.TestWorker;
 #endif
-*/
+
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
             TargetApartment = wrappedItem.TargetApartment;
 #endif

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -67,9 +67,14 @@ namespace NUnit.Framework.Internal.Execution
                 : ParallelScope.Default;
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
-            TargetApartment = Test.Properties.ContainsKey(PropertyNames.ApartmentState)
-                ? (ApartmentState)Test.Properties.Get(PropertyNames.ApartmentState)
-                : ApartmentState.Unknown;
+            if ((ApartmentState) (Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) == ApartmentState.Unknown &&
+                (ApartmentState) (Test.Parent?.Properties?.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) != ApartmentState.Unknown)
+            {
+                Test.Properties.Set(PropertyNames.ApartmentState, 
+                    Test.Parent?.Properties?.Get(PropertyNames.ApartmentState));
+            }
+
+            TargetApartment = (ApartmentState)(Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown);
 #endif
 
             State = WorkItemState.Ready;

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -67,14 +67,9 @@ namespace NUnit.Framework.Internal.Execution
                 : ParallelScope.Default;
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
-            if ((ApartmentState) (Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) == ApartmentState.Unknown &&
-                (ApartmentState) (Test.Parent?.Properties?.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown) != ApartmentState.Unknown)
-            {
-                Test.Properties.Set(PropertyNames.ApartmentState, 
-                    Test.Parent?.Properties?.Get(PropertyNames.ApartmentState));
-            }
-
-            TargetApartment = (ApartmentState)(Test.Properties.Get(PropertyNames.ApartmentState) ?? ApartmentState.Unknown);
+            TargetApartment = Test.Properties.ContainsKey(PropertyNames.ApartmentState)
+                ? (ApartmentState)Test.Properties.Get(PropertyNames.ApartmentState)
+                : ApartmentState.Unknown;
 #endif
 
             State = WorkItemState.Ready;

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012-2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -90,11 +90,9 @@ namespace NUnit.Framework.Internal.Execution
             Result = wrappedItem.Result;
             Context = wrappedItem.Context;
             ParallelScope = wrappedItem.ParallelScope;
-
 #if PARALLEL
             TestWorker = wrappedItem.TestWorker;
 #endif
-
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
             TargetApartment = wrappedItem.TargetApartment;
 #endif
@@ -490,8 +488,12 @@ namespace NUnit.Framework.Internal.Execution
                 Test is TestFixture && Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
                 return ParallelExecutionStrategy.Parallel;
 
-            // If all else fails, run on same thread
-            return ParallelExecutionStrategy.Direct;
+            // There is no scope specified either on the item itself or in the context.
+            // In that case, simple work items are test cases and just run on the same
+            // thread, while composite work items and teardowns are non-parallel.
+            return this is SimpleWorkItem
+                ? ParallelExecutionStrategy.Direct
+                : ParallelExecutionStrategy.NonParallel;
         }
 #endif
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -40,8 +40,9 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="test">The test for which this WorkItem is being created.</param>
         /// <param name="filter">The filter to be used in selecting any child Tests.</param>
         /// <param name="recursive">True if child work items should be created and added.</param>
+        /// <param name="parentWorkItem">Parent Work Item</param>
         /// <returns></returns>
-        static public WorkItem CreateWorkItem(ITest test, ITestFilter filter, bool recursive = false)
+        static public WorkItem CreateWorkItem(ITest test, ITestFilter filter, bool recursive = false, WorkItem parentWorkItem = null)
         {
             TestSuite suite = test as TestSuite;
             if (suite == null)
@@ -57,11 +58,12 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     if (filter.Pass(childTest))
                     {
-                        var childItem = CreateWorkItem(childTest, filter, recursive);
+                        var childItem = CreateWorkItem(childTest, filter, recursive, work);
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
-                        if (childItem.TargetApartment == ApartmentState.Unknown && work.TargetApartment != ApartmentState.Unknown)
-                            childItem.TargetApartment = work.TargetApartment;
+                        if (childItem.TargetApartment == ApartmentState.Unknown && 
+                           (parentWorkItem?.TargetApartment ?? ApartmentState.Unknown) != ApartmentState.Unknown)
+                            childItem.TargetApartment = parentWorkItem.TargetApartment;
 #endif
 
                         if (childTest.Properties.ContainsKey(PropertyNames.Order))


### PR DESCRIPTION
Tested using console runner 3.7.0 on a mock assembly with Apartment attribute set at assembly, fixture and method level to see if it is being observed correctly.