### PR TITLE
Disallow ExpectedResult on TestAttribute with a parameterized method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+launchSettings.json
 
 # Build results
 

--- a/src/NUnitFramework/testdata/TestMethodSignatureFixture.cs
+++ b/src/NUnitFramework/testdata/TestMethodSignatureFixture.cs
@@ -29,10 +29,10 @@ namespace NUnit.TestData.TestMethodSignatureFixture
     [TestFixture]
     public class TestMethodSignatureFixture
     {
-        public static int Tests = 21;
-        public static int Runnable = 12;
-        public static int NotRunnable = 9;
-        public static int Errors = 3;
+        public static int Tests = 24;
+        public static int Runnable = 13;
+        public static int NotRunnable = 11;
+        public static int Errors = 4;
         public static int Failures = 0;
 
         [Test]
@@ -119,15 +119,29 @@ namespace NUnit.TestData.TestMethodSignatureFixture
         private void PrivateTestMethod() { }
 
         [Test]
-        public bool TestMethodWithReturnType() 
+        public bool TestMethodWithReturnValue_WithoutExpectedResult() 
         {
             return true;
         }
 
         [Test(ExpectedResult = true)]
-        public bool TestMethodWithExpectedReturnType()
+        public bool TestMethodWithReturnValue_WithExpectedResult()
         {
             return true;
+        }
+
+        [Test(ExpectedResult = true)]
+        public bool TestMethodWithReturnValueAndArgs_WithExpectedResult(int x, int y)
+        {
+            return x == y;
+        }
+
+        [Test(ExpectedResult = 1024)]
+        [TestCase(1, 1, ExpectedResult = 2)]
+        [TestCase(5, 3, ExpectedResult = 8)]
+        public int TestCasesWithReturnValueAndArgs_WithExpectedResult(int x, int y)
+        {
+            return x + y;
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestExpectedResult.cs
+++ b/src/NUnitFramework/tests/Attributes/TestExpectedResult.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 // 
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
+
+using NUnit.TestData.TestMethodSignatureFixture;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
@@ -50,12 +53,10 @@ namespace NUnit.Framework.Attributes
             return null;
         }
 
-        [Test(ExpectedResult = 1024)]
-        [TestCase(1, 1, ExpectedResult = 2)]
-        [TestCase(5, 3, ExpectedResult = 8)]
-        public int TestAttributeExpectedResultDoesNotOverrideTestCaseExpectedResult(int x, int y)
+        [Test]
+        public void ExpectedResultNotAllowedOnParameterizedMethod()
         {
-            return x + y;
+            TestAssert.IsNotRunnable(typeof(TestMethodSignatureFixture), nameof(TestMethodSignatureFixture.TestCasesWithReturnValueAndArgs_WithExpectedResult));
         }
 
         [Test(ExpectedResult = 42), Description("A description")]

--- a/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
@@ -138,13 +138,19 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestMethodWithReturnTypeIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnType));
+            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithoutExpectedResult));
         }
 
         [Test]
         public void TestMethodWithExpectedReturnTypeIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithExpectedReturnType));
+            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithExpectedResult));
+        }
+
+        [Test]
+        public void TestMethodWithExpectedReturnAndArgumentsIsNotRunnable()
+        {
+            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValueAndArgs_WithExpectedResult));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #2639 

I'm aiming at the simplest possible fix here. While there's more that could be done, I think it's better to get the error notified to users first.