### PR TITLE
Made TestFixtureData.SetName internal for 3.9 (see #2538)

### DIFF
--- a/src/NUnitFramework/framework/TestFixtureData.cs
+++ b/src/NUnitFramework/framework/TestFixtureData.cs
@@ -85,7 +85,7 @@ namespace NUnit.Framework
         /// Sets the name of the test fixture
         /// </summary>
         /// <returns>The modified TestFixtureData instance</returns>
-        public TestFixtureData SetName(string name)
+        internal TestFixtureData SetName(string name)
         {
             TestName = name;
             return this;


### PR DESCRIPTION
Addresses the immediate concern (see https://github.com/nunit/nunit/pull/2538) that we want to finish discussion on `TestFixtureData.SetName` and how it fits in the bigger picture before it ships.

API diff:

```diff
namespace NUnit.Framework
{
    public class TestFixtureData : NUnit.Framework.Internal.TestFixtureParameters
    {
-       public TestFixtureData SetName(string name);
    }
}
```