### PR TITLE
Initial nameof conversion

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         /// <param name="apartmentState">The apartment state that this test must be run under. You must pass in a valid apartment state.</param>
         public ApartmentAttribute(ApartmentState apartmentState)
         {
-            Guard.ArgumentValid(apartmentState != ApartmentState.Unknown, "must be STA or MTA", "apartmentState");
+            Guard.ArgumentValid(apartmentState != ApartmentState.Unknown, "must be STA or MTA", nameof(apartmentState));
             Properties.Add(PropertyNames.ApartmentState, apartmentState);
         }
     }

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -623,7 +623,7 @@ namespace NUnit.Framework
 
             public override IEnumerable GetData(IParameterInfo parameter)
             {
-                Guard.ArgumentValid(parameter.ParameterType.GetTypeInfo().IsEnum, "EnumDataSource requires an enum parameter", "parameter");
+                Guard.ArgumentValid(parameter.ParameterType.GetTypeInfo().IsEnum, "EnumDataSource requires an enum parameter", nameof(parameter));
 
                 Randomizer randomizer = Randomizer.GetRandomizer(parameter.ParameterInfo);
                 DataType = parameter.ParameterType;

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework
         public RangeAttribute(int from, int to, int step)
         {
             Guard.ArgumentValid(step > 0 && to >= from || step < 0 && to <= from,
-                "Step must be positive with to >= from or negative with to <= from", "step");
+                "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
             int count = (to - from) / step + 1;
             _data = new object[count];
@@ -91,8 +91,8 @@ namespace NUnit.Framework
         [CLSCompliant(false)]
         public RangeAttribute(uint from, uint to, uint step)
         {
-            Guard.ArgumentValid(step > 0, "Step must be greater than zero", "step");
-            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", "to");
+            Guard.ArgumentValid(step > 0, "Step must be greater than zero", nameof(step));
+            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", nameof(to));
 
             uint count = (to - from) / step + 1;
             _data = new object[count];
@@ -121,7 +121,7 @@ namespace NUnit.Framework
         public RangeAttribute(long from, long to, long step)
         {
             Guard.ArgumentValid(step > 0L && to >= from || step < 0L && to <= from,
-                "Step must be positive with to >= from or negative with to <= from", "step");
+                "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
             long count = (to - from) / step + 1;
             _data = new object[count];
@@ -151,8 +151,8 @@ namespace NUnit.Framework
         [CLSCompliant(false)]
         public RangeAttribute(ulong from, ulong to, ulong step)
         {
-            Guard.ArgumentValid(step > 0, "Step must be greater than zero", "step");
-            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", "to");
+            Guard.ArgumentValid(step > 0, "Step must be greater than zero", nameof(step));
+            Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", nameof(to));
 
             ulong count = (to - from) / step + 1;
             _data = new object[count];
@@ -174,7 +174,7 @@ namespace NUnit.Framework
         public RangeAttribute(double from, double to, double step)
         {
             Guard.ArgumentValid(step > 0.0D && to >= from || step < 0.0D && to <= from,
-                "Step must be positive with to >= from or negative with to <= from", "step");
+                "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
             double aStep = Math.Abs(step);
             double tol = aStep / 1000;
@@ -198,7 +198,7 @@ namespace NUnit.Framework
         public RangeAttribute(float from, float to, float step)
         {
             Guard.ArgumentValid(step > 0.0F && to >= from || step < 0.0F && to <= from,
-                "Step must be positive with to >= from or negative with to <= from", "step");
+                "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
             float aStep = Math.Abs(step);
             float tol = aStep / 1000;

--- a/src/NUnitFramework/framework/Compatibility/AttributeHelper.cs
+++ b/src/NUnitFramework/framework/Compatibility/AttributeHelper.cs
@@ -42,7 +42,7 @@ namespace NUnit.Compatibility
         {
             var attrProvider = actual as ICustomAttributeProvider;
             if (attrProvider == null)
-                throw new ArgumentException(string.Format("Actual value {0} does not implement ICustomAttributeProvider.", actual), "actual");
+                throw new ArgumentException(string.Format("Actual value {0} does not implement ICustomAttributeProvider.", actual), nameof(actual));
 
             return (Attribute[])attrProvider.GetCustomAttributes(attributeType, inherit);
         }

--- a/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
 
             if (!typeof(Attribute).GetTypeInfo().IsAssignableFrom(expectedType.GetTypeInfo()))
                 throw new ArgumentException(string.Format(
-                    "Type {0} is not an attribute", expectedType), "type");
+                    "Type {0} is not an attribute", expectedType), nameof(type));
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Constraints
             Guard.ArgumentNotNull(actual, "actual");
             Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, expectedType, true);
             if (attrs.Length == 0)
-                throw new ArgumentException(string.Format("Attribute {0} was not found", expectedType), "actual");
+                throw new ArgumentException(string.Format("Attribute {0} was not found", expectedType), nameof(actual));
 
             attrFound = attrs[0];
             return BaseConstraint.ApplyTo(attrFound);

--- a/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            Guard.ArgumentNotNull(actual, "actual");
+            Guard.ArgumentNotNull(actual, nameof(actual));
             Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, expectedType, true);
             if (attrs.Length == 0)
                 throw new ArgumentException(string.Format("Attribute {0} was not found", expectedType), nameof(actual));

--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if the expected attribute is present, otherwise false</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            Guard.ArgumentNotNull(actual, "actual");
+            Guard.ArgumentNotNull(actual, nameof(actual));
             Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, expectedType, true);
             ConstraintResult result = new ConstraintResult(this, actual);
             result.Status = attrs.Length > 0

--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
 
             if (!typeof(Attribute).GetTypeInfo().IsAssignableFrom(expectedType.GetTypeInfo()))
                 throw new ArgumentException(string.Format(
-                    "Type {0} is not an attribute", expectedType), "type");
+                    "Type {0} is not an attribute", expectedType), nameof(type));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/BinaryConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinaryConstraint.cs
@@ -46,10 +46,10 @@ namespace NUnit.Framework.Constraints
         protected BinaryConstraint(IConstraint left, IConstraint right)
             : base(left, right)
         {
-            Guard.ArgumentNotNull(left, "left");
+            Guard.ArgumentNotNull(left, nameof(left));
             this.Left = left;
 
-            Guard.ArgumentNotNull(right, "right");
+            Guard.ArgumentNotNull(right, nameof(right));
             this.Right = right;
         }
     }

--- a/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             if (actual == null)
-                throw new ArgumentNullException("actual");
+                throw new ArgumentNullException(nameof(actual));
 
             MemoryStream stream = new MemoryStream();
             bool succeeded = false;

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
             bool isSuccess)
             : base(constraint, actual, isSuccess)
         {
-            Guard.ArgumentNotNull(tallyResult, "tallyResult");
+            Guard.ArgumentNotNull(tallyResult, nameof(tallyResult));
 
             _tallyResult = tallyResult;
         }

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -214,7 +214,7 @@ namespace NUnit.Framework.Constraints
             : base(baseConstraint)
         {
             if (delayInMilliseconds < 0)
-                throw new ArgumentException("Cannot check a condition in the past", "delayInMilliseconds");
+                throw new ArgumentException("Cannot check a condition in the past", nameof(delayInMilliseconds));
 
             DelayInterval = new Interval(delayInMilliseconds).InMilliseconds;
             PollingInterval = new Interval(pollingIntervalInMilliseconds).InMilliseconds;

--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
             if (typeof(TActual) == typeof(string))
                 realConstraint = new EmptyStringConstraint();
             else if (actual == null)
-                throw new System.ArgumentException("The actual value must be a string or a non-null IEnumerable or DirectoryInfo", "actual");
+                throw new System.ArgumentException("The actual value must be a string or a non-null IEnumerable or DirectoryInfo", nameof(actual));
             else if (actual is System.IO.DirectoryInfo)
                 realConstraint = new EmptyDirectoryConstraint();
             else

--- a/src/NUnitFramework/framework/Constraints/EmptyDirectoryConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyDirectoryConstraint.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
         {
             DirectoryInfo dirInfo = actual as DirectoryInfo;
             if (dirInfo == null)
-                throw new ArgumentException("The actual value must be a DirectoryInfo", "actual");
+                throw new ArgumentException("The actual value must be a DirectoryInfo", nameof(actual));
             files = dirInfo.GetFiles().Length;
             subdirs = dirInfo.GetDirectories().Length;
             bool hasSucceeded = files == 0 && subdirs == 0;

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
         public ExactCountConstraint(int expectedCount, IConstraint itemConstraint)
             : base(itemConstraint)
         {
-            Guard.ArgumentNotNull(itemConstraint, "itemConstraint");
+            Guard.ArgumentNotNull(itemConstraint, nameof(itemConstraint));
 
             _itemConstraint = itemConstraint.Resolve();
             _expectedCount = expectedCount;

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
             Exception castedToException = actual as Exception;
 
             if (actual != null && castedToException == null)
-                throw new ArgumentException("Actual value must be an Exception", "actual");
+                throw new ArgumentException("Actual value must be an Exception", nameof(actual));
 
             actualType = actual == null ? null : actual.GetType();
 

--- a/src/NUnitFramework/framework/Constraints/FileOrDirectoryExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/FileOrDirectoryExistsConstraint.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             if(actual == null)
-                throw new ArgumentNullException("actual", "The actual value must be a non-null string" + ErrorSubstring);
+                throw new ArgumentNullException(nameof(actual), "The actual value must be a non-null string" + ErrorSubstring);
 
             if(actual is string)
             {
@@ -122,14 +122,14 @@ namespace NUnit.Framework.Constraints
             {
                 return new ConstraintResult(this, actual, directoryInfo.Exists);
             }
-            throw new ArgumentException("The actual value must be a string" + ErrorSubstring, "actual");
+            throw new ArgumentException("The actual value must be a string" + ErrorSubstring, nameof(actual));
         }
 
         private ConstraintResult CheckString<TActual>(TActual actual)
         {
             var str = actual as string;
             if (String.IsNullOrEmpty(str))
-                throw new ArgumentException("The actual value cannot be an empty string", "actual");
+                throw new ArgumentException("The actual value cannot be an empty string", nameof(actual));
 
             var fileInfo = new FileInfo(str);
             if (_ignoreDirectories && !_ignoreFiles)

--- a/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
         protected PrefixConstraint(IResolveConstraint baseConstraint)
             : base(baseConstraint)
         {
-            Guard.ArgumentNotNull(baseConstraint, "baseConstraint");
+            Guard.ArgumentNotNull(baseConstraint, nameof(baseConstraint));
 
             BaseConstraint = baseConstraint.Resolve();
         }

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             // TODO: Use an error result for null
-            Guard.ArgumentNotNull(actual, "actual");
+            Guard.ArgumentNotNull(actual, nameof(actual));
 
             Type actualType = actual as Type;
             if (actualType == null)

--- a/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            Guard.ArgumentNotNull(actual, "actual");
+            Guard.ArgumentNotNull(actual, nameof(actual));
 
             actualType = actual as Type;
             if (actualType == null)

--- a/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             if ( from == null || to == null || actual == null)
-                throw new ArgumentException( "Cannot compare using a null reference", "actual" );
+                throw new ArgumentException( "Cannot compare using a null reference", nameof(actual) );
             CompareFromAndTo();
             bool isInsideRange = comparer.Compare(from, actual) <= 0 && comparer.Compare(to, actual) >= 0;
             return new ConstraintResult(this, actual, isInsideRange);

--- a/src/NUnitFramework/framework/Constraints/StringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StringConstraint.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Constraints
         {
             string actualAsString = actual as string;
             if (actual != null && actualAsString == null)
-                throw new ArgumentException("Actual value must be a string", "actual");
+                throw new ArgumentException("Actual value must be a string", nameof(actual));
 
             return new ConstraintResult(this, actual, Matches(actualAsString));
         }

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -220,7 +220,7 @@ namespace NUnit.Framework.Constraints
                         String.Format(
                             "The actual value must be a TestDelegate or AsyncTestDelegate but was {0}",
                             actual.GetType().Name),
-                        "actual");
+                        nameof(actual));
 
                 return invocationDescriptor;
             }

--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Constraints
             else
 #endif
             {
-                throw new ArgumentException(string.Format("The actual value must be a TestDelegate or AsyncTestDelegate but was {0}", actual.GetType().Name), "actual");
+                throw new ArgumentException(string.Format("The actual value must be a TestDelegate or AsyncTestDelegate but was {0}", actual.GetType().Name), nameof(actual));
             }
             return new ThrowsExceptionConstraintResult(this, caughtException);
         }

--- a/src/NUnitFramework/framework/Constraints/XmlSerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/XmlSerializableConstraint.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             if(actual == null)
-                throw new ArgumentNullException("actual");
+                throw new ArgumentNullException(nameof(actual));
 
             MemoryStream stream = new MemoryStream();
 

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -289,7 +289,7 @@ namespace NUnit.Framework.Interfaces
 
         private static NodeList ApplySelection(NodeList nodeList, string xpath)
         {
-            Guard.ArgumentNotNullOrEmpty(xpath, "xpath");
+            Guard.ArgumentNotNullOrEmpty(xpath, nameof(xpath));
             if (xpath[0] == '/')
                 throw new ArgumentException("XPath expressions starting with '/' are not supported", nameof(xpath));
             if (xpath.IndexOf("//") >= 0)

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -291,9 +291,9 @@ namespace NUnit.Framework.Interfaces
         {
             Guard.ArgumentNotNullOrEmpty(xpath, "xpath");
             if (xpath[0] == '/')
-                throw new ArgumentException("XPath expressions starting with '/' are not supported", "xpath");
+                throw new ArgumentException("XPath expressions starting with '/' are not supported", nameof(xpath));
             if (xpath.IndexOf("//") >= 0)
-                throw new ArgumentException("XPath expressions with '//' are not supported", "xpath");
+                throw new ArgumentException("XPath expressions with '//' are not supported", nameof(xpath));
 
             string head = xpath;
             string tail = null;
@@ -374,14 +374,14 @@ namespace NUnit.Framework.Interfaces
                 if (lbrack >= 0)
                 {
                     if (!xpath.EndsWith("]"))
-                        throw new ArgumentException("Invalid property expression", "xpath");
+                        throw new ArgumentException("Invalid property expression", nameof(xpath));
 
                     _nodeName = xpath.Substring(0, lbrack);
                     string filter = xpath.Substring(lbrack+1, xpath.Length - lbrack - 2);
 
                     int equals = filter.IndexOf('=');
                     if (equals < 0 || filter[0] != '@')
-                        throw new ArgumentException("Invalid property expression", "xpath");
+                        throw new ArgumentException("Invalid property expression", nameof(xpath));
 
                     _propName = filter.Substring(1, equals - 1).Trim();
                     _propValue = filter.Substring(equals + 1).Trim(new char[] { ' ', '"', '\'' });

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns></returns>
         public TestSuite BuildFrom(ITypeInfo typeInfo, ITestFixtureData testFixtureData)
         {
-            Guard.ArgumentNotNull(testFixtureData, "testFixtureData");
+            Guard.ArgumentNotNull(testFixtureData, nameof(testFixtureData));
 
             object[] arguments = testFixtureData.Arguments;
 

--- a/src/NUnitFramework/framework/Internal/Commands/AfterTestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/AfterTestActionCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal.Commands
         public AfterTestActionCommand(TestCommand innerCommand, TestActionItem action)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestSuite, "BeforeTestActionCommand may only apply to a TestSuite", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestSuite, "BeforeTestActionCommand may only apply to a TestSuite", nameof(innerCommand));
             Guard.ArgumentNotNull(action, nameof(action));
 
             AfterTest = (context) =>

--- a/src/NUnitFramework/framework/Internal/Commands/BeforeTestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeTestActionCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal.Commands
         public BeforeTestActionCommand(TestCommand innerCommand, TestActionItem action)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestSuite, "TestActionBeforeCommand may only apply to a TestSuite", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestSuite, "TestActionBeforeCommand may only apply to a TestSuite", nameof(innerCommand));
             Guard.ArgumentNotNull(action, nameof(action));
 
             BeforeTest = (context) =>

--- a/src/NUnitFramework/framework/Internal/Commands/ConstructFixtureCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/ConstructFixtureCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Internal.Commands
         public ConstructFixtureCommand(TestCommand innerCommand)
             : base(innerCommand) 
         {
-            Guard.ArgumentValid(Test is TestSuite, "ConstructFixtureCommand must reference a TestSuite", "innerCommand");
+            Guard.ArgumentValid(Test is TestSuite, "ConstructFixtureCommand must reference a TestSuite", nameof(innerCommand));
 
             BeforeTest = (context) =>
             {

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal.Commands
             : base(innerCommand) 
         {
             Guard.ArgumentValid(Test is TestSuite && Test.TypeInfo != null, 
-                "OneTimeSetUpCommand must reference a TestFixture or SetUpFixture", "innerCommand");
+                "OneTimeSetUpCommand must reference a TestFixture or SetUpFixture", nameof(innerCommand));
 
             BeforeTest = (context) =>
             {

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2012 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal.Commands
         public OneTimeTearDownCommand(TestCommand innerCommand, SetUpTearDownItem setUpTearDownItem)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestSuite, "OneTimeTearDownCommand may only apply to a TestSuite", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestSuite, "OneTimeTearDownCommand may only apply to a TestSuite", nameof(innerCommand));
             Guard.ArgumentNotNull(setUpTearDownItem, nameof(setUpTearDownItem));
 
             AfterTest = (context) =>

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Internal.Commands
         public SetUpTearDownCommand(TestCommand innerCommand, SetUpTearDownItem setUpTearDown)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestMethod, "SetUpTearDownCommand may only apply to a TestMethod", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestMethod, "SetUpTearDownCommand may only apply to a TestMethod", nameof(innerCommand));
             Guard.OperationValid(Test.TypeInfo != null, "TestMethod must have a non-null TypeInfo");
             Guard.ArgumentNotNull(setUpTearDown, nameof(setUpTearDown));
 

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal.Commands
         public TestActionCommand(TestCommand innerCommand, ITestAction action)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestMethod, "TestActionCommand may only apply to a TestMethod", "innerCommand");
+            Guard.ArgumentValid(innerCommand.Test is TestMethod, "TestActionCommand may only apply to a TestMethod", nameof(innerCommand));
             Guard.ArgumentNotNull(action, nameof(action));
 
             BeforeTest = (context) =>

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -49,8 +49,8 @@ namespace NUnit.Framework.Internal.Commands
         public TimeoutCommand(TestCommand innerCommand, int timeout)
             : base(innerCommand)
         {
-            Guard.ArgumentValid(innerCommand.Test is TestMethod, "TimeoutCommand may only apply to a TestMethod", "innerCommand");
-            Guard.ArgumentValid(timeout > 0, "Timeout value must be greater than zero", "timeout");
+            Guard.ArgumentValid(innerCommand.Test is TestMethod, "TimeoutCommand may only apply to a TestMethod", nameof(innerCommand));
+            Guard.ArgumentValid(timeout > 0, "Timeout value must be greater than zero", nameof(timeout));
 
             BeforeTest = (context) =>
             {

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Internal.Execution
         internal void Enqueue(WorkItem work, int priority)
         {
             Guard.ArgumentInRange(priority >= 0 && priority < PRIORITY_LEVELS,
-                "Invalid priority specified", "priority");
+                "Invalid priority specified", nameof(priority));
 
             do
             {

--- a/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Internal
         /// <param name="method">MethodInfo for the method to examine</param>
         public GenericMethodHelper(MethodInfo method)
         {
-            Guard.ArgumentValid(method.IsGenericMethod, "Specified method must be generic", "method");
+            Guard.ArgumentValid(method.IsGenericMethod, "Specified method must be generic", nameof(method));
 
             Method = method;
 
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Internal
         /// <returns>An array of type arguments.</returns>
         public Type[] GetTypeArguments(object[] argList)
         {
-            Guard.ArgumentValid(argList.Length == ParmTypes.Length, "Supplied arguments do not match required method parameters", "argList");
+            Guard.ArgumentValid(argList.Length == ParmTypes.Length, "Supplied arguments do not match required method parameters", nameof(argList));
 
             for (int argIndex = 0; argIndex < ParmTypes.Length; argIndex++)
             {

--- a/src/NUnitFramework/framework/Internal/PropertyBag.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyBag.cs
@@ -67,8 +67,8 @@ namespace NUnit.Framework.Internal
         public void Set(string key, object value)
         {
             // Guard against mystery exceptions later!
-            Guard.ArgumentNotNull(key, "key");
-            Guard.ArgumentNotNull(value, "value");
+            Guard.ArgumentNotNull(key, nameof(key));
+            Guard.ArgumentNotNull(value, nameof(value));
 
             IList list = new List<object>();
             list.Add(value);

--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2013-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -172,7 +172,7 @@ namespace NUnit.Framework.Internal
         [CLSCompliant(false)]
         public uint NextUInt(uint min, uint max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", "max");
+            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
 
             if (min == max)
                 return min;
@@ -275,7 +275,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public long NextLong(long min, long max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", "max");
+            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
 
             if (min == max)
                 return min;
@@ -322,7 +322,7 @@ namespace NUnit.Framework.Internal
         [CLSCompliant(false)]
         public ulong NextULong(ulong min, ulong max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", "max");
+            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
 
             ulong range = max - min;
 
@@ -417,7 +417,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool NextBool(double probability)
         {
-            Guard.ArgumentInRange(probability >= 0.0 && probability <= 1.0, "Probability must be from 0.0 to 1.0", "probability");
+            Guard.ArgumentInRange(probability >= 0.0 && probability <= 1.0, "Probability must be from 0.0 to 1.0", nameof(probability));
 
             return NextDouble() < probability;
         }
@@ -441,7 +441,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public double NextDouble(double min, double max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", "max");
+            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
 
             if (max == min)
                 return min;
@@ -587,12 +587,12 @@ namespace NUnit.Framework.Internal
         /// </remarks>
         public decimal NextDecimal(decimal min, decimal max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", "max");
+            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
 
             // Check that the range is not greater than MaxValue without 
             // first calculating it, since this would cause overflow
             Guard.ArgumentValid(max < 0M == min < 0M || min + decimal.MaxValue >= max,
-                "Range too great for decimal data, use double range", "max");
+                "Range too great for decimal data, use double range", nameof(max));
 
             if (min == max)
                 return min;

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -213,7 +213,7 @@ namespace NUnit.Framework.Internal
 
         private static void ThrowInvalidFrameworkVersion(Version version)
         {
-            throw new ArgumentException("Unknown framework version " + version, "version");
+            throw new ArgumentException("Unknown framework version " + version, nameof(version));
         }
 
         private void InitFromClrVersion(Version version)

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Internal
         /// <param name="name">The name of the test</param>
         protected Test( string name )
         {
-            Guard.ArgumentNotNullOrEmpty(name, "name");
+            Guard.ArgumentNotNullOrEmpty(name, nameof(name));
 
             Initialize(name);
         }
@@ -353,7 +353,7 @@ namespace NUnit.Framework.Internal
         /// <param name="reason">The reason the test is not runnable</param>
         public void MakeInvalid(string reason)
         {
-            Guard.ArgumentNotNullOrEmpty(reason, "reason");
+            Guard.ArgumentNotNullOrEmpty(reason, nameof(reason));
 
             RunState = RunState.NotRunnable;
             Properties.Add(PropertyNames.SkipReason, reason);

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public TypeWrapper(Type type)
         {
-            Guard.ArgumentNotNull(type, "Type");
+            Guard.ArgumentNotNull(type, nameof(Type));
 
             Type = type;
         }

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -54,7 +54,7 @@ namespace NUnit.Common
         internal CommandLineOptions(IDefaultOptionsProvider defaultOptionsProvider, bool requireInputFile, params string[] args)
         {
             // Apply default options
-            if (defaultOptionsProvider == null) throw new ArgumentNullException("defaultOptionsProvider");
+            if (defaultOptionsProvider == null) throw new ArgumentNullException(nameof(defaultOptionsProvider));
 
             TeamCity = defaultOptionsProvider.TeamCity;
 

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -205,7 +205,7 @@ namespace NUnit.Options
             if (c.Option == null)
                 throw new InvalidOperationException ("OptionContext.Option is null.");
             if (index >= c.Option.MaxValueCount)
-                throw new ArgumentOutOfRangeException ("index");
+                throw new ArgumentOutOfRangeException (nameof(index));
             if (c.Option.OptionValueType == OptionValueType.Required &&
                     index >= values.Count)
                 throw new OptionException (string.Format (
@@ -298,11 +298,11 @@ namespace NUnit.Options
         protected Option (string prototype, string description, int maxValueCount)
         {
             if (prototype == null)
-                throw new ArgumentNullException ("prototype");
+                throw new ArgumentNullException (nameof(prototype));
             if (prototype.Length == 0)
-                throw new ArgumentException ("Cannot be the empty string.", "prototype");
+                throw new ArgumentException ("Cannot be the empty string.", nameof(prototype));
             if (maxValueCount < 0)
-                throw new ArgumentOutOfRangeException ("maxValueCount");
+                throw new ArgumentOutOfRangeException (nameof(maxValueCount));
 
             this.prototype   = prototype;
             this.names       = prototype.Split ('|');
@@ -314,17 +314,17 @@ namespace NUnit.Options
                 throw new ArgumentException (
                         "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
                             "OptionValueType.Optional.",
-                        "maxValueCount");
+                        nameof(maxValueCount));
             if (this.type == OptionValueType.None && maxValueCount > 1)
                 throw new ArgumentException (
                         string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
-                        "maxValueCount");
+                        nameof(maxValueCount));
             if (Array.IndexOf (names, "<>") >= 0 &&
                     ((names.Length == 1 && this.type != OptionValueType.None) ||
                      (names.Length > 1 && this.MaxValueCount > 1)))
                 throw new ArgumentException (
                         "The default option handler '<>' cannot require values.",
-                        "prototype");
+                        nameof(prototype));
         }
 
         public string           Prototype       {get {return prototype;}}
@@ -530,7 +530,7 @@ namespace NUnit.Options
         protected override string GetKeyForItem (Option item)
         {
             if (item == null)
-                throw new ArgumentNullException ("option");
+                throw new ArgumentNullException (nameof(item));
             if (item.Names != null && item.Names.Length > 0)
                 return item.Names [0];
             // This should never happen, as it's invalid for Option to be
@@ -542,7 +542,7 @@ namespace NUnit.Options
         protected Option GetOptionForName (string option)
         {
             if (option == null)
-                throw new ArgumentNullException ("option");
+                throw new ArgumentNullException (nameof(option));
             try {
                 return base [option];
             }
@@ -577,7 +577,7 @@ namespace NUnit.Options
         private void AddImpl (Option option)
         {
             if (option == null)
-                throw new ArgumentNullException ("option");
+                throw new ArgumentNullException (nameof(option));
             List<string> added = new List<string> (option.Names.Length);
             try {
                 // KeyedCollection.InsertItem/SetItem handle the 0th name.
@@ -606,7 +606,7 @@ namespace NUnit.Options
                 : base (prototype, description, count)
             {
                 if (action == null)
-                    throw new ArgumentNullException ("action");
+                    throw new ArgumentNullException (nameof(action));
                 this.action = action;
             }
 
@@ -624,7 +624,7 @@ namespace NUnit.Options
         public OptionSet Add (string prototype, string description, Action<string> action)
         {
             if (action == null)
-                throw new ArgumentNullException ("action");
+                throw new ArgumentNullException (nameof(action));
             Option p = new ActionOption (prototype, description, 1,
                     delegate (OptionValueCollection v) { action (v [0]); });
             base.Add (p);
@@ -639,7 +639,7 @@ namespace NUnit.Options
         public OptionSet Add (string prototype, string description, OptionAction<string, string> action)
         {
             if (action == null)
-                throw new ArgumentNullException ("action");
+                throw new ArgumentNullException (nameof(action));
             Option p = new ActionOption (prototype, description, 2,
                     delegate (OptionValueCollection v) {action (v [0], v [1]);});
             base.Add (p);
@@ -653,7 +653,7 @@ namespace NUnit.Options
                 : base (prototype, description, 1)
             {
                 if (action == null)
-                    throw new ArgumentNullException ("action");
+                    throw new ArgumentNullException (nameof(action));
                 this.action = action;
             }
 
@@ -670,7 +670,7 @@ namespace NUnit.Options
                 : base (prototype, description, 2)
             {
                 if (action == null)
-                    throw new ArgumentNullException ("action");
+                    throw new ArgumentNullException (nameof(action));
                 this.action = action;
             }
 
@@ -750,7 +750,7 @@ namespace NUnit.Options
         protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
         {
             if (argument == null)
-                throw new ArgumentNullException ("argument");
+                throw new ArgumentNullException (nameof(argument));
 
             flag = name = sep = value = null;
             Match m = ValueOption.Match (argument);

--- a/src/NUnitFramework/nunitlite/OutputManager.cs
+++ b/src/NUnitFramework/nunitlite/OutputManager.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2011 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -75,7 +75,7 @@ namespace NUnitLite
                 default:
                     throw new ArgumentException(
                         string.Format("Invalid XML output format '{0}'", spec.Format),
-                        "spec");
+                        nameof(spec));
             }
 
             outputWriter.WriteResultFile(result, outputPath, runSettings, filter);
@@ -105,7 +105,7 @@ namespace NUnitLite
                 default:
                     throw new ArgumentException(
                         string.Format("Invalid output format '{0}'", spec.Format),
-                        "spec");
+                        nameof(spec));
             }
 
             outputWriter.WriteTestFile(test, outputPath);

--- a/src/NUnitFramework/nunitlite/Tokenizer.cs
+++ b/src/NUnitFramework/nunitlite/Tokenizer.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -116,7 +116,7 @@ namespace NUnit.Common
         public Tokenizer(string input)
         {
             if (input == null)
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
 
             _input = input;
             _index = 0;

--- a/src/NUnitFramework/testdata/CategoryAttributeData.cs
+++ b/src/NUnitFramework/testdata/CategoryAttributeData.cs
@@ -39,7 +39,7 @@ namespace NUnit.TestData.CategoryAttributeData
         public void Test2() { }
 
         [Test, Category("Top")]
-        [TestCaseSource("Test3Data")]
+        [TestCaseSource(nameof(Test3Data))]
         public void Test3(int x) { }
 
         [Test, Category("A-B"), Category("A,B"), Category("A!B"), Category("A+B")]

--- a/src/NUnitFramework/testdata/GenericTestMethodData.cs
+++ b/src/NUnitFramework/testdata/GenericTestMethodData.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -41,7 +41,7 @@ namespace NUnit.TestData
 
     public class IncompatibleGenericTestCaseSourceData
     {
-        [TestCaseSource("Source")]
+        [TestCaseSource(nameof(Source))]
         public void TestCaseSource_OneTypeParameterOnTwoArgs<T>(T x, T y, string label)
         {
         }

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -32,7 +32,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
     {
         #region Test Calling Assert.Ignore
 
-        [TestCaseSource("source")]
+        [TestCaseSource(nameof(source))]
         public void MethodCallsIgnore(int x, int y, int z)
         {
             Assert.Ignore("Ignore this");
@@ -47,7 +47,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
 
         #region Test With Ignored TestCaseData
 
-        [TestCaseSource("ignored_source")]
+        [TestCaseSource(nameof(ignored_source))]
         public void MethodWithIgnoredTestCases(int num)
         {
         }
@@ -67,7 +67,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
 
         #region Test With Explicit TestCaseData
 
-        [TestCaseSource("explicit_source")]
+        [TestCaseSource(nameof(explicit_source))]
         public void MethodWithExplicitTestCases(int num)
         {
         }
@@ -88,7 +88,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
 
         #region Tests Using Instance Members as Source
 
-        [Test, TestCaseSource("InstanceProperty")]
+        [Test, TestCaseSource(nameof(InstanceProperty))]
         public void MethodWithInstancePropertyAsSource(string source)
         {
             Assert.AreEqual("InstanceProperty", source);
@@ -99,7 +99,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             get { return new object[] { new object[] { "InstanceProperty" } }; }
         }
 
-        [Test, TestCaseSource("InstanceMethod")]
+        [Test, TestCaseSource(nameof(InstanceMethod))]
         public void MethodWithInstanceMethodAsSource(string source)
         {
             Assert.AreEqual("InstanceMethod", source);
@@ -110,7 +110,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             return new object[] { new object[] { "InstanceMethod" } };
         }
 
-        [Test, TestCaseSource("InstanceField")]
+        [Test, TestCaseSource(nameof(InstanceField))]
         public void MethodWithInstanceFieldAsSource(string source)
         {
             Assert.AreEqual("InstanceField", source);
@@ -122,22 +122,22 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
 
         #endregion
 
-        [Test, TestCaseSource(typeof(DivideDataProvider), "MyField", new object[] { 100, 4, 25 })]
+        [Test, TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.MyField), new object[] { 100, 4, 25 })]
         public void SourceInAnotherClassPassingParamsToField(int n, int d, int q)
         {
         }
 
-        [Test, TestCaseSource(typeof(DivideDataProvider), "MyProperty", new object[] { 100, 4, 25 })]
+        [Test, TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.MyProperty), new object[] { 100, 4, 25 })]
         public void SourceInAnotherClassPassingParamsToProperty(int n, int d, int q)
         {
         }
 
-        [Test, TestCaseSource(typeof(DivideDataProvider), "HereIsTheDataWithParameters", new object[] { 100, 4 })]
+        [Test, TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.HereIsTheDataWithParameters), new object[] { 100, 4 })]
         public void SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam(int n, int d, int q)
         {
         }
 
-        [TestCaseSource("exception_source")]
+        [TestCaseSource(nameof(exception_source))]
         public void MethodWithSourceThrowingException(string lhs, string rhs)
         {
         }

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -189,7 +189,7 @@ namespace NUnit.Framework.Assertions
         }
         public object Run(MethodInfo method, params object[] parameters)
         {
-            if (method == null) throw new ArgumentNullException("method");
+            if (method == null) throw new ArgumentNullException(nameof(method));
             if (_appDomain == null) throw new ObjectDisposedException(null);
 
             var methodRunnerType = typeof(MethodRunner);

--- a/src/NUnitFramework/tests/Attributes/AuthorTests.cs
+++ b/src/NUnitFramework/tests/Attributes/AuthorTests.cs
@@ -1,4 +1,4 @@
-﻿// **********************************************************************************
+// **********************************************************************************
 // The MIT License (MIT)
 // 
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
@@ -44,21 +44,21 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ReflectionTest()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "Method");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.Method));
             Assert.AreEqual(RunState.Runnable, testCase.RunState);
         }
 
         [Test]
         public void Author()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "Method");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.Method));
             Assert.AreEqual("Rob Prouse", testCase.Properties.Get(PropertyNames.Author));
         }
 
         [Test]
         public void NoAuthor()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "NoAuthorMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.NoAuthorMethod));
             Assert.IsNull(testCase.Properties.Get(PropertyNames.Author));
         }
 
@@ -76,21 +76,21 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SeparateAuthorAttribute()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "SeparateAuthorMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.SeparateAuthorMethod));
             Assert.AreEqual("Rob Prouse", testCase.Properties.Get(PropertyNames.Author));
         }
 
         [Test]
         public void SeparateAuthorWithEmailAttribute()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "SeparateAuthorWithEmailMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.SeparateAuthorWithEmailMethod));
             Assert.AreEqual("Rob Prouse <rob@prouse.org>", testCase.Properties.Get(PropertyNames.Author));
         }
 
         [Test]
         public void AuthorOnTestCase()
         {
-            TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, "TestCaseWithAuthor");
+            TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(AuthorFixture.TestCaseWithAuthor));
             Assert.AreEqual("Rob Prouse", parameterizedMethodSuite.Properties.Get(PropertyNames.Author));
             var testCase = (Test)parameterizedMethodSuite.Tests[0];
             Assert.AreEqual("Charlie Poole", testCase.Properties.Get(PropertyNames.Author));
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Attributes
         [Author("NUnit")]
         public void TestMethodMultipleAuthors()
         {
-            Test test = TestBuilder.MakeTestFromMethod(FixtureType, "TestMethodMultipleAuthors");
+            Test test = TestBuilder.MakeTestFromMethod(FixtureType, nameof(AuthorFixture.TestMethodMultipleAuthors));
             Assert.That(test.Properties[PropertyNames.Author], Is.EquivalentTo(
                 new[] { "Rob Prouse <rob@prouse.org>","Charlie Poole <charlie@poole.org>", "NUnit"}));
         }

--- a/src/NUnitFramework/tests/Attributes/DescriptionTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DescriptionTests.cs
@@ -34,33 +34,33 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class DescriptionTests
     {
-        static readonly Type FixtureType = typeof( DescriptionFixture );
+        static readonly Type FixtureType = typeof(DescriptionFixture);
 
         [Test]
         public void ReflectionTest()
         {
-            Test testCase = TestBuilder.MakeTestCase( FixtureType, "Method" );
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.Method));
             Assert.AreEqual( RunState.Runnable, testCase.RunState );
         }
 
         [Test]
         public void Description()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "Method");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.Method));
             Assert.AreEqual("Test Description", testCase.Properties.Get(PropertyNames.Description));
         }
 
         [Test]
         public void NoDescription()
         {
-            Test testCase = TestBuilder.MakeTestCase( FixtureType, "NoDescriptionMethod" );
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.NoDescriptionMethod) );
             Assert.IsNull(testCase.Properties.Get(PropertyNames.Description));
         }
 
         [Test]
         public void LongDescription()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "TestWithLongDescription");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.TestWithLongDescription));
             Assert.AreEqual("This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description", testCase.Properties.Get(PropertyNames.Description));
         }
 
@@ -78,14 +78,14 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SeparateDescriptionAttribute()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "SeparateDescriptionMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.SeparateDescriptionMethod));
             Assert.AreEqual("Separate Description", testCase.Properties.Get(PropertyNames.Description));
         }
 
         [Test]
         public void DescriptionOnTestCase()
         {
-            TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, "TestCaseWithDescription");
+            TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(DescriptionFixture.TestCaseWithDescription));
             Assert.AreEqual("method description", parameterizedMethodSuite.Properties.Get(PropertyNames.Description));
             Test testCase = (Test)parameterizedMethodSuite.Tests[0];
             Assert.AreEqual("case description", testCase.Properties.Get(PropertyNames.Description));

--- a/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Attributes
             new TestCaseData( new int[] { 5, 5, 5 }, 25, 25 ).SetName("Test 5x5x5")
         };
 
-        [Test, TestCaseSource("cases")]
+        [Test, TestCaseSource(nameof(cases))]
         public void Test(int[] dimensions, int bestSoFar, int targetCases)
         {
             int features = dimensions.Length;

--- a/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MayNotUseParallelScopeFixturesOnParameterizedTestMethod()
         {
-            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyTestCase));
+            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(DummyTestCase));
             var attr = new ParallelizableAttribute(ParallelScope.Fixtures);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -128,9 +128,9 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void OkTotUseParallelScopeChildrenOnParameterizedTestMethod()
+        public void OkToUseParallelScopeChildrenOnParameterizedTestMethod()
         {
-            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyTestCase));
+            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(DummyTestCase));
             var attr = new ParallelizableAttribute(ParallelScope.Children);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MayNotUseParallelScopeFixturesOnTestMethod()
         {
-            var test = TestBuilder.MakeTestCase(GetType(), "DummyMethod");
+            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyMethod));
             var attr = new ParallelizableAttribute(ParallelScope.Fixtures);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MayNotUseParallelScopeFixturesOnParameterizedTestMethod()
         {
-            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "DummyTestCase");
+            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyTestCase));
             var attr = new ParallelizableAttribute(ParallelScope.Fixtures);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -121,7 +121,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MayNotUseParallelScopeChildrenOnTestMethod()
         {
-            var test = TestBuilder.MakeTestCase(GetType(), "DummyMethod");
+            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyMethod));
             var attr = new ParallelizableAttribute(ParallelScope.Children);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void OkTotUseParallelScopeChildrenOnParameterizedTestMethod()
         {
-            var test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "DummyTestCase");
+            var test = TestBuilder.MakeTestCase(GetType(), nameof(DummyTestCase));
             var attr = new ParallelizableAttribute(ParallelScope.Children);
             attr.ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRange()
         {
-            CheckValues("MethodWithIntRange", 11, 12, 13, 14, 15);
+            CheckValues(nameof(MethodWithIntRange), 11, 12, 13, 14, 15);
         }
 
         private void MethodWithIntRange([Range(11, 15)] int x) { }
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRange_Reversed()
         {
-            CheckValues("MethodWithIntRange_Reversed", 15, 14, 13, 12, 11);
+            CheckValues(nameof(MethodWithIntRange_Reversed), 15, 14, 13, 12, 11);
         }
 
         private void MethodWithIntRange_Reversed([Range(15, 11)] int x) { }
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRange_FromEqualsTo()
         {
-            CheckValues("MethodWithIntRange_FromEqualsTo", 11);
+            CheckValues(nameof(MethodWithIntRange_FromEqualsTo), 11);
         }
 
         private void MethodWithIntRange_FromEqualsTo([Range(11, 11)] int x) { }
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeAndStep()
         {
-            CheckValues("MethodWithIntRangeAndStep", 11, 13, 15);
+            CheckValues(nameof(MethodWithIntRangeAndStep), 11, 13, 15);
         }
 
         private void MethodWithIntRangeAndStep([Range(11, 15, 2)] int x) { }
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithIntRangeAndZeroStep", 11, 12, 13));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndZeroStep), 11, 12, 13));
         }
 
         private void MethodWithIntRangeAndZeroStep([Range(11, 15, 0)] int x) { }
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithIntRangeAndStep_Reversed", 11, 13, 15));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndStep_Reversed), 11, 13, 15));
         }
 
         private void MethodWithIntRangeAndStep_Reversed([Range(15, 11, 2)] int x) { }
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeAndNegativeStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithIntRangeAndNegativeStep", 11, 13, 15));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndNegativeStep), 11, 13, 15));
         }
 
         private void MethodWithIntRangeAndNegativeStep([Range(11, 15, -2)] int x) { }
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeAndNegativeStep_Reversed()
         {
-            CheckValues("MethodWithIntRangeAndNegativeStep_Reversed", 15, 13, 11);
+            CheckValues(nameof(MethodWithIntRangeAndNegativeStep_Reversed), 15, 13, 11);
         }
 
         private void MethodWithIntRangeAndNegativeStep_Reversed([Range(15, 11, -2)] int x) { }
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IntRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleIntRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleIntRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRange()
         {
-            CheckValues("MethodWithUintRange", 11u, 12u, 13u, 14u, 15u);
+            CheckValues(nameof(MethodWithUintRange), 11u, 12u, 13u, 14u, 15u);
         }
 
         private void MethodWithUintRange([Range(11u, 15u)] uint x) { }
@@ -125,7 +125,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRange_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRange_Reversed", 15u, 14u, 13u, 12u, 11u));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUintRange_Reversed), 15u, 14u, 13u, 12u, 11u));
         }
 
         private void MethodWithUintRange_Reversed([Range(15u, 11u)] uint x) { }
@@ -133,7 +133,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRange_FromEqualsTo()
         {
-            CheckValues("MethodWithUintRange_FromEqualsTo", 11u);
+            CheckValues(nameof(MethodWithUintRange_FromEqualsTo), 11u);
         }
 
         private void MethodWithUintRange_FromEqualsTo([Range(11u, 11u)] uint x) { }
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRangeAndStep()
         {
-            CheckValues("MethodWithUintRangeAndStep", 11u, 13u, 15u);
+            CheckValues(nameof(MethodWithUintRangeAndStep), 11u, 13u, 15u);
         }
 
         private void MethodWithUintRangeAndStep([Range(11u, 15u, 2u)] uint x) { }
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRangeAndZeroStep", 11u, 12u, 13u));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUintRangeAndZeroStep), 11u, 12u, 13u));
         }
 
         private void MethodWithUintRangeAndZeroStep([Range(11u, 15u, 0u)] uint x) { }
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UintRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUintRangeAndStep_Reversed", 11u, 13u, 15u));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUintRangeAndStep_Reversed), 11u, 13u, 15u));
         }
 
         private void MethodWithUintRangeAndStep_Reversed([Range(15u, 11u, 2u)] uint x) { }
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UnsignedIntRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleUnsignedIntRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleUnsignedIntRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -179,7 +179,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRange()
         {
-            CheckValues("MethodWithLongRange", 11L, 12L, 13L, 14L, 15L);
+            CheckValues(nameof(MethodWithLongRange), 11L, 12L, 13L, 14L, 15L);
         }
 
         private void MethodWithLongRange([Range(11L, 15L)] long x) { }
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRange_Reversed()
         {
-            CheckValues("MethodWithLongRange_Reversed", 15L, 14L, 13L, 12L, 11L);
+            CheckValues(nameof(MethodWithLongRange_Reversed), 15L, 14L, 13L, 12L, 11L);
         }
 
         private void MethodWithLongRange_Reversed([Range(15L, 11L)] long x) { }
@@ -195,7 +195,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRange_FromEqualsTo()
         {
-            CheckValues("MethodWithLongRange_FromEqualsTo", 11L);
+            CheckValues(nameof(MethodWithLongRange_FromEqualsTo), 11L);
         }
 
         private void MethodWithLongRange_FromEqualsTo([Range(11L, 11L)] long x) { }
@@ -203,7 +203,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeAndStep()
         {
-            CheckValues("MethodWithLongRangeAndStep", 11L, 13L, 15L);
+            CheckValues(nameof(MethodWithLongRangeAndStep), 11L, 13L, 15L);
         }
 
         private void MethodWithLongRangeAndStep([Range(11L, 15L, 2)] long x) { }
@@ -211,7 +211,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndZeroStep", 11L, 12L, 13L));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithLongRangeAndZeroStep), 11L, 12L, 13L));
         }
 
         private void MethodWithLongRangeAndZeroStep([Range(11L, 15L, 0L)] long x) { }
@@ -219,7 +219,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndStep_Reversed", 11L, 13L, 15L));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithLongRangeAndStep_Reversed), 11L, 13L, 15L));
         }
 
         private void MethodWithLongRangeAndStep_Reversed([Range(15L, 11L, 2L)] long x) { }
@@ -227,7 +227,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeAndNegativeStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithLongRangeAndNegativeStep", 11L, 13L, 15L));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithLongRangeAndNegativeStep), 11L, 13L, 15L));
         }
 
         private void MethodWithLongRangeAndNegativeStep([Range(11L, 15L, -2L)] long x) { }
@@ -235,7 +235,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeAndNegativeStep_Reversed()
         {
-            CheckValues("MethodWithLongRangeAndNegativeStep_Reversed", 15L, 13L, 11L);
+            CheckValues(nameof(MethodWithLongRangeAndNegativeStep_Reversed), 15L, 13L, 11L);
         }
 
         private void MethodWithLongRangeAndNegativeStep_Reversed([Range(15L, 11L, -2L)] long x) { }
@@ -243,7 +243,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void LongRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleLongRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleLongRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -257,7 +257,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRange()
         {
-            CheckValues("MethodWithUlongRange", 11ul, 12ul, 13ul, 14ul, 15ul);
+            CheckValues(nameof(MethodWithUlongRange), 11ul, 12ul, 13ul, 14ul, 15ul);
         }
 
         private void MethodWithUlongRange([Range(11ul, 15ul)] ulong x) { }
@@ -265,7 +265,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRange_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRange_Reversed", 15ul, 14ul, 13ul, 12ul, 11ul));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUlongRange_Reversed), 15ul, 14ul, 13ul, 12ul, 11ul));
         }
 
         private void MethodWithUlongRange_Reversed([Range(15ul, 11ul)] ulong x) { }
@@ -273,7 +273,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRange_FromEqualsTo()
         {
-            CheckValues("MethodWithUlongRange_FromEqualsTo", 11ul);
+            CheckValues(nameof(MethodWithUlongRange_FromEqualsTo), 11ul);
         }
 
         private void MethodWithUlongRange_FromEqualsTo([Range(11ul, 11ul)] ulong x) { }
@@ -281,7 +281,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRangeAndStep()
         {
-            CheckValues("MethodWithUlongRangeAndStep", 11ul, 13ul, 15ul);
+            CheckValues(nameof(MethodWithUlongRangeAndStep), 11ul, 13ul, 15ul);
         }
 
         private void MethodWithUlongRangeAndStep([Range(11ul, 15ul, 2ul)] ulong x) { }
@@ -289,7 +289,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRangeAndZeroStep", 11ul, 12ul, 13ul));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUlongRangeAndZeroStep), 11ul, 12ul, 13ul));
         }
 
         private void MethodWithUlongRangeAndZeroStep([Range(11ul, 15ul, 0ul)] ulong x) { }
@@ -297,7 +297,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UlongRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues("MethodWithUlongRangeAndStep_Reversed", 11ul, 13ul, 15ul));
+            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithUlongRangeAndStep_Reversed), 11ul, 13ul, 15ul));
         }
 
         private void MethodWithUlongRangeAndStep_Reversed([Range(15ul, 11ul, 2ul)] ulong x) { }
@@ -305,7 +305,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void UnsignedLongRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleUnsignedLongRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleUnsignedLongRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -319,7 +319,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeAndStep()
         {
-            CheckValuesWithinTolerance("MethodWithDoubleRangeAndStep", 0.7, 0.9, 1.1);
+            CheckValuesWithinTolerance(nameof(MethodWithDoubleRangeAndStep), 0.7, 0.9, 1.1);
         }
 
         private void MethodWithDoubleRangeAndStep([Range(0.7, 1.2, 0.2)] double x) { }
@@ -327,7 +327,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndZeroStep", 0.7, 0.9, 1.1));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithDoubleRangeAndZeroStep), 0.7, 0.9, 1.1));
         }
 
         private void MethodWithDoubleRangeAndZeroStep([Range(0.7, 1.2, 0.0)] double x) { }
@@ -335,7 +335,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndStep_Reversed", 0.7, 0.9, 1.1));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithDoubleRangeAndStep_Reversed), 0.7, 0.9, 1.1));
         }
 
         private void MethodWithDoubleRangeAndStep_Reversed([Range(1.2, 0.7, 0.2)] double x) { }
@@ -343,7 +343,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeAndNegativeStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithDoubleRangeAndNegativeStep", 0.7, 0.9, 1.1));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithDoubleRangeAndNegativeStep), 0.7, 0.9, 1.1));
         }
 
         private void MethodWithDoubleRangeAndNegativeStep([Range(0.7, 1.2, -0.2)] double x) { }
@@ -351,7 +351,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeAndNegativeStep_Reversed()
         {
-            CheckValuesWithinTolerance("MethodWithDoubleRangeAndNegativeStep_Reversed", 1.2, 1.0, 0.8);
+            CheckValuesWithinTolerance(nameof(MethodWithDoubleRangeAndNegativeStep_Reversed), 1.2, 1.0, 0.8);
         }
 
         private void MethodWithDoubleRangeAndNegativeStep_Reversed([Range(1.2, 0.7, -0.2)] double x) { }
@@ -359,7 +359,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DoubleRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleDoubleRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleDoubleRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -373,7 +373,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeAndStep()
         {
-            CheckValuesWithinTolerance("MethodWithFloatRangeAndStep", 0.7f, 0.9f, 1.1f);
+            CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndStep), 0.7f, 0.9f, 1.1f);
         }
 
         private void MethodWithFloatRangeAndStep([Range(0.7f, 1.2f, 0.2f)] float x) { }
@@ -381,7 +381,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndZeroStep", 0.7f, 0.9f, 1.1f));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndZeroStep), 0.7f, 0.9f, 1.1f));
         }
 
         private void MethodWithFloatRangeAndZeroStep([Range(0.7f, 1.2f, 0.0f)] float x) { }
@@ -389,7 +389,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndStep_Reversed", 0.7f, 0.9f, 1.1f));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndStep_Reversed), 0.7f, 0.9f, 1.1f));
         }
 
         private void MethodWithFloatRangeAndStep_Reversed([Range(1.2f, 0.7, 0.2f)] float x) { }
@@ -397,7 +397,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeAndNegativeStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance("MethodWithFloatRangeAndNegativeStep", 0.7f, 0.9f, 1.1f));
+            Assert.Throws<ArgumentException>(() => CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndNegativeStep), 0.7f, 0.9f, 1.1f));
         }
 
         private void MethodWithFloatRangeAndNegativeStep([Range(0.7f, 1.2f, -0.2f)] float x) { }
@@ -405,7 +405,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeAndNegativeStep_Reversed()
         {
-            CheckValuesWithinTolerance("MethodWithFloatRangeAndNegativeStep_Reversed", 1.2f, 1.0f, 0.8f);
+            CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndNegativeStep_Reversed), 1.2f, 1.0f, 0.8f);
         }
 
         private void MethodWithFloatRangeAndNegativeStep_Reversed([Range(1.2f, 0.7, -0.2f)] float x) { }
@@ -413,7 +413,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void FloatRangeWithMultipleAttributes()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), "MethodWithMultipleFloatRange");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleFloatRange));
 
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -427,7 +427,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertIntRangeToShort()
         {
-            CheckValues("MethodWithIntRangeAndShortArgument", (short)1, (short)2, (short)3);
+            CheckValues(nameof(MethodWithIntRangeAndShortArgument), (short)1, (short)2, (short)3);
         }
 
         private void MethodWithIntRangeAndShortArgument([Range(1, 3)] short x) { }
@@ -435,7 +435,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertIntRangeToByte() 
         {
-            CheckValues("MethodWithIntRangeAndByteArgument", (byte)1, (byte)2, (byte)3);
+            CheckValues(nameof(MethodWithIntRangeAndByteArgument), (byte)1, (byte)2, (byte)3);
         }
         
         private void MethodWithIntRangeAndByteArgument([Range(1, 3)] byte x) { }
@@ -443,7 +443,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertIntRangeToSByte() 
         {
-            CheckValues("MethodWithIntRangeAndSByteArgument", (sbyte)1, (sbyte)2, (sbyte)3);
+            CheckValues(nameof(MethodWithIntRangeAndSByteArgument), (sbyte)1, (sbyte)2, (sbyte)3);
         }
         
         private void MethodWithIntRangeAndSByteArgument([Range(1, 3)] sbyte x) { }
@@ -451,7 +451,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertIntRangeToDecimal()
         {
-            CheckValues("MethodWithIntRangeAndDecimalArgument", 1M, 2M, 3M);
+            CheckValues(nameof(MethodWithIntRangeAndDecimalArgument), 1M, 2M, 3M);
         }
         
         private void MethodWithIntRangeAndDecimalArgument([Range(1, 3)] decimal x) { }
@@ -459,7 +459,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertDoubleRangeToDecimal() 
         {
-            CheckValues("MethodWithDoubleRangeAndDecimalArgument", 1.0M, 1.1M, 1.2M);
+            CheckValues(nameof(MethodWithDoubleRangeAndDecimalArgument), 1.0M, 1.1M, 1.2M);
         }
 
         // Use max of 1.21 rather than 1.3 so rounding won't give an extra value

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -350,10 +350,10 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), methodName);
 
-            Test testCase1 = TestFinder.Find("MethodWithExcludePlatform(1)", suite, false);
-            Test testCase2 = TestFinder.Find("MethodWithExcludePlatform(2)", suite, false);
-            Test testCase3 = TestFinder.Find("MethodWithExcludePlatform(3)", suite, false);
-            Test testCase4 = TestFinder.Find("MethodWithExcludePlatform(4)", suite, false);
+            Test testCase1 = TestFinder.Find($"{methodName}(1)", suite, false);
+            Test testCase2 = TestFinder.Find($"{methodName}(2)", suite, false);
+            Test testCase3 = TestFinder.Find($"{methodName}(3)", suite, false);
+            Test testCase4 = TestFinder.Find($"{methodName}(4)", suite, false);
             if (isLinux)
             {
                 Assert.That(testCase1.RunState, Is.EqualTo(RunState.Runnable));

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -99,9 +99,9 @@ namespace NUnit.Framework.Attributes
             return (sbyte)(x + y);
         }
 
-        [TestCase("MethodCausesConversionOverflow", RunState.NotRunnable)]
-        [TestCase("VoidTestCaseWithExpectedResult", RunState.NotRunnable)]
-        [TestCase("TestCaseWithNullableReturnValueAndNullExpectedResult", RunState.Runnable)]
+        [TestCase(nameof(TestCaseAttributeFixture.MethodCausesConversionOverflow), RunState.NotRunnable)]
+        [TestCase(nameof(TestCaseAttributeFixture.VoidTestCaseWithExpectedResult), RunState.NotRunnable)]
+        [TestCase(nameof(TestCaseAttributeFixture.TestCaseWithNullableReturnValueAndNullExpectedResult), RunState.Runnable)]
         public void TestCaseRunnableState(string methodName, RunState expectedState)
         {
             var test = (Test)TestBuilder.MakeParameterizedMethodSuite(
@@ -226,7 +226,7 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyDescription()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodHasDescriptionSpecified").Tests[0];
+                typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasDescriptionSpecified)).Tests[0];
             Assert.AreEqual("My Description", test.Properties.Get(PropertyNames.Description));
         }
 
@@ -234,7 +234,7 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyTestName_FixedText()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodHasTestNameSpecified_FixedText").Tests[0];
+                typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasTestNameSpecified_FixedText)).Tests[0];
             Assert.AreEqual("XYZ", test.Name);
             Assert.AreEqual("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture.XYZ", test.FullName);
         }
@@ -243,7 +243,7 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyTestName_WithMethodName()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodHasTestNameSpecified_WithMethodName").Tests[0];
+                typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasTestNameSpecified_WithMethodName)).Tests[0];
             var expectedName = "MethodHasTestNameSpecified_WithMethodName+XYZ";
             Assert.AreEqual(expectedName, test.Name);
             Assert.AreEqual("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture." + expectedName, test.FullName);
@@ -253,7 +253,7 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyCategory()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodHasSingleCategory").Tests[0];
+                typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasSingleCategory)).Tests[0];
             IList categories = test.Properties["Category"];
             Assert.AreEqual(new string[] { "XYZ" }, categories);
         }
@@ -262,7 +262,7 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyMultipleCategories()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodHasMultipleCategories").Tests[0];
+                typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasMultipleCategories)).Tests[0];
             IList categories = test.Properties["Category"];
             Assert.AreEqual(new string[] { "X", "Y", "Z" }, categories);
         }
@@ -270,16 +270,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanIgnoreIndividualTestCases()
         {
+            var methodName = nameof(TestCaseAttributeFixture.MethodWithIgnoredTestCases);
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodWithIgnoredTestCases");
+                typeof(TestCaseAttributeFixture), methodName);
 
-            Test testCase = TestFinder.Find("MethodWithIgnoredTestCases(1)", suite, false);
+            Test testCase = TestFinder.Find($"{methodName}(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
  
-            testCase = TestFinder.Find("MethodWithIgnoredTestCases(2)", suite, false);
+            testCase = TestFinder.Find($"{methodName}(2)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Ignored));
  
-            testCase = TestFinder.Find("MethodWithIgnoredTestCases(3)", suite, false);
+            testCase = TestFinder.Find($"{methodName}(3)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Ignored));
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Don't Run Me!"));
         }
@@ -287,16 +288,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanMarkIndividualTestCasesExplicit()
         {
+            var methodName = nameof(TestCaseAttributeFixture.MethodWithExplicitTestCases);
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodWithExplicitTestCases");
+                typeof(TestCaseAttributeFixture), methodName);
 
-            Test testCase = TestFinder.Find("MethodWithExplicitTestCases(1)", suite, false);
+            Test testCase = TestFinder.Find($"{methodName}(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
  
-            testCase = TestFinder.Find("MethodWithExplicitTestCases(2)", suite, false);
+            testCase = TestFinder.Find($"{methodName}(2)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Explicit));
  
-            testCase = TestFinder.Find("MethodWithExplicitTestCases(3)", suite, false);
+            testCase = TestFinder.Find($"{methodName}(3)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Explicit));
             Assert.That(testCase.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Connection failing"));
         }
@@ -344,8 +346,9 @@ namespace NUnit.Framework.Attributes
             bool isLinux = OSPlatform.CurrentPlatform.IsUnix;
             bool isMacOSX = OSPlatform.CurrentPlatform.IsMacOSX;
 
+            const string methodName = nameof(TestCaseAttributeFixture.MethodWithExcludePlatform);
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodWithExcludePlatform");
+                typeof(TestCaseAttributeFixture), methodName);
 
             Test testCase1 = TestFinder.Find("MethodWithExcludePlatform(1)", suite, false);
             Test testCase2 = TestFinder.Find("MethodWithExcludePlatform(2)", suite, false);

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SourceUsingInstanceMethodIsNotRunnable()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstanceMethodAsSource");
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstanceMethodAsSource));
             Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
         }
 
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SourceUsingInstanceFieldIsNotRunnable()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstanceFieldAsSource");
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstanceFieldAsSource));
             Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
         }
 
@@ -197,8 +197,8 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SourceInAnotherClassPassingParamsToField()
         {
-            var testMethod = (TestMethod)TestBuilder.mpMakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingParamsToField").Tests[0];
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingParamsToField)).Tests[0];
             Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
             ITestResult result = TestBuilder.RunTest(testMethod, null);
             Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
@@ -211,7 +211,7 @@ namespace NUnit.Framework.Attributes
         public void SourceInAnotherClassPassingParamsToProperty()
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingParamsToProperty").Tests[0];
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingParamsToProperty)).Tests[0];
             Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
             ITestResult result = TestBuilder.RunTest(testMethod, null);
             Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
@@ -224,7 +224,7 @@ namespace NUnit.Framework.Attributes
         public void SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam()
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam").Tests[0];
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam)).Tests[0];
             Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
             ITestResult result = TestBuilder.RunTest(testMethod, null);
             Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
@@ -243,7 +243,7 @@ namespace NUnit.Framework.Attributes
         public void IgnoreTakesPrecedenceOverExpectedException()
         {
             var result = TestBuilder.RunParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "MethodCallsIgnore").Children.ToArray()[0];
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodCallsIgnore)).Children.ToArray()[0];
             Assert.AreEqual(ResultState.Ignored, result.ResultState);
             Assert.AreEqual("Ignore this", result.Message);
         }
@@ -252,7 +252,7 @@ namespace NUnit.Framework.Attributes
         public void CanIgnoreIndividualTestCases()
         {
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "MethodWithIgnoredTestCases");
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithIgnoredTestCases));
 
             Test testCase = TestFinder.Find("MethodWithIgnoredTestCases(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
@@ -266,7 +266,7 @@ namespace NUnit.Framework.Attributes
         public void CanMarkIndividualTestCasesExplicit()
         {
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "MethodWithExplicitTestCases");
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithExplicitTestCases));
 
             Test testCase = TestFinder.Find("MethodWithExplicitTestCases(1)", suite, false);
             Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
@@ -283,7 +283,7 @@ namespace NUnit.Framework.Attributes
         public void HandlesExceptionInTestCaseSource()
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseSourceAttributeFixture), "MethodWithSourceThrowingException").Tests[0];
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithSourceThrowingException)).Tests[0];
             Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
             ITestResult result = TestBuilder.RunTest(testMethod, null);
             Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
@@ -307,7 +307,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestMethodIsNotRunnableWhenSourceDoesNotExist()
         {
-            TestSuite suiteToTest = TestBuilder.MakeParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithNonExistingSource");
+            TestSuite suiteToTest = TestBuilder.MakeParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithNonExistingSource));
             
             Assert.That(suiteToTest.Tests.Count == 1);
             Assert.AreEqual(RunState.NotRunnable, suiteToTest.Tests[0].RunState);

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -37,13 +37,13 @@ namespace NUnit.Framework.Attributes
     {
         #region Tests With Static and Instance Members as Source
 
-        [Test, TestCaseSource("StaticProperty")]
+        [Test, TestCaseSource(nameof(StaticProperty))]
         public void SourceCanBeStaticProperty(string source)
         {
             Assert.AreEqual("StaticProperty", source);
         }
 
-        [Test, TestCaseSource("InheritedStaticProperty")]
+        [Test, TestCaseSource(nameof(InheritedStaticProperty))]
         public void TestSourceCanBeInheritedStaticProperty(bool source)
         {
             Assert.AreEqual(true, source);
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
         }
 
-        [Test, TestCaseSource("StaticMethod")]
+        [Test, TestCaseSource(nameof(StaticMethod))]
         public void SourceCanBeStaticMethod(string source)
         {
             Assert.AreEqual("StaticMethod", source);
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Attributes
             return new object[] { new object[] { "InstanceMethod" } };
         }
 
-        [Test, TestCaseSource("StaticField")]
+        [Test, TestCaseSource(nameof(StaticField))]
         public void SourceCanBeStaticField(string source)
         {
             Assert.AreEqual("StaticField", source);
@@ -124,59 +124,59 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-        [Test, TestCaseSource("MyData")]
+        [Test, TestCaseSource(nameof(MyData))]
         public void SourceMayReturnArgumentsAsObjectArray(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
         }
 
-        [TestCaseSource("MyData")]
+        [TestCaseSource(nameof(MyData))]
         public void TestAttributeIsOptional(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
         }
 
-        [Test, TestCaseSource("MyIntData")]
+        [Test, TestCaseSource(nameof(MyIntData))]
         public void SourceMayReturnArgumentsAsIntArray(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
         }
 
-        [Test, TestCaseSource("MyArrayData")]
+        [Test, TestCaseSource(nameof(MyArrayData))]
         public void SourceMayReturnArrayForArray(int[] array)
         {
             Assert.That(true);
         }
 
-        [Test, TestCaseSource("EvenNumbers")]
+        [Test, TestCaseSource(nameof(EvenNumbers))]
         public void SourceMayReturnSinglePrimitiveArgumentAlone(int n)
         {
             Assert.AreEqual(0, n % 2);
         }
 
-        [Test, TestCaseSource("Params")]
+        [Test, TestCaseSource(nameof(Params))]
         public int SourceMayReturnArgumentsAsParamSet(int n, int d)
         {
             return n / d;
         }
 
         [Test]
-        [TestCaseSource("MyData")]
-        [TestCaseSource("MoreData", Category = "Extra")]
+        [TestCaseSource(nameof(MyData))]
+        [TestCaseSource(nameof(MoreData), Category = "Extra")]
         [TestCase(12, 2, 6)]
         public void TestMayUseMultipleSourceAttributes(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
         }
 
-        [Test, TestCaseSource("FourArgs")]
+        [Test, TestCaseSource(nameof(FourArgs))]
         public void TestWithFourArguments(int n, int d, int q, int r)
         {
             Assert.AreEqual(q, n / d);
             Assert.AreEqual(r, n % d);
         }
 
-        [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), "HereIsTheData")]
+        [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.HereIsTheData))]
         public void SourceMayBeInAnotherClass(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
@@ -188,7 +188,7 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(q, n / d);
         }
 
-        [Test, Category("Top"), TestCaseSource("StaticMethodDataWithParameters", new object[] { 8000, 8, 1000 })]
+        [Test, Category("Top"), TestCaseSource(nameof(StaticMethodDataWithParameters), new object[] { 8000, 8, 1000 })]
         public void SourceCanBeStaticMethodPassingSomeDataToConstructor(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
@@ -233,7 +233,7 @@ namespace NUnit.Framework.Attributes
                             "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.", result.Message);
         }
 
-        [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), "TestCases")]
+        [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), nameof(DivideDataProviderWithReturnValue.TestCases))]
         public int SourceMayBeInAnotherClassWithReturn(int n, int d)
         {
             return n / d;
@@ -290,7 +290,7 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual("System.Exception : my message", result.Message);
         }
 
-        [TestCaseSource("exception_source"), Explicit("Used for GUI tests")]
+        [TestCaseSource(nameof(exception_source)), Explicit("Used for GUI tests")]
         public void HandlesExceptionInTestCaseSource_GuiDisplay(string lhs, string rhs)
         {
             Assert.AreEqual(lhs, rhs);
@@ -299,7 +299,7 @@ namespace NUnit.Framework.Attributes
 
         private static IEnumerable<TestCaseData> ZeroTestCasesSource() => Enumerable.Empty<TestCaseData>();
 
-        [TestCaseSource("ZeroTestCasesSource")]
+        [TestCaseSource(nameof(ZeroTestCasesSource))]
         public void TestWithZeroTestSourceCasesShouldPassWithoutRequiringArguments(int requiredParameter)
         {
         }
@@ -320,14 +320,14 @@ namespace NUnit.Framework.Attributes
                 new string[] { "B" })
         };
 
-        [Test, TestCaseSource("testCases")]
+        [Test, TestCaseSource(nameof(testCases))]
         public void MethodTakingTwoStringArrays(string[] a, string[] b)
         {
             Assert.That(a, Is.TypeOf(typeof(string[])));
             Assert.That(b, Is.TypeOf(typeof(string[])));
         }
 
-        [TestCaseSource("SingleMemberArrayAsArgument")]
+        [TestCaseSource(nameof(SingleMemberArrayAsArgument))]
         public void Issue1337SingleMemberArrayAsArgument(string[] args)
         {
             Assert.That(args.Length == 1 && args[0] == "1");

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SourceUsingInstancePropertyIsNotRunnable()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), "MethodWithInstancePropertyAsSource");
+            var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstancePropertyAsSource));
             Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
         }
 
@@ -197,7 +197,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SourceInAnotherClassPassingParamsToField()
         {
-            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+            var testMethod = (TestMethod)TestBuilder.mpMakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), "SourceInAnotherClassPassingParamsToField").Tests[0];
             Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
             ITestResult result = TestBuilder.RunTest(testMethod, null);

--- a/src/NUnitFramework/tests/Attributes/TestOfTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOfTests.cs
@@ -1,4 +1,4 @@
-﻿// **********************************************************************************
+// **********************************************************************************
 // The MIT License (MIT)
 // 
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
@@ -44,21 +44,21 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ReflectionTest()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "Method");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.Method));
             Assert.AreEqual(RunState.Runnable, testCase.RunState);
         }
 
         [Test]
         public void TestOf()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "Method");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.Method));
             Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
         }
 
         [Test]
         public void NoTestOf()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "NoTestOfMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.NoTestOfMethod));
             Assert.IsNull(testCase.Properties.Get(PropertyNames.TestOf));
         }
 
@@ -76,14 +76,14 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SeparateTestOfAttribute()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "SeparateTestOfTypeMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.SeparateTestOfTypeMethod));
             Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
         }
 
         [Test]
         public void SeparateTestOfStringMethod()
         {
-            Test testCase = TestBuilder.MakeTestCase(FixtureType, "SeparateTestOfStringMethod");
+            Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.SeparateTestOfStringMethod));
             Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
         }
 

--- a/src/NUnitFramework/tests/Attributes/TheoryTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TheoryTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -37,25 +37,25 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TheoryWithNoArgumentsIsTreatedAsTest()
         {
-            TestAssert.IsRunnable(fixtureType, "TheoryWithNoArguments");
+            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TheoryWithNoArguments));
         }
 
         [Test]
         public void TheoryWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, "TheoryWithArgumentsButNoDatapoints", ResultState.Failure);
+            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TheoryWithArgumentsButNoDatapoints), ResultState.Failure);
         }
 
         [Test]
         public void UnsupportedNullableTypeArgumentWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, "TestWithUnsupportedNullableTypeArgumentWithNoDataPoints", ResultState.Failure);
+            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TestWithUnsupportedNullableTypeArgumentWithNoDataPoints), ResultState.Failure);
         }
 
         [Test]
         public void TheoryWithDatapointsIsRunnable()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TheoryWithArgumentsAndDatapoints");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TheoryWithArgumentsAndDatapoints));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(9));
         }
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void BooleanArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithBooleanArguments");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithBooleanArguments));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NullableBooleanArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithNullableBooleanArguments");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithNullableBooleanArguments));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(9));
         }
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DatapointAndAttributeDataMayBeCombined()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithBothDatapointAndAttributeData");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithBothDatapointAndAttributeData));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void EnumArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithEnumAsArgument");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithEnumAsArgument));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(16));
         }
@@ -105,7 +105,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NullableEnumArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithNullableEnumAsArgument");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithNullableEnumAsArgument));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(17));
         }
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Attributes
             // TheoryAttribute and CombinatorialAttribute were adding cases.
             // Solution is to make TheoryAttribute a CombiningAttribute so
             // that no extra attribute is added to the method.
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithAllDataSuppliedByAttributes");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithAllDataSuppliedByAttributes));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
@@ -156,14 +156,14 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SimpleTestIgnoresDataPoints()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, "TestWithArguments");
+            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithArguments));
             Assert.That(test.TestCaseCount, Is.EqualTo(2));
         }
 
         [Test]
         public void TheoryFailsIfAllTestsAreInconclusive()
         {
-            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, "TestWithAllBadValues");
+            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithAllBadValues));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Is.EqualTo("All test cases were inconclusive"));
         }

--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Attributes
     {
         [Test]
         public void ValueSourceCanBeStaticProperty(
-            [ValueSource("StaticProperty")] string source)
+            [ValueSource(nameof(StaticProperty))] string source)
         {
             Assert.AreEqual("StaticProperty", source);
         }
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         public void ValueSourceCanBeInheritedStaticProperty(
-            [ValueSource("InheritedStaticProperty")] bool source)
+            [ValueSource(nameof(InheritedStaticProperty))] bool source)
         {
             Assert.AreEqual(true, source);
         }
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Attributes
         }
 
         public void MethodWithValueSourceInstanceProperty(
-            [ValueSource("InstanceProperty")] string source)
+            [ValueSource(nameof(InstanceProperty))] string source)
         {
             Assert.AreEqual("InstanceProperty", source);
         }
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         public void ValueSourceCanBeStaticMethod(
-            [ValueSource("StaticMethod")] string source)
+            [ValueSource(nameof(StaticMethod))] string source)
         {
             Assert.AreEqual("StaticMethod", source);
         }
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Attributes
         }
 
         public void MethodWithValueSourceInstanceMethod(
-            [ValueSource("InstanceMethod")] string source)
+            [ValueSource(nameof(InstanceMethod))] string source)
         {
             Assert.AreEqual("InstanceMethod", source);
         }
@@ -109,7 +109,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         public void ValueSourceCanBeStaticField(
-            [ValueSource("StaticField")] string source)
+            [ValueSource(nameof(StaticField))] string source)
         {
             Assert.AreEqual("StaticField", source);
         }
@@ -124,7 +124,7 @@ namespace NUnit.Framework.Attributes
         }
 
         public void MethodWithValueSourceInstanceField(
-            [ValueSource("InstanceField")] string source)
+            [ValueSource(nameof(InstanceField))] string source)
         {
             Assert.AreEqual("InstanceField", source);
         }
@@ -133,9 +133,9 @@ namespace NUnit.Framework.Attributes
 
         [Test, Sequential]
         public void MultipleArguments(
-            [ValueSource("Numerators")] int n, 
-            [ValueSource("Denominators")] int d, 
-            [ValueSource("Quotients")] int q)
+            [ValueSource(nameof(Numerators))] int n, 
+            [ValueSource(nameof(Denominators))] int d, 
+            [ValueSource(nameof(Quotients))] int q)
         {
             Assert.AreEqual(q, n / d);
         }
@@ -146,9 +146,9 @@ namespace NUnit.Framework.Attributes
 
         [Test, Sequential]
         public void ValueSourceMayBeInAnotherClass(
-            [ValueSource(typeof(DivideDataProvider), "Numerators")] int n,
-            [ValueSource(typeof(DivideDataProvider), "Denominators")] int d,
-            [ValueSource(typeof(DivideDataProvider), "Quotients")] int q)
+            [ValueSource(typeof(DivideDataProvider), nameof(DivideDataProvider.Numerators))] int n,
+            [ValueSource(typeof(DivideDataProvider), nameof(DivideDataProvider.Denominators))] int d,
+            [ValueSource(typeof(DivideDataProvider), nameof(DivideDataProvider.Quotients))] int q)
         {
             Assert.AreEqual(q, n / d);
         }
@@ -162,7 +162,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         public void ValueSourceMayBeGeneric(
-            [ValueSourceAttribute(typeof(ValueProvider), "IntegerProvider")] int val)
+            [ValueSourceAttribute(typeof(ValueProvider), nameof(ValueProvider.IntegerProvider))] int val)
         {
             Assert.That(2 * val, Is.EqualTo(val + val));
         }
@@ -201,10 +201,10 @@ namespace NUnit.Framework.Attributes
 
         [Test, Explicit("Null or nonexisting data sources definitions should not prevent other tests from run #1121")]
         public void ValueSourceMayNotBeNull(
-            [ValueSource("NullSource")] string nullSource,
-            [ValueSource("NullDataSourceProvider")] string nullDataSourceProvided,
-            [ValueSource(typeof(ValueProvider), "ForeignNullResultProvider")] string nullDataSourceProvider,
-            [ValueSource("NullDataSourceProperty")] int nullDataSourceProperty,
+            [ValueSource(nameof(NullSource))] string nullSource,
+            [ValueSource(nameof(NullDataSourceProvider))] string nullDataSourceProvided,
+            [ValueSource(typeof(ValueProvider), nameof(ValueProvider.ForeignNullResultProvider))] string nullDataSourceProvider,
+            [ValueSource(nameof(NullDataSourceProperty))] int nullDataSourceProperty,
             [ValueSource("SomeNonExistingMemberSource")] int nonExistingMember)
         {
             Assert.Fail();

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
                 TextMessageWriter.Pfx_Actual + "5" + Environment.NewLine));
         }
 
-        [TestCaseSource( "IgnoreCaseData" )]
+        [TestCaseSource( nameof(IgnoreCaseData) )]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             Assert.That( expected, Is.EqualTo( actual ).IgnoreCase );

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
-        [TestCaseSource(typeof(IgnoreCaseDataProvider), "TestCases")]
+        [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             var constraint = new CollectionEquivalentConstraint( expected ).IgnoreCase;

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Constraints
 
         #region Ordering Tests
 
-        [TestCaseSource("OrderedByData")]
+        [TestCaseSource(nameof(OrderedByData))]
         public void IsOrderedBy(IEnumerable collection, Constraint constraint)
         {
             Assert.That(collection, constraint);

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
             new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" } };
 
         [Test]
-        [TestCaseSource(typeof(IgnoreCaseDataProvider), "TestCases")]
+        [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             var constraint = new CollectionSubsetConstraint( expected ).IgnoreCase;

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
         };
 
         [Test]
-        [TestCaseSource(typeof(IgnoreCaseDataProvider), "TestCases")]
+        [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
         public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
         {
             var constraint = new CollectionSupersetConstraint( expected ).IgnoreCase;

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -87,14 +87,14 @@ namespace NUnit.Framework.Constraints
             FailureDelegates = new ActualValueDelegate<object>[] { DelegateReturningFalse, DelegateReturningZero };
         }
 
-        [Test, TestCaseSource("SuccessDelegates")]
+        [Test, TestCaseSource(nameof(SuccessDelegates))]
         public void SucceedsWithGoodDelegates(ActualValueDelegate<object> del)
         {
             SetValuesAfterDelay(DELAY);
             Assert.That(theConstraint.ApplyTo(del).IsSuccess);
         }
 
-        [Test, TestCaseSource("FailureDelegates")]
+        [Test, TestCaseSource(nameof(FailureDelegates))]
         public void FailsWithBadDelegates(ActualValueDelegate<object> del)
         {
             Assert.IsFalse(theConstraint.ApplyTo(del).IsSuccess);

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -747,7 +747,7 @@ namespace NUnit.Framework.Constraints
             Assert.AreEqual(ex.Message, "  Expected: <<equal 0>>"+ NL + "  But was:  <<equal 0>>"+ NL);
         }
 
-        [Test, TestCaseSource("DifferentTypeSameValueTestData")]
+        [Test, TestCaseSource(nameof(DifferentTypeSameValueTestData))]
         public void SameValueDifferentTypeRegexMatch(object expected, object actual)
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(expected, actual));

--- a/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Constraints
             test.Using(comparer);
             Assert.DoesNotThrow(() => test.ApplyTo(7));
         }
-        [TestCaseSource("NoIComparableTestCase")]
+        [TestCaseSource(nameof(NoIComparableTestCase))]
         public void RangeConstructorComparerThrowExceptionIfFromIsLessThanTo(object testObj,object from, object to, System.Collections.IComparer comparer)
         {
             RangeConstraint test = new RangeConstraint(from, to);

--- a/src/NUnitFramework/tests/Constraints/RangeTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -104,25 +104,25 @@ namespace NUnit.Framework.Constraints
             Assert.That(val, Is.InRange(min, max));
         }
 
-        [Test, TestCaseSource("InRangeObjectsWithNoIComparable")]
+        [Test, TestCaseSource(nameof(InRangeObjectsWithNoIComparable))]
         public void InRangeNoIComparableTest(object testObj, object from, object to, ObjectToStringComparer comparer)
         {
             Assert.That(testObj, Is.InRange(from, to).Using(comparer));
             Assert.AreEqual(comparer.WasCalled, true);
         }
 
-        [Test, TestCaseSource("NotInRangeObjectsWithNoIComparable")]
+        [Test, TestCaseSource(nameof(NotInRangeObjectsWithNoIComparable))]
         public void NotInRangeNoIComparableTest(object testObj, object from, object to, ObjectToStringComparer comparer)
         {
             Assert.That(testObj, Is.Not.InRange(from, to).Using(comparer));
             Assert.AreEqual(comparer.WasCalled, true);
         }
-        [TestCaseSource("InRangeObjectsWithNoIComparableAndNotUsingComparerException")]
+        [TestCaseSource(nameof(InRangeObjectsWithNoIComparableAndNotUsingComparerException))]
         public void InRangeNoIComparableThrowsExceptionTest(object testObj, object from, object to)
         {
             Assert.Throws<ArgumentException>(() => Assert.That(testObj, Is.InRange(from, to)));
         }
-        [TestCaseSource("InRangeObjectsWithNoIComparableAndNotUsingComparerException")]
+        [TestCaseSource(nameof(InRangeObjectsWithNoIComparableAndNotUsingComparerException))]
         public void NotInRangeNoIComparableThrowsExceptionTest(object testObj, object from, object to)
         {
             Assert.Throws<ArgumentException>(() => Assert.That(testObj, Is.Not.InRange(from, to)));

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Constraints
         static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
 
         [Test]
-        [TestCaseSource( "IgnoreCaseData" )]
+        [TestCaseSource( nameof(IgnoreCaseData) )]
         public void HonorsIgnoreCase( IEnumerable actual )
         {
             Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should not be unique ignoring case", actual );

--- a/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Internal.Filters
                     return filter.Pass(_dummyFixture);
                 default:
                     throw new ArgumentException(
-                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", "matchFunction");
+                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", nameof(matchFunction));
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Internal.Filters
                     return filter.Pass(_dummyFixture);
                 default:
                     throw new ArgumentException(
-                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", "matchFunction");
+                        "Unexpected StrictIdFilterForTests.EqualValueFunction.", nameof(matchFunction));
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/GenericMethodHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericMethodHelperTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Internal
                 TypeArgs<string,int,string[]>()) 
         };
 
-        [TestCaseSource("TypeArgData")]
+        [TestCaseSource(nameof(TypeArgData))]
         public void GetTypeArgumentsForMethodTests(string methodName, object[] args, Type[] typeArgs)
         {
             MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual("ABC", label);
         }
 
-        [TestCaseSource("Source")]
+        [TestCaseSource(nameof(Source))]
         public void TestCaseSource_OneTypeParameterOnTwoArgs<T>(T x, T y, string label)
         {
             Assert.AreEqual(5, x);
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Internal
             Assert.That(invalid, Is.EqualTo(2), "Invalid count");
         }
 
-        [TestCaseSource("Source")]
+        [TestCaseSource(nameof(Source))]
         public void TestCaseSource_TwoTypeParameters<T1, T2>(T1 x, T2 y, string label)
         {
             Assert.AreEqual(5, x);

--- a/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -34,27 +34,27 @@ namespace NUnit.Framework.Internal
 #if ASYNC
         private readonly Type fixtureType = typeof(AsyncDummyFixture);
 
-        [TestCase("AsyncVoid", RunState.NotRunnable)]
-        [TestCase("AsyncTask", RunState.Runnable)]
-        [TestCase("AsyncGenericTask", RunState.NotRunnable)]
-        [TestCase("NonAsyncTask", RunState.Runnable)]
-        [TestCase("NonAsyncGenericTask", RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncVoid), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncTask), RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncGenericTask), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.NonAsyncTask), RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.NonAsyncGenericTask), RunState.NotRunnable)]
         public void AsyncTests(string methodName, RunState expectedState)
         {
             var test = TestBuilder.MakeTestCase(fixtureType, methodName);
             Assert.That(test.RunState, Is.EqualTo(expectedState));
         }
 
-        [TestCase("AsyncVoidTestCase", RunState.NotRunnable)]
-        [TestCase("AsyncVoidTestCaseWithExpectedResult", RunState.NotRunnable)]
-        [TestCase("AsyncTaskTestCase", RunState.Runnable)]
-        [TestCase("AsyncTaskTestCaseWithExpectedResult", RunState.NotRunnable)]
-        [TestCase("AsyncGenericTaskTestCase", RunState.NotRunnable)]
-        [TestCase("AsyncGenericTaskTestCaseWithExpectedResult", RunState.Runnable)]
-        [TestCase("TaskTestCase", RunState.Runnable)]
-        [TestCase("TaskTestCaseWithExpectedResult", RunState.NotRunnable)]
-        [TestCase("GenericTaskTestCase", RunState.NotRunnable)]
-        [TestCase("GenericTaskTestCaseWithExpectedResult", RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncVoidTestCase), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncVoidTestCaseWithExpectedResult), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncTaskTestCase), RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncTaskTestCaseWithExpectedResult), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncGenericTaskTestCase), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.AsyncGenericTaskTestCaseWithExpectedResult), RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.TaskTestCase), RunState.Runnable)]
+        [TestCase(nameof(AsyncDummyFixture.TaskTestCaseWithExpectedResult), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.GenericTaskTestCase), RunState.NotRunnable)]
+        [TestCase(nameof(AsyncDummyFixture.GenericTaskTestCaseWithExpectedResult), RunState.Runnable)]
         public void AsyncTestCases(string methodName, RunState expectedState)
         {
             var suite = TestBuilder.MakeParameterizedMethodSuite(fixtureType, methodName);
@@ -65,14 +65,14 @@ namespace NUnit.Framework.Internal
 
         private readonly Type optionalTestParametersFixtureType = typeof(OptionalTestParametersFixture);
 
-        [TestCase("MethodWithOptionalParams0", RunState.NotRunnable)]
-        [TestCase("MethodWithOptionalParams1", RunState.Runnable)]
-        [TestCase("MethodWithOptionalParams2", RunState.Runnable)]
-        [TestCase("MethodWithOptionalParams3", RunState.NotRunnable)]
-        [TestCase("MethodWithAllOptionalParams0", RunState.Runnable)]
-        [TestCase("MethodWithAllOptionalParams1", RunState.Runnable)]
-        [TestCase("MethodWithAllOptionalParams2", RunState.Runnable)]
-        [TestCase("MethodWithAllOptionalParams3", RunState.NotRunnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithOptionalParams0), RunState.NotRunnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithOptionalParams1), RunState.Runnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithOptionalParams2), RunState.Runnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithOptionalParams3), RunState.NotRunnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithAllOptionalParams0), RunState.Runnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithAllOptionalParams1), RunState.Runnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithAllOptionalParams2), RunState.Runnable)]
+        [TestCase(nameof(OptionalTestParametersFixture.MethodWithAllOptionalParams3), RunState.NotRunnable)]
         public void ParametrizedTestCaseTests(string methodName, RunState expectedState)
         {
             var suite = TestBuilder.MakeParameterizedMethodSuite(optionalTestParametersFixtureType, methodName);

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
             Assert.That(RuntimeFramework.CurrentFramework.ClrVersion.Build, Is.GreaterThan(0));
         }
 
-        [TestCaseSource("frameworkData")]
+        [TestCaseSource(nameof(frameworkData))]
         public void CanCreateUsingFrameworkVersion(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.runtime, data.frameworkVersion);
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(data.clrVersion, framework.ClrVersion, "#3");
         }
 
-        [TestCaseSource("frameworkData")]
+        [TestCaseSource(nameof(frameworkData))]
         public void CanCreateUsingClrVersion(FrameworkData data)
         {
             Assume.That(data.frameworkVersion.Major != 3, "#0");
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(data.clrVersion, framework.ClrVersion, "#3");
         }
 
-        [TestCaseSource("frameworkData")]
+        [TestCaseSource(nameof(frameworkData))]
         public void CanParseRuntimeFramework(FrameworkData data)
         {
             RuntimeFramework framework = RuntimeFramework.Parse(data.representation);
@@ -109,7 +109,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(data.clrVersion, framework.ClrVersion, "#2");
         }
 
-        [TestCaseSource("frameworkData")]
+        [TestCaseSource(nameof(frameworkData))]
         public void CanDisplayFrameworkAsString(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.runtime, data.frameworkVersion);
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(data.displayName, framework.DisplayName, "#2");
         }
 
-        [TestCaseSource("matchData")]
+        [TestCaseSource(nameof(matchData))]
         public bool CanMatchRuntimes(RuntimeFramework f1, RuntimeFramework f2)
         {
             return f1.Supports(f2);

--- a/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
@@ -37,31 +37,31 @@ namespace NUnit.Framework.Internal
         [Test]
         public void InstanceTestMethodIsRunnable()
         {
-            TestAssert.IsRunnable( fixtureType, "InstanceTestMethod" );
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.InstanceTestMethod) );
         }
 
         [Test]
         public void StaticTestMethodIsRunnable()
         {
-            TestAssert.IsRunnable( fixtureType, "StaticTestMethod" );
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethod) );
         }
 
         [Test]
         public void TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, "TestMethodWithoutParametersWithArgumentsProvided");
+            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithoutParametersWithArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithArgumentsNotProvidedIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, "TestMethodWithArgumentsNotProvided");
+            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvided));
         }
 
         [Test]
         public void TestMethodHasAttributesAppliedCorrectlyEvenIfNotRunnable()
         {
-            var test = TestBuilder.MakeTestCase(fixtureType, "TestMethodWithArgumentsNotProvidedAndExtraAttributes");
+            var test = TestBuilder.MakeTestCase(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvidedAndExtraAttributes));
             // NOTE: IgnoreAttribute has no effect, either on RunState or on the reason
             Assert.That(test.RunState == RunState.NotRunnable);
             Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("No arguments were provided"));
@@ -72,85 +72,85 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestMethodWithArgumentsProvidedIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, "TestMethodWithArgumentsProvided");
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, "TestMethodWithWrongNumberOfArgumentsProvided");
+            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongNumberOfArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithWrongArgumentTypesProvidedGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, "TestMethodWithWrongArgumentTypesProvided", ResultState.Error);
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongArgumentTypesProvided), ResultState.Error);
         }
 
         [Test]
         public void StaticTestMethodWithArgumentsNotProvidedIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, "StaticTestMethodWithArgumentsNotProvided");
+            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsNotProvided));
         }
 
         [Test]
         public void StaticTestMethodWithArgumentsProvidedIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, "StaticTestMethodWithArgumentsProvided");
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsProvided));
         }
 
         [Test]
         public void StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, "StaticTestMethodWithWrongNumberOfArgumentsProvided");
+            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongNumberOfArgumentsProvided));
         }
 
         [Test]
         public void StaticTestMethodWithWrongArgumentTypesProvidedGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, "StaticTestMethodWithWrongArgumentTypesProvided", ResultState.Error);
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongArgumentTypesProvided), ResultState.Error);
         }
 
         [Test]
         public void TestMethodWithConvertibleArgumentsIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, "TestMethodWithConvertibleArguments");
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithConvertibleArguments));
         }
 
         [Test]
         public void TestMethodWithNonConvertibleArgumentsGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, "TestMethodWithNonConvertibleArguments", ResultState.Error);
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithNonConvertibleArguments), ResultState.Error);
         }
 
         [Test]
         public void ProtectedTestMethodIsNotRunnable()
         {
-            TestAssert.IsNotRunnable( fixtureType, "ProtectedTestMethod" );
+            TestAssert.IsNotRunnable(fixtureType, "ProtectedTestMethod");
         }
 
         [Test]
         public void PrivateTestMethodIsNotRunnable()
         {
-            TestAssert.IsNotRunnable( fixtureType, "PrivateTestMethod" );
+            TestAssert.IsNotRunnable(fixtureType, "PrivateTestMethod");
         }
 
         [Test]
         public void TestMethodWithReturnTypeIsNotRunnable()
         {
-            TestAssert.IsNotRunnable( fixtureType, "TestMethodWithReturnType" );
+            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnType));
         }
 
         [Test]
         public void TestMethodWithExpectedReturnTypeIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, "TestMethodWithExpectedReturnType");
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithExpectedReturnType));
         }
 
         [Test]
         public void TestMethodWithMultipleTestCasesExecutesMultipleTimes()
         {
-            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, "TestMethodWithMultipleTestCases");
+            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithMultipleTestCases));
 
             Assert.That( result.ResultState, Is.EqualTo(ResultState.Success) );
             ResultSummary summary = new ResultSummary(result);
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestMethodWithMultipleTestCasesUsesCorrectNames()
         {
-            string name = "TestMethodWithMultipleTestCases";
+            string name = nameof(TestMethodSignatureFixture.TestMethodWithMultipleTestCases);
             string fullName = typeof (TestMethodSignatureFixture).FullName + "." + name;
 
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(fixtureType, name);

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework
             Assert.That(_testDirectory, Is.Not.Null);
         }
 
-        [TestCaseSource("TestDirectorySource")]
+        [TestCaseSource(nameof(TestDirectorySource))]
         public void TestCaseSourceCanAccessTestDirectory(string testDirectory)
         {
             Assert.That(testDirectory, Is.EqualTo(_testDirectory));
@@ -113,7 +113,7 @@ namespace NUnit.Framework
             Assert.That(Directory.Exists(workDirectory), string.Format("Directory {0} does not exist", workDirectory));
         }
 
-        [TestCaseSource("WorkDirectorySource")]
+        [TestCaseSource(nameof(WorkDirectorySource))]
         public void TestCaseSourceCanAccessWorkDirectory(string workDirectory)
         {
             Assert.That(workDirectory, Is.EqualTo(_workDirectory));

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -57,7 +57,7 @@ namespace NUnit.Framework
         [Test]
         public void ConsoleErrorWrite_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWrite");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), nameof(TextOutputFixture.ConsoleErrorWrite));
             var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
@@ -73,7 +73,7 @@ namespace NUnit.Framework
         [Test]
         public void ConsoleErrorWriteLine_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "ConsoleErrorWriteLine");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), nameof(TextOutputFixture.ConsoleErrorWriteLine));
             var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
@@ -100,7 +100,7 @@ namespace NUnit.Framework
         [Test]
         public void TestContextError_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextErrorWriteLine");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), nameof(TextOutputFixture.TestContextErrorWriteLine));
             var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);
@@ -116,7 +116,7 @@ namespace NUnit.Framework
         [Test]
         public void TestContextProgress_WritesToListener()
         {
-            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), "TestContextProgressWriteLine");
+            var test = TestBuilder.MakeTestFromMethod(typeof(TextOutputFixture), nameof(TextOutputFixture.TestContextProgressWriteLine));
             var work = TestBuilder.CreateWorkItem(test, new TextOutputFixture());
             work.Context.Listener = this;
             var result = TestBuilder.ExecuteWorkItem(work);


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2033. 

@yaakov-h's [comment](https://github.com/nunit/nunit/pull/2597#issuecomment-349589183) made me think we should make some movement on this one:

> Can we use nameof? I noticed the existing code wasn't using it

I've no doubt this isn't everything, but hopefully it's a good start, and we can patch up other places as we go. Things covered include:

- ArgExceptions 
- TestCaseSources
- Guard class
- TestAsserts
- TestBuilders

I've reviewed the changes by hand, and reverted changes to the mono classes that we don't generally edit. Plenty of places where `nameof` has gone in would be nicer with string interpolation or Guards, but let's work on one improvement at a time! :smile: