### PR TITLE
GetCustomAttributes(typeof(TAttr)) is invalid for interface types

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -393,12 +393,14 @@ namespace NUnit.Compatibility
             return infos;
         }
     }
+#endif
 
     /// <summary>
     /// Extensions to the various MemberInfo derived classes
     /// </summary>
     public static class MemberInfoExtensions
     {
+#if NETSTANDARD1_6
         /// <summary>
         /// Returns the get method for the given property
         /// </summary>
@@ -415,13 +417,14 @@ namespace NUnit.Compatibility
 
             return pinfo.GetMethod;
         }
+#endif
 
         /// <summary>
         /// Returns an array of custom attributes of the specified type applied to this member
         /// </summary>
         public static IEnumerable<T> GetAttributes<T>(this MemberInfo info, bool inherit) where T : class
         {
-            return GetAttributesImpl<T>(info.GetCustomAttributes(inherit));
+            return info.GetCustomAttributes(inherit).OfType<T>();
         }
 
         /// <summary>
@@ -429,7 +432,7 @@ namespace NUnit.Compatibility
         /// </summary>
         public static IEnumerable<T> GetAttributes<T>(this ParameterInfo info, bool inherit) where T : class
         {
-            return GetAttributesImpl<T>(info.GetCustomAttributes(inherit));
+            return info.GetCustomAttributes(inherit).OfType<T>();
         }
 
         /// <summary>
@@ -437,50 +440,13 @@ namespace NUnit.Compatibility
         /// </summary>
         public static IEnumerable<T> GetAttributes<T>(this Assembly asm) where T : class
         {
-            return GetAttributesImpl<T>(asm.GetCustomAttributes());
-        }
-
-        private static IEnumerable<T> GetAttributesImpl<T>(IEnumerable<Attribute> attributes) where T : class
-        {
-            var attrs = new List<T>();
-
-            attributes.Where(a => typeof(T).IsAssignableFrom(a.GetType()))
-                .All(a => { attrs.Add(a as T); return true; });
-
-            return attrs;
-        }
-    }
-
-    /// <summary>
-    /// Extensions for Assembly that are not available in .NET Standard
-    /// </summary>
-    public static class AssemblyExtensions
-    {
-        /// <summary>
-        /// DNX does not have a version of GetCustomAttributes on Assembly that takes an inherit
-        /// parameter since it doesn't make sense on Assemblies. This version just ignores the
-        /// inherit parameter.
-        /// </summary>
-        /// <param name="asm">The assembly</param>
-        /// <param name="attributeType">The type of attribute you are looking for</param>
-        /// <param name="inherit">Ignored</param>
-        /// <returns></returns>
-        public static object[] GetCustomAttributes(this Assembly asm, Type attributeType, bool inherit)
-        {
-            return asm.GetCustomAttributes(attributeType).ToArray();
-        }
-
-        /// <summary>
-        /// Gets the types in a given assembly
-        /// </summary>
-        /// <param name="asm"></param>
-        /// <returns></returns>
-        public static IList<Type> GetTypes(this Assembly asm)
-        {
-            return asm.DefinedTypes.Select(info => info.AsType()).ToList();
-        }
-    }
+#if NET20 || NET35 || NET40
+            return asm.GetCustomAttributes(false).OfType<T>();
+#else
+            return asm.GetCustomAttributes().OfType<T>();
 #endif
+        }
+    }
 
     /// <summary>
     /// Type extensions that apply to all target frameworks

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -22,13 +22,10 @@
 // ***********************************************************************
 
 using System;
+using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
-
-#if NETSTANDARD1_6
-using System.Linq;
-#endif
 
 namespace NUnit.Framework.Internal
 {
@@ -162,11 +159,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if NETSTANDARD1_6
             return MethodInfo.GetAttributes<T>(inherit).ToArray();
-#else
-            return (T[])MethodInfo.GetCustomAttributes(typeof(T), inherit);
-#endif
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/ParameterWrapper.cs
@@ -22,14 +22,10 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
-
-#if NETSTANDARD1_6
-using System.Linq;
-#endif
 
 namespace NUnit.Framework.Internal
 {
@@ -87,11 +83,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if NETSTANDARD1_6
             return ParameterInfo.GetAttributes<T>(inherit).ToArray();
-#else
-            return (T[])ParameterInfo.GetCustomAttributes(typeof(T), inherit);
-#endif
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -333,35 +333,6 @@ namespace NUnit.Framework.Internal
         /// <returns>A TestResult suitable for this type of test.</returns>
         public abstract TestResult MakeTestResult();
 
-#if NETSTANDARD1_6
-        /// <summary>
-        /// Modify a newly constructed test by applying any of NUnit's common
-        /// attributes, based on a supplied ICustomAttributeProvider, which is
-        /// usually the reflection element from which the test was constructed,
-        /// but may not be in some instances. The attributes retrieved are
-        /// saved for use in subsequent operations.
-        /// </summary>
-        /// <param name="provider">An object deriving from MemberInfo</param>
-        public void ApplyAttributesToTest(MemberInfo provider)
-        {
-            foreach (IApplyToTest iApply in provider.GetAttributes<IApplyToTest>(true))
-                iApply.ApplyToTest(this);
-        }
-
-        /// <summary>
-        /// Modify a newly constructed test by applying any of NUnit's common
-        /// attributes, based on a supplied ICustomAttributeProvider, which is
-        /// usually the reflection element from which the test was constructed,
-        /// but may not be in some instances. The attributes retrieved are
-        /// saved for use in subsequent operations.
-        /// </summary>
-        /// <param name="provider">An object deriving from MemberInfo</param>
-        public void ApplyAttributesToTest(Assembly provider)
-        {
-            foreach (IApplyToTest iApply in provider.GetAttributes<IApplyToTest>())
-                iApply.ApplyToTest(this);
-        }
-#else
         /// <summary>
         /// Modify a newly constructed test by applying any of NUnit's common
         /// attributes, based on a supplied ICustomAttributeProvider, which is
@@ -372,10 +343,9 @@ namespace NUnit.Framework.Internal
         /// <param name="provider">An object implementing ICustomAttributeProvider</param>
         public void ApplyAttributesToTest(ICustomAttributeProvider provider)
         {
-            foreach (IApplyToTest iApply in provider.GetCustomAttributes(typeof(IApplyToTest), true))
+            foreach (IApplyToTest iApply in provider.GetCustomAttributes(true).OfType<IApplyToTest>())
                 iApply.ApplyToTest(this);
         }
-#endif
 
         /// <summary>
         /// Mark the test as Invalid (not runnable) specifying a reason
@@ -395,14 +365,10 @@ namespace NUnit.Framework.Internal
         public virtual TAttr[] GetCustomAttributes<TAttr>(bool inherit) where TAttr : class
         {
             if (Method != null)
-#if NETSTANDARD1_6
-                return Method.GetCustomAttributes<TAttr>(inherit).ToArray();
-#else
-                return (TAttr[])Method.MethodInfo.GetCustomAttributes(typeof(TAttr), inherit);
-#endif
+                return Method.GetCustomAttributes<TAttr>(inherit);
 
             if (TypeInfo != null)
-                return TypeInfo.GetCustomAttributes<TAttr>(inherit).ToArray();
+                return TypeInfo.GetCustomAttributes<TAttr>(inherit);
 
             return new TAttr[0];
         }
@@ -443,17 +409,10 @@ namespace NUnit.Framework.Internal
             {
                 actions.AddRange(GetActionsForType(type.GetTypeInfo().BaseType));
 
-#if NETSTANDARD1_6
                 foreach (Type interfaceType in TypeHelper.GetDeclaredInterfaces(type))
-                    actions.AddRange(interfaceType.GetTypeInfo().GetAttributes<ITestAction>(false).ToArray());
+                    actions.AddRange(interfaceType.GetTypeInfo().GetAttributes<ITestAction>(false));
 
-                actions.AddRange(type.GetTypeInfo().GetAttributes<ITestAction>(false).ToArray());
-#else
-                foreach (Type interfaceType in TypeHelper.GetDeclaredInterfaces(type))
-                    actions.AddRange((ITestAction[])interfaceType.GetTypeInfo().GetCustomAttributes(typeof(ITestAction), false));
-
-                actions.AddRange((ITestAction[])type.GetTypeInfo().GetCustomAttributes(typeof(ITestAction), false));
-#endif
+                actions.AddRange(type.GetTypeInfo().GetAttributes<ITestAction>(false));
             }
 
             return actions.ToArray();

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -96,11 +96,7 @@ namespace NUnit.Framework.Internal
         public override TAttr[] GetCustomAttributes<TAttr>(bool inherit)
         {
             return Assembly != null
-#if NETSTANDARD1_6
                 ? Assembly.GetAttributes<TAttr>().ToArray()
-#else
-                ? (TAttr[])Assembly.GetCustomAttributes(typeof(TAttr), false)
-#endif
                 : new TAttr[0];
         }
     }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -191,11 +191,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public T[] GetCustomAttributes<T>(bool inherit) where T : class
         {
-#if NETSTANDARD1_6
             return Type.GetTypeInfo().GetAttributes<T>(inherit).ToArray();
-#else
-            return (T[])Type.GetCustomAttributes(typeof(T), inherit);
-#endif
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -21,13 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Reflection;
-using NUnit.Framework.Internal;
-
-#if NETCOREAPP1_1
 using System.Linq;
-#endif
+using System.Reflection;
+using NUnit.Compatibility;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Attributes
 {
@@ -83,13 +80,11 @@ namespace NUnit.Framework.Attributes
 
         private void CheckValues(string methodName, params object[] expected)
         {
-            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo method = GetType().GetTypeInfo().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
             ParameterInfo param = method.GetParameters()[0];
-#if NETCOREAPP1_1
-            var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false).First() as ValuesAttribute;
-#else
-            var attr = param.GetCustomAttributes(typeof(ValuesAttribute), false)[0] as ValuesAttribute;
-#endif
+
+            var attr = param.GetAttributes<ValuesAttribute>(false).Single();
+
             Assert.That(attr.GetData(new ParameterWrapper(new MethodWrapper(GetType(), method), param)), Is.EqualTo(expected));
         }
 

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -310,7 +310,7 @@ namespace NUnit.Framework.Compatibility
         public void CanGetStaticMethodsOnBase()
         {
             var result = typeof(DerivedTestClass).GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
-            foreach(var info in result)
+            foreach (var info in result)
             {
                 if (info.Name == "StaticMethod")
                     Assert.Pass();
@@ -343,7 +343,6 @@ namespace NUnit.Framework.Compatibility
             Assert.That(minfo != null, Is.EqualTo(shouldFind));
         }
 
-#if NETCOREAPP1_1
         [Test]
         public void CanGetAttributesUsingAnInterface()
         {
@@ -359,7 +358,6 @@ namespace NUnit.Framework.Compatibility
             var result = typeof(NoGetterPropertyDerivedClass).GetMember("NoGetter", BindingFlags.Default);
             Assert.That(result, Is.Not.Null);
         }
-#endif
     }
 
     public class BaseTestClass : IDisposable
@@ -447,8 +445,6 @@ namespace NUnit.Framework.Compatibility
         }
     }
 
-
-#if NETCOREAPP1_1
     public class NoGetterPropertyBaseClass
     {
         public string NoGetter { set { } }
@@ -457,5 +453,4 @@ namespace NUnit.Framework.Compatibility
     public class NoGetterPropertyDerivedClass : NoGetterPropertyBaseClass
     {
     }
-#endif
 }


### PR DESCRIPTION
This makes our various DLLs behave more consistently and reduces platform-conditional preprocessor.

Our API polyfill for `GetCustomAttributes` for .NET Standard was acting differently than the identically-named APIs in .NET Framework. Rather than returning `object[]` instances they were returning `T[]` instances, and rather than throwing for interface types (and any type not assignable to `Attribute`) they were allowing the calls to succeed.

The result was that when unifying the syntax on all platforms, the .NET Framework platforms started throwing because we had been passing interface types directly to `GetCustomAttributes` on .NET Standard 1.6 only. Hopefully this PR simplifies things.

(Split out of #2586 for quicker merge and because it can stand on its own.)