### PR TITLE
Minimalize csprojs

### DIFF
--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -1,0 +1,21 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- netcoreapp1.1 tests currently pull the netstandard1.6 framework, so they should not have PARALLEL defined yet. -->
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6' and '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);PARALLEL</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35'">$(DefineConstants);ASYNC</DefineConstants>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -1,56 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
   <PropertyGroup>
-    <AssemblyName>nunit.framework</AssemblyName>
-    <RootNamespace>NUnit.Framework</RootNamespace>
     <TargetFrameworks>net20;net35;net40;net45;netstandard1.6</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>..\..\..\bin\$(Configuration)\$(TargetFramework)\nunit.framework.xml</DocumentationFile>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netstandard1.6'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <RootNamespace>NUnit.Framework</RootNamespace>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\nunit.framework.xml</DocumentationFile>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35'">
-    <DefineConstants>TRACE;PARALLEL</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net45'">
-    <DefineConstants>TRACE;PARALLEL;ASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <DefineConstants>TRACE;ASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -1,32 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AssemblyName>mock-assembly</AssemblyName>
-    <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
+  <Import Project="..\Common.props" />
+  <PropertyGroup>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
@@ -36,4 +14,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -1,34 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AssemblyName>nunitlite-runner</AssemblyName>
-    <RootNamespace>NUnitLite</RootNamespace>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
+  <Import Project="..\Common.props" />
+  <PropertyGroup>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>NUnitLite</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
     <ProjectReference Include="..\nunitlite\nunitlite.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -1,58 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
   <PropertyGroup>
-    <AssemblyName>nunitlite.tests</AssemblyName>
-    <RootNamespace>NUnitLite.Tests</RootNamespace>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE</DefineConstants>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>NUnitLite.Tests</RootNamespace>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-    <Compile Include="..\Fakes.cs">
-      <Link>TestUtilities\Fakes.cs</Link>
-    </Compile>
-    <Compile Include="..\TestBuilder.cs">
-      <Link>TestUtilities\TestBuilder.cs</Link>
-    </Compile>
-    <Compile Include="..\TestFile.cs">
-      <Link>TestUtilities\TestFile.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="TestListFile.txt" />
-    <EmbeddedResource Include="TestListFile2.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp1.1'">
-    <Reference Include="System.Web" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\framework\nunit.framework.csproj" />
     <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
     <ProjectReference Include="..\nunitlite\nunitlite.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Fakes.cs" Link="TestUtilities\Fakes.cs" />
+    <Compile Include="..\TestBuilder.cs" Link="TestUtilities\TestBuilder.cs" />
+    <Compile Include="..\TestFile.cs" Link="TestUtilities\TestFile.cs" />
+
+    <EmbeddedResource Include="TestListFile.txt" />
+    <EmbeddedResource Include="TestListFile2.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -1,44 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
   <PropertyGroup>
-    <AssemblyName>nunitlite</AssemblyName>
-    <RootNamespace>NUnitLite</RootNamespace>
     <TargetFrameworks>net20;net35;net40;net45;netstandard1.6</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netstandard1.6'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE</DefineConstants>
+    <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
+    <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\framework\nunit.framework.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -1,32 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AssemblyName>slow-nunit-tests</AssemblyName>
-    <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
+  <Import Project="..\Common.props" />
+  <PropertyGroup>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
@@ -35,4 +13,5 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -1,49 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
   <PropertyGroup>
-    <AssemblyName>nunit.testdata</AssemblyName>
-    <RootNamespace>NUnit.TestData</RootNamespace>
     <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>TRACE;ASYNC</DefineConstants>
+    <RootNamespace>NUnit.TestData</RootNamespace>
     <Optimize>false</Optimize>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35'">
-    <DefineConstants>TRACE;PARALLEL</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>TRACE;ASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net20' AND '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'netcoreapp1.1'">
-    <DefineConstants>TRACE;PARALLEL;ASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="packages.config" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="Microsoft.Bcl" version="1.1.10" />
@@ -58,4 +20,5 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
     <RootNamespace>NUnit.TestData</RootNamespace>
+
+    <!-- Needed because we test stack traces and don't want to have to put
+         [MethodImpl(MethodImplOptions.NoInlining)] on everything involved. -->
     <Optimize>false</Optimize>
   </PropertyGroup>
 

--- a/src/NUnitFramework/tests/TestDataAssemblyTests.cs
+++ b/src/NUnitFramework/tests/TestDataAssemblyTests.cs
@@ -1,0 +1,38 @@
+// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace NUnit.Framework
+{
+    public static class TestDataAssemblyTests
+    {
+        [Test(Description = "Needed because we test stack traces and don’t want to have to put [MethodImpl(MethodImplOptions.NoInlining)] on everything involved.")]
+        public static void AssemblyIsNotOptimized()
+        {
+            Assert.That(Assembly.Load(new AssemblyName("nunit.testdata")),
+                Has.Attribute<DebuggableAttribute>().With.Property("IsJITOptimizerDisabled").EqualTo(true));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,73 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
   <PropertyGroup>
-    <AssemblyName>nunit.framework.tests</AssemblyName>
-    <RootNamespace>NUnit.Framework</RootNamespace>
     <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35'">
-    <DefineConstants>TRACE;PARALLEL</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>TRACE;ASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net20' AND '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'netcoreapp1.1'">
-    <DefineConstants>TRACE;PARALLEL;ASYNC</DefineConstants>
+    <RootNamespace>NUnit.Framework</RootNamespace>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="packages.config" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\FrameworkVersion.cs">
-      <Link>Properties\FrameworkVersion.cs</Link>
-    </Compile>
-    <Compile Include="..\Fakes.cs">
-      <Link>TestUtilities\Fakes.cs</Link>
-    </Compile>
-    <Compile Include="..\TestBuilder.cs">
-      <Link>TestUtilities\TestBuilder.cs</Link>
-    </Compile>
-    <Compile Include="..\TestFile.cs">
-      <Link>TestUtilities\TestFile.cs</Link>
-    </Compile>
-    <Compile Include="..\TestSuiteExtensions.cs" Link="TestUtilities\TestSuiteExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="TestImage1.jpg" />
-    <EmbeddedResource Include="TestImage2.jpg" />
-    <EmbeddedResource Include="TestText1.txt" />
-    <EmbeddedResource Include="TestText2.txt" />
-    <EmbeddedResource Include="TestListFile.txt" />
-    <EmbeddedResource Include="TestListFile2.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\nunit.snk">
-      <Link>nunit.snk</Link>
-    </None>
+    <ProjectReference Include="..\framework\nunit.framework.csproj" />
+    <ProjectReference Include="..\slow-tests\slow-nunit-tests.csproj" />
+    <ProjectReference Include="..\testdata\nunit.testdata.csproj" />
+    <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
-    <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
@@ -76,7 +25,7 @@
     <PackageReference Include="Microsoft.Bcl.Build" version="1.0.21" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net20' AND '$(TargetFramework)' != 'net35'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35'">
     <PackageReference Include="System.ValueTuple" version="4.3.1" />
   </ItemGroup>
 
@@ -86,13 +35,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\framework\nunit.framework.csproj" />
-    <ProjectReference Include="..\slow-tests\slow-nunit-tests.csproj" />
-    <ProjectReference Include="..\testdata\nunit.testdata.csproj" />
-    <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
+    <Compile Include="..\Fakes.cs" Link="TestUtilities\Fakes.cs" />
+    <Compile Include="..\TestBuilder.cs" Link="TestUtilities\TestBuilder.cs" />
+    <Compile Include="..\TestFile.cs" Link="TestUtilities\TestFile.cs" />
+    <Compile Include="..\TestSuiteExtensions.cs" Link="TestUtilities\TestSuiteExtensions.cs" />
+
+    <EmbeddedResource Include="TestImage1.jpg" />
+    <EmbeddedResource Include="TestImage2.jpg" />
+    <EmbeddedResource Include="TestText1.txt" />
+    <EmbeddedResource Include="TestText2.txt" />
+    <EmbeddedResource Include="TestListFile.txt" />
+    <EmbeddedResource Include="TestListFile2.txt" />
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Re: https://github.com/orgs/nunit/teams/framework-and-engine-team/discussions/3

Simplified as much in the csprojs possible, mainly by introducing a typical Common.props include.

I also took advantage of the fact that the NUnit 3 test adapter fails to discover tests for assemblies with portable PDBs beside them and only allowed `<DebugType>Full</DebugType>` on the projects that people are supposed to test in VS anyway. :-}

