### PR TITLE
Enable access to the current Retry attempt count from within a Test

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -87,12 +87,15 @@ namespace NUnit.Framework
             /// <returns>A TestResult</returns>
             public override TestResult Execute(TestExecutionContext context)
             {
-                int count = _tryCount;
+                int currentAttempt = 0;
 
-                while (count-- > 0)
+                while (currentAttempt++ < _tryCount)
                 {
                     try
                     {
+                        // update CurrentAttempt property in test
+                        context.CurrentTest.Properties.Set(PropertyNames.CurrentAttempt, currentAttempt);
+
                         context.CurrentResult = innerCommand.Execute(context);
                     }
                     // Commands are supposed to catch exceptions, but some don't
@@ -107,7 +110,7 @@ namespace NUnit.Framework
                         break;
 
                     // Clear result for retry
-                    if (count > 0)
+                    if (currentAttempt < _tryCount)
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
                 }
 

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -87,15 +87,12 @@ namespace NUnit.Framework
             /// <returns>A TestResult</returns>
             public override TestResult Execute(TestExecutionContext context)
             {
-                int currentAttempt = 0;
+                int count = _tryCount;
 
-                while (currentAttempt++ < _tryCount)
+                while (count-- > 0)
                 {
                     try
                     {
-                        // update CurrentAttempt property in test
-                        context.CurrentTest.Properties.Set(PropertyNames.CurrentAttempt, currentAttempt);
-
                         context.CurrentResult = innerCommand.Execute(context);
                     }
                     // Commands are supposed to catch exceptions, but some don't
@@ -110,8 +107,11 @@ namespace NUnit.Framework
                         break;
 
                     // Clear result for retry
-                    if (currentAttempt < _tryCount)
+                    if (count > 0)
+                    {
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
+                    }
                 }
 
                 return context.CurrentResult;

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2010 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -137,6 +137,11 @@ namespace NUnit.Framework.Internal
         /// The optional Order the test will run in
         /// </summary>
         public const string Order = "Order";
+
+        /// <summary>
+        /// The attempt currently being executed in a test using the <see cref="RetryAttribute"/>
+        /// </summary>
+        public const string CurrentAttempt = "CurrentAttempt";
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -137,11 +137,6 @@ namespace NUnit.Framework.Internal
         /// The optional Order the test will run in
         /// </summary>
         public const string Order = "Order";
-
-        /// <summary>
-        /// The attempt currently being executed in a test using the <see cref="RetryAttribute"/>
-        /// </summary>
-        public const string CurrentAttempt = "CurrentAttempt";
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -428,6 +428,12 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool IsSingleThreaded { get; set; }
 
+        /// <summary>
+        /// The number of times the current test has been scheduled for execution.
+        /// Currently only being executed in a test using the <see cref="RetryAttribute"/>
+        /// </summary>
+        public int CurrentRepeatCount { get; set; }
+
 #endregion
 
 #region Instance Methods

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -181,6 +181,16 @@ namespace NUnit.Framework
             get { return _testExecutionContext.AssertCount; }
         }
 
+        /// <summary>
+        /// Get the number of times the current Test has been repeated. This is currently only 
+        /// set when using the <see cref="RetryAttribute"/>.
+        /// TODO: add this to the RepeatAttribute as well
+        /// </summary>
+        public int CurrentRepeatCount
+        {
+            get { return _testExecutionContext.CurrentRepeatCount; }
+        }
+
         #endregion
 
         #region Static Methods

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -23,6 +23,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace NUnit.TestData.RepeatingTests
 {
@@ -201,6 +202,17 @@ namespace NUnit.TestData.RepeatingTests
         {
             Count++;
             throw new Exception("Deliberate exception");
+        }
+    }
+
+    public class RetryTestVerifyAttempt : RepeatingTestsFixtureBase
+    {
+        [Test, Retry(3)]
+        public void NeverPasses()
+        {
+            string currentAttemptStr = TestContext.CurrentContext.Test.Properties.Get(PropertyNames.CurrentAttempt).ToString();
+            count = int.Parse(currentAttemptStr);
+            Assert.Fail("forcing a failure so we retry maximum times");
         }
     }
 }

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -210,9 +210,19 @@ namespace NUnit.TestData.RepeatingTests
         [Test, Retry(3)]
         public void NeverPasses()
         {
-            string currentAttemptStr = TestContext.CurrentContext.Test.Properties.Get(PropertyNames.CurrentAttempt).ToString();
-            count = int.Parse(currentAttemptStr);
+            count = TestContext.CurrentContext.CurrentRepeatCount;
             Assert.Fail("forcing a failure so we retry maximum times");
+        }
+
+        [Test, Retry(3)]
+        public void PassesOnLastRetry()
+        {
+            Assert.That(count, Is.EqualTo(TestContext.CurrentContext.CurrentRepeatCount), "expected CurrentRepeatCount to be incremented only after first attempt");
+            if (count < 2) // second Repeat is 3rd Retry (i.e. end of attempts)
+            {
+                count++;
+                Assert.Fail("forced failure so we will use maximum number of Retries for PassesOnLastRetry");
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -101,5 +101,15 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(1, categories.Count);
             Assert.AreEqual("SAMPLE", categories[0]);
         }
+
+        [Test]
+        public void RetryUpdatesCurrentAttemptProperty()
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
+            ITestResult result = TestBuilder.RunTestCase(fixture, "NeverPasses");
+
+            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count, "expected the CurrentAttempt property to equal the number of executions");
+            Assert.AreEqual(result.Test.Properties.Get(PropertyNames.CurrentAttempt), fixture.Count, "expected the CurrentAttempt property in the result to be set correctly after execution");
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -103,13 +103,23 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void RetryUpdatesCurrentAttemptProperty()
+        public void RetryUpdatesCurrentRepeatCountPropertyOnAlwaysFailingTest()
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, "NeverPasses");
 
-            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count, "expected the CurrentAttempt property to equal the number of executions");
-            Assert.AreEqual(result.Test.Properties.Get(PropertyNames.CurrentAttempt), fixture.Count, "expected the CurrentAttempt property in the result to be set correctly after execution");
+            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.AreEqual(result.FailCount, 1, "expected that the test failed all retries");
+        }
+
+        [Test]
+        public void RetryUpdatesCurrentRepeatCountPropertyOnEachAttempt()
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
+            ITestResult result = TestBuilder.RunTestCase(fixture, "PassesOnLastRetry");
+
+            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.AreEqual(result.FailCount, 0, "expected that the test passed final retry");
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -984,6 +984,16 @@ namespace NUnit.Framework.Internal
         }
 #endif
 
+        #endregion
+
+#region CurrentRepeatCount Tests
+        [Test]
+        public void CanAccessCurrentRepeatCount()
+        {
+            Assert.That(_fixtureContext.CurrentRepeatCount, Is.EqualTo(0), "expected value to default to zero");
+            _fixtureContext.CurrentRepeatCount++;
+            Assert.That(_fixtureContext.CurrentRepeatCount, Is.EqualTo(1), "expected value to be able to be incremented from the TestExecutionContext");
+        }
 #endregion
 
 #region Helper Methods

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -417,6 +417,16 @@ namespace NUnit.Framework
         }
 
         #endregion
+
+        #region Retry
+        [Test]
+        public void TestCanAccessCurrentRepeatCount()
+        {
+            var context = TestExecutionContext.CurrentContext;
+
+            Assert.That(context.CurrentRepeatCount, Is.EqualTo(0), "expected TestContext.CurrentRepeatCount to be accessible and be zero on first execution of test");
+        }
+        #endregion
     }
 
     [TestFixture]


### PR DESCRIPTION
### Changes:
* modification to RetryAttribute such that it exposes the current attempt in the Test properties as per issue #2647
* addition of unit test that uses the newly exposed value to set a _Count_ field which is checked at the end of execution and compared to the expected number of executions performed. If these match then it means the value exposed via the _TestContext.CurrentContext.Test.Properties_ is working as expected
  