### PR TITLE
Fix for failure to retry when tests have no setup and teardown

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -94,13 +94,15 @@ namespace NUnit.Framework
                     try
                     {
                         context.CurrentResult = innerCommand.Execute(context);
-
-                        if (context.CurrentResult.ResultState != ResultState.Failure)
-                            break;
                     }
-                    catch when (count > 0)
+                    catch (Exception ex)
                     {
+                        if (context.CurrentResult == null) context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.RecordException(ex);
                     }
+
+                    if (context.CurrentResult.ResultState != ResultState.Failure)
+                        break;
 
                     // Clear result for retry
                     if (count > 0)

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -91,10 +91,16 @@ namespace NUnit.Framework
 
                 while (count-- > 0)
                 {
-                    context.CurrentResult = innerCommand.Execute(context);
+                    try
+                    {
+                        context.CurrentResult = innerCommand.Execute(context);
 
-                    if (context.CurrentResult.ResultState != ResultState.Failure)
-                        break;
+                        if (context.CurrentResult.ResultState != ResultState.Failure)
+                            break;
+                    }
+                    catch when (count > 0)
+                    {
+                    }
 
                     // Clear result for retry
                     if (count > 0)

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -95,6 +95,8 @@ namespace NUnit.Framework
                     {
                         context.CurrentResult = innerCommand.Execute(context);
                     }
+                    // Commands are supposed to catch exceptions, but some don't
+                    // and we want to look at restructuring the API in the future.
                     catch (Exception ex)
                     {
                         if (context.CurrentResult == null) context.CurrentResult = context.CurrentTest.MakeTestResult();

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -72,6 +72,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
 
                 Context.CurrentResult.RecordException(ex);
+                Result = Context.CurrentResult;
             }
             finally
             {

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -42,7 +42,7 @@ namespace NUnit.TestData.RepeatingTests
         public void FailsEveryTime()
         {
             count++;
-            Assert.IsFalse (true);
+            Assert.IsFalse(true);
         }
     }
 
@@ -187,6 +187,13 @@ namespace NUnit.TestData.RepeatingTests
 
             if (Count < 3)
                 Assert.Fail();
+        }
+
+        [Test, Retry(3)]
+        public void FailsEveryTime()
+        {
+            Count++;
+            Assert.Fail();
         }
     }
 }

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -175,4 +175,18 @@ namespace NUnit.TestData.RepeatingTests
             Assert.IsTrue(false);
         }
     }
+
+    public sealed class RetryWithoutSetUpOrTearDownFixture
+    {
+        public int Count { get; private set; }
+
+        [Test, Retry(3)]
+        public void SucceedsOnThirdTry()
+        {
+            Count++;
+
+            if (Count < 3)
+                Assert.Fail();
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -195,5 +195,12 @@ namespace NUnit.TestData.RepeatingTests
             Count++;
             Assert.Fail();
         }
+
+        [Test, Retry(3)]
+        public void ErrorsOnFirstTry()
+        {
+            Count++;
+            throw new Exception("Deliberate exception");
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -58,11 +58,12 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(nTries, fixture.Count);
         }
 
-        [TestCase(typeof(RetryWithoutSetUpOrTearDownFixture), "Passed", 3)]
-        public void RetryWorksAsExpectedOnFixturesWithoutSetupOrTeardown(Type fixtureType, string outcome, int nTries)
+        [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.SucceedsOnThirdTry), "Passed", 3)]
+        [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.FailsEveryTime), "Failed", 3)]
+        public void RetryWorksAsExpectedOnFixturesWithoutSetupOrTeardown(string methodName, string outcome, int nTries)
         {
-            var fixture = (RetryWithoutSetUpOrTearDownFixture)Reflect.Construct(fixtureType);
-            ITestResult result = TestBuilder.RunTestFixture(fixture);
+            var fixture = (RetryWithoutSetUpOrTearDownFixture)Reflect.Construct(typeof(RetryWithoutSetUpOrTearDownFixture));
+            ITestResult result = TestBuilder.RunTestCase(fixture, methodName);
 
             Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
             Assert.AreEqual(nTries, fixture.Count);

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -60,6 +60,7 @@ namespace NUnit.Framework.Attributes
 
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.SucceedsOnThirdTry), "Passed", 3)]
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.FailsEveryTime), "Failed", 3)]
+        [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.ErrorsOnFirstTry), "Failed:Error", 1)]
         public void RetryWorksAsExpectedOnFixturesWithoutSetupOrTeardown(string methodName, string outcome, int nTries)
         {
             var fixture = (RetryWithoutSetUpOrTearDownFixture)Reflect.Construct(typeof(RetryWithoutSetUpOrTearDownFixture));

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(typeof(RetryErrorOnSecondTryFixture), "Failed(Child)", 2)]
         [TestCase(typeof(RetryErrorOnThirdTryFixture), "Failed(Child)", 3)]
         [TestCase(typeof(RetryTestCaseFixture), "Failed(Child)", 3)]
-        public void RetryWorksAsExpected(Type fixtureType, string outcome, int nTries)
+        public void RetryWorksAsExpectedOnFixturesWithSetupAndTeardown(Type fixtureType, string outcome, int nTries)
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
             ITestResult result = TestBuilder.RunTestFixture(fixture);
@@ -57,6 +57,17 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(nTries, fixture.TeardownCount);
             Assert.AreEqual(nTries, fixture.Count);
         }
+
+        [TestCase(typeof(RetryWithoutSetUpOrTearDownFixture), "Passed", 3)]
+        public void RetryWorksAsExpectedOnFixturesWithoutSetupOrTeardown(Type fixtureType, string outcome, int nTries)
+        {
+            var fixture = (RetryWithoutSetUpOrTearDownFixture)Reflect.Construct(fixtureType);
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
+            Assert.AreEqual(nTries, fixture.Count);
+        }
+
 
         [Test]
         public void CategoryWorksWithRetry()


### PR DESCRIPTION
Fixes #2325

(The fourth commit is an example of the TestCommand API being a little unsettling for me. I wonder if there's a way to make it less magical in the future.)