### PR TITLE
Ensure that FailureSite.Child is used where appropriate.

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/ResultState.cs
+++ b/src/NUnitFramework/framework/Interfaces/ResultState.cs
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Interfaces
         public readonly static ResultState ChildFailure = ResultState.Failure.WithSite(FailureSite.Child);
 
         /// <summary>
-        /// A suite failed because one or more child tests failed or had errors
+        /// A suite failed because one or more child tests had warnings
         /// </summary>
         public readonly static ResultState ChildWarning = ResultState.Warning.WithSite(FailureSite.Child);
 

--- a/src/NUnitFramework/framework/Interfaces/ResultState.cs
+++ b/src/NUnitFramework/framework/Interfaces/ResultState.cs
@@ -135,6 +135,11 @@ namespace NUnit.Framework.Interfaces
         public readonly static ResultState ChildFailure = ResultState.Failure.WithSite(FailureSite.Child);
 
         /// <summary>
+        /// A suite failed because one or more child tests failed or had errors
+        /// </summary>
+        public readonly static ResultState ChildWarning = ResultState.Warning.WithSite(FailureSite.Child);
+
+        /// <summary>
         /// A suite failed in its OneTimeSetUp
         /// </summary>
         public readonly static ResultState SetUpFailure = ResultState.Failure.WithSite(FailureSite.SetUp);

--- a/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Internal
 
                 case TestStatus.Warning:
                     if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
-                        SetResult(childResultState, CHILD_WARNINGS_MESSAGE);
+                        SetResult(ResultState.ChildWarning, CHILD_WARNINGS_MESSAGE);
                     break;
 
                 case TestStatus.Failed:

--- a/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultIsWarning()
         {
-            Assert.AreEqual(ResultState.Warning, _suiteResult.ResultState);
+            Assert.AreEqual(ResultState.ChildWarning, _suiteResult.ResultState);
             Assert.AreEqual(TestResult.CHILD_WARNINGS_MESSAGE, _suiteResult.Message);
 
             Assert.AreEqual(0, _suiteResult.PassCount);
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal.Results
 
             Assert.AreEqual("Warning", suiteNode.Attributes["result"]);
             Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual(null, suiteNode.Attributes["site"]);
+            Assert.AreEqual("Child", suiteNode.Attributes["site"]);
             Assert.AreEqual("0", suiteNode.Attributes["passed"]);
             Assert.AreEqual("0", suiteNode.Attributes["failed"]);
             Assert.AreEqual("1", suiteNode.Attributes["warnings"]);


### PR DESCRIPTION
Fixes #2670 

This PR makes sure that a suite with a Warning result due to a child test is always given `FailureSite.Child` just as is done for Failed results. By doing this, we allow runners to display the warning where it occurs without needing to parser the wording of the message.