### PR TITLE
Remove unused defines

### DIFF
--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -15,15 +15,15 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PARALLEL</DefineConstants>
+    <DefineConstants>TRACE;PARALLEL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net45'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PARALLEL;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;PARALLEL;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -12,7 +12,7 @@
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -153,17 +153,7 @@ using System.Runtime.Serialization;
 using System.Linq;
 #endif
 
-#if TEST
-using NDesk.Options;
-#endif
-
-#if NUNIT_CONSOLE || NUNITLITE || NUNIT_ENGINE
 namespace NUnit.Options
-#elif NDESK_OPTIONS
-namespace NDesk.Options
-#else
-namespace Mono.Options
-#endif
 {
     public class OptionValueCollection : IList, IList<string> {
 

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -11,7 +11,7 @@
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netstandard1.6'">Full</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -14,15 +14,15 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PARALLEL;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;PARALLEL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;NUNITLITE;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'net20' AND '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'netcoreapp1.1'">
-    <DefineConstants>TRACE;NUNIT_FRAMEWORK;PARALLEL;NUNITLITE;ASYNC</DefineConstants>
+    <DefineConstants>TRACE;PARALLEL;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The NUNIT_FRAMEWORK and NUNITLITE defines are no longer used, so removing from the project files.