### PR TITLE
Switch editorconfig warnings to suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -49,8 +49,8 @@ csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#naming
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # The first matching rule wins, more specific rules at the top
 
@@ -60,20 +60,20 @@ dotnet_style_predefined_type_for_member_access = true:warning
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
-dotnet_naming_rule.namespaces_types_and_non_field_members.severity = warning
+dotnet_naming_rule.namespaces_types_and_non_field_members.severity = suggestion
 dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
 dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
 
 dotnet_naming_symbols.public_fields.applicable_kinds = field
 dotnet_naming_symbols.public_fields.applicable_accessibilities = public
-dotnet_naming_rule.public_fields.severity = warning
+dotnet_naming_rule.public_fields.severity = suggestion
 dotnet_naming_rule.public_fields.symbols = public_fields
 dotnet_naming_rule.public_fields.style = pascal_case
 
 dotnet_naming_style.camel_case.capitalization = camel_case
 
 dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
-dotnet_naming_rule.parameters_and_locals.severity = warning
+dotnet_naming_rule.parameters_and_locals.severity = suggestion
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
 dotnet_naming_rule.parameters_and_locals.style = camel_case
 


### PR DESCRIPTION
Fixes #2698 

See the issue for more info, but I have confirmed that even though `editorconfig` had various rules explicitly set to warnings, they were showing up as errors in both the editor and in the error list. Switching to Suggestion works. It isn't as obvious, but we have so much code that doesn't match that it is probably the best solution for now.

They now show up as grey blocks in the scroll bar and with grey dots under the suggestion.

![image](https://user-images.githubusercontent.com/493828/35920435-dd7bb502-0be5-11e8-8f9a-d20b6609b4bc.png)

The suggestions also appear in the error list as messages now.

![image](https://user-images.githubusercontent.com/493828/35920499-07c6117c-0be6-11e8-9663-53aae497f166.png)
