### PR TITLE
Add tests for #2619

### DIFF
--- a/src/NUnitFramework/testdata/RepeatingTestsFixtureBase.cs
+++ b/src/NUnitFramework/testdata/RepeatingTestsFixtureBase.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -35,6 +35,7 @@ namespace NUnit.TestData.RepeatingTests
         private int fixtureTeardownCount;
         private int setupCount;
         private int teardownCount;
+        private List<string> tearDownResults = new List<string>();
         protected int count;
 
         [OneTimeSetUp]
@@ -58,6 +59,7 @@ namespace NUnit.TestData.RepeatingTests
         [TearDown]
         public void TearDown()
         {
+            tearDownResults.Add(TestContext.CurrentContext.Result.Outcome.ToString());
             teardownCount++;
         }
 
@@ -76,6 +78,11 @@ namespace NUnit.TestData.RepeatingTests
         public int TeardownCount
         {
             get { return teardownCount; }
+        }
+
+        public List<string> TearDownResults
+        {
+            get { return tearDownResults; }
         }
         public int Count
         {

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -58,6 +58,26 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(nTries, fixture.Count);
         }
 
+        [TestCase(typeof(RetrySucceedsOnFirstTryFixture), "Passed")]
+        [TestCase(typeof(RetrySucceedsOnSecondTryFixture), "Failed", "Passed")]
+        [TestCase(typeof(RetrySucceedsOnThirdTryFixture), "Failed", "Failed", "Passed")]
+        [TestCase(typeof(RetryFailsEveryTimeFixture), "Failed", "Failed", "Failed")]
+        [TestCase(typeof(RetryIgnoredOnFirstTryFixture), "Skipped:Ignored")]
+        [TestCase(typeof(RetryIgnoredOnSecondTryFixture), "Failed", "Skipped:Ignored")]
+        [TestCase(typeof(RetryIgnoredOnThirdTryFixture), "Failed", "Failed", "Skipped:Ignored")]
+        [TestCase(typeof(RetryErrorOnFirstTryFixture), "Failed:Error")]
+        [TestCase(typeof(RetryErrorOnSecondTryFixture), "Failed", "Failed:Error")]
+        [TestCase(typeof(RetryErrorOnThirdTryFixture), "Failed", "Failed", "Failed:Error")]
+        public void RetryExposesEachResultInTearDown(Type fixtureType, params string[] results)
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            Assert.AreEqual(results.Length, fixture.TearDownResults.Count);
+            for (int i = 0; i < results.Length; i++)
+                Assert.That(fixture.TearDownResults[i], Is.EqualTo(results[i]), $"Teardown {i} received incorrect result");
+        }
+
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.SucceedsOnThirdTry), "Passed", 3)]
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.FailsEveryTime), "Failed", 3)]
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.ErrorsOnFirstTry), "Failed:Error", 1)]


### PR DESCRIPTION
Fixes #2619 

There's actually no fix here, since the reported problem was with a user's own `RetryAttribute`. This PR adds tests, which were not previously included, to demonstrate that the `TearDown` method has correct access to the test result at each iteration of the NUnit `RetryAttribute`.