### PR TITLE
[WIP] SetArgDisplayNames for TestCase/FixtureData and templating for TestFixtureData.SetName

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -75,19 +75,7 @@ namespace NUnit.Framework.Internal.Builders
 
             if (parms != null)
             {
-                parms.ApplyToTest(testMethod);
-
-                if (parms.TestName != null)
-                {
-                    // The test is simply for efficiency
-                    testMethod.Name = parms.TestName.Contains("{")
-                        ? new TestNameGenerator(parms.TestName).GetDisplayName(testMethod, parms.OriginalArguments)
-                        : parms.TestName;
-                }
-                else
-                {
-                    testMethod.Name = _nameGenerator.GetDisplayName(testMethod, parms.OriginalArguments);
-                }
+                parms.ApplyToTest(testMethod, _nameGenerator);
             }
             else
             {
@@ -134,7 +122,7 @@ namespace NUnit.Framework.Internal.Builders
             int minArgsNeeded = 0;
             foreach (var parameter in parameters)
             {
-                // IsOptional is supported since .NET 1.1 
+                // IsOptional is supported since .NET 1.1
                 if (!parameter.IsOptional)
                     minArgsNeeded++;
             }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal.Builders
             }
             else
             {
-                testMethod.Name = _nameGenerator.GetDisplayName(testMethod, null);
+                testMethod.Name = _nameGenerator.GetDisplayName(testMethod, null, null);
             }
 
             testMethod.FullName = prefix + "." + testMethod.Name;

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -44,13 +44,12 @@ namespace NUnit.Framework.Internal.Builders
         }
 
         /// <summary>
-        /// Builds a single NUnitTestMethod, either as a child of the fixture
-        /// or as one of a set of test cases under a ParameterizedTestMethodSuite.
+        /// Builds a single <see cref="TestMethod"/>, either as a child of the fixture
+        /// or as one of a set of test cases under a <see cref="ParameterizedMethodSuite"/>.
         /// </summary>
-        /// <param name="method">The MethodInfo from which to construct the TestMethod</param>
+        /// <param name="method">The <see cref="IMethodInfo"/> from which to construct the <see cref="TestMethod"/></param>
         /// <param name="parentSuite">The suite or fixture to which the new test will be added</param>
-        /// <param name="parms">The ParameterSet to be used, or null</param>
-        /// <returns></returns>
+        /// <param name="parms">The <see cref="TestCaseParameters"/> to be used, or null</param>
         public TestMethod BuildTestMethod(IMethodInfo method, Test parentSuite, TestCaseParameters parms)
         {
             var testMethod = new TestMethod(method, parentSuite)

--- a/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal
     /// other selected parameters needed for constructing
     /// a parameterized test case.
     /// </summary>
-    public class TestCaseParameters : TestParameters, ITestCaseData, IApplyToTest
+    public class TestCaseParameters : TestParameters, ITestCaseData
     {
         #region Instance Fields
 

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -119,7 +119,8 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// If not <see langword="null"/>, overrides the list of argument display names to be used when generating a test name.
         /// </summary>
-        protected string[] ArgNames { private get; set; }
+        // TODO: use private protected as soon as the codebase supports C# 7.2
+        internal string[] ArgNames { private get; set; }
 
         /// <summary>
         /// Gets the property dictionary for this test

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         /// If not <see langword="null"/>, overrides the list of argument display names to be used when generating a test name.
         /// </summary>
         // TODO: use private protected as soon as the codebase supports C# 7.2
-        internal string[] ArgNames { private get; set; }
+        internal string[] ArgDisplayNames { private get; set; }
 
         /// <summary>
         /// Gets the property dictionary for this test
@@ -143,12 +143,12 @@ namespace NUnit.Framework.Internal
 
             if (TestName == null)
             {
-                test.Name = defaultTestNameGenerator.GetDisplayName(test, ArgNames, ArgNames != null ? null : OriginalArguments);
+                test.Name = defaultTestNameGenerator.GetDisplayName(test, ArgDisplayNames, ArgDisplayNames != null ? null : OriginalArguments);
             }
             else
             {
                 test.Name = TestName.Contains("{")
-                    ? new TestNameGenerator(TestName).GetDisplayName(test, ArgNames, ArgNames != null ? null : OriginalArguments)
+                    ? new TestNameGenerator(TestName).GetDisplayName(test, ArgDisplayNames, ArgDisplayNames != null ? null : OriginalArguments)
                     : TestName;
             }
         }

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -117,6 +117,11 @@ namespace NUnit.Framework.Internal
         public string TestName { get; set; }
 
         /// <summary>
+        /// If not <see langword="null"/>, overrides the list of argument display names to be used when generating a test name.
+        /// </summary>
+        protected string[] ArgNames { private get; set; }
+
+        /// <summary>
         /// Gets the property dictionary for this test
         /// </summary>
         public IPropertyBag Properties { get; private set; }
@@ -137,12 +142,12 @@ namespace NUnit.Framework.Internal
 
             if (TestName == null)
             {
-                test.Name = defaultTestNameGenerator.GetDisplayName(test, OriginalArguments);
+                test.Name = defaultTestNameGenerator.GetDisplayName(test, ArgNames, ArgNames != null ? null : OriginalArguments);
             }
             else
             {
                 test.Name = TestName.Contains("{")
-                    ? new TestNameGenerator(TestName).GetDisplayName(test, OriginalArguments)
+                    ? new TestNameGenerator(TestName).GetDisplayName(test, ArgNames, ArgNames != null ? null : OriginalArguments)
                     : TestName;
             }
         }

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -129,9 +129,9 @@ namespace NUnit.Framework.Internal
         #endregion
 
         /// <summary>
-        /// Applies the encapsulated parameters to the test method.
+        /// Applies the encapsulated parameters to the test.
         /// </summary>
-        public void ApplyToTest(TestMethod test, TestNameGenerator defaultTestNameGenerator)
+        public void ApplyToTest(Test test, TestNameGenerator defaultTestNameGenerator)
         {
             if (RunState != RunState.Runnable)
                 test.RunState = RunState;

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
     /// TestParameters is the abstract base class for all classes
     /// that know how to provide data for constructing a test.
     /// </summary>
-    public abstract class TestParameters : ITestData, IApplyToTest
+    public abstract class TestParameters : ITestData
     {
         #region Constructors
 
@@ -123,23 +123,29 @@ namespace NUnit.Framework.Internal
 
         #endregion
 
-        #region IApplyToTest Members
-
         /// <summary>
-        /// Applies ParameterSet values to the test itself.
+        /// Applies the encapsulated parameters to the test method.
         /// </summary>
-        /// <param name="test">A test.</param>
-        public void ApplyToTest(Test test)
+        public void ApplyToTest(TestMethod test, TestNameGenerator defaultTestNameGenerator)
         {
-            if (this.RunState != RunState.Runnable)
-                test.RunState = this.RunState;
+            if (RunState != RunState.Runnable)
+                test.RunState = RunState;
 
             foreach (string key in Properties.Keys)
                 foreach (object value in Properties[key])
                     test.Properties.Add(key, value);
-        }
 
-        #endregion
+            if (TestName == null)
+            {
+                test.Name = defaultTestNameGenerator.GetDisplayName(test, OriginalArguments);
+            }
+            else
+            {
+                test.Name = TestName.Contains("{")
+                    ? new TestNameGenerator(TestName).GetDisplayName(test, OriginalArguments)
+                    : TestName;
+            }
+        }
 
         #region Other Public Properties
 

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -103,9 +103,9 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the list of display names to use as the parameters in the test name.
         /// </summary>
-        public TestCaseData SetArgNames(params string[] displayNames)
+        public TestCaseData SetArgDisplay(params string[] displayNames)
         {
-            ArgNames = displayNames;
+            ArgDisplayNames = displayNames;
             return this;
         }
 

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -101,7 +101,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Sets the list of display names to use as the parameters in the test name.
+        /// Sets the list of display names to use as the whole argument list in the test name.
+        /// There may be more or fewer names in the display list than actual arguments.
         /// </summary>
         public TestCaseData SetArgDisplayNames(params string[] displayNames)
         {

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -103,7 +103,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the list of display names to use as the parameters in the test name.
         /// </summary>
-        public TestCaseData SetArgDisplay(params string[] displayNames)
+        public TestCaseData SetArgDisplayNames(params string[] displayNames)
         {
             ArgDisplayNames = displayNames;
             return this;

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -93,12 +92,20 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Sets the name of the test case
+        /// Sets the name of the test case.
         /// </summary>
-        /// <returns>The modified TestCaseData instance</returns>
         public TestCaseData SetName(string name)
         {
-            this.TestName = name;
+            TestName = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the list of display names to use as the parameters in the test name.
+        /// </summary>
+        public TestCaseData SetArgNames(params string[] displayNames)
+        {
+            ArgNames = displayNames;
             return this;
         }
 

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -106,7 +106,7 @@ namespace NUnit.Framework
         /// </summary>
         public TestCaseData SetArgDisplayNames(params string[] displayNames)
         {
-            ArgDisplayNames = displayNames;
+            ArgDisplayNames = displayNames ?? new string[] { null };
             return this;
         }
 

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -90,7 +90,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Sets the list of display names to use as the parameters in the test name.
+        /// Sets the list of display names to use as the whole argument list in the test name.
+        /// There may be more or fewer names in the display list than actual arguments.
         /// </summary>
         public TestFixtureData SetArgDisplayNames(params string[] displayNames)
         {

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -83,8 +83,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the name of the test fixture
         /// </summary>
-        /// <returns>The modified TestFixtureData instance</returns>
-        internal TestFixtureData SetName(string name)
+        public TestFixtureData SetName(string name)
         {
             TestName = name;
             return this;

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the list of display names to use as the parameters in the test name.
         /// </summary>
-        public TestFixtureData SetArgDisplay(params string[] displayNames)
+        public TestFixtureData SetArgDisplayNames(params string[] displayNames)
         {
             ArgDisplayNames = displayNames;
             return this;

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -92,9 +92,9 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the list of display names to use as the parameters in the test name.
         /// </summary>
-        public TestFixtureData SetArgNames(params string[] displayNames)
+        public TestFixtureData SetArgDisplay(params string[] displayNames)
         {
-            ArgNames = displayNames;
+            ArgDisplayNames = displayNames;
             return this;
         }
 

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -88,6 +87,15 @@ namespace NUnit.Framework
         internal TestFixtureData SetName(string name)
         {
             TestName = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the list of display names to use as the parameters in the test name.
+        /// </summary>
+        public TestFixtureData SetArgNames(params string[] displayNames)
+        {
+            ArgNames = displayNames;
             return this;
         }
 

--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -95,7 +95,7 @@ namespace NUnit.Framework
         /// </summary>
         public TestFixtureData SetArgDisplayNames(params string[] displayNames)
         {
-            ArgDisplayNames = displayNames;
+            ArgDisplayNames = displayNames ?? new string[] { null };
             return this;
         }
 

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -210,7 +210,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
             var data = new TestCaseData(args) { Properties = { ["ExpectedTestName"] = { expectedTestName } } };
             if (testName != null) data.SetName(testName);
-            if (argDisplayNames != null) data.SetArgDisplay(argDisplayNames);
+            if (argDisplayNames != null) data.SetArgDisplayNames(argDisplayNames);
             return data;
         }
 

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -206,11 +206,11 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
         }
 
-        private static TestCaseData CreateTestCaseData(string testName, object[] args, string[] argNames, string expectedTestName)
+        private static TestCaseData CreateTestCaseData(string testName, object[] args, string[] argDisplayNames, string expectedTestName)
         {
             var data = new TestCaseData(args) { Properties = { ["ExpectedTestName"] = { expectedTestName } } };
             if (testName != null) data.SetName(testName);
-            if (argNames != null) data.SetArgNames(argNames);
+            if (argDisplayNames != null) data.SetArgDisplay(argDisplayNames);
             return data;
         }
 

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -189,6 +189,9 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
             yield return CreateTestCaseData(null, new object[] { "argValue" }, null, nameof(TestCaseNameTestDataMethod) + "(\"argValue\")");
 
+            yield return CreateTestCaseData(null, new object[] { "argValue" }, null, nameof(TestCaseNameTestDataMethod) + "()")
+                .SetArgDisplayNames(null); // Test use of target-typed null literal
+
             yield return CreateTestCaseData(null, new object[] { "argValue" }, new[] { "argName" }, nameof(TestCaseNameTestDataMethod) + "(argName)");
 
             yield return CreateTestCaseData("a", new object[] { "argValue" }, new[] { "argName" }, "a");
@@ -202,6 +205,8 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             yield return CreateTestCaseData("{a}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "(argName1,argName2)");
 
             yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue1", "argValue2" }, new[] { "argName" }, "argName, ");
+
+            yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
 
             yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
         }

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace NUnit.TestData.TestCaseSourceAttributeFixture
@@ -178,5 +179,41 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
                 }
             }
         }
+
+        #region Test name tests
+
+        [TestCaseSource(nameof(TestCaseNameTestDataSource))]
+        public static void TestCaseNameTestDataMethod(params object[] args) { }
+
+        public static IEnumerable<TestCaseData> TestCaseNameTestDataSource()
+        {
+            yield return CreateTestCaseData(null, new object[] { "argValue" }, null, nameof(TestCaseNameTestDataMethod) + "(\"argValue\")");
+
+            yield return CreateTestCaseData(null, new object[] { "argValue" }, new[] { "argName" }, nameof(TestCaseNameTestDataMethod) + "(argName)");
+
+            yield return CreateTestCaseData("a", new object[] { "argValue" }, new[] { "argName" }, "a");
+
+            yield return CreateTestCaseData("{a}", new object[] { "argValue" }, null, "(\"argValue\")");
+
+            yield return CreateTestCaseData("{a}", new object[] { "argValue" }, new[] { "argName" }, "(argName)");
+
+            yield return CreateTestCaseData("{a}", new object[] { "argValue1", "argValue2" }, new[] { "argName" }, "(argName)");
+
+            yield return CreateTestCaseData("{a}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "(argName1,argName2)");
+
+            yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue1", "argValue2" }, new[] { "argName" }, "argName, ");
+
+            yield return CreateTestCaseData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
+        }
+
+        private static TestCaseData CreateTestCaseData(string testName, object[] args, string[] argNames, string expectedTestName)
+        {
+            var data = new TestCaseData(args) { Properties = { ["ExpectedTestName"] = { expectedTestName } } };
+            if (testName != null) data.SetName(testName);
+            if (argNames != null) data.SetArgNames(argNames);
+            return data;
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -282,11 +282,11 @@ namespace NUnit.TestData.TestFixtureSourceData
             yield return CreateTestFixtureData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
         }
 
-        private static TestFixtureData CreateTestFixtureData(string testName, object[] args, string[] argNames, string expectedFixtureName)
+        private static TestFixtureData CreateTestFixtureData(string testName, object[] args, string[] argDisplayNames, string expectedFixtureName)
         {
             var data = new TestFixtureData(args) { Properties = { ["ExpectedFixtureName"] = { expectedFixtureName } } };
             if (testName != null) data.SetName(testName);
-            if (argNames != null) data.SetArgNames(argNames);
+            if (argDisplayNames != null) data.SetArgDisplay(argDisplayNames);
             return data;
         }
     }

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -286,7 +286,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         {
             var data = new TestFixtureData(args) { Properties = { ["ExpectedFixtureName"] = { expectedFixtureName } } };
             if (testName != null) data.SetName(testName);
-            if (argDisplayNames != null) data.SetArgDisplay(argDisplayNames);
+            if (argDisplayNames != null) data.SetArgDisplayNames(argDisplayNames);
             return data;
         }
     }

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -25,6 +25,7 @@ using System.Collections;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.TestData.TestFixtureSourceData
 {
@@ -90,7 +91,7 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 
     [TestFixtureSource("StaticProperty")]
-    public class StaticProperty_InheritedClass : StaticProperty_SameClass 
+    public class StaticProperty_InheritedClass : StaticProperty_SameClass
     {
         public StaticProperty_InheritedClass (string arg) : base(arg, "StaticPropertyInClass") { }
     }
@@ -247,6 +248,46 @@ namespace NUnit.TestData.TestFixtureSourceData
             yield return new TestFixtureData("GoodData");
             yield return new TestFixtureData("ExplicitData").Explicit("Runs long");
             yield return new TestFixtureData("MoreExplicitData").Explicit();
+        }
+    }
+
+    [TestFixtureSource(nameof(NamedData))]
+    public sealed class IndividualInstanceNameTestDataFixture
+    {
+        public IndividualInstanceNameTestDataFixture(params object[] args)
+        {
+        }
+
+        [Test]
+        public void Test() { }
+
+        public static IEnumerable<TestFixtureData> NamedData()
+        {
+            yield return CreateTestFixtureData(null, new object[] { "argValue" }, null, typeof(IndividualInstanceNameTestDataFixture).Name + "(\"argValue\")");
+
+            yield return CreateTestFixtureData(null, new object[] { "argValue" }, new[] { "argName" }, typeof(IndividualInstanceNameTestDataFixture).Name + "(argName)");
+
+            yield return CreateTestFixtureData("a", new object[] { "argValue" }, new[] { "argName" }, "a");
+
+            yield return CreateTestFixtureData("{a}", new object[] { "argValue" }, null, "(\"argValue\")");
+
+            yield return CreateTestFixtureData("{a}", new object[] { "argValue" }, new[] { "argName" }, "(argName)");
+
+            yield return CreateTestFixtureData("{a}", new object[] { "argValue1", "argValue2" }, new[] { "argName" }, "(argName)");
+
+            yield return CreateTestFixtureData("{a}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "(argName1,argName2)");
+
+            yield return CreateTestFixtureData("{0}, {1}", new object[] { "argValue1", "argValue2" }, new[] { "argName" }, "argName, ");
+
+            yield return CreateTestFixtureData("{0}, {1}", new object[] { "argValue" }, new[] { "argName1", "argName2" }, "argName1, argName2");
+        }
+
+        private static TestFixtureData CreateTestFixtureData(string testName, object[] args, string[] argNames, string expectedFixtureName)
+        {
+            var data = new TestFixtureData(args) { Properties = { ["ExpectedFixtureName"] = { expectedFixtureName } } };
+            if (testName != null) data.SetName(testName);
+            if (argNames != null) data.SetArgNames(argNames);
+            return data;
         }
     }
 

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -265,6 +265,9 @@ namespace NUnit.TestData.TestFixtureSourceData
         {
             yield return CreateTestFixtureData(null, new object[] { "argValue" }, null, typeof(IndividualInstanceNameTestDataFixture).Name + "(\"argValue\")");
 
+            yield return CreateTestFixtureData(null, new object[] { "argValue" }, null, typeof(IndividualInstanceNameTestDataFixture).Name + "()")
+                .SetArgDisplayNames(null); // Test use of target-typed null literal
+
             yield return CreateTestFixtureData(null, new object[] { "argValue" }, new[] { "argName" }, typeof(IndividualInstanceNameTestDataFixture).Name + "(argName)");
 
             yield return CreateTestFixtureData("a", new object[] { "argValue" }, new[] { "argName" }, "a");

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -335,6 +335,38 @@ namespace NUnit.Framework.Attributes
 
         static string[][] SingleMemberArrayAsArgument = { new[] { "1" }  };
 
+        #region Test name tests
+
+        public static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
+        {
+            var suite = (ParameterizedMethodSuite)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture),
+                nameof(TestCaseSourceAttributeFixture.TestCaseNameTestDataMethod));
+
+            foreach (var test in suite.Tests)
+            {
+                var expectedName = (string)test.Properties.Get("ExpectedTestName");
+
+                yield return new TestCaseData(test, expectedName)
+                    .SetArgNames(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+            }
+        }
+
+        [TestCaseSource(nameof(IndividualInstanceNameTestDataSource))]
+        public static void IndividualInstanceName(ITest test, string expectedName)
+        {
+            Assert.That(test.Name, Is.EqualTo(expectedName));
+        }
+
+        [TestCaseSource(nameof(IndividualInstanceNameTestDataSource))]
+        public static void IndividualInstanceFullName(ITest test, string expectedName)
+        {
+            var expectedFullName = typeof(TestCaseSourceAttributeFixture).FullName + "." + expectedName;
+            Assert.That(test.FullName, Is.EqualTo(expectedFullName));
+        }
+
+        #endregion
+
         #region Sources used by the tests
         static object[] MyData = new object[] {
             new object[] { 12, 3, 4 },

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -348,7 +348,7 @@ namespace NUnit.Framework.Attributes
                 var expectedName = (string)test.Properties.Get("ExpectedTestName");
 
                 yield return new TestCaseData(test, expectedName)
-                    .SetArgDisplay(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+                    .SetArgDisplayNames(expectedName); // SetArgDisplayNames (here) is purely cosmetic for the purposes of these tests
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -348,7 +348,7 @@ namespace NUnit.Framework.Attributes
                 var expectedName = (string)test.Properties.Get("ExpectedTestName");
 
                 yield return new TestCaseData(test, expectedName)
-                    .SetArgNames(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+                    .SetArgDisplay(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Attributes
                 var expectedName = (string)testFixture.Properties.Get("ExpectedFixtureName");
 
                 yield return new TestCaseData((TestFixture)testFixture, expectedName)
-                    .SetArgDisplay(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+                    .SetArgDisplayNames(expectedName); // SetArgDisplayNames (here) is purely cosmetic for the purposes of these tests
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -22,10 +22,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Framework;
+using System.Collections.Generic;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.Filters;
 using NUnit.TestData.TestFixtureSourceData;
 using NUnit.TestUtilities;
 
@@ -86,6 +85,34 @@ namespace NUnit.Framework.Attributes
             Assert.That(suite.Tests[1].Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Runs long"));
             Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Explicit));
         }
+
+
+        public static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
+        {
+            var suite = (ParameterizedFixtureSuite)TestBuilder.MakeFixture(typeof(IndividualInstanceNameTestDataFixture));
+
+            foreach (var testFixture in suite.Tests)
+            {
+                var expectedName = (string)testFixture.Properties.Get("ExpectedFixtureName");
+
+                yield return new TestCaseData((TestFixture)testFixture, expectedName)
+                    .SetArgNames(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+            }
+        }
+
+        [TestCaseSource(nameof(IndividualInstanceNameTestDataSource))]
+        public static void IndividualInstanceName(TestFixture testFixture, string expectedName)
+        {
+            Assert.That(testFixture.Name, Is.EqualTo(expectedName));
+        }
+
+        [TestCaseSource(nameof(IndividualInstanceNameTestDataSource))]
+        public static void IndividualInstanceFullName(TestFixture testFixture, string expectedName)
+        {
+            var expectedFullName = typeof(IndividualInstanceNameTestDataFixture).Namespace + "." + expectedName;
+            Assert.That(testFixture.FullName, Is.EqualTo(expectedFullName));
+        }
+
 
         [Test]
         public void Issue1118()

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Attributes
                 var expectedName = (string)testFixture.Properties.Get("ExpectedFixtureName");
 
                 yield return new TestCaseData((TestFixture)testFixture, expectedName)
-                    .SetArgNames(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
+                    .SetArgDisplay(expectedName); // SetArgNames (here) is purely cosmetic for the purposes of these tests
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -84,6 +84,19 @@ namespace NUnit.Framework.Internal
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, null, args);
         }
 
+        [TestCase("{a}", new[] { "1", "2" }, ExpectedResult = "(1,2)")]
+        [TestCase("{a}", new[] { ",", " " }, ExpectedResult = "(,, )")]
+        [TestCase("{a}", new string[0], ExpectedResult = "()")]
+        [TestCase("{0}", new[] { "1", "2" }, ExpectedResult = "1")]
+        [TestCase("{0}{1}", new[] { "1", "2" }, ExpectedResult = "12")]
+        [TestCase("{0},{1},{2}", new[] { "1", "2" }, ExpectedResult = "1,2,")]
+        [TestCase("{0:20}", new[] { "Now is the time for all good men to come to the aid of their country." }, ExpectedResult = "Now is the time f...")]
+        [TestCase("{a:20}", new[] { "42", "Now is the time for all good men to come to the aid of their country." }, ExpectedResult = "(42,Now is the time f...)")]
+        public string ArgumentDisplayNames(string pattern, string[] argDisplayNames)
+        {
+            return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, argDisplayNames, new object[] { 1, 2, 3 });
+        }
+
         [TestCase("FIXED", ExpectedResult="FIXED")]
         [TestCase("{m}",   ExpectedResult="GenericTest<T,U,V>")]
         [TestCase("{n}", ExpectedResult = "NUnit.Framework.Internal")]

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
             ExpectedResult = "TestMethod(\"Now is the time f...\")")]
         public string ParameterizedTests(string pattern, object[] args)
         {
-            return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, args);
+            return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, null, args);
         }
 
         [TestCase("FIXED", ExpectedResult="FIXED")]
@@ -139,7 +139,7 @@ namespace NUnit.Framework.Internal
         [TestCase(sbyte.MinValue, ExpectedResult = "sbyte.MinValue")]
         public string SpecialNamedValues(object arg)
         {
-            return new TestNameGenerator("{0}").GetDisplayName(_simpleTest, new[] { arg } );
+            return new TestNameGenerator("{0}").GetDisplayName(_simpleTest, null, new[] { arg } );
         }
 
         #region Methods Used as Data


### PR DESCRIPTION
Closes #2536 and also brings `TestFixtureData.SetName` into consistency with `TestCaseSource.SetName`.

See the TestNameGeneratorTests for a quick intro to the approach I took. Walking through the commits one by one could help because they are separable.

I also added it to TestFixtureData which made it super easy to make `TestFixtureData.SetName` consistent with `TestCaseData` with name generation. Expansions will work. This is something we should discuss and agree on before `TestFixtureData.SetName` makes its debut in 3.9. /cc @rprouse @CharliePoole 

API changes:

```diff
namespace NUnit.Framework
{
    public class TestCaseData : NUnit.Framework.Internal.TestCaseParameters
    {
+       public TestCaseData SetArgDisplay(params string[] displayNames);
    }

    public class TestFixtureData : NUnit.Framework.Internal.TestFixtureParameters
    {
+       public TestFixtureData SetArgDisplay(params string[] displayNames);
    }
}
namespace NUnit.Framework.Internal
{
-   public abstract class TestParameters : NUnit.Framework.Interfaces.ITestData, NUnit.Framework.Interfaces.IApplyToTest
+   public abstract class TestParameters : NUnit.Framework.Interfaces.ITestData
    {
-       public void ApplyToTest(Test test)
+       public void ApplyToTest(Test test, TestNameGenerator defaultTestNameGenerator)
    }
}
```

/fyi @stewart-r