### PR TITLE
Changed .editorconfig errors to warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -49,8 +49,8 @@ csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#naming
-dotnet_style_predefined_type_for_locals_parameters_members = true:error
-dotnet_style_predefined_type_for_member_access = true:error
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
 
 # The first matching rule wins, more specific rules at the top
 
@@ -60,20 +60,20 @@ dotnet_style_predefined_type_for_member_access = true:error
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
-dotnet_naming_rule.namespaces_types_and_non_field_members.severity = error
+dotnet_naming_rule.namespaces_types_and_non_field_members.severity = warning
 dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
 dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
 
 dotnet_naming_symbols.public_fields.applicable_kinds = field
 dotnet_naming_symbols.public_fields.applicable_accessibilities = public
-dotnet_naming_rule.public_fields.severity = error
+dotnet_naming_rule.public_fields.severity = warning
 dotnet_naming_rule.public_fields.symbols = public_fields
 dotnet_naming_rule.public_fields.style = pascal_case
 
 dotnet_naming_style.camel_case.capitalization = camel_case
 
 dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
-dotnet_naming_rule.parameters_and_locals.severity = error
+dotnet_naming_rule.parameters_and_locals.severity = warning
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
 dotnet_naming_rule.parameters_and_locals.style = camel_case
 
@@ -81,5 +81,5 @@ dotnet_naming_rule.parameters_and_locals.style = camel_case
 dotnet_sort_system_directives_first = true
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#use-of-the-var-keyword
-# Would be true:error, except that that so much existing code is not consistent with the coding standard.
+# Would be true:warning, except that that so much existing code is not consistent with the coding standard.
 csharp_style_var_when_type_is_apparent = true:suggestion


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2659

Doesn't look like the VS folks put much time towards .editorconfig since the last time we looked, but they are making up for it in other areas IMO so I'm just fine with that.