### PR TITLE
Fix for Matches<T>(Predicate<T>) not accepting null for nullable types

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -68,6 +68,20 @@ namespace NUnit.Compatibility
         {
             T[] attrs = (T[])assembly.GetCustomAttributes(typeof(T), false);
             return attrs.Length > 0 ? attrs[0] : null;
+        }
+    }
+
+    /// <summary>
+    /// Extensions for MethodInfo that are not available in pre-4.5 .NET releases
+    /// </summary>
+    public static class MethodInfoExtensions
+    {
+        /// <summary>
+        /// See <see cref="Delegate.CreateDelegate(Type, MethodInfo)"/>.
+        /// </summary>
+        public static Delegate CreateDelegate(this MethodInfo method, Type type)
+        {
+            return Delegate.CreateDelegate(type, method);
         }
     }
 

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -22,8 +22,8 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -67,10 +67,9 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if (!(actual is T))
-                throw new ArgumentException("The actual value is not of type " + typeof(T).Name, "actual");
+            var argument = ConstraintUtils.RequireActual<T>(actual, nameof(actual), allowNull: true);
 
-            return new ConstraintResult(this, actual, predicate((T)(object)actual));
+            return new ConstraintResult(this, actual, predicate(argument));
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/ConstraintUtils.cs
+++ b/src/NUnitFramework/framework/Internal/ConstraintUtils.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Globalization;
 
 namespace NUnit.Framework.Internal
 {
@@ -32,16 +31,18 @@ namespace NUnit.Framework.Internal
     internal static class ConstraintUtils
     {
         /// <summary>
-        /// Require that the provided object is actually of the type required,
-        /// and that it is not null.
+        /// Requires that the provided object is actually of the type required.
         /// </summary>
         /// <param name="actual">The object to verify.</param>
         /// <param name="paramName">Name of the parameter as passed into the checking method.</param>
-        /// <typeparam name="T">The type to require.</typeparam>  
-        /// <returns>A properly typed object, or throws. Never null.</returns>
-        public static T RequireActual<T>(object actual, string paramName)
+        /// <param name="allowNull">
+        /// If <see langword="true"/> and <typeparamref name="T"/> can be null, returns null rather than throwing when <paramref name="actual"/> is null.
+        /// If <typeparamref name="T"/> cannot be null, this parameter is ignored.</param>
+        /// <typeparam name="T">The type to require.</typeparam>
+        public static T RequireActual<T>(object actual, string paramName, bool allowNull = false)
         {
             if (actual is T) return (T)actual;
+            if (allowNull && actual == null && default(T) == null) return default(T);
 
             var actualDisplay = actual == null ? "null" : actual.GetType().Name;
             throw new ArgumentException($"Expected: {typeof(T).Name} But was: {actualDisplay}", paramName);

--- a/src/NUnitFramework/tests/Constraints/PredicateConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PredicateConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -22,6 +22,9 @@
 // ***********************************************************************
 
 using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Compatibility;
 
 namespace NUnit.Framework.Constraints
 {
@@ -31,12 +34,12 @@ namespace NUnit.Framework.Constraints
         [SetUp]
         public void SetUp()
         {
-            theConstraint = new PredicateConstraint<int>((x) => x < 5 );
+            theConstraint = new PredicateConstraint<int>((x) => x < 5);
             expectedDescription = @"value matching lambda expression";
             stringRepresentation = "<predicate>";
         }
 
-        static object[] SuccessData = new object[] 
+        static object[] SuccessData = new object[]
         {
             0,
             -5
@@ -51,6 +54,47 @@ namespace NUnit.Framework.Constraints
         public void CanUseConstraintExpressionSyntax()
         {
             Assert.That(123, Is.TypeOf<int>().And.Matches<int>((int x) => x > 100));
+        }
+
+        [TestCase(typeof(object))]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(int?))]
+        [TestCase(typeof(AttributeTargets?))]
+        public static void ActualMayBeNullForNullableTypes(Type type)
+        {
+            // https://github.com/nunit/nunit/issues/1215
+            var methodInfo = typeof(PredicateConstraintTests)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                .Single(method => method.Name == nameof(ActualMayBeNullForNullableTypes) && method.GetParameters().Length == 0)
+                .MakeGenericMethod(type);
+
+            ((Action)methodInfo.CreateDelegate(typeof(Action))).Invoke();
+        }
+
+        private static void ActualMayBeNullForNullableTypes<T>()
+        {
+            Assert.That(null, new ConstraintExpression().Matches<T>(actual => true));
+        }
+
+        [TestCase(typeof(int))]
+        [TestCase(typeof(AttributeTargets))]
+        public static void ActualMustNotBeNullForNonNullableTypes(Type type)
+        {
+            // https://github.com/nunit/nunit/issues/1215
+            var methodInfo = typeof(PredicateConstraintTests)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                .Single(method => method.Name == nameof(ActualMustNotBeNullForNonNullableTypes) && method.GetParameters().Length == 0)
+                .MakeGenericMethod(type);
+
+            ((Action)methodInfo.CreateDelegate(typeof(Action))).Invoke();
+        }
+
+        private static void ActualMustNotBeNullForNonNullableTypes<T>()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, new ConstraintExpression().Matches<T>(actual => true));
+            }, Throws.ArgumentException);
         }
     }
 }


### PR DESCRIPTION
Fixes #2533.