### PR TITLE
Don't suppress output under Assert.Throws

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -30,17 +30,15 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using NUnit.Framework.Interfaces;
-#if NET20
 using NUnit.Compatibility;
-#endif
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
     /// <summary>
     /// The TestResult class represents the result of a test.
     /// </summary>
-    public abstract class TestResult : ITestResult
+    public abstract class TestResult : LongLivedMarshalByRefObject, ITestResult
     {
         #region Fields
 

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -563,6 +563,7 @@ namespace NUnit.Framework.Internal
             /// </summary>
             public void Dispose()
             {
+                _originalContext.OutWriter.Write(CurrentContext.CurrentResult.Output);
                 CurrentContext = _originalContext;
             }
         }

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
@@ -37,18 +37,34 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void ThrowsDoesNotDiscardOutput()
+        public void AssertThrowsDoesNotDiscardOutput()
         {
             Console.WriteLine(1);
             Assert.Throws<Exception>(() =>
             {
                 Console.WriteLine(2);
+                TestContext.WriteLine(3);
                 throw new Exception("test");
             });
-            Console.WriteLine(3);
+            Console.WriteLine(4);
 
-            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output, 
-                Is.EqualTo("1" + Environment.NewLine + "2" + Environment.NewLine + "3" + Environment.NewLine));
+            var NL = Environment.NewLine;
+            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output,
+                Is.EqualTo($"1{NL}2{NL}3{NL}4{NL}"));
+        }
+
+        [Test]
+        public void ThrowsConstraintDoesNotDiscardOutput()
+        {
+            Console.WriteLine(1);
+            Assert.That(
+                () => { Console.WriteLine(2); TestContext.WriteLine(3); throw new Exception("test"); }, 
+                Throws.Exception);
+            Console.WriteLine(4);
+
+            var NL = Environment.NewLine;
+            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output,
+                Is.EqualTo($"1{NL}2{NL}3{NL}4{NL}"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
@@ -37,6 +37,21 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
+        public void ThrowsDoesNotDiscardOutput()
+        {
+            Console.WriteLine(1);
+            Assert.Throws<Exception>(() =>
+            {
+                Console.WriteLine(2);
+                throw new Exception("test");
+            });
+            Console.WriteLine(3);
+
+            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output, 
+                Is.EqualTo("1" + Environment.NewLine + "2" + Environment.NewLine + "3" + Environment.NewLine));
+        }
+
+        [Test]
         public void GenericThrowsSucceedsWithDelegate()
         {
             Assert.Throws<ArgumentException>(


### PR DESCRIPTION
Fixes #2688

The fix takes any saved output in the isolated context and writes it to the original context.