### PR TITLE
Added .props with ProjectCapability to suppress test project service GUID item

### DIFF
--- a/nuget/framework/NUnit.props
+++ b/nuget/framework/NUnit.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
+
+</Project>

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -48,5 +48,6 @@ Supported platforms:
     <file src="bin/net45/nunit.framework.xml" target="lib\net45" />
     <file src="bin/netstandard1.6/nunit.framework.dll" target="lib\netstandard1.6" />
     <file src="bin/netstandard1.6/nunit.framework.xml" target="lib\netstandard1.6" />
+    <file src="..\..\nuget\framework\NUnit.props" target="build" />
   </files>
 </package>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The first commit fixes #2592.
@rprouse I hesitated to edit the CreateImage task to copy to `build\NUnit.props`, so the nuspec uses the path `..\..\nuget\framework\NUnit.props`. I'm not sure what you would want here.
(I'm already planning to propose moving to MSBuild-based Pack, so if that happens everything gets rearranged anyway.)

The second commit is cosmetic. If we wanted, we could also replace the item group with `<Import Project="..\..\..\nuget\framework\NUnit.props" />`. What do you think?