### PR TITLE
Filter visibility

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -31,9 +31,6 @@ namespace NUnit.Framework.Internal.Filters
     /// Combines multiple filters so that a test must pass all 
     /// of them in order to pass this filter.
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class AndFilter : CompositeFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class AndFilter : CompositeFilter
+    internal class AndFilter : CompositeFilter
     {
         /// <summary>
         /// Constructs an empty AndFilter

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -33,10 +33,6 @@ namespace NUnit.Framework.Internal.Filters
     /// CategoryFilter is able to select or exclude tests
     /// based on their categories.
     /// </summary>
-    /// 
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class CategoryFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class CategoryFilter : ValueMatchFilter
+    internal class CategoryFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a CategoryFilter using a single category name

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class ClassNameFilter : ValueMatchFilter
+    internal class ClassNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a FullNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// ClassName filter selects tests based on the class FullName
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class ClassNameFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// A base class for multi-part filters
     /// </summary>
-    public abstract class CompositeFilter : TestFilter
+    internal abstract class CompositeFilter : TestFilter
     {
         /// <summary>
         /// Constructs an empty CompositeFilter

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class FullNameFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class FullNameFilter : ValueMatchFilter
+    internal class FullNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a FullNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -30,9 +30,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// IdFilter selects tests based on their id
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class IdFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class IdFilter : ValueMatchFilter
+    internal class IdFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct an IdFilter for a single value

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class MethodNameFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class MethodNameFilter : ValueMatchFilter
+    internal class MethodNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a MethodNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// ClassName filter selects tests based on the class FullName
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class NamespaceFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class NamespaceFilter : ValueMatchFilter
+    internal class NamespaceFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a NamespaceFilter for a single namespace

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class NotFilter : TestFilter
+    internal class NotFilter : TestFilter
     {
         /// <summary>
         /// Construct a not filter on another filter

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// NotFilter negates the operation of another filter
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class NotFilter : TestFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -31,9 +31,6 @@ namespace NUnit.Framework.Internal.Filters
     /// Combines multiple filters so that a test must pass one 
     /// of them in order to pass this filter.
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class OrFilter : CompositeFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class OrFilter : CompositeFilter
+    internal class OrFilter : CompositeFilter
     {
         /// <summary>
         /// Constructs an empty OrFilter

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class PropertyFilter : ValueMatchFilter
+    internal class PropertyFilter : ValueMatchFilter
     {
         private string _propertyName;
 

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -33,10 +33,6 @@ namespace NUnit.Framework.Internal.Filters
     /// PropertyFilter is able to select or exclude tests
     /// based on their properties.
     /// </summary>
-    /// 
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class PropertyFilter : ValueMatchFilter
     {
         private string _propertyName;

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -29,9 +29,6 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// TestName filter selects tests based on their Name
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal class TestNameFilter : ValueMatchFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class TestNameFilter : ValueMatchFilter
+    internal class TestNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a TestNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal.Filters
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
     [Serializable]
 #endif
-    public abstract class ValueMatchFilter : TestFilter
+    internal abstract class ValueMatchFilter : TestFilter
     {
         /// <summary>
         /// Returns the value matched by the filter - used for testing

--- a/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
@@ -32,9 +32,6 @@ namespace NUnit.Framework.Internal.Filters
     /// ValueMatchFilter selects tests based on some value, which
     /// is expected to be contained in the test.
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     internal abstract class ValueMatchFilter : TestFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -33,9 +33,6 @@ namespace NUnit.Framework.Internal
     /// The filter applies when running the test, after it has been
     /// loaded, since this is the only time an ITest exists.
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     public abstract class TestFilter : ITestFilter
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -34,6 +34,22 @@ using System.Security;
                               "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
                               "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
+[assembly: InternalsVisibleTo("nunitlite.tests, PublicKey=002400000480000094" +
+                              "000000060200000024000052534131000400000100010031eea" +
+                              "370b1984bfa6d1ea760e1ca6065cee41a1a279ca234933fe977" +
+                              "a096222c0e14f9e5a17d5689305c6d7f1206a85a53c48ca0100" +
+                              "80799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9" +
+                              "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
+                              "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
+
+[assembly: InternalsVisibleTo("nunitlite, PublicKey=002400000480000094" +
+                              "000000060200000024000052534131000400000100010031eea" +
+                              "370b1984bfa6d1ea760e1ca6065cee41a1a279ca234933fe977" +
+                              "a096222c0e14f9e5a17d5689305c6d7f1206a85a53c48ca0100" +
+                              "80799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9" +
+                              "bee5e972a004ddd692dec8fa404ba4591e847a8cf35de21c2d3" +
+                              "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
+
 #if NET_4_5
 [assembly: AssemblyTitle("NUnit Framework .NET 4.5")]
 #elif NET_4_0

--- a/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
@@ -36,9 +36,6 @@ namespace NUnit.Framework.Internal.Filters
     /// 
     /// It would be better to use a Mocking-Framework for this.
     /// </summary>
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6
-    [Serializable]
-#endif
     public class MockTestFilter : TestFilter
     {
         public enum MatchFunction


### PR DESCRIPTION
This is a partial contribution toward issue #1426.

All classes in the `NUnit.Framework.Internal.Filters` are changed to have `internal` visibility.

In addition, I removed `[Serializable]` from all of these classes because I can't see any reason they would need to be serializable, since NUnit no longer passes filters over remoting as it did in V2. If it turns out they need to be serialized because of some other, external usage we can squash out the second commit. However, ideally, external classes should be passing XML strings to represent filters.

The `TestFilter` class itself has some external usage and its visibility remains unchanged for now.