### PR TITLE
Enable 'strict' compilation flag

### DIFF
--- a/src/NUnitFramework/Common.props
+++ b/src/NUnitFramework/Common.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This flag turns on a few correctness warnings in the C# compiler which could not be enabled by default due to backwards compatibility requirements.

💡 Please do not rebase or squash this pull request on merge.