### PR TITLE
Respect ApartmentState when running tests in Parallel

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="pathName">The parent tests full name</param>
         /// <param name="name">The name of the test</param>
-        protected Test( string pathName, string name ) 
+        protected Test( string pathName, string name )
         {
             Initialize(name);
 
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         }
 
         private static string GetNextId()
-        {            
+        {
             return IdPrefix + unchecked(_nextID++);
         }
 
@@ -231,9 +231,9 @@ namespace NUnit.Framework.Internal
         /// Gets a count of test cases represented by
         /// or contained under this test.
         /// </summary>
-        public virtual int TestCaseCount 
-        { 
-            get { return 1; } 
+        public virtual int TestCaseCount
+        {
+            get { return 1; }
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public MethodInfo[] TearDownMethods { get; protected set; }
 
-        #endregion 
+        #endregion
 
         #region Internal Properties
 
@@ -322,7 +322,7 @@ namespace NUnit.Framework.Internal
                 return _actions;
             }
         }
-        
+
         #endregion
 
         #region Other Public Methods
@@ -338,7 +338,7 @@ namespace NUnit.Framework.Internal
         /// Modify a newly constructed test by applying any of NUnit's common
         /// attributes, based on a supplied ICustomAttributeProvider, which is
         /// usually the reflection element from which the test was constructed,
-        /// but may not be in some instances. The attributes retrieved are 
+        /// but may not be in some instances. The attributes retrieved are
         /// saved for use in subsequent operations.
         /// </summary>
         /// <param name="provider">An object deriving from MemberInfo</param>
@@ -352,7 +352,7 @@ namespace NUnit.Framework.Internal
         /// Modify a newly constructed test by applying any of NUnit's common
         /// attributes, based on a supplied ICustomAttributeProvider, which is
         /// usually the reflection element from which the test was constructed,
-        /// but may not be in some instances. The attributes retrieved are 
+        /// but may not be in some instances. The attributes retrieved are
         /// saved for use in subsequent operations.
         /// </summary>
         /// <param name="provider">An object deriving from MemberInfo</param>
@@ -366,7 +366,7 @@ namespace NUnit.Framework.Internal
         /// Modify a newly constructed test by applying any of NUnit's common
         /// attributes, based on a supplied ICustomAttributeProvider, which is
         /// usually the reflection element from which the test was constructed,
-        /// but may not be in some instances. The attributes retrieved are 
+        /// but may not be in some instances. The attributes retrieved are
         /// saved for use in subsequent operations.
         /// </summary>
         /// <param name="provider">An object implementing ICustomAttributeProvider</param>

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -139,6 +139,27 @@ namespace NUnit.Framework.Attributes
                 Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
             }
         }
+
+        [TestFixture]
+        [Apartment(ApartmentState.STA)]
+        [Parallelizable(ParallelScope.Children)]
+        public class ParallelStaFixtureWithMtaTests
+        {
+            [Test]
+            [Apartment(ApartmentState.MTA)]
+            public void TestMethodsShouldRespectTheirApartment()
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+            }
+
+            [TestCase(1)]
+            [TestCase(2)]
+            [Apartment(ApartmentState.MTA)]
+            public void TestCasesShouldRespectTheirApartment(int n)
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+            }
+        }
     }
 }
 #endif

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -120,6 +120,25 @@ namespace NUnit.Framework.Attributes
                     "RequiresMTAAttribute was not inherited from the base class");
             }
         }
+
+        [TestFixture]
+        [Apartment(ApartmentState.STA)]
+        [Parallelizable(ParallelScope.Children)]
+        public class ParallelStaFixture
+        {
+            [Test]
+            public void TestMethodsShouldInheritApartmentFromFixture()
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+            }
+
+            [TestCase(1)]
+            [TestCase(2)]
+            public void TestCasesShouldInheritApartmentFromFixture(int n)
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+            }
+        }
     }
 }
 #endif

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -160,6 +160,46 @@ namespace NUnit.Framework.Attributes
                 Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
             }
         }
+
+        [TestFixture]
+        [Apartment(ApartmentState.STA)]
+        [Parallelizable(ParallelScope.None)]
+        public class NonParallelStaFixture
+        {
+            [Test]
+            public void TestMethodsShouldInheritApartmentFromFixture()
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+            }
+
+            [TestCase(1)]
+            [TestCase(2)]
+            public void TestCasesShouldInheritApartmentFromFixture(int n)
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+            }
+        }
+
+        [TestFixture]
+        [Apartment(ApartmentState.STA)]
+        [Parallelizable(ParallelScope.None)]
+        public class NonParallelStaFixtureWithMtaTests
+        {
+            [Test]
+            [Apartment(ApartmentState.MTA)]
+            public void TestMethodsShouldRespectTheirApartment()
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+            }
+
+            [TestCase(1)]
+            [TestCase(2)]
+            [Apartment(ApartmentState.MTA)]
+            public void TestCasesShouldRespectTheirApartment(int n)
+            {
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
Fixes #2426 Confirmed by adding the tests from the issue to an integration test project.
Fixes #2288 Confirmed by adding the tests from this issue to the framework tests.

Walking through the code, I think this used to work before because test methods were not run in parallel. Because of this, if their parent was running STA, the tests would just run in that thread. Now the tests are possibly run in parallel too, they cannot rely on their parent. It still worked for simple tests where the test was the direct child of whatever was marked STA, but not more than one level of difference.

This fix has the tests walk up their parent hierarchy until they find the first level that specifies an `ApartmentState` other than `Unknown`. The tests then assume they should be running in the `ApartmentState` that their parent specifies.



