### PR TITLE
Added .NET Standard 2.0 build! 🎉

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,7 +72,7 @@ Feature constants are defined in [Common.props](src/NUnitFramework/Common.props)
 
  - `ASYNC` enables asynchrony
  - `PARALLEL` enables running tests in parallel
- - `PLATFORM` enables platform detection
+ - `PLATFORM_DETECTION` enables platform detection
  - `THREAD_ABORT` enables timeouts and forcible cancellation
 
 Platform constants are defined by convention by the csproj SDK, one per target framework.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,3 +60,38 @@ Once in a while you may find it desirable to be primarily developing the reposit
 For example, to build and test everything: `.\build-mono-docker.ps1 -t test`
 
 This will run a temporary container using the latest [Mono image](https://hub.docker.com/r/library/mono/), mounting the repo inside the container and executing the [build.sh](build.sh) Cake bootstrapper with the arguments you specify.
+
+### Defined constants
+
+NUnit often uses conditional preprocessor to light up APIs and behaviors per platform.
+
+In general, try to use feature constants rather than platform constants.
+This brings clarity to the code and makes it easy to change the mapping between features and platforms.
+
+Feature constants are defined in [Common.props](src/NUnitFramework/Common.props):
+
+ - `ASYNC` enables asynchrony
+ - `PARALLEL` enables running tests in parallel
+ - `PLATFORM` enables platform detection
+ - `THREAD_ABORT` enables timeouts and forcible cancellation
+
+Platform constants are defined by convention by the csproj SDK, one per target framework.
+For example, `NET20` or `NET45`, `NETSTANDARD1_6`, `NETCOREAPP2_0`, and so on.
+It is most helpful to call out which platforms are the exception in rather than the rule
+in a given scenario. Keep in mind the effect the preprocessor would have on a newly added platform.
+
+For example, rather than this code:
+
+```cs
+#if NET45 || NETSTANDARD1_6 || NETSTANDARD2_0
+// Something that .NET Framework 4.0 can't do
+#endif
+```
+
+Consider this:
+
+```cs
+#if !(NET20 || NET35 || NET40)
+// Something that .NET Framework 4.0 can't do
+#endif
+```

--- a/build.cake
+++ b/build.cake
@@ -27,8 +27,17 @@ var packageVersion = version + modifier + dbgSuffix;
 // SUPPORTED FRAMEWORKS
 //////////////////////////////////////////////////////////////////////
 
-var AllFrameworks = new string[] {
-    "net45", "net40", "net35", "net20", "netstandard1.6", "netcoreapp1.1" };
+var AllFrameworks = new string[]
+{
+    "net45",
+    "net40",
+    "net35",
+    "net20",
+    "netstandard1.6",
+    "netstandard2.0",
+    "netcoreapp1.1",
+    "netcoreapp2.0"
+};
 
 //////////////////////////////////////////////////////////////////////
 // DEFINE RUN CONSTANTS
@@ -222,6 +231,19 @@ Task("TestNetStandard16")
         RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);
     });
 
+Task("TestNetStandard20")
+    .Description("Tests the .NET Standard 2.0 version of the framework")
+    .WithCriteria(IsRunningOnWindows())
+    .IsDependentOn("Build")
+    .OnError(exception => { ErrorDetail.Add(exception.Message); })
+    .Does(() =>
+    {
+        var runtime = "netcoreapp2.0";
+        var dir = BIN_DIR + runtime + "/";
+        RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);
+    });
+
 //////////////////////////////////////////////////////////////////////
 // PACKAGE
 //////////////////////////////////////////////////////////////////////
@@ -328,7 +350,8 @@ Task("PackageZip")
             GetFiles(currentImageDir + "bin/net35/*.*") +
             GetFiles(currentImageDir + "bin/net40/*.*") +
             GetFiles(currentImageDir + "bin/net45/*.*") +
-            GetFiles(currentImageDir + "bin/netstandard1.6/*.*");
+            GetFiles(currentImageDir + "bin/netstandard1.6/*.*") +
+            GetFiles(currentImageDir + "bin/netstandard2.0/*.*");
         Zip(currentImageDir, File(ZIP_PACKAGE), zipFiles);
     });
 
@@ -459,7 +482,8 @@ Task("Test")
     .IsDependentOn("Test40")
     .IsDependentOn("Test35")
     .IsDependentOn("Test20")
-    .IsDependentOn("TestNetStandard16");
+    .IsDependentOn("TestNetStandard16")
+    .IsDependentOn("TestNetStandard20");
 
 Task("Package")
     .Description("Packages all versions of the framework")

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -17,7 +17,7 @@ This package includes the NUnit 3 framework assembly, which is referenced by you
 
 Supported platforms:
 - .NET Framework 2.0+
-- .NET Standard 1.6
+- .NET Standard 1.6+
 - .NET Core</description>
     <releaseNotes>This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.</releaseNotes>
     <language>en-US</language>
@@ -29,7 +29,10 @@ Supported platforms:
       <group targetFramework="net40" />
       <group targetFramework="net45" />
       <group targetFramework="netstandard1.6">
-        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="NETStandard.Library" version="2.0.0" />
       </group>
     </dependencies>
   </metadata>
@@ -48,6 +51,8 @@ Supported platforms:
     <file src="bin/net45/nunit.framework.xml" target="lib\net45" />
     <file src="bin/netstandard1.6/nunit.framework.dll" target="lib\netstandard1.6" />
     <file src="bin/netstandard1.6/nunit.framework.xml" target="lib\netstandard1.6" />
+    <file src="bin/netstandard2.0/nunit.framework.dll" target="lib\netstandard2.0" />
+    <file src="bin/netstandard2.0/nunit.framework.xml" target="lib\netstandard2.0" />
     <file src="..\..\nuget\framework\NUnit.props" target="build" />
   </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -15,7 +15,7 @@
 
 Supported platforms:
 - .NET Framework 2.0+
-- .NET Standard 1.6
+- .NET Standard 1.6+
 - .NET Core
 
 How to use this package:
@@ -41,7 +41,11 @@ How to use this package:
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="NUnit" version="[$version$]" />
-        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="NUnit" version="[$version$]" />
+        <dependency id="NETStandard.Library" version="2.0.0" />
       </group>
     </dependencies>
   </metadata>
@@ -54,11 +58,13 @@ How to use this package:
     <file src="bin/net40/nunitlite.dll" target="lib\net40" />
     <file src="bin/net45/nunitlite.dll" target="lib\net45" />
     <file src="bin/netstandard1.6/nunitlite.dll" target="lib\netstandard1.6" />
+    <file src="bin/netstandard2.0/nunitlite.dll" target="lib\netstandard2.0" />
     <file src="bin/net20/nunitlite-runner.exe" target="tools\net20" />
     <file src="bin/net35/nunitlite-runner.exe" target="tools\net35" />
     <file src="bin/net40/nunitlite-runner.exe" target="tools\net40" />
     <file src="bin/net45/nunitlite-runner.exe" target="tools\net45" />
     <file src="bin/netcoreapp1.1/nunitlite-runner.dll" target="tools\netcoreapp1.1" />
+    <file src="bin/netcoreapp2.0/nunitlite-runner.dll" target="tools\netcoreapp2.0" />
     <file src="../../nuget/nunitlite/Program.cs" target="content" />
     <file src="../../nuget/nunitlite/Program.vb" target="content" />
     <file src="../../nuget/nunitlite/install.ps1" target="tools" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -33,30 +33,42 @@ using System.Reflection;
 
 #if DEBUG
 #if NET45
-[assembly: AssemblyConfiguration(".NET 4.5 Debug")]
+[assembly: AssemblyConfiguration(".NET Framework 4.5 Debug")]
 #elif NET40
-[assembly: AssemblyConfiguration(".NET 4.0 Debug")]
+[assembly: AssemblyConfiguration(".NET Framework 4.0 Debug")]
 #elif NET35
-[assembly: AssemblyConfiguration(".NET 3.5 Debug")]
+[assembly: AssemblyConfiguration(".NET Framework 3.5 Debug")]
 #elif NET20
-[assembly: AssemblyConfiguration(".NET 2.0 Debug")]
+[assembly: AssemblyConfiguration(".NET Framework 2.0 Debug")]
+#elif NETSTANDARD1_6
+[assembly: AssemblyConfiguration(".NET Standard 1.6 Debug")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
 #elif NETCOREAPP1_1
 [assembly: AssemblyConfiguration(".NET Core 1.1 Debug")]
+#elif NETCOREAPP2_0
+[assembly: AssemblyConfiguration(".NET Core 2.0 Debug")]
 #else
-[assembly: AssemblyConfiguration("Debug")]
+#error Missing AssemblyConfiguration attribute for this target.
 #endif
 #else
 #if NET45
-[assembly: AssemblyConfiguration(".NET 4.5")]
+[assembly: AssemblyConfiguration(".NET Framework 4.5")]
 #elif NET40
-[assembly: AssemblyConfiguration(".NET 4.0")]
+[assembly: AssemblyConfiguration(".NET Framework 4.0")]
 #elif NET35
-[assembly: AssemblyConfiguration(".NET 3.5")]
+[assembly: AssemblyConfiguration(".NET Framework 3.5")]
 #elif NET20
-[assembly: AssemblyConfiguration(".NET 2.0")]
+[assembly: AssemblyConfiguration(".NET Framework 2.0")]
+#elif NETSTANDARD1_6
+[assembly: AssemblyConfiguration(".NET Standard 1.6")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyConfiguration(".NET Standard 2.0")]
 #elif NETCOREAPP1_1
 [assembly: AssemblyConfiguration(".NET Core 1.1")]
+#elif NETCOREAPP2_0
+[assembly: AssemblyConfiguration(".NET Core 2.0")]
 #else
-[assembly: AssemblyConfiguration("")]
+#error Missing AssemblyConfiguration attribute for this target.
 #endif
 #endif

--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -23,7 +23,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6'
                             and '$(TargetFramework)' != 'netcoreapp1.1'
                             and '$(TargetFramework)' != 'netstandard2.0'
-                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM;THREAD_ABORT</DefineConstants>
+                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM_DETECTION;THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -1,10 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- netcoreapp1.1 tests currently pull the netstandard1.6 framework, so they should not have PARALLEL defined yet. -->
-    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6' and '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);PARALLEL</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35'">$(DefineConstants);ASYNC</DefineConstants>
-
     <LangVersion>6</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
@@ -12,6 +8,22 @@
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- netcoreapp1.1 tests currently pull the netstandard1.6 framework, and
+         netcoreapp2.0 tests currently pull the netstandard2.0 framework -->
+
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6'
+                            and '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);PARALLEL</DefineConstants>
+
+    <DefineConstants Condition="'$(TargetFramework)' != 'net20'
+                            and '$(TargetFramework)' != 'net35'">$(DefineConstants);ASYNC</DefineConstants>
+
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6'
+                            and '$(TargetFramework)' != 'netcoreapp1.1'
+                            and '$(TargetFramework)' != 'netstandard2.0'
+                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -23,7 +23,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.6'
                             and '$(TargetFramework)' != 'netcoreapp1.1'
                             and '$(TargetFramework)' != 'netstandard2.0'
-                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM</DefineConstants>
+                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM;THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -34,9 +34,6 @@ using System.Web.UI;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-#if NETSTANDARD1_6
-using System.Runtime.InteropServices;
-#endif
 
 namespace NUnit.Framework.Api
 {
@@ -371,11 +368,16 @@ namespace NUnit.Framework.Api
 
             env.AddAttribute("framework-version", typeof(FrameworkController).GetTypeInfo().Assembly.GetName().Version.ToString());
 #if NETSTANDARD1_6
-            env.AddAttribute("clr-version", RuntimeInformation.FrameworkDescription);
-            env.AddAttribute("os-version", RuntimeInformation.OSDescription);
+            env.AddAttribute("clr-version", System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
 #else
             env.AddAttribute("clr-version", Environment.Version.ToString());
+#endif
+#if !PLATFORM
+            env.AddAttribute("os-version", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
+#else
             env.AddAttribute("os-version", OSPlatform.CurrentPlatform.ToString());
+#endif
+#if !NETSTANDARD1_6
             env.AddAttribute("platform", Environment.OSVersion.Platform.ToString());
 #endif
             env.AddAttribute("cwd", Directory.GetCurrentDirectory());
@@ -460,11 +462,11 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region Nested Action Classes
+#region Nested Action Classes
 
-        #region TestContollerAction
+#region TestContollerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions
@@ -474,9 +476,9 @@ namespace NUnit.Framework.Api
         {
         }
 
-        #endregion
+#endregion
 
-        #region LoadTestsAction
+#region LoadTestsAction
 
         /// <summary>
         /// LoadTestsAction loads a test into the FrameworkController
@@ -494,9 +496,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region ExploreTestsAction
+#region ExploreTestsAction
 
         /// <summary>
         /// ExploreTestsAction returns info about the tests in an assembly
@@ -515,9 +517,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region CountTestsAction
+#region CountTestsAction
 
         /// <summary>
         /// CountTestsAction counts the number of test cases in the loaded TestSuite
@@ -537,9 +539,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region RunTestsAction
+#region RunTestsAction
 
         /// <summary>
         /// RunTestsAction runs the loaded TestSuite held by the FrameworkController.
@@ -558,9 +560,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region RunAsyncAction
+#region RunAsyncAction
 
         /// <summary>
         /// RunAsyncAction initiates an asynchronous test run, returning immediately
@@ -579,9 +581,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region StopRunAction
+#region StopRunAction
 
         /// <summary>
         /// StopRunAction stops an ongoing run.
@@ -602,8 +604,8 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -372,7 +372,7 @@ namespace NUnit.Framework.Api
 #else
             env.AddAttribute("clr-version", Environment.Version.ToString());
 #endif
-#if !PLATFORM
+#if !PLATFORM_DETECTION
             env.AddAttribute("os-version", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
             env.AddAttribute("os-version", OSPlatform.CurrentPlatform.ToString());

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -29,9 +29,13 @@ using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using System.Collections.Generic;
 using System.IO;
+
 #if !NETSTANDARD1_6
 using System.Diagnostics;
 using System.Security;
+#endif
+
+#if NET20 || NET35 || NET40 || NET45
 using System.Windows.Forms;
 #endif
 
@@ -56,7 +60,7 @@ namespace NUnit.Framework.Api
         private EventPump _pump;
 #endif
 
-        #region Constructors
+#region Constructors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitTestAssemblyRunner"/> class.
@@ -67,9 +71,9 @@ namespace NUnit.Framework.Api
             _builder = builder;
         }
 
-        #endregion
+#endregion
 
-        #region Properties
+#region Properties
 
 #if PARALLEL
         /// <summary>
@@ -133,9 +137,9 @@ namespace NUnit.Framework.Api
         /// </summary>
         private TestExecutionContext Context { get; set; }
 
-        #endregion
+#endregion
 
-        #region Public Methods
+#region Public Methods
 
         /// <summary>
         /// Loads the tests found in an Assembly
@@ -265,9 +269,9 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
-        #region Helper Methods
+#region Helper Methods
 
         /// <summary>
         /// Initiate the test run.
@@ -316,7 +320,7 @@ namespace NUnit.Framework.Api
                 }
             }
 
-#if !NETSTANDARD1_6
+#if NET20 || NET35 || NET40 || NET45
             if (Settings.ContainsKey(FrameworkPackageSettings.PauseBeforeRun) &&
                 (bool)Settings[FrameworkPackageSettings.PauseBeforeRun])
                 PauseBeforeRun();
@@ -396,7 +400,7 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-#if !NETSTANDARD1_6
+#if NET20 || NET35 || NET40 || NET45
         // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of
         // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the
         // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
@@ -410,6 +414,6 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM
+#if PLATFORM_DETECTION
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -20,7 +20,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !NETSTANDARD1_6
+
+#if PLATFORM
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -225,7 +225,7 @@ namespace NUnit.Framework
             }
         }
 
-#if !NETSTANDARD1_6
+#if PLATFORM
         /// <summary>
         /// Comma-delimited list of platforms to run the test for
         /// </summary>
@@ -423,7 +423,7 @@ namespace NUnit.Framework
         {
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
 
-#if !NETSTANDARD1_6
+#if PLATFORM
             if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)
             {

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -225,7 +225,7 @@ namespace NUnit.Framework
             }
         }
 
-#if PLATFORM
+#if PLATFORM_DETECTION
         /// <summary>
         /// Comma-delimited list of platforms to run the test for
         /// </summary>
@@ -423,7 +423,7 @@ namespace NUnit.Framework
         {
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
 
-#if PLATFORM
+#if PLATFORM_DETECTION
             if (test.RunState != RunState.NotRunnable &&
                 test.RunState != RunState.Ignored)
             {

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
+#if THREAD_ABORT
 using System;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 namespace NUnit.Compatibility
 {
-#if !NET45 && !NETSTANDARD1_6
+#if NET20 || NET35 || NET40
     /// <summary>
     /// Provides NUnit specific extensions to aid in Reflection
     /// across multiple frameworks

--- a/src/NUnitFramework/framework/Compatibility/System.Web.UI/ICallbackEventHandler.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Web.UI/ICallbackEventHandler.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NETSTANDARD1_6
+#if !(NET20 || NET35 || NET40 || NET45)
 namespace System.Web.UI
 {
     /// <summary>

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal
 
         #region Load
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_6 || NETSTANDARD2_0
         private sealed class ReflectionAssemblyLoader
         {
             private static ReflectionAssemblyLoader instance;

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
+#if THREAD_ABORT
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012-2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Internal.Execution
                     command = new ApplyChangesToContextCommand(command, attr);
 
                 // If a timeout is specified, create a TimeoutCommand
-#if !NETSTANDARD1_6
+#if THREAD_ABORT
                 // Timeout set at a higher level
                 int timeout = Context.TestCaseTimeout;
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -461,13 +461,13 @@ namespace NUnit.Framework.Internal.Execution
         {
             thread = new Thread(() =>
             {
+                thread.CurrentCulture = Context.CurrentCulture;
+                thread.CurrentUICulture = Context.CurrentUICulture;
                 lock (threadLock)
                     nativeThreadId = ThreadUtility.GetCurrentThreadNativeId();
                 RunOnCurrentThread();
             });
             thread.SetApartmentState(apartment);
-            thread.CurrentCulture = Context.CurrentCulture;
-            thread.CurrentUICulture = Context.CurrentUICulture;
             thread.Start();
             thread.Join();
         }

--- a/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM
+#if PLATFORM_DETECTION
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
+#if PLATFORM
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM
+#if PLATFORM_DETECTION
 using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008-2016 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
+#if PLATFORM
 using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -20,7 +20,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !NETSTANDARD1_6
+
+#if PLATFORM
 using System;
 using System.Linq;
 

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM
+#if PLATFORM_DETECTION
 using System;
 using System.Linq;
 

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_6 || NETSTANDARD2_0)
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -33,9 +33,12 @@ using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
 
 #if !NETSTANDARD1_6
-using System.Runtime.Remoting.Messaging;
 using System.Security;
 using System.Security.Principal;
+#endif
+
+#if NET20 || NET35 || NET40 || NET45
+using System.Runtime.Remoting.Messaging;
 #endif
 
 namespace NUnit.Framework.Internal
@@ -45,9 +48,9 @@ namespace NUnit.Framework.Internal
     /// singleton settings in the environment that affect tests
     /// or which might be changed by the user tests.
     /// </summary>
-    public class TestExecutionContext
-#if !NETSTANDARD1_6
-        : LongLivedMarshalByRefObject, ILogicalThreadAffinative
+    public class TestExecutionContext : LongLivedMarshalByRefObject
+#if NET20 || NET35 || NET40 || NET45
+        , ILogicalThreadAffinative
 #endif
     {
         // NOTE: Be very careful when modifying this class. It uses
@@ -103,9 +106,9 @@ namespace NUnit.Framework.Internal
         private IPrincipal _currentPrincipal;
 #endif
 
-        #endregion
+#endregion
 
-        #region Constructors
+#region Constructors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestExecutionContext"/> class.
@@ -160,13 +163,13 @@ namespace NUnit.Framework.Internal
             IsSingleThreaded = other.IsSingleThreaded;
         }
 
-        #endregion
+#endregion
 
-        #region CurrentContext Instance
+#region CurrentContext Instance
 
         // NOTE: We use different implementations for various platforms.
 
-#if NETSTANDARD1_6
+#if !(NET20 || NET35 || NET40 || NET45)
         private static readonly AsyncLocal<TestExecutionContext> _currentContext = new AsyncLocal<TestExecutionContext>();
         /// <summary>
         /// Gets and sets the current context.
@@ -221,9 +224,9 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
-        #endregion
+#endregion
 
-        #region Properties
+#region Properties
 
         /// <summary>
         /// Gets or sets the current test
@@ -425,9 +428,9 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool IsSingleThreaded { get; set; }
 
-        #endregion
+#endregion
 
-        #region Instance Methods
+#region Instance Methods
 
         /// <summary>
         /// Record any changes in the environment made by
@@ -501,9 +504,9 @@ namespace NUnit.Framework.Internal
             return context;
         }
 
-        #endregion
+#endregion
 
-        #region InitializeLifetimeService
+#region InitializeLifetimeService
 
 #if !NETSTANDARD1_6
         /// <summary>
@@ -517,9 +520,9 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
-        #endregion
+#endregion
 
-        #region Nested IsolatedContext Class
+#region Nested IsolatedContext Class
 
         /// <summary>
         /// An IsolatedContext is used when running code
@@ -558,9 +561,9 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        #endregion
+#endregion
 
-        #region Nested AdhocTestExecutionContext
+#region Nested AdhocTestExecutionContext
 
         /// <summary>
         /// An AdhocTestExecutionContext is created whenever a context is needed
@@ -585,6 +588,6 @@ namespace NUnit.Framework.Internal
             private void AdhocTestMethod() { }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Internal
 #endif
         }
 
-#if !NETSTANDARD1_6
+#if THREAD_ABORT
         private const int ThreadAbortedCheckDelay = 100;
 
         /// <summary>

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -51,17 +51,19 @@ using System.Security;
                               "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
 #if NET45
-[assembly: AssemblyTitle("NUnit Framework .NET 4.5")]
+[assembly: AssemblyTitle("NUnit Framework (.NET Framework 4.5)")]
 #elif NET40
-[assembly: AssemblyTitle("NUnit Framework .NET 4.0")]
+[assembly: AssemblyTitle("NUnit Framework (.NET Framework 4.0)")]
 #elif NET35
-[assembly: AssemblyTitle("NUnit Framework .NET 4.0")]
+[assembly: AssemblyTitle("NUnit Framework (.NET Framework 3.5)")]
 #elif NET20
-[assembly: AssemblyTitle("NUnit Framework .NET 2.0")]
+[assembly: AssemblyTitle("NUnit Framework (.NET Framework 2.0)")]
 #elif NETSTANDARD1_6
-[assembly: AssemblyTitle("NUnit Framework .NET Standard 1.6")]
+[assembly: AssemblyTitle("NUnit Framework (.NET Standard 1.6)")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyTitle("NUnit Framework (.NET Standard 2.0)")]
 #else
-[assembly: AssemblyTitle("NUnit Framework")]
+#error Missing AssemblyTitle attribute for this target.
 #endif
 
 [assembly: AssemblyDescription("")]

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\nunit.framework.xml</DocumentationFile>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -2,8 +2,11 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
+
+    <!-- Required for NUnitLite.Tests.TextUIReportTests.ErrorsAndFailuresReportTest -->
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite.tests/TextUIReportTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUIReportTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -120,6 +120,8 @@ namespace NUnitLite.Tests
                 "    Duration: 0.123 seconds\n\n"));
         }
 
+        // Requires mock-assembly to be compiled with /optimize-
+        // or else the test methods do tail calls and the stack frame disappears
         [Test]
         public void ErrorsAndFailuresReportTest()
         {

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
     <DebugType>Full</DebugType>

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -30,9 +30,6 @@ using System.IO;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-#if NETSTANDARD1_6
-using System.Runtime.InteropServices;
-#endif
 
 namespace NUnitLite
 {
@@ -123,16 +120,21 @@ namespace NUnitLite
                                            assemblyName.Version.ToString());
 #if NETSTANDARD1_6
             xmlWriter.WriteAttributeString("clr-version",
-                                           RuntimeInformation.FrameworkDescription);
-            xmlWriter.WriteAttributeString("os-version",
-                                           RuntimeInformation.OSDescription);
+                                           System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
 #else
             xmlWriter.WriteAttributeString("clr-version",
-                                           Environment.Version.ToString());
+                Environment.Version.ToString());
+#endif
+#if !PLATFORM
+            xmlWriter.WriteAttributeString("os-version",
+                                           System.Runtime.InteropServices.RuntimeInformation.OSDescription);
+#else
             xmlWriter.WriteAttributeString("os-version",
                                            OSPlatform.CurrentPlatform.ToString());
+#endif
+#if !NETSTANDARD1_6
             xmlWriter.WriteAttributeString("platform",
-                                           Environment.OSVersion.Platform.ToString());
+                Environment.OSVersion.Platform.ToString());
 #endif
             xmlWriter.WriteAttributeString("cwd",
                                            Directory.GetCurrentDirectory());

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -125,7 +125,7 @@ namespace NUnitLite
             xmlWriter.WriteAttributeString("clr-version",
                 Environment.Version.ToString());
 #endif
-#if !PLATFORM
+#if !PLATFORM_DETECTION
             xmlWriter.WriteAttributeString("os-version",
                                            System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else

--- a/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
@@ -33,13 +33,19 @@ using System.Runtime.CompilerServices;
                               "723bc8d775a66b594adeb967537729fe2a446b548cd57a6")]
 
 #if NET45
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.5")]
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 4.5)")]
 #elif NET40
-[assembly: AssemblyTitle("NUnitLite Runner .NET 4.0")]
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 4.0)")]
+#elif NET35
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 3.5)")]
 #elif NET20
-[assembly: AssemblyTitle("NUnitLite Runner .NET 2.0")]
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 2.0)")]
+#elif NETSTANDARD1_6
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Standard 1.6)")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyTitle("NUnitLite Runner (.NET Standard 2.0)")]
 #else
-[assembly: AssemblyTitle("NUnitLite Runner")]
+#error Missing AssemblyTitle attribute for this target.
 #endif
 
 [assembly: AssemblyDescription("")]

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -30,9 +30,6 @@ using NUnit.Common;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-#if NETSTANDARD1_6
-using System.Runtime.InteropServices;
-#endif
 
 namespace NUnitLite
 {
@@ -170,11 +167,14 @@ namespace NUnitLite
         public void DisplayRuntimeEnvironment()
         {
             WriteSectionHeader("Runtime Environment");
-#if NETSTANDARD1_6
-            Writer.WriteLabelLine("   OS Version: ", RuntimeInformation.OSDescription);
-            Writer.WriteLabelLine("  CLR Version: ", RuntimeInformation.FrameworkDescription);
+#if !PLATFORM
+            Writer.WriteLabelLine("   OS Version: ", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
             Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);
+#endif
+#if NETSTANDARD1_6
+            Writer.WriteLabelLine("  CLR Version: ", System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+#else
             Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
 #endif
             Writer.WriteLine();

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -167,7 +167,7 @@ namespace NUnitLite
         public void DisplayRuntimeEnvironment()
         {
             WriteSectionHeader("Runtime Environment");
-#if !PLATFORM
+#if !PLATFORM_DETECTION
             Writer.WriteLabelLine("   OS Version: ", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
             Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/testdata/SingleThreadedFixtureData.cs
+++ b/src/NUnitFramework/testdata/SingleThreadedFixtureData.cs
@@ -5,24 +5,10 @@ using NUnit.Framework;
 namespace NUnit.TestData
 {
     [SingleThreaded]
-    public class SingleThreadedFixture_TestWithTimeout
-    {
-        [Test, Timeout(100)]
-        public void TestWithTimeout() { }
-    }
-
-    [SingleThreaded]
     public class SingleThreadedFixture_TestWithRequiresThread
     {
         [Test, RequiresThread]
         public void TestWithRequiresThread() { }
-    }
-
-    [SingleThreaded]
-    public class SingleThreadedFixture_TestWithTimeoutAndRequiresThread
-    {
-        [Test, Timeout(100), RequiresThread]
-        public void TestWithTimeoutAndRequiresThread() { }
     }
 
     [SingleThreaded]
@@ -33,17 +19,32 @@ namespace NUnit.TestData
     }
 
     [SingleThreaded]
-    public class SingleThreadedFixture_TestWithTimeoutAndDifferentApartment
-    {
-        [Test, Timeout(100), Apartment(ApartmentState.STA)]
-        public void TestWithTimeoutAndDifferentApartment() { }
-    }
-
-    [SingleThreaded]
     public class SingleThreadedFixture_TestWithRequiresThreadAndDifferentApartment
     {
         [Test, RequiresThread, Apartment(ApartmentState.STA)]
         public void TestWithRequiresThreadAndDifferentApartment() { }
+    }
+
+#if THREAD_ABORT
+    [SingleThreaded]
+    public class SingleThreadedFixture_TestWithTimeout
+    {
+        [Test, Timeout(100)]
+        public void TestWithTimeout() { }
+    }
+
+    [SingleThreaded]
+    public class SingleThreadedFixture_TestWithTimeoutAndRequiresThread
+    {
+        [Test, Timeout(100), RequiresThread]
+        public void TestWithTimeoutAndRequiresThread() { }
+    }
+
+    [SingleThreaded]
+    public class SingleThreadedFixture_TestWithTimeoutAndDifferentApartment
+    {
+        [Test, Timeout(100), Apartment(ApartmentState.STA)]
+        public void TestWithTimeoutAndDifferentApartment() { }
     }
 
     [SingleThreaded]
@@ -52,5 +53,6 @@ namespace NUnit.TestData
         [Test, Timeout(100), RequiresThread, Apartment(ApartmentState.STA)]
         public void TestWithTimeoutRequiresThreadAndDifferentApartment() { }
     }
+#endif
 }
 #endif

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -83,7 +83,7 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         {
         }
 
-#if !NETCOREAPP1_1
+#if PLATFORM
         [TestCase(1, IncludePlatform = "Win")]
         [TestCase(2, IncludePlatform = "Linux")]
         [TestCase(3, IncludePlatform = "MacOSX")]
@@ -96,7 +96,7 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         [TestCase(2, ExcludePlatform = "Linux")]
         [TestCase(3, ExcludePlatform = "MacOSX")]
         [TestCase(4, ExcludePlatform = "XBox")]
-        public void MethodWitExcludePlatform(int num)
+        public void MethodWithExcludePlatform(int num)
         {
         }
 #endif

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -83,7 +83,7 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         {
         }
 
-#if PLATFORM
+#if PLATFORM_DETECTION
         [TestCase(1, IncludePlatform = "Win")]
         [TestCase(2, IncludePlatform = "Linux")]
         [TestCase(3, IncludePlatform = "MacOSX")]

--- a/src/NUnitFramework/testdata/TestFixtureData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureData.cs
@@ -526,7 +526,7 @@ namespace NUnit.TestData.TestFixtureTests
         }
     }
 
-#if !NETCOREAPP1_1
+#if !(NETCOREAPP1_1 || NETCOREAPP2_0)
     [TestFixture]
     public class FixtureThatChangesTheCurrentPrincipal
     {

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if THREAD_ABORT
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>NUnit.TestData</RootNamespace>
 
     <!-- Needed because we test stack traces and don't want to have to put

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Internal;
 
-#if !NETCOREAPP1_1
+#if NET20 || NET35 || NET40 || NET45
 using System.Runtime.Remoting.Messaging;
 #endif
 
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Assertions
                 throw testException;
         }
 
-#if NETCOREAPP1_1
+#if !(NET20 || NET35 || NET40 || NET45)
         private TestExecutionContext ClearExecutionContext()
         {
             var savedContext = TestExecutionContext.CurrentContext;

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -346,7 +346,7 @@ namespace NUnit.Framework.Assertions
                 Assert.That(async () => await AsyncReturnOne(), Is.EqualTo(2)));
         }
 
-#if !NETCOREAPP1_1
+#if PLATFORM
         [Test, Platform(Exclude="Linux", Reason="Intermittent failures on Linux")]
         public void AssertThatErrorTask()
         {

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -346,7 +346,7 @@ namespace NUnit.Framework.Assertions
                 Assert.That(async () => await AsyncReturnOne(), Is.EqualTo(2)));
         }
 
-#if PLATFORM
+#if PLATFORM_DETECTION
         [Test, Platform(Exclude="Linux", Reason="Intermittent failures on Linux")]
         public void AssertThatErrorTask()
         {

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if NET20 || NET35 || NET40 || NET45
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -258,7 +258,7 @@ namespace NUnit.Framework.Assertions
         // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
         [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
         [TestCase(nameof(WarningFixture.WarningInThreadStart), 2)]
-#if !PLATFORM
+#if !PLATFORM_DETECTION
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4)]
 #else
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4, ExcludePlatform = "mono", Reason = "Warning has no effect inside BeginInvoke on Mono")]

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -258,7 +258,7 @@ namespace NUnit.Framework.Assertions
         // See https://github.com/nunit/nunit/pull/2431#issuecomment-328404432.
         [TestCase(nameof(WarningFixture.WarningSynchronous), 1)]
         [TestCase(nameof(WarningFixture.WarningInThreadStart), 2)]
-#if NETCOREAPP1_1
+#if !PLATFORM
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4)]
 #else
         [TestCase(nameof(WarningFixture.WarningInBeginInvoke), 4, ExcludePlatform = "mono", Reason = "Warning has no effect inside BeginInvoke on Mono")]

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -45,7 +45,9 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+#if THREAD_ABORT
         [Timeout(10000)]
+#endif
         [Apartment(ApartmentState.STA)]
         public void TestWithTimeoutAndSTARunsInSTA()
         {
@@ -53,7 +55,9 @@ namespace NUnit.Framework.Attributes
         }
 
         [TestFixture]
+#if THREAD_ABORT
         [Timeout(10000)]
+#endif
         [Apartment(ApartmentState.STA)]
         public class FixtureWithTimeoutRequiresSTA
         {

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -61,7 +61,9 @@ namespace NUnit.Framework.Attributes
             attr.ApplyToContext(_context);
             Assert.That(_context.CurrentUICulture, Is.EqualTo(new CultureInfo("fr-FR")));
         }
+#endif
 
+#if THREAD_ABORT
         [Test]
         public void TimeoutAttribute()
         {

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -351,7 +351,7 @@ namespace NUnit.Framework.Attributes
 
         #region PlatformAttribute
 
-#if PLATFORM
+#if PLATFORM_DETECTION
         [Test]
         public void PlatformAttributeRunsTest()
         {

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -351,7 +351,7 @@ namespace NUnit.Framework.Attributes
 
         #region PlatformAttribute
 
-#if !NETCOREAPP1_1
+#if PLATFORM
         [Test]
         public void PlatformAttributeRunsTest()
         {
@@ -421,7 +421,7 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if !NETCOREAPP1_1
+#if PARALLEL
 
         #region RequiresMTAAttribute
 
@@ -514,7 +514,7 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if !NETCOREAPP1_1
+#if PARALLEL
 
         #region SetCultureAttribute
 

--- a/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
@@ -38,6 +38,8 @@ namespace NUnit.Framework.Attributes
         [TestCase(typeof(SetUICultureAttribute), PropertyNames.SetUICulture, "fr-FR")]
         [TestCase(typeof(ApartmentAttribute), PropertyNames.ApartmentState, ApartmentState.MTA)]
         [TestCase(typeof(ApartmentAttribute), PropertyNames.ApartmentState, ApartmentState.STA)]
+#endif
+#if THREAD_ABORT
         [TestCase(typeof(TimeoutAttribute), PropertyNames.Timeout, 50)]
 #endif
         public void ConstructWithOneArg<T>(Type attrType, string propName, T propValue)

--- a/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SingleThreadedFixtureTests.cs
@@ -40,11 +40,13 @@ namespace NUnit.Framework.Attributes
             Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
 
+#if THREAD_ABORT
         [Test, Timeout(100)]
         public void TestWithTimeoutIsValid()
         {
             Assert.That(Thread.CurrentThread, Is.EqualTo(ParentThread));
         }
+#endif
 
         [Test]
         public void TestWithRequiresThreadIsInvalid()

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -301,7 +301,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Connection failing"));
         }
 
-#if !NETCOREAPP1_1
+#if PLATFORM
         [Test]
         public void CanIncludePlatform()
         {
@@ -345,12 +345,12 @@ namespace NUnit.Framework.Attributes
             bool isMacOSX = OSPlatform.CurrentPlatform.IsMacOSX;
 
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodWitExcludePlatform");
+                typeof(TestCaseAttributeFixture), "MethodWithExcludePlatform");
 
-            Test testCase1 = TestFinder.Find("MethodWitExcludePlatform(1)", suite, false);
-            Test testCase2 = TestFinder.Find("MethodWitExcludePlatform(2)", suite, false);
-            Test testCase3 = TestFinder.Find("MethodWitExcludePlatform(3)", suite, false);
-            Test testCase4 = TestFinder.Find("MethodWitExcludePlatform(4)", suite, false);
+            Test testCase1 = TestFinder.Find("MethodWithExcludePlatform(1)", suite, false);
+            Test testCase2 = TestFinder.Find("MethodWithExcludePlatform(2)", suite, false);
+            Test testCase3 = TestFinder.Find("MethodWithExcludePlatform(3)", suite, false);
+            Test testCase4 = TestFinder.Find("MethodWithExcludePlatform(4)", suite, false);
             if (isLinux)
             {
                 Assert.That(testCase1.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -301,7 +301,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Connection failing"));
         }
 
-#if PLATFORM
+#if PLATFORM_DETECTION
         [Test]
         public void CanIncludePlatform()
         {

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM
+#if PLATFORM_DETECTION
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if PLATFORM
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Constraints
 		}
 
 		[Test]
-#if !NETCOREAPP1_1
+#if PLATFORM
         [Platform(Exclude="Linux", Reason="Intermittent failure under Linux")]
 #endif
 		public void SyntaxError()

--- a/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Constraints
 		}
 
 		[Test]
-#if PLATFORM
+#if PLATFORM_DETECTION
         [Platform(Exclude="Linux", Reason="Intermittent failure under Linux")]
 #endif
 		public void SyntaxError()

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class AsyncTestMethodTests
     {
-#if !PLATFORM
+#if !PLATFORM_DETECTION
         private static readonly bool PLATFORM_IGNORE = true;
 #else
         private static readonly bool PLATFORM_IGNORE = OSPlatform.CurrentPlatform.IsUnix;

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class AsyncTestMethodTests
     {
-#if NETCOREAPP1_1
+#if !PLATFORM
         private static readonly bool PLATFORM_IGNORE = true;
 #else
         private static readonly bool PLATFORM_IGNORE = OSPlatform.CurrentPlatform.IsUnix;

--- a/src/NUnitFramework/tests/Internal/CallContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/CallContextTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PARALLEL
+#if NET20 || NET35 || NET40 || NET45
 using System;
 using System.Threading;
 using System.Runtime.Remoting.Messaging;

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Internal.Execution
             [Test]
 #if NET35
             [Timeout(2000)]
-#else
+#elif THREAD_ABORT
             [Timeout(1000)]
 #endif
             public void DequeueBlocking_Stop()
@@ -168,7 +168,7 @@ namespace NUnit.Framework.Internal.Execution
             [Test]
 #if NET35
             [Timeout(2000)]
-#else
+#elif THREAD_ABORT
             [Timeout(1000)]
 #endif
             public void SetWaitHandle_Enqueue_Asynchronous()
@@ -227,7 +227,9 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         [Test]
+#if THREAD_ABORT
         [Timeout(3000)]
+#endif
         public void PumpEvents()
         {
             EventQueue q = new EventQueue();
@@ -246,7 +248,9 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         [Test]
-        [Timeout(1000)]
+#if THREAD_ABORT
+        [Timeout(3000)]
+#endif
         public void PumpSynchronousAndAsynchronousEvents()
         {
             EventQueue q = new EventQueue();
@@ -273,7 +277,7 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        #endregion
+#endregion
 
         public abstract class ProducerConsumerTest
         {
@@ -292,7 +296,9 @@ namespace NUnit.Framework.Internal.Execution
                 }
                 finally
                 {
+#if THREAD_ABORT
                     ThreadUtility.Kill(consumerThread);
+#endif
                 }
 
                 Assert.IsNull(this.myConsumerException);

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if PLATFORM
+#if PLATFORM_DETECTION
 using System;
 using System.Collections;
 

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -20,7 +20,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !NETCOREAPP1_1
+#if PLATFORM
 using System;
 using System.Collections;
 

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if !(NETCOREAPP1_1 || NETCOREAPP2_0)
 using System;
 using System.Reflection;
 

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -962,7 +962,7 @@ namespace NUnit.Framework.Internal
 
 #region Cross-domain Tests
 
-#if !NETCOREAPP1_1
+#if NET20 || NET35 || NET40 || NET45
         [Test, Platform(Exclude="Mono", Reason="Intermittent failures")]
         public void CanCreateObjectInAppDomain()
         {
@@ -1017,7 +1017,7 @@ namespace NUnit.Framework.Internal
 #endregion
     }
 
-#if !NETCOREAPP1_1
+#if NET20 || NET35 || NET40 || NET45
     [TestFixture, Platform(Exclude="Mono", Reason="Intermittent failures")]
     public class TextExecutionContextInAppDomain
     {

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -834,20 +834,20 @@ namespace NUnit.Framework.Internal
         [Test]
         public void CanAccessCurrentPrincipal()
         {
-            Type expectedType = Thread.CurrentPrincipal.GetType();
-            Assert.That(_fixtureContext.CurrentPrincipal, Is.TypeOf(expectedType), "Fixture");
-            Assert.That(_setupContext.CurrentPrincipal, Is.TypeOf(expectedType), "SetUp");
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "Test");
+            var expectedInstance = Thread.CurrentPrincipal;
+            Assert.That(_fixtureContext.CurrentPrincipal, Is.SameAs(expectedInstance), "Fixture");
+            Assert.That(_setupContext.CurrentPrincipal, Is.SameAs(expectedInstance), "SetUp");
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.SameAs(expectedInstance), "Test");
         }
 
 #if ASYNC
         [Test]
         public async Task CanAccessCurrentPrincipal_Async()
         {
-            Type expectedType = Thread.CurrentPrincipal.GetType();
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "Before yield");
+            var expectedInstance = Thread.CurrentPrincipal;
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.SameAs(expectedInstance), "Before yield");
             await YieldAsync();
-            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.TypeOf(expectedType), "After yield");
+            Assert.That(TestExecutionContext.CurrentContext.CurrentPrincipal, Is.SameAs(expectedInstance), "After yield");
         }
 #endif
 

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -21,8 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
-
+#if PARALLEL && PLATFORM
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.TestUtilities;

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PARALLEL && PLATFORM
+#if PARALLEL && PLATFORM_DETECTION
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.TestUtilities;

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Internal
         public void FailRecordsInnerExceptionsAsPartOfAggregateException()
         {
             string expectedMessage =
-#if NETCOREAPP1_1
+#if NETCOREAPP1_1 || NETCOREAPP2_0
                 "System.AggregateException : Outer Aggregate Exception (Inner Exception 1 of 2) (Inner Exception 2 of 2)" + Environment.NewLine +
 #else
                 "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal
         public void FailRecordsNestedInnerExceptionAsPartOfAggregateException()
         {
             string expectedMessage =
-#if NETCOREAPP1_1
+#if NETCOREAPP1_1 || NETCOREAPP2_0
                 "System.AggregateException : Outer Aggregate Exception (Inner Exception)" + Environment.NewLine +
 #else
                 "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +

--- a/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
+++ b/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if !(NETCOREAPP1_1 || NETCOREAPP2_0)
 using System;
 using System.Collections;
 using System.CodeDom.Compiler;

--- a/src/NUnitFramework/tests/Syntax/TestCompiler.cs
+++ b/src/NUnitFramework/tests/Syntax/TestCompiler.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+#if !(NETCOREAPP1_1 || NETCOREAPP2_0)
 using System;
 using System.CodeDom.Compiler;
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -402,7 +402,7 @@ namespace NUnit.Framework
         }
 
         [TestCase(null)]
-#if !NETCOREAPP1_1
+#if PLATFORM
         [TestCase("bad<>path.png", IncludePlatform = "Win")]
 #endif
         public void InvalidFilePathsThrowsArgumentException(string filePath)

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -402,7 +402,7 @@ namespace NUnit.Framework
         }
 
         [TestCase(null)]
-#if PLATFORM
+#if PLATFORM_DETECTION
         [TestCase("bad<>path.png", IncludePlatform = "Win")]
 #endif
         public void InvalidFilePathsThrowsArgumentException(string filePath)

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <DebugType>Full</DebugType>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
@@ -29,7 +29,7 @@
     <PackageReference Include="System.ValueTuple" version="4.3.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2542.

In the first commit I got the thing building and in each other commit I fixed tests.

I introduced two new feature defines: PLATFORM for platform detection and THREAD_ABORT for things needing Thread.Abort like timeout and cancellation since CoreCLR throws PlatformNotSupportedException for Thread.Abort.

Conditional preprocessor is the simple workaround. A more sophisticated approach would be to leave the Thread.Abort call there and to do platform capability detection at runtime, but that is complexity we can implement at any point in the future if desired.