### PR TITLE
Fix [Values(null)] behavior inconsistency with TestCaseAttribute

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework
         /// <param name="args"></param>
         public ValuesAttribute(params object[] args)
         {
-            data = args;
+            data = args ?? new object[] { null };
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -39,6 +39,9 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static IEnumerable ConvertData(object[] data, Type targetType)
         {
+            Guard.ArgumentNotNull(data, nameof(data));
+            Guard.ArgumentNotNull(targetType, nameof(targetType));
+
             if (targetType.GetTypeInfo().IsEnum && data.Length == 0)
             {
                 return Enum.GetValues(targetType);

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
@@ -89,5 +90,35 @@ namespace NUnit.Framework.Attributes
         }
 
         #endregion
+
+        [Test]
+        public void SupportsNullableDecimal([Values(null)] decimal? x)
+        {
+            Assert.That(x.HasValue, Is.False);
+        }
+
+        [Test]
+        public void SupportsNullableDateTime([Values(null)] DateTime? dt)
+        {
+            Assert.That(dt.HasValue, Is.False);
+        }
+
+        [Test]
+        public void SupportsNullableTimeSpan([Values(null)] TimeSpan? dt)
+        {
+            Assert.That(dt.HasValue, Is.False);
+        }
+
+        [Test]
+        public void NullableSimpleFormalParametersWithArgument([Values(1)] int? a)
+        {
+            Assert.AreEqual(1, a);
+        }
+
+        [Test]
+        public void NullableSimpleFormalParametersWithNullArgument([Values(null)] int? a)
+        {
+            Assert.IsNull(a);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/ParamAttributeTypeConversionTests.cs
+++ b/src/NUnitFramework/tests/Internal/ParamAttributeTypeConversionTests.cs
@@ -29,6 +29,18 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class ParamAttributeTypeConversionTests
     {
+        [Test]
+        public static void NullDataArgumentShouldThrowArgumentNullException()
+        {
+            Assert.That(() => ParamAttributeTypeConversions.ConvertData(null, typeof(object)), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public static void NullTypeArgumentShouldThrowArgumentNullException()
+        {
+            Assert.That(() => ParamAttributeTypeConversions.ConvertData(new object[0], null), Throws.ArgumentNullException);
+        }
+
         [TestCase(typeof(short))]
         [TestCase(typeof(byte))]
         [TestCase(typeof(sbyte))]


### PR DESCRIPTION
Fixes #2630.

This brings over some of the tests from TestCaseAttribute to ValuesAttribute. I wanted to bring more, but they require at least two separate PRs for unrelated flaws in ValuesAttribute. Sometime in the future I'd like to look at a more automated brute-force method of proving every combination of attributes and data types to be consistent across NUnit.

@ChrisMaddock I looked at https://github.com/nunit/nunit/pull/2104 and this PR seems limited enough in scope to be perpendicular.

@StanEgo are you still interested in https://github.com/nunit/nunit/pull/2104? If you are, please review this PR. If not, I want to build on the progress you've made with https://github.com/nunit/nunit/pull/2104 after this to reach the end goal of unifying the inconsistent type coercion logic.