### PR TITLE
Changed '.NET' to '.NET Framework' in nuspecs

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -16,7 +16,7 @@
 This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
 
 Supported platforms:
-- .NET 2.0+
+- .NET Framework 2.0+
 - .NET Standard 1.6
 - .NET Core</description>
     <releaseNotes>This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.</releaseNotes>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -14,7 +14,7 @@
     <description>NUnitLite provides a simple way to run NUnit tests, without the overhead of a full NUnit installation. It is suitable for projects that want to have a quick way to run tests using a console runner and don't need all the features of the NUnit engine and console runner.
 
 Supported platforms:
-- .NET 2.0+
+- .NET Framework 2.0+
 - .NET Standard 1.6
 - .NET Core
 


### PR DESCRIPTION
The .NET Framework is now mentioned with the same specificity as the other compatible frameworks we're listing.