### PR TITLE
Prevent emails for successful builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: csharp
 sudo: false
 
+notifications:
+  email:
+    on_success: never
+
 # Need 2.*, should keep up to date with security releases
 dotnet: 2.0.3
 


### PR DESCRIPTION
Does anyone else get irritated by getting emails from Travis on every build? This will prevent emails on success - and mean the build author only gets an email on failure.

What do people think?