### PR TITLE
Same DBNull behavior for netstandard1.6

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -372,13 +372,13 @@ namespace NUnit.Framework
 
                 if (targetType.IsAssignableFrom(arg.GetType()))
                     continue;
-#if !NETSTANDARD1_6
-                if (arg is DBNull)
+
+                if (arg.GetType().FullName == "System.DBNull")
                 {
                     arglist[i] = null;
                     continue;
                 }
-#endif
+
                 bool convert = false;
 
                 if (targetType == typeof(short) || targetType == typeof(byte) || targetType == typeof(sbyte) || targetType == typeof(long?) ||

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -66,13 +66,11 @@ namespace NUnit.Framework.Internal
                     continue;
                 }
 
-#if !NETSTANDARD1_6
-                if (arg is DBNull)
+                if (arg.GetType().FullName == "System.DBNull")
                 {
                     data[i] = null;
                     continue;
                 }
-#endif
 
                 bool convert = false;
 


### PR DESCRIPTION
This makes our various DLLs behave more consistently and reduces platform-conditional preprocessor.
By contract, it's possible for our netstandard1.6 DLL to run on several platforms.

(Split out of #2586 for quicker merge and because it can stand on its own.)