### PR TITLE
Adding testname attribute in test case xml

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -182,6 +182,15 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Gets the value associated with TestName attribute of the test.
+        /// Returns null if the test is not implemented as a method.
+        /// </summary>
+        public virtual string TestName
+        {
+            get { return null; }
+        }
+
+        /// <summary>
         /// The arguments to use in creating the test or empty array if none required.
         /// </summary>
         public abstract object[] Arguments { get; }
@@ -392,6 +401,8 @@ namespace NUnit.Framework.Internal
             if (this.ClassName != null)
                 thisNode.AddAttribute("classname", this.ClassName);
             thisNode.AddAttribute("runstate", this.RunState.ToString());
+            if(this.TestName != null)
+                thisNode.AddAttribute("testname", this.TestName);
 
             if (Properties.Keys.Count > 0)
                 Properties.AddToXml(thisNode, recursive);

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -121,6 +121,11 @@ namespace NUnit.Framework.Internal
 
             PopulateTestNode(thisNode, recursive);
 
+            if (!string.IsNullOrEmpty(this.parms.TestName))
+            {
+                thisNode.AddAttribute("TestName", this.parms.TestName);
+            }
+
             thisNode.AddAttribute("seed", this.Seed.ToString());
 
             return thisNode;

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override string TestName
         {
-            get { return parms.TestName; }
+            get { return (parms != null ? parms.TestName : null); }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -121,11 +121,6 @@ namespace NUnit.Framework.Internal
 
             PopulateTestNode(thisNode, recursive);
 
-            if (!string.IsNullOrEmpty(this.parms.TestName))
-            {
-                thisNode.AddAttribute("TestName", this.parms.TestName);
-            }
-
             thisNode.AddAttribute("seed", this.Seed.ToString());
 
             return thisNode;
@@ -155,6 +150,14 @@ namespace NUnit.Framework.Internal
         public override string MethodName
         {
             get { return Method.Name; }
+        }
+
+        /// <summary>
+        /// Returns the TestName of the method
+        /// </summary>
+        public override string TestName
+        {
+            get { return parms.TestName; }
         }
 
         #endregion


### PR DESCRIPTION
If TestName attribute is not null or empty then add it in test case attributes. This value will be read by nunit VS adapter. If value of this attribute is present then a test property with name 'AdjustedFQN' will get added in TestCase object. This will help Test Window in determining correct source information for the test method having TestName attribute.