### PR TITLE
Encoding.Default is lossy; we should use UTF8-no-BOM everywhere

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -53,14 +53,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Get the Encoding for this TextWriter
         /// </summary>
-        override public System.Text.Encoding Encoding
-		{
-#if NETSTANDARD1_6
-            get { return Encoding.UTF8; }
-#else
-            get { return Encoding.Default; }
-#endif
-        }
+        public override Encoding Encoding { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         private bool TrySendToListener(string text)
         {

--- a/src/NUnitFramework/nunitlite/DebugWriter.cs
+++ b/src/NUnitFramework/nunitlite/DebugWriter.cs
@@ -103,13 +103,6 @@ namespace NUnitLite
         /// <returns>
         /// The Encoding in which the output is written.
         /// </returns>
-        public override System.Text.Encoding Encoding
-        {
-#if NETSTANDARD1_6
-            get { return System.Text.Encoding.UTF8; }
-#else
-            get { return System.Text.Encoding.Default; }
-#endif
-        }
+        public override System.Text.Encoding Encoding { get; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
     }
 }


### PR DESCRIPTION
The Encoding property is not used because neither writer is converting chars to bytes at any time.
This reduces platform-conditional preprocessor.

(Split out of https://github.com/nunit/nunit/pull/2586 for quicker merge and because it can stand on its own.)