### PR TITLE
Fixed GetAllMethods for multi-level inheritance scenario - .NET Standard ReflectionExtensions (#2626)

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -348,7 +348,7 @@ namespace NUnit.Compatibility
             if (type != null)
             {
                 var baseMethods = type.GetAllMethods(includeBaseStatic)
-                    .Where(b => !b.IsPrivate && (includeBaseStatic || !b.IsStatic) && !methods.Any(m => m.GetRuntimeBaseDefinition() == b));
+                    .Where(b => !b.IsPrivate && (includeBaseStatic || !b.IsStatic) && !methods.Any(m => m.GetRuntimeBaseDefinition() == b.GetRuntimeBaseDefinition()));
                 methods.AddRange(baseMethods);
             }
 

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -256,6 +256,15 @@ namespace NUnit.Framework.Compatibility
             CollectionAssert.AreEquivalent(methodNames, new string[] { "Hello", "Hello", "DerivedInstanceMethod" });
         }
 
+        [Test]
+        public void CanGetVirtualMethodsFromMostDerivedClassOnly()
+        {
+            var result = typeof(MostDerivedTestClass).GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public);
+            var methodNames = result.Where(m => m.Name == "Hello").Select(m => m.Name);
+
+            CollectionAssert.AreEquivalent(new string[] { "Hello", "Hello" }, methodNames);
+        }
+
         [TestCase(BindingFlags.Instance | BindingFlags.Public,
             new[] { "DerivedInstanceMethod", "InstanceMethod" },
             new[] { "DerivedProtectedInstanceMethod", "DerivedPrivateInstanceMethod", "ProtectedInstanceMethod", "PrivateInstanceMethod" })]
@@ -428,6 +437,13 @@ namespace NUnit.Framework.Compatibility
 
         private static void DerivedPrivateStaticMethod() { }
 
+        public override void Hello() { }
+
+        public override void Hello(string msg) { }
+    }
+
+    public class MostDerivedTestClass : DerivedTestClass
+    {
         public override void Hello() { }
 
         public override void Hello(string msg) { }

--- a/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/ReflectionExtensionsTests.cs
@@ -253,7 +253,7 @@ namespace NUnit.Framework.Compatibility
         {
             var result = typeof(DerivedTestClass).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
             var methodNames = result.Select(m => m.Name);
-            CollectionAssert.AreEquivalent(methodNames, new string[] { "Hello", "Hello", "DerivedInstanceMethod" });
+            CollectionAssert.AreEquivalent(new string[] { "Hello", "Hello", "DerivedInstanceMethod" }, methodNames);
         }
 
         [Test]


### PR DESCRIPTION
This is my proposal to fix issue #2626. 

The previous implementation of **GetAllMethods** (ReflectionExtensions for .NET Standard) worked properly only for simple two-level inheritance scenario. My change adds multi-level inheritance support for **GetAllMethods**. When virtual method is declared in base class and is overriden in derived classes then **GetMethods** returns a methods top most in inheritance hierarchy, so virtual **SetUp/TearDown** methods are correctly invoked only once before/after each test. 

