### PR TITLE
Direct users to NUnit.StaticExpect as a replacement for AssertionHelper

### DIFF
--- a/src/NUnitFramework/framework/AssertionHelper.cs
+++ b/src/NUnitFramework/framework/AssertionHelper.cs
@@ -31,7 +31,8 @@ namespace NUnit.Framework
     /// AssertionHelper is an optional base class for user tests,
     /// allowing the use of shorter names in making asserts.
     /// </summary>
-    [Obsolete("The AssertionHelper class will be removed in a coming release.")]
+    [Obsolete("The AssertionHelper class will be removed in a coming release. " +
+              "Consider using the NUnit.StaticExpect NuGet package as a replacement.")]
     public class AssertionHelper
     {
         #region Expect


### PR DESCRIPTION
Fixes #1212 - according to the plans discussed in https://github.com/nunit/nunit/issues/1212#issuecomment-337187015. I've created a separate issue for the documentation aspect, which I'll come back to after going away.