### PR TITLE
Restore LangVersion setting after csproj migration

### DIFF
--- a/nunit.sln
+++ b/nunit.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.cake = build.cake
 		BUILDING.md = BUILDING.md
 		CHANGES.md = CHANGES.md
+		src\NUnitFramework\Common.props = src\NUnitFramework\Common.props
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.txt = LICENSE.txt
 		NOTICES.txt = NOTICES.txt

--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -5,6 +5,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6' and '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);PARALLEL</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35'">$(DefineConstants);ASYNC</DefineConstants>
 
+    <LangVersion>6</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
I was being tormented all evening by code suggestions which I strongly agreed with until it dawned on me that we'd somehow dropped the LangVersion restriction. 😆

Also added Common.props to Solution Items to make it easier to get to.