### PR TITLE
Use IsInstanceOfType(obj) instead of IsAssignableFrom(obj.GetType())

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -278,8 +278,7 @@ namespace NUnit.Framework
                     {
                         if (argsProvided == argsNeeded)
                         {
-                            Type lastArgumentType = parms.Arguments[argsProvided - 1].GetType();
-                            if (!lastParameterType.GetTypeInfo().IsAssignableFrom(lastArgumentType.GetTypeInfo()))
+                            if (!lastParameterType.IsInstanceOfType(parms.Arguments[argsProvided - 1]))
                             {
                                 Array array = Array.CreateInstance(elementType, 1);
                                 array.SetValue(parms.Arguments[argsProvided - 1], 0);
@@ -370,7 +369,7 @@ namespace NUnit.Framework
                 if (arg == null)
                     continue;
 
-                if (targetType.IsAssignableFrom(arg.GetType()))
+                if (targetType.IsInstanceOfType(arg))
                     continue;
 #if !NETSTANDARD1_6
                 if (arg is DBNull)

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -154,7 +154,7 @@ namespace NUnit.Compatibility
         /// <returns></returns>
         public static bool IsInstanceOfType(this Type type, object other)
         {
-            return other != null && type.IsAssignableFrom(other.GetType());
+            return type.GetTypeInfo().IsInstanceOfType(other);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/AssignableToConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AssignableToConstraint.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if the constraint succeeds, otherwise false.</returns>
         protected override bool Matches(object actual)
         {
-            return expectedType != null && actual != null && expectedType.GetTypeInfo().IsAssignableFrom(actual.GetType().GetTypeInfo());
+            return expectedType != null && actual != null && expectedType.IsInstanceOfType(actual);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -26,6 +26,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -129,13 +130,15 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             public override int Compare(object expected, object actual)
             {
-                if (!typeof(T).GetTypeInfo().IsAssignableFrom(expected.GetType().GetTypeInfo()))
-                    throw new ArgumentException("Cannot compare " + expected.ToString());
+                T expectedCast;
+                if (!TypeHelper.TryCast(expected, out expectedCast))
+                    throw new ArgumentException($"Cannot compare {expected?.ToString() ?? "null"}");
 
-                if (!typeof(T).GetTypeInfo().IsAssignableFrom(actual.GetType().GetTypeInfo()))
-                    throw new ArgumentException("Cannot compare to " + actual.ToString());
+                T actualCast;
+                if (!TypeHelper.TryCast(actual, out actualCast))
+                    throw new ArgumentException($"Cannot compare to {actual?.ToString() ?? "null"}");
 
-                return comparer.Compare((T)expected, (T)actual);
+                return comparer.Compare(expectedCast, actualCast);
             }
         }
 
@@ -156,11 +159,13 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             public override int Compare(object expected, object actual)
             {
-                if (!typeof(T).GetTypeInfo().IsAssignableFrom(expected.GetType().GetTypeInfo()))
-                    throw new ArgumentException("Cannot compare " + expected.ToString());
+                T expectedCast;
+                if (!TypeHelper.TryCast(expected, out expectedCast))
+                    throw new ArgumentException($"Cannot compare {expected?.ToString() ?? "null"}");
 
-                if (!typeof(T).GetTypeInfo().IsAssignableFrom(actual.GetType().GetTypeInfo()))
-                    throw new ArgumentException("Cannot compare to " + actual.ToString());
+                T actualCast;
+                if (!TypeHelper.TryCast(actual, out actualCast))
+                    throw new ArgumentException($"Cannot compare to {actual?.ToString() ?? "null"}");
 
                 return comparison.Invoke((T)expected, (T)actual);
             }

--- a/src/NUnitFramework/framework/Internal/ConstraintUtils.cs
+++ b/src/NUnitFramework/framework/Internal/ConstraintUtils.cs
@@ -41,8 +41,11 @@ namespace NUnit.Framework.Internal
         /// <typeparam name="T">The type to require.</typeparam>
         public static T RequireActual<T>(object actual, string paramName, bool allowNull = false)
         {
-            if (actual is T) return (T)actual;
-            if (allowNull && actual == null && default(T) == null) return default(T);
+            T result;
+            if (TypeHelper.TryCast(actual, out result) && (allowNull || result != null))
+            {
+                return result;
+            }
 
             var actualDisplay = actual == null ? "null" : actual.GetType().Name;
             throw new ArgumentException($"Expected: {typeof(T).Name} But was: {actualDisplay}", paramName);

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Internal
         public bool IsDefined<T>(bool inherit)
         {
 #if NETSTANDARD1_6
-            return MethodInfo.GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
+            return MethodInfo.GetCustomAttributes(inherit).Any(typeof(T).IsInstanceOfType);
 #else
             return MethodInfo.IsDefined(typeof(T), inherit);
 #endif

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal
                     continue;
                 }
 
-                if (targetType.GetTypeInfo().IsAssignableFrom(arg.GetType().GetTypeInfo()))
+                if (targetType.GetTypeInfo().IsInstanceOfType(arg))
                 {
                     continue;
                 }

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal
         public bool IsDefined<T>(bool inherit)
         {
 #if NETSTANDARD1_6
-            return ParameterInfo.GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
+            return ParameterInfo.GetCustomAttributes(inherit).Any(typeof(T).IsInstanceOfType);
 #else
             return ParameterInfo.IsDefined(typeof(T), inherit);
 #endif

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Internal
         {
 #if NETSTANDARD1_6
             return fixtureType.GetMethods(AllMembers | BindingFlags.FlattenHierarchy)
-                .Any(m => m.GetCustomAttributes(false).Any(a => attributeType.IsAssignableFrom(a.GetType())));
+                .Any(m => m.GetCustomAttributes(false).Any(attributeType.IsInstanceOfType));
 #else
             foreach (MethodInfo method in fixtureType.GetMethods(AllMembers | BindingFlags.FlattenHierarchy))
             {

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -250,25 +250,22 @@ namespace NUnit.Framework.Internal
             {
                 object arg = arglist[i];
 
-                if (arg != null && arg is IConvertible)
+                if (arg is IConvertible)
                 {
                     Type argType = arg.GetType();
                     Type targetType = parameters[i].ParameterType;
                     bool convert = false;
 
-                    if (argType != targetType && !argType.IsAssignableFrom(targetType))
+                    if (argType != targetType && IsNumeric(argType) && IsNumeric(targetType))
                     {
-                        if (IsNumeric(argType) && IsNumeric(targetType))
-                        {
-                            if (targetType == typeof(double) || targetType == typeof(float))
-                                convert = arg is int || arg is long || arg is short || arg is byte || arg is sbyte;
+                        if (targetType == typeof(double) || targetType == typeof(float))
+                            convert = arg is int || arg is long || arg is short || arg is byte || arg is sbyte;
+                        else
+                            if (targetType == typeof(long))
+                                convert = arg is int || arg is short || arg is byte || arg is sbyte;
                             else
-                                if (targetType == typeof(long))
-                                    convert = arg is int || arg is short || arg is byte || arg is sbyte;
-                                else
-                                    if (targetType == typeof(short))
-                                        convert = arg is byte || arg is sbyte;
-                        }
+                                if (targetType == typeof(short))
+                                    convert = arg is byte || arg is sbyte;
                     }
 
                     if (convert)

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -344,6 +344,36 @@ namespace NUnit.Framework.Internal
             }
 
             return declaredInterfaces.ToArray();
+        }
+
+        /// <summary>
+        /// Determines whether the cast to the given type would succeed.
+        /// If <paramref name="obj"/> is <see langword="null"/> and <typeparamref name="T"/>
+        /// can be <see langword="null"/>, the cast succeeds just like the C# language feature.
+        /// </summary>
+        /// <param name="obj">The object to cast.</param>
+        internal static bool CanCast<T>(object obj)
+        {
+            return obj is T || (obj == null && default(T) == null);
+        }
+
+        /// <summary>
+        /// Casts to a value of the given type if possible.
+        /// If <paramref name="obj"/> is <see langword="null"/> and <typeparamref name="T"/>
+        /// can be <see langword="null"/>, the cast succeeds just like the C# language feature.
+        /// </summary>
+        /// <param name="obj">The object to cast.</param>
+        /// <param name="value">The value of the object, if the cast succeeded.</param>
+        internal static bool TryCast<T>(object obj, out T value)
+        {
+            if (obj is T)
+            {
+                value = (T)obj;
+                return true;
+            }
+
+            value = default(T);
+            return obj == null && default(T) == null;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Internal
         public bool IsDefined<T>(bool inherit)
         {
 #if NETSTANDARD1_6
-            return Type.GetTypeInfo().GetCustomAttributes(inherit).Any(a => typeof(T).IsAssignableFrom(a.GetType()));
+            return Type.GetTypeInfo().GetCustomAttributes(inherit).Any(typeof(T).IsInstanceOfType);
 #else
             return Type.GetTypeInfo().IsDefined(typeof(T), inherit);
 #endif

--- a/src/NUnitFramework/tests/Constraints/ComparisonAdapterTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ComparisonAdapterTests.cs
@@ -1,0 +1,51 @@
+// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Constraints
+{
+    public static class ComparisonAdapterTests
+    {
+        public static IEnumerable<ComparisonAdapter> ComparisonAdapters()
+        {
+            return new[]
+            {
+                ComparisonAdapter.Default,
+                ComparisonAdapter.For((IComparer)StringComparer.Ordinal),
+                ComparisonAdapter.For((IComparer<string>)StringComparer.Ordinal),
+                ComparisonAdapter.For<string>(StringComparer.Ordinal.Compare)
+            };
+        }
+
+        [TestCaseSource(nameof(ComparisonAdapters))]
+        public static void CanCompareWithNull(ComparisonAdapter adapter)
+        {
+            Assert.That(adapter.Compare(null, "a"), Is.LessThan(0));
+            Assert.That(adapter.Compare("a", null), Is.GreaterThan(0));
+            Assert.That(adapter.Compare(null, null), Is.Zero);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/EqualityAdapterTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualityAdapterTests.cs
@@ -1,0 +1,53 @@
+// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Constraints
+{
+    public static class EqualityAdapterTests
+    {
+        public static IEnumerable<EqualityAdapter> EqualityAdapters()
+        {
+            return new[]
+            {
+                EqualityAdapter.For((IEqualityComparer)StringComparer.Ordinal),
+                EqualityAdapter.For((IEqualityComparer<string>)StringComparer.Ordinal),
+                EqualityAdapter.For<string, string>(StringComparer.Ordinal.Equals),
+                EqualityAdapter.For((IComparer)StringComparer.Ordinal),
+                EqualityAdapter.For((IComparer<string>)StringComparer.Ordinal),
+                EqualityAdapter.For<string>(StringComparer.Ordinal.Compare)
+            };
+        }
+
+        [TestCaseSource(nameof(EqualityAdapters))]
+        public static void CanCompareWithNull(EqualityAdapter adapter)
+        {
+            Assert.That(adapter.AreEqual(null, "a"), Is.False);
+            Assert.That(adapter.AreEqual("a", null), Is.False);
+            Assert.That(adapter.AreEqual(null, null), Is.True);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

They are semantically identical (http://referencesource.microsoft.com/#mscorlib/system/type.cs,fe506f282c6fb9c5) except for the null check (for which this PR does include some bug fixes):

```cs
public virtual bool IsInstanceOfType(Object o) 
{
    if (o == null)
        return false;

    // No need for transparent proxy casting check here
    // because it never returns true for a non-rutnime type.
    
    return IsAssignableFrom(o.GetType());
}
```

However, there is a real benefit to using IsInstanceOfType instead. It results in terser code.

```diff
-.Any(a => typeof(T).IsAssignableFrom(a.GetType())
+.Any(typeof(T).IsInstanceOfType)
```

And the runtime is optimized to run same logic much faster because there is no need to allocate an expensive `Type` object and compare it. Rather, it compares the type handle straight off the object reference (http://referencesource.microsoft.com/#mscorlib/system/rttype.cs,11e2cc8ec5607523) and the JIT optimizes it:

```cs
public override bool IsInstanceOfType(Object o)
{
    return RuntimeTypeHandle.IsInstanceOfType(this, o);
}
```

## Outcomes

I discovered that the type checks in our generic equality and comparer adapters threw NRE rather than following proper runtime semantics and delegating the nulls to the adaptee.

In fixing this, I unified the identical logic with ConstraintUtils.RequireActual. The resulting API makes use of out parameters which is okay, following a dignified tradition in .NET. But once we move to C# 7, the try/out pattern will seem much more appealing too.