### PR TITLE
Replace the ConcurrentQueue and SpinWait compatibility classes

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
@@ -1,32 +1,31 @@
+#if NET20 || NET35
+#pragma warning disable 0420
+
+// ==++==
+//
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+// ==--==
+// =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+//
 // ConcurrentQueue.cs
 //
-// Copyright (c) 2008 Jérémie "Garuma" Laval
+// <OWNER>Microsoft</OWNER>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+// A lock-free, concurrent queue primitive, and its associated debugger view type.
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-//
-#if NET20 || NET35
+// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
 using System;
-using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Security;
+using System.Security.Permissions;
+using System.Threading;
 
 namespace System.Collections.Concurrent
 {
@@ -36,31 +35,64 @@ namespace System.Collections.Concurrent
     /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the queue.</typeparam>
     /// <remarks>
-    /// All public and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
+    /// All public  and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </remarks>
-	[System.Diagnostics.DebuggerDisplay ("Count={Count}")]
-	[System.Diagnostics.DebuggerTypeProxy (typeof (CollectionDebuggerView<>))]
-	internal class ConcurrentQueue<T> : IProducerConsumerCollection<T>, IEnumerable<T>, ICollection,
-	                                  IEnumerable
-	{
-		class Node
-		{
-			public T Value;
-			public Node Next;
-		}
+    [ComVisible(false)]
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<>))]
+    [HostProtection(Synchronization = true, ExternalThreading = true)]
+    [Serializable]
+    public class ConcurrentQueue<T> : IProducerConsumerCollection<T>//, IReadOnlyCollection<T>
+    {
+        //fields of ConcurrentQueue
+        [NonSerialized]
+        private volatile Segment m_head;
 
-		Node head = new Node ();
-		Node tail;
-		int count;
+        [NonSerialized]
+        private volatile Segment m_tail;
+
+        private T[] m_serializationArray; // Used for custom serialization.
+
+        private const int SEGMENT_SIZE = 32;
+
+        //number of snapshot takers, GetEnumerator(), ToList() and ToArray() operations take snapshot.
+        [NonSerialized]
+        internal volatile int m_numSnapshotTakers = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentQueue{T}"/> class.
         /// </summary>
-		public ConcurrentQueue ()
-		{
-			tail = head;
-		}
+        public ConcurrentQueue()
+        {
+            m_head = m_tail = new Segment(0, this);
+        }
+
+        /// <summary>
+        /// Initializes the contents of the queue from an existing collection.
+        /// </summary>
+        /// <param name="collection">A collection from which to copy elements.</param>
+        private void InitializeFromCollection(IEnumerable<T> collection)
+        {
+            Segment localTail = new Segment(0, this);//use this local variable to avoid the extra volatile read/write. this is safe because it is only called from ctor
+            m_head = localTail;
+
+            int index = 0;
+            foreach (T element in collection)
+            {
+                // Contract.Assert(index >= 0 && index < SEGMENT_SIZE);
+                localTail.UnsafeAdd(element);
+                index++;
+
+                if (index >= SEGMENT_SIZE)
+                {
+                    localTail = localTail.UnsafeGrow();
+                    index = 0;
+                }
+            }
+
+            m_tail = localTail;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentQueue{T}"/>
@@ -70,186 +102,36 @@ namespace System.Collections.Concurrent
         /// cref="ConcurrentQueue{T}"/>.</param>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="collection"/> argument is
         /// null.</exception>
-        public ConcurrentQueue (IEnumerable<T> collection): this()
-		{
+        public ConcurrentQueue(IEnumerable<T> collection)
+        {
             if (collection == null)
+            {
                 throw new ArgumentNullException("collection");
+            }
 
-            foreach (T item in collection)
-				Enqueue (item);
-		}
-
-        /// <summary>
-        /// Adds an object to the end of the <see cref="ConcurrentQueue{T}"/>.
-        /// </summary>
-        /// <param name="item">The object to add to the end of the <see
-        /// cref="ConcurrentQueue{T}"/>. The value can be a null reference
-        /// (Nothing in Visual Basic) for reference types.
-        /// </param>
-        public void Enqueue (T item)
-		{
-			Node node = new Node ();
-			node.Value = item;
-
-			Node oldTail = null;
-			Node oldNext = null;
-
-			bool update = false;
-			while (!update) {
-				oldTail = tail;
-				oldNext = oldTail.Next;
-
-				// Did tail was already updated ?
-				if (tail == oldTail) {
-					if (oldNext == null) {
-						// The place is for us
-						update = Interlocked.CompareExchange (ref tail.Next, node, null) == null;
-					} else {
-						// another Thread already used the place so give him a hand by putting tail where it should be
-						Interlocked.CompareExchange (ref tail, oldNext, oldTail);
-					}
-				}
-			}
-			// At this point we added correctly our node, now we have to update tail. If it fails then it will be done by another thread
-			Interlocked.CompareExchange (ref tail, node, oldTail);
-			Interlocked.Increment (ref count);
-		}
+            InitializeFromCollection(collection);
+        }
 
         /// <summary>
-        /// Attempts to add an object to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// Get the data array to be serialized
         /// </summary>
-        /// <param name="item">The object to add to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
-        /// reference (Nothing in Visual Basic) for reference types.
-        /// </param>
-        /// <returns>true if the object was added successfully; otherwise, false.</returns>
-        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will always add the object to the
-        /// end of the <see cref="ConcurrentQueue{T}"/>
-        /// and return true.</remarks>
-        bool IProducerConsumerCollection<T>.TryAdd (T item)
-		{
-			Enqueue (item);
-			return true;
-		}
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            // save the data into the serialization array to be saved
+            m_serializationArray = ToArray();
+        }
 
         /// <summary>
-        /// Attempts to remove and return the object at the beginning of the <see
-        /// cref="ConcurrentQueue{T}"/>.
+        /// Construct the queue from a previously seiralized one
         /// </summary>
-        /// <param name="result">
-        /// When this method returns, if the operation was successful, <paramref name="result"/> contains the
-        /// object removed. If no object was available to be removed, the value is unspecified.
-        /// </param>
-        /// <returns>true if an element was removed and returned from the beginning of the <see
-        /// cref="ConcurrentQueue{T}"/>
-        /// successfully; otherwise, false.</returns>
-		public bool TryDequeue (out T result)
-		{
-			result = default (T);
-			Node oldNext = null;
-			bool advanced = false;
-
-			while (!advanced) {
-				Node oldHead = head;
-				Node oldTail = tail;
-				oldNext = oldHead.Next;
-
-				if (oldHead == head) {
-					// Empty case ?
-					if (oldHead == oldTail) {
-						// This should be false then
-						if (oldNext != null) {
-							// If not then the linked list is malformed, update tail
-							Interlocked.CompareExchange (ref tail, oldNext, oldTail);
-							continue;
-						}
-						result = default (T);
-						return false;
-					} else {
-						result = oldNext.Value;
-						advanced = Interlocked.CompareExchange (ref head, oldNext, oldHead) == oldHead;
-					}
-				}
-			}
-
-			oldNext.Value = default (T);
-
-			Interlocked.Decrement (ref count);
-
-			return true;
-		}
-
-        /// <summary>
-        /// Attempts to return an object from the beginning of the <see cref="ConcurrentQueue{T}"/>
-        /// without removing it.
-        /// </summary>
-        /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
-        /// the beginning of the <see cref="T:System.Collections.Concurrent.ConcurrentQueue{T}"/> or an
-        /// unspecified value if the operation failed.</param>
-        /// <returns>true if and object was returned successfully; otherwise, false.</returns>
-        public bool TryPeek (out T result)
-		{
-			result = default (T);
-			bool update = true;
-
-			while (update)
-			{
-				Node oldHead = head;
-				Node oldNext = oldHead.Next;
-
-				if (oldNext == null) {
-					result = default (T);
-					return false;
-				}
-
-				result = oldNext.Value;
-
-				//check if head has been updated
-				update = head != oldHead;
-			}
-			return true;
-		}
-
-		internal void Clear ()
-		{
-			count = 0;
-			tail = head = new Node ();
-		}
-
-        /// <summary>
-        /// Returns an enumerator that iterates through a collection.
-        /// </summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator"/> that can be used to iterate through the collection.</returns>
-        IEnumerator IEnumerable.GetEnumerator ()
-		{
-			return (IEnumerator)InternalGetEnumerator ();
-		}
-
-        /// <summary>
-        /// Returns an enumerator that iterates through the <see
-        /// cref="ConcurrentQueue{T}"/>.
-        /// </summary>
-        /// <returns>An enumerator for the contents of the <see
-        /// cref="ConcurrentQueue{T}"/>.</returns>
-        /// <remarks>
-        /// The enumeration represents a moment-in-time snapshot of the contents
-        /// of the queue.  It does not reflect any updates to the collection after
-        /// <see cref="GetEnumerator"/> was called.  The enumerator is safe to use
-        /// concurrently with reads from and writes to the queue.
-        /// </remarks>
-        public IEnumerator<T> GetEnumerator ()
-		{
-			return InternalGetEnumerator ();
-		}
-
-		IEnumerator<T> InternalGetEnumerator ()
-		{
-			Node my_head = head;
-			while ((my_head = my_head.Next) != null) {
-				yield return my_head.Value;
-			}
-		}
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            // Contract.Assert(m_serializationArray != null);
+            InitializeFromCollection(m_serializationArray);
+            m_serializationArray = null;
+        }
 
         /// <summary>
         /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an <see
@@ -276,20 +158,267 @@ namespace System.Collections.Concurrent
         /// cref="T:System.Collections.ICollection"/> cannot be cast automatically to the type of the
         /// destination <paramref name="array"/>.
         /// </exception>
-        void ICollection.CopyTo (Array array, int index)
-		{
-			if (array == null)
-				throw new ArgumentNullException ("array");
-			if (array.Rank > 1)
-				throw new ArgumentException ("The array can't be multidimensional");
-			if (array.GetLowerBound (0) != 0)
-				throw new ArgumentException ("The array needs to be 0-based");
+        void ICollection.CopyTo(Array array, int index)
+        {
+            // Validate arguments.
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
 
-			T[] dest = array as T[];
-			if (dest == null)
-				throw new ArgumentException ("The array cannot be cast to the collection element type", "array");
-			CopyTo (dest, index);
-		}
+            // We must be careful not to corrupt the array, so we will first accumulate an
+            // internal list of elements that we will then copy to the array. This requires
+            // some extra allocation, but is necessary since we don't know up front whether
+            // the array is sufficiently large to hold the stack's contents.
+            ((ICollection)ToList()).CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// synchronized with the SyncRoot.
+        /// </summary>
+        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentQueue{T}"/>, this property always
+        /// returns false.</value>
+        bool ICollection.IsSynchronized
+        {
+            // Gets a value indicating whether access to this collection is synchronized. Always returns
+            // false. The reason is subtle. While access is in face thread safe, it's not the case that
+            // locking on the SyncRoot would have prevented concurrent pushes and pops, as this property
+            // would typically indicate; that's because we internally use CAS operations vs. true locks.
+            get { return false; }
+        }
+
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize access to the <see
+        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// </summary>
+        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        object ICollection.SyncRoot
+        {
+            get
+            {
+                throw new NotSupportedException("ConcurrentCollection SyncRoot Not Supported");
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator"/> that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<T>)this).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Attempts to add an object to the <see
+        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to add to the <see
+        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
+        /// reference (Nothing in Visual Basic) for reference types.
+        /// </param>
+        /// <returns>true if the object was added successfully; otherwise, false.</returns>
+        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will always add the object to the
+        /// end of the <see cref="ConcurrentQueue{T}"/>
+        /// and return true.</remarks>
+        bool IProducerConsumerCollection<T>.TryAdd(T item)
+        {
+            Enqueue(item);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to remove and return an object from the <see
+        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        /// When this method returns, if the operation was successful, <paramref name="item"/> contains the
+        /// object removed. If no object was available to be removed, the value is unspecified.
+        /// </param>
+        /// <returns>true if an element was removed and returned succesfully; otherwise, false.</returns>
+        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will attempt to remove the object
+        /// from the beginning of the <see cref="ConcurrentQueue{T}"/>.
+        /// </remarks>
+        bool IProducerConsumerCollection<T>.TryTake(out T item)
+        {
+            return TryDequeue(out item);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the <see cref="ConcurrentQueue{T}"/> is empty.
+        /// </summary>
+        /// <value>true if the <see cref="ConcurrentQueue{T}"/> is empty; otherwise, false.</value>
+        /// <remarks>
+        /// For determining whether the collection contains any items, use of this property is recommended
+        /// rather than retrieving the number of items from the <see cref="Count"/> property and comparing it
+        /// to 0.  However, as this collection is intended to be accessed concurrently, it may be the case
+        /// that another thread will modify the collection after <see cref="IsEmpty"/> returns, thus invalidating
+        /// the result.
+        /// </remarks>
+        public bool IsEmpty
+        {
+            get
+            {
+                Segment head = m_head;
+                if (!head.IsEmpty)
+                    //fast route 1:
+                    //if current head is not empty, then queue is not empty
+                    return false;
+                else if (head.Next == null)
+                    //fast route 2:
+                    //if current head is empty and it's the last segment
+                    //then queue is empty
+                    return true;
+                else
+                //slow route:
+                //current head is empty and it is NOT the last segment,
+                //it means another thread is growing new segment
+                {
+                    SpinWait spin = new SpinWait();
+                    while (head.IsEmpty)
+                    {
+                        if (head.Next == null)
+                            return true;
+
+                        spin.SpinOnce();
+                        head = m_head;
+                    }
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the elements stored in the <see cref="ConcurrentQueue{T}"/> to a new array.
+        /// </summary>
+        /// <returns>A new array containing a snapshot of elements copied from the <see
+        /// cref="ConcurrentQueue{T}"/>.</returns>
+        public T[] ToArray()
+        {
+            return ToList().ToArray();
+        }
+
+        /// <summary>
+        /// Copies the <see cref="ConcurrentQueue{T}"/> elements to a new <see
+        /// cref="T:System.Collections.Generic.List{T}"/>.
+        /// </summary>
+        /// <returns>A new <see cref="T:System.Collections.Generic.List{T}"/> containing a snapshot of
+        /// elements copied from the <see cref="ConcurrentQueue{T}"/>.</returns>
+        private List<T> ToList()
+        {
+            // Increments the number of active snapshot takers. This increment must happen before the snapshot is
+            // taken. At the same time, Decrement must happen after list copying is over. Only in this way, can it
+            // eliminate race condition when Segment.TryRemove() checks whether m_numSnapshotTakers == 0.
+            Interlocked.Increment(ref m_numSnapshotTakers);
+
+            List<T> list = new List<T>();
+            try
+            {
+                //store head and tail positions in buffer,
+                Segment head, tail;
+                int headLow, tailHigh;
+                GetHeadTailPositions(out head, out tail, out headLow, out tailHigh);
+
+                if (head == tail)
+                {
+                    head.AddToList(list, headLow, tailHigh);
+                }
+                else
+                {
+                    head.AddToList(list, headLow, SEGMENT_SIZE - 1);
+                    Segment curr = head.Next;
+                    while (curr != tail)
+                    {
+                        curr.AddToList(list, 0, SEGMENT_SIZE - 1);
+                        curr = curr.Next;
+                    }
+                    //Add tail segment
+                    tail.AddToList(list, 0, tailHigh);
+                }
+            }
+            finally
+            {
+                // This Decrement must happen after copying is over.
+                Interlocked.Decrement(ref m_numSnapshotTakers);
+            }
+            return list;
+        }
+
+        /// <summary>
+        /// Store the position of the current head and tail positions.
+        /// </summary>
+        /// <param name="head">return the head segment</param>
+        /// <param name="tail">return the tail segment</param>
+        /// <param name="headLow">return the head offset, value range [0, SEGMENT_SIZE]</param>
+        /// <param name="tailHigh">return the tail offset, value range [-1, SEGMENT_SIZE-1]</param>
+        private void GetHeadTailPositions(out Segment head, out Segment tail,
+            out int headLow, out int tailHigh)
+        {
+            head = m_head;
+            tail = m_tail;
+            headLow = head.Low;
+            tailHigh = tail.High;
+            SpinWait spin = new SpinWait();
+
+            //we loop until the observed values are stable and sensible.
+            //This ensures that any update order by other methods can be tolerated.
+            while (
+                //if head and tail changed, retry
+                head != m_head || tail != m_tail
+                //if low and high pointers, retry
+                || headLow != head.Low || tailHigh != tail.High
+                //if head jumps ahead of tail because of concurrent grow and dequeue, retry
+                || head.m_index > tail.m_index)
+            {
+                spin.SpinOnce();
+                head = m_head;
+                tail = m_tail;
+                headLow = head.Low;
+                tailHigh = tail.High;
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        /// <value>The number of elements contained in the <see cref="ConcurrentQueue{T}"/>.</value>
+        /// <remarks>
+        /// For determining whether the collection contains any items, use of the <see cref="IsEmpty"/>
+        /// property is recommended rather than retrieving the number of items from the <see cref="Count"/>
+        /// property and comparing it to 0.
+        /// </remarks>
+        public int Count
+        {
+            get
+            {
+                //store head and tail positions in buffer,
+                Segment head, tail;
+                int headLow, tailHigh;
+                GetHeadTailPositions(out head, out tail, out headLow, out tailHigh);
+
+                if (head == tail)
+                {
+                    return tailHigh - headLow + 1;
+                }
+
+                //head segment
+                int count = SEGMENT_SIZE - headLow;
+
+                //middle segment(s), if any, are full.
+                //We don't deal with overflow to be consistent with the behavior of generic types in CLR.
+                count += SEGMENT_SIZE * ((int)(tail.m_index - head.m_index - 1));
+
+                //tail segment
+                count += tailHigh + 1;
+
+                return count;
+            }
+        }
+
 
         /// <summary>
         /// Copies the <see cref="ConcurrentQueue{T}"/> elements to an existing one-dimensional <see
@@ -311,102 +440,524 @@ namespace System.Collections.Concurrent
         /// available space from <paramref name="index"/> to the end of the destination <paramref
         /// name="array"/>.
         /// </exception>
-        public void CopyTo (T[] array, int index)
-		{
-			if (array == null)
-				throw new ArgumentNullException ("array");
-			if (index < 0)
-				throw new ArgumentOutOfRangeException ("index");
-			if (index >= array.Length)
-				throw new ArgumentException ("The index is greater than or equal to the array length", "index");
+        public void CopyTo(T[] array, int index)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
 
-			IEnumerator<T> e = InternalGetEnumerator ();
-			int i = index;
-			while (e.MoveNext ()) {
-				if (i == array.Length - index)
-					throw new ArgumentException ("The number of elements in the collection exceeds the capacity of array", "array");
-				array[i++] = e.Current;
-			}
-		}
+            // We must be careful not to corrupt the array, so we will first accumulate an
+            // internal list of elements that we will then copy to the array. This requires
+            // some extra allocation, but is necessary since we don't know up front whether
+            // the array is sufficiently large to hold the stack's contents.
+            ToList().CopyTo(array, index);
+        }
+
 
         /// <summary>
-        /// Copies the elements stored in the <see cref="ConcurrentQueue{T}"/> to a new array.
+        /// Returns an enumerator that iterates through the <see
+        /// cref="ConcurrentQueue{T}"/>.
         /// </summary>
-        /// <returns>A new array containing a snapshot of elements copied from the <see
+        /// <returns>An enumerator for the contents of the <see
         /// cref="ConcurrentQueue{T}"/>.</returns>
-        public T[] ToArray ()
-		{
-			return new List<T> (this).ToArray ();
-		}
+        /// <remarks>
+        /// The enumeration represents a moment-in-time snapshot of the contents
+        /// of the queue.  It does not reflect any updates to the collection after
+        /// GetEnumerator was called.  The enumerator is safe to use
+        /// concurrently with reads from and writes to the queue.
+        /// </remarks>
+        public IEnumerator<T> GetEnumerator()
+        {
+            // Increments the number of active snapshot takers. This increment must happen before the snapshot is
+            // taken. At the same time, Decrement must happen after the enumeration is over. Only in this way, can it
+            // eliminate race condition when Segment.TryRemove() checks whether m_numSnapshotTakers == 0.
+            Interlocked.Increment(ref m_numSnapshotTakers);
+
+            // Takes a snapshot of the queue.
+            // A design flaw here: if a Thread.Abort() happens, we cannot decrement m_numSnapshotTakers. But we cannot
+            // wrap the following with a try/finally block, otherwise the decrement will happen before the yield return
+            // statements in the GetEnumerator (head, tail, headLow, tailHigh) method.
+            Segment head, tail;
+            int headLow, tailHigh;
+            GetHeadTailPositions(out head, out tail, out headLow, out tailHigh);
+
+            //If we put yield-return here, the iterator will be lazily evaluated. As a result a snapshot of
+            // the queue is not taken when GetEnumerator is initialized but when MoveNext() is first called.
+            // This is inconsistent with existing generic collections. In order to prevent it, we capture the
+            // value of m_head in a buffer and call out to a helper method.
+            //The old way of doing this was to return the ToList().GetEnumerator(), but ToList() was an
+            // unnecessary perfomance hit.
+            return GetEnumerator(head, tail, headLow, tailHigh);
+        }
 
         /// <summary>
-        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
-        /// synchronized with the SyncRoot.
+        /// Helper method of GetEnumerator to seperate out yield return statement, and prevent lazy evaluation.
         /// </summary>
-        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
-        /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentQueue{T}"/>, this property always
-        /// returns false.</value>
-        bool ICollection.IsSynchronized {
-			get { return false; }
-		}
+        private IEnumerator<T> GetEnumerator(Segment head, Segment tail, int headLow, int tailHigh)
+        {
+            try
+            {
+                SpinWait spin = new SpinWait();
+
+                if (head == tail)
+                {
+                    for (int i = headLow; i <= tailHigh; i++)
+                    {
+                        // If the position is reserved by an Enqueue operation, but the value is not written into,
+                        // spin until the value is available.
+                        spin.Reset();
+                        while (!head.m_state[i].m_value)
+                        {
+                            spin.SpinOnce();
+                        }
+                        yield return head.m_array[i];
+                    }
+                }
+                else
+                {
+                    //iterate on head segment
+                    for (int i = headLow; i < SEGMENT_SIZE; i++)
+                    {
+                        // If the position is reserved by an Enqueue operation, but the value is not written into,
+                        // spin until the value is available.
+                        spin.Reset();
+                        while (!head.m_state[i].m_value)
+                        {
+                            spin.SpinOnce();
+                        }
+                        yield return head.m_array[i];
+                    }
+                    //iterate on middle segments
+                    Segment curr = head.Next;
+                    while (curr != tail)
+                    {
+                        for (int i = 0; i < SEGMENT_SIZE; i++)
+                        {
+                            // If the position is reserved by an Enqueue operation, but the value is not written into,
+                            // spin until the value is available.
+                            spin.Reset();
+                            while (!curr.m_state[i].m_value)
+                            {
+                                spin.SpinOnce();
+                            }
+                            yield return curr.m_array[i];
+                        }
+                        curr = curr.Next;
+                    }
+
+                    //iterate on tail segment
+                    for (int i = 0; i <= tailHigh; i++)
+                    {
+                        // If the position is reserved by an Enqueue operation, but the value is not written into,
+                        // spin until the value is available.
+                        spin.Reset();
+                        while (!tail.m_state[i].m_value)
+                        {
+                            spin.SpinOnce();
+                        }
+                        yield return tail.m_array[i];
+                    }
+                }
+            }
+            finally
+            {
+                // This Decrement must happen after the enumeration is over.
+                Interlocked.Decrement(ref m_numSnapshotTakers);
+            }
+        }
 
         /// <summary>
-        /// Attempts to remove and return an object from the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// Adds an object to the end of the <see cref="ConcurrentQueue{T}"/>.
         /// </summary>
-        /// <param name="item">
-        /// When this method returns, if the operation was successful, <paramref name="item"/> contains the
+        /// <param name="item">The object to add to the end of the <see
+        /// cref="ConcurrentQueue{T}"/>. The value can be a null reference
+        /// (Nothing in Visual Basic) for reference types.
+        /// </param>
+        public void Enqueue(T item)
+        {
+            SpinWait spin = new SpinWait();
+            while (true)
+            {
+                Segment tail = m_tail;
+                if (tail.TryAppend(item))
+                    return;
+                spin.SpinOnce();
+            }
+        }
+
+
+        /// <summary>
+        /// Attempts to remove and return the object at the beginning of the <see
+        /// cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        /// <param name="result">
+        /// When this method returns, if the operation was successful, <paramref name="result"/> contains the
         /// object removed. If no object was available to be removed, the value is unspecified.
         /// </param>
-        /// <returns>true if an element was removed and returned successfully; otherwise, false.</returns>
-        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will attempt to remove the object
-        /// from the beginning of the <see cref="ConcurrentQueue{T}"/>.
-        /// </remarks>
-		bool IProducerConsumerCollection<T>.TryTake (out T item)
-		{
-			return TryDequeue (out item);
-		}
+        /// <returns>true if an element was removed and returned from the beggining of the <see
+        /// cref="ConcurrentQueue{T}"/>
+        /// succesfully; otherwise, false.</returns>
+        public bool TryDequeue(out T result)
+        {
+            while (!IsEmpty)
+            {
+                Segment head = m_head;
+                if (head.TryRemove(out result))
+                    return true;
+                //since method IsEmpty spins, we don't need to spin in the while loop
+            }
+            result = default(T);
+            return false;
+        }
 
         /// <summary>
-        /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// Attempts to return an object from the beginning of the <see cref="ConcurrentQueue{T}"/>
+        /// without removing it.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
-		object ICollection.SyncRoot {
-			get { throw new NotSupportedException (); }
-		}
+        /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
+        /// the beginning of the <see cref="T:System.Collections.Concurrent.ConccurrentQueue{T}"/> or an
+        /// unspecified value if the operation failed.</param>
+        /// <returns>true if and object was returned successfully; otherwise, false.</returns>
+        public bool TryPeek(out T result)
+        {
+            Interlocked.Increment(ref m_numSnapshotTakers);
+
+            while (!IsEmpty)
+            {
+                Segment head = m_head;
+                if (head.TryPeek(out result))
+                {
+                    Interlocked.Decrement(ref m_numSnapshotTakers);
+                    return true;
+                }
+                //since method IsEmpty spins, we don't need to spin in the while loop
+            }
+            result = default(T);
+            Interlocked.Decrement(ref m_numSnapshotTakers);
+            return false;
+        }
+
 
         /// <summary>
-        /// Gets the number of elements contained in the <see cref="ConcurrentQueue{T}"/>.
+        /// private class for ConcurrentQueue.
+        /// a queue is a linked list of small arrays, each node is called a segment.
+        /// A segment contains an array, a pointer to the next segment, and m_low, m_high indices recording
+        /// the first and last valid elements of the array.
         /// </summary>
-        /// <value>The number of elements contained in the <see cref="ConcurrentQueue{T}"/>.</value>
-        /// <remarks>
-        /// For determining whether the collection contains any items, use of the <see cref="IsEmpty"/>
-        /// property is recommended rather than retrieving the number of items from the <see cref="Count"/>
-        /// property and comparing it to 0.
-        /// </remarks>
-        public int Count {
-			get {
-				return count;
-			}
-		}
+        private class Segment
+        {
+            //we define two volatile arrays: m_array and m_state. Note that the accesses to the array items
+            //do not get volatile treatment. But we don't need to worry about loading adjacent elements or
+            //store/load on adjacent elements would suffer reordering.
+            // - Two stores:  these are at risk, but CLRv2 memory model guarantees store-release hence we are safe.
+            // - Two loads: because one item from two volatile arrays are accessed, the loads of the array references
+            //          are sufficient to prevent reordering of the loads of the elements.
+            internal volatile T[] m_array;
 
-        /// <summary>
-        /// Gets a value that indicates whether the <see cref="ConcurrentQueue{T}"/> is empty.
-        /// </summary>
-        /// <value>true if the <see cref="ConcurrentQueue{T}"/> is empty; otherwise, false.</value>
-        /// <remarks>
-        /// For determining whether the collection contains any items, use of this property is recommended
-        /// rather than retrieving the number of items from the <see cref="Count"/> property and comparing it
-        /// to 0.  However, as this collection is intended to be accessed concurrently, it may be the case
-        /// that another thread will modify the collection after <see cref="IsEmpty"/> returns, thus invalidating
-        /// the result.
-        /// </remarks>
-        public bool IsEmpty {
-			get {
-				return count == 0;
-			}
-		}
-	}
+            // For each entry in m_array, the corresponding entry in m_state indicates whether this position contains
+            // a valid value. m_state is initially all false.
+            internal volatile VolatileBool[] m_state;
+
+            //pointer to the next segment. null if the current segment is the last segment
+            private volatile Segment m_next;
+
+            //We use this zero based index to track how many segments have been created for the queue, and
+            //to compute how many active segments are there currently.
+            // * The number of currently active segments is : m_tail.m_index - m_head.m_index + 1;
+            // * m_index is incremented with every Segment.Grow operation. We use Int64 type, and we can safely
+            //   assume that it never overflows. To overflow, we need to do 2^63 increments, even at a rate of 4
+            //   billion (2^32) increments per second, it takes 2^31 seconds, which is about 64 years.
+            internal readonly long m_index;
+
+            //indices of where the first and last valid values
+            // - m_low points to the position of the next element to pop from this segment, range [0, infinity)
+            //      m_low >= SEGMENT_SIZE implies the segment is disposable
+            // - m_high points to the position of the latest pushed element, range [-1, infinity)
+            //      m_high == -1 implies the segment is new and empty
+            //      m_high >= SEGMENT_SIZE-1 means this segment is ready to grow.
+            //        and the thread who sets m_high to SEGMENT_SIZE-1 is responsible to grow the segment
+            // - Math.Min(m_low, SEGMENT_SIZE) > Math.Min(m_high, SEGMENT_SIZE-1) implies segment is empty
+            // - initially m_low =0 and m_high=-1;
+            private volatile int m_low;
+            private volatile int m_high;
+
+            private volatile ConcurrentQueue<T> m_source;
+
+            /// <summary>
+            /// Create and initialize a segment with the specified index.
+            /// </summary>
+            internal Segment(long index, ConcurrentQueue<T> source)
+            {
+                m_array = new T[SEGMENT_SIZE];
+                m_state = new VolatileBool[SEGMENT_SIZE]; //all initialized to false
+                m_high = -1;
+                // Contract.Assert(index >= 0);
+                m_index = index;
+                m_source = source;
+            }
+
+            /// <summary>
+            /// return the next segment
+            /// </summary>
+            internal Segment Next
+            {
+                get { return m_next; }
+            }
+
+
+            /// <summary>
+            /// return true if the current segment is empty (doesn't have any element available to dequeue,
+            /// false otherwise
+            /// </summary>
+            internal bool IsEmpty
+            {
+                get { return (Low > High); }
+            }
+
+            /// <summary>
+            /// Add an element to the tail of the current segment
+            /// exclusively called by ConcurrentQueue.InitializedFromCollection
+            /// InitializeFromCollection is responsible to guaratee that there is no index overflow,
+            /// and there is no contention
+            /// </summary>
+            /// <param name="value"></param>
+            internal void UnsafeAdd(T value)
+            {
+                // Contract.Assert(m_high < SEGMENT_SIZE - 1);
+                m_high++;
+                m_array[m_high] = value;
+                m_state[m_high].m_value = true;
+            }
+
+            /// <summary>
+            /// Create a new segment and append to the current one
+            /// Does not update the m_tail pointer
+            /// exclusively called by ConcurrentQueue.InitializedFromCollection
+            /// InitializeFromCollection is responsible to guaratee that there is no index overflow,
+            /// and there is no contention
+            /// </summary>
+            /// <returns>the reference to the new Segment</returns>
+            internal Segment UnsafeGrow()
+            {
+                // Contract.Assert(m_high >= SEGMENT_SIZE - 1);
+                Segment newSegment = new Segment(m_index + 1, m_source); //m_index is Int64, we don't need to worry about overflow
+                m_next = newSegment;
+                return newSegment;
+            }
+
+            /// <summary>
+            /// Create a new segment and append to the current one
+            /// Update the m_tail pointer
+            /// This method is called when there is no contention
+            /// </summary>
+            internal void Grow()
+            {
+                //no CAS is needed, since there is no contention (other threads are blocked, busy waiting)
+                Segment newSegment = new Segment(m_index + 1, m_source);  //m_index is Int64, we don't need to worry about overflow
+                m_next = newSegment;
+                // Contract.Assert(m_source.m_tail == this);
+                m_source.m_tail = m_next;
+            }
+
+
+            /// <summary>
+            /// Try to append an element at the end of this segment.
+            /// </summary>
+            /// <param name="value">the element to append</param>
+            /// <returns>true if the element is appended, false if the current segment is full</returns>
+            /// <remarks>if appending the specified element succeeds, and after which the segment is full,
+            /// then grow the segment</remarks>
+            internal bool TryAppend(T value)
+            {
+                //quickly check if m_high is already over the boundary, if so, bail out
+                if (m_high >= SEGMENT_SIZE - 1)
+                {
+                    return false;
+                }
+
+                //Now we will use a CAS to increment m_high, and store the result in newhigh.
+                //Depending on how many free spots left in this segment and how many threads are doing this Increment
+                //at this time, the returning "newhigh" can be
+                // 1) < SEGMENT_SIZE - 1 : we took a spot in this segment, and not the last one, just insert the value
+                // 2) == SEGMENT_SIZE - 1 : we took the last spot, insert the value AND grow the segment
+                // 3) > SEGMENT_SIZE - 1 : we failed to reserve a spot in this segment, we return false to
+                //    Queue.Enqueue method, telling it to try again in the next segment.
+
+                int newhigh = SEGMENT_SIZE; //initial value set to be over the boundary
+
+                //We need do Interlocked.Increment and value/state update in a finally block to ensure that they run
+                //without interuption. This is to prevent anything from happening between them, and another dequeue
+                //thread maybe spinning forever to wait for m_state[] to be true;
+                try
+                { }
+                finally
+                {
+                    newhigh = Interlocked.Increment(ref m_high);
+                    if (newhigh <= SEGMENT_SIZE - 1)
+                    {
+                        m_array[newhigh] = value;
+                        m_state[newhigh].m_value = true;
+                    }
+
+                    //if this thread takes up the last slot in the segment, then this thread is responsible
+                    //to grow a new segment. Calling Grow must be in the finally block too for reliability reason:
+                    //if thread abort during Grow, other threads will be left busy spinning forever.
+                    if (newhigh == SEGMENT_SIZE - 1)
+                    {
+                        Grow();
+                    }
+                }
+
+                //if newhigh <= SEGMENT_SIZE-1, it means the current thread successfully takes up a spot
+                return newhigh <= SEGMENT_SIZE - 1;
+            }
+
+
+            /// <summary>
+            /// try to remove an element from the head of current segment
+            /// </summary>
+            /// <param name="result">The result.</param>
+            /// <returns>return false only if the current segment is empty</returns>
+            internal bool TryRemove(out T result)
+            {
+                SpinWait spin = new SpinWait();
+                int lowLocal = Low, highLocal = High;
+                while (lowLocal <= highLocal)
+                {
+                    //try to update m_low
+                    if (Interlocked.CompareExchange(ref m_low, lowLocal + 1, lowLocal) == lowLocal)
+                    {
+                        //if the specified value is not available (this spot is taken by a push operation,
+                        // but the value is not written into yet), then spin
+                        SpinWait spinLocal = new SpinWait();
+                        while (!m_state[lowLocal].m_value)
+                        {
+                            spinLocal.SpinOnce();
+                        }
+                        result = m_array[lowLocal];
+
+                        // If there is no other thread taking snapshot (GetEnumerator(), ToList(), etc), reset the deleted entry to null.
+                        // It is ok if after this conditional check m_numSnapshotTakers becomes > 0, because new snapshots won't include
+                        // the deleted entry at m_array[lowLocal].
+                        if (m_source.m_numSnapshotTakers <= 0)
+                        {
+                            m_array[lowLocal] = default(T); //release the reference to the object.
+                        }
+
+                        //if the current thread sets m_low to SEGMENT_SIZE, which means the current segment becomes
+                        //disposable, then this thread is responsible to dispose this segment, and reset m_head
+                        if (lowLocal + 1 >= SEGMENT_SIZE)
+                        {
+                            //  Invariant: we only dispose the current m_head, not any other segment
+                            //  In usual situation, disposing a segment is simply seting m_head to m_head.m_next
+                            //  But there is one special case, where m_head and m_tail points to the same and ONLY
+                            //segment of the queue: Another thread A is doing Enqueue and finds that it needs to grow,
+                            //while the *current* thread is doing *this* Dequeue operation, and finds that it needs to
+                            //dispose the current (and ONLY) segment. Then we need to wait till thread A finishes its
+                            //Grow operation, this is the reason of having the following while loop
+                            spinLocal = new SpinWait();
+                            while (m_next == null)
+                            {
+                                spinLocal.SpinOnce();
+                            }
+                            // Contract.Assert(m_source.m_head == this);
+                            m_source.m_head = m_next;
+                        }
+                        return true;
+                    }
+                    else
+                    {
+                        //CAS failed due to contention: spin briefly and retry
+                        spin.SpinOnce();
+                        lowLocal = Low; highLocal = High;
+                    }
+                }//end of while
+                result = default(T);
+                return false;
+            }
+
+            /// <summary>
+            /// try to peek the current segment
+            /// </summary>
+            /// <param name="result">holds the return value of the element at the head position,
+            /// value set to default(T) if there is no such an element</param>
+            /// <returns>true if there are elements in the current segment, false otherwise</returns>
+            internal bool TryPeek(out T result)
+            {
+                result = default(T);
+                int lowLocal = Low;
+                if (lowLocal > High)
+                    return false;
+                SpinWait spin = new SpinWait();
+                while (!m_state[lowLocal].m_value)
+                {
+                    spin.SpinOnce();
+                }
+                result = m_array[lowLocal];
+                return true;
+            }
+
+            /// <summary>
+            /// Adds part or all of the current segment into a List.
+            /// </summary>
+            /// <param name="list">the list to which to add</param>
+            /// <param name="start">the start position</param>
+            /// <param name="end">the end position</param>
+            internal void AddToList(List<T> list, int start, int end)
+            {
+                for (int i = start; i <= end; i++)
+                {
+                    SpinWait spin = new SpinWait();
+                    while (!m_state[i].m_value)
+                    {
+                        spin.SpinOnce();
+                    }
+                    list.Add(m_array[i]);
+                }
+            }
+
+            /// <summary>
+            /// return the position of the head of the current segment
+            /// Value range [0, SEGMENT_SIZE], if it's SEGMENT_SIZE, it means this segment is exhausted and thus empty
+            /// </summary>
+            internal int Low
+            {
+                get
+                {
+                    return Math.Min(m_low, SEGMENT_SIZE);
+                }
+            }
+
+            /// <summary>
+            /// return the logical position of the tail of the current segment
+            /// Value range [-1, SEGMENT_SIZE-1]. When it's -1, it means this is a new segment and has no elemnet yet
+            /// </summary>
+            internal int High
+            {
+                get
+                {
+                    //if m_high > SEGMENT_SIZE, it means it's out of range, we should return
+                    //SEGMENT_SIZE-1 as the logical position
+                    return Math.Min(m_high, SEGMENT_SIZE - 1);
+                }
+            }
+
+        }
+    }//end of class Segment
+
+    /// <summary>
+    /// A wrapper struct for volatile bool, please note the copy of the struct it self will not be volatile
+    /// for example this statement will not include in volatilness operation volatileBool1 = volatileBool2 the jit will copy the struct and will ignore the volatile
+    /// </summary>
+    struct VolatileBool
+    {
+        public VolatileBool(bool value)
+        {
+            m_value = value;
+        }
+        public volatile bool m_value;
+    }
 }
+
 #endif

--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
@@ -1,34 +1,26 @@
-// IConcurrentCollection.cs
-//
-// Copyright (c) 2008 Jérémie "Garuma" Laval
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-//
-
 #if NET20 || NET35
-using System;
+// ==++==
+//
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+// ==--==
+// =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+//
+// IProducerConsumerCollection.cs
+//
+// <OWNER>Microsoft</OWNER>
+//
+// A common interface for all concurrent collections.
+//
+// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Collections.Concurrent
 {
+
     /// <summary>
     /// Defines methods to manipulate thread-safe collections intended for producer/consumer usage.
     /// </summary>
@@ -37,34 +29,8 @@ namespace System.Collections.Concurrent
     /// All implementations of this interface must enable all members of this interface
     /// to be used concurrently from multiple threads.
     /// </remarks>
-	internal interface IProducerConsumerCollection<T> : IEnumerable<T>, ICollection, IEnumerable
-	{
-        /// <summary>
-        /// Attempts to add an object to the <see
-        /// cref="IProducerConsumerCollection{T}"/>.
-        /// </summary>
-        /// <param name="item">The object to add to the <see
-        /// cref="IProducerConsumerCollection{T}"/>.</param>
-        /// <returns>true if the object was added successfully; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="item"/> was invalid for this collection.</exception>
-		bool TryAdd (T item);
-
-        /// <summary>
-        /// Attempts to remove and return an object from the <see cref="IProducerConsumerCollection{T}"/>.
-        /// </summary>
-        /// <param name="item">
-        /// When this method returns, if the object was removed and returned successfully, <paramref
-        /// name="item"/> contains the removed object. If no object was available to be removed, the value is
-        /// unspecified.
-        /// </param>
-        /// <returns>true if an object was removed and returned successfully; otherwise, false.</returns>
-		bool TryTake (out T item);
-
-        /// <summary>
-        /// Copies the elements contained in the <see cref="IProducerConsumerCollection{T}"/> to a new array.
-        /// </summary>
-        /// <returns>A new array containing the elements copied from the <see cref="IProducerConsumerCollection{T}"/>.</returns>
-		T[] ToArray ();
+    public interface IProducerConsumerCollection<T> : IEnumerable<T>, ICollection
+    {
 
         /// <summary>
         /// Copies the elements of the <see cref="IProducerConsumerCollection{T}"/> to
@@ -86,7 +52,70 @@ namespace System.Collections.Concurrent
         /// available space from <paramref name="index"/> to the end of the destination <paramref
         /// name="array"/>.
         /// </exception>
-		void CopyTo (T[] array, int index);
-	}
+        void CopyTo(T[] array, int index);
+
+        /// <summary>
+        /// Attempts to add an object to the <see
+        /// cref="IProducerConsumerCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to add to the <see
+        /// cref="IProducerConsumerCollection{T}"/>.</param>
+        /// <returns>true if the object was added successfully; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="item"/> was invalid for this collection.</exception>
+        bool TryAdd(T item);
+
+        /// <summary>
+        /// Attempts to remove and return an object from the <see cref="IProducerConsumerCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        /// When this method returns, if the object was removed and returned successfully, <paramref
+        /// name="item"/> contains the removed object. If no object was available to be removed, the value is
+        /// unspecified.
+        /// </param>
+        /// <returns>true if an object was removed and returned successfully; otherwise, false.</returns>
+        bool TryTake(out T item);
+
+        /// <summary>
+        /// Copies the elements contained in the <see cref="IProducerConsumerCollection{T}"/> to a new array.
+        /// </summary>
+        /// <returns>A new array containing the elements copied from the <see cref="IProducerConsumerCollection{T}"/>.</returns>
+        T[] ToArray();
+
+    }
+
+
+    /// <summary>
+    /// A debugger view of the IProducerConsumerCollection that makes it simple to browse the
+    /// collection's contents at a point in time.
+    /// </summary>
+    /// <typeparam name="T">The type of elements stored within.</typeparam>
+    internal sealed class SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<T>
+    {
+        private IProducerConsumerCollection<T> m_collection; // The collection being viewed.
+
+        /// <summary>
+        /// Constructs a new debugger view object for the provided collection object.
+        /// </summary>
+        /// <param name="collection">A collection to browse in the debugger.</param>
+        public SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView(IProducerConsumerCollection<T> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+
+            m_collection = collection;
+        }
+
+        /// <summary>
+        /// Returns a snapshot of the underlying collection's elements.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get { return m_collection.ToArray(); }
+        }
+
+    }
 }
 #endif

--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -1,139 +1,363 @@
+#if NET20 || NET35
+// ==++==
+//
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+// ==--==
+// =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+//
 // SpinWait.cs
 //
-// Copyright (c) 2008 Jérémie "Garuma" Laval
+// <OWNER>Microsoft</OWNER>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+// Central spin logic used across the entire code-base.
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-//
+// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-#if NET20 || NET35
 using System;
-using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Security.Permissions;
+using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Threading
 {
+    // SpinWait is just a little value type that encapsulates some common spinning
+    // logic. It ensures we always yield on single-proc machines (instead of using busy
+    // waits), and that we work well on HT. It encapsulates a good mixture of spinning
+    // and real yielding. It's a value type so that various areas of the engine can use
+    // one by allocating it on the stack w/out unnecessary GC allocation overhead, e.g.:
+    //
+    //     void f() {
+    //         SpinWait wait = new SpinWait();
+    //         while (!p) { wait.SpinOnce(); }
+    //         ...
+    //     }
+    //
+    // Internally it just maintains a counter that is used to decide when to yield, etc.
+    //
+    // A common usage is to spin before blocking. In those cases, the NextSpinWillYield
+    // property allows a user to decide to fall back to waiting once it returns true:
+    //
+    //     void f() {
+    //         SpinWait wait = new SpinWait();
+    //         while (!p) {
+    //             if (wait.NextSpinWillYield) { /* block! */ }
+    //             else { wait.SpinOnce(); }
+    //         }
+    //         ...
+    //     }
+
     /// <summary>
-    ///
+    /// Provides support for spin-based waiting.
     /// </summary>
-	internal struct SpinWait
-	{
-		// The number of step until SpinOnce yield on multicore machine
-		const           int  step = 10;
-		const           int  maxTime = 200;
-		static readonly bool isSingleCpu = (Environment.ProcessorCount == 1);
-		int ntime;
+    /// <remarks>
+    /// <para>
+    /// <see cref="SpinWait"/> encapsulates common spinning logic. On single-processor machines, yields are
+    /// always used instead of busy waits, and on computers with Intel� processors employing Hyper-Threading�
+    /// technology, it helps to prevent hardware thread starvation. SpinWait encapsulates a good mixture of
+    /// spinning and true yielding.
+    /// </para>
+    /// <para>
+    /// <see cref="SpinWait"/> is a value type, which means that low-level code can utilize SpinWait without
+    /// fear of unnecessary allocation overheads. SpinWait is not generally useful for ordinary applications.
+    /// In most cases, you should use the synchronization classes provided by the .NET Framework, such as
+    /// <see cref="System.Threading.Monitor"/>. For most purposes where spin waiting is required, however,
+    /// the <see cref="SpinWait"/> type should be preferred over the <see
+    /// cref="System.Threading.Thread.SpinWait"/> method.
+    /// </para>
+    /// <para>
+    /// While SpinWait is designed to be used in concurrent applications, it is not designed to be
+    /// used from multiple threads concurrently.  SpinWait's members are not thread-safe.  If multiple
+    /// threads must spin, each should use its own instance of SpinWait.
+    /// </para>
+    /// </remarks>
+    [HostProtection(Synchronization = true, ExternalThreading = true)]
+    public struct SpinWait
+    {
+
+        // These constants determine the frequency of yields versus spinning. The
+        // numbers may seem fairly arbitrary, but were derived with at least some
+        // thought in the design document.  I fully expect they will need to change
+        // over time as we gain more experience with performance.
+        internal const int YIELD_THRESHOLD = 10; // When to switch over to a true yield.
+        internal const int SLEEP_0_EVERY_HOW_MANY_TIMES = 5; // After how many yields should we Sleep(0)?
+        internal const int SLEEP_1_EVERY_HOW_MANY_TIMES = 20; // After how many yields should we Sleep(1)?
+
+        // The number of times we've spun already.
+        private int m_count;
 
         /// <summary>
-        ///
+        /// Gets the number of times <see cref="SpinOnce"/> has been called on this instance.
         /// </summary>
-		public void SpinOnce ()
-		{
-			ntime += 1;
+        public int Count
+        {
+            get { return m_count; }
+        }
 
-			if (isSingleCpu) {
-                // On a single-CPU system, spinning does no good
-#if NET20 || NET35
-                Thread.Sleep(ntime % step == 0 ? 1 : 0);
-#else
-                Thread.Yield ();
-#endif
-			}
-			else {
-				if (ntime % step == 0)
-#if NET20 || NET35
+        /// <summary>
+        /// Gets whether the next call to <see cref="SpinOnce"/> will yield the processor, triggering a
+        /// forced context switch.
+        /// </summary>
+        /// <value>Whether the next call to <see cref="SpinOnce"/> will yield the processor, triggering a
+        /// forced context switch.</value>
+        /// <remarks>
+        /// On a single-CPU machine, <see cref="SpinOnce"/> always yields the processor. On machines with
+        /// multiple CPUs, <see cref="SpinOnce"/> may yield after an unspecified number of calls.
+        /// </remarks>
+        public bool NextSpinWillYield
+        {
+            get { return m_count > YIELD_THRESHOLD || PlatformHelper.IsSingleProcessor; }
+        }
+
+        /// <summary>
+        /// Performs a single spin.
+        /// </summary>
+        /// <remarks>
+        /// This is typically called in a loop, and may change in behavior based on the number of times a
+        /// <see cref="SpinOnce"/> has been called thus far on this instance.
+        /// </remarks>
+        public void SpinOnce()
+        {
+            if (NextSpinWillYield)
+            {
+                //
+                // We must yield.
+                //
+                // We prefer to call Thread.Yield first, triggering a SwitchToThread. This
+                // unfortunately doesn't consider all runnable threads on all OS SKUs. In
+                // some cases, it may only consult the runnable threads whose ideal processor
+                // is the one currently executing code. Thus we oc----ionally issue a call to
+                // Sleep(0), which considers all runnable threads at equal priority. Even this
+                // is insufficient since we may be spin waiting for lower priority threads to
+                // execute; we therefore must call Sleep(1) once in a while too, which considers
+                // all runnable threads, regardless of ideal processor and priority, but may
+                // remove the thread from the scheduler's queue for 10+ms, if the system is
+                // configured to use the (default) coarse-grained system timer.
+                //
+
+                int yieldsSoFar = (m_count >= YIELD_THRESHOLD ? m_count - YIELD_THRESHOLD : m_count);
+
+                if ((yieldsSoFar % SLEEP_1_EVERY_HOW_MANY_TIMES) == (SLEEP_1_EVERY_HOW_MANY_TIMES - 1))
+                {
                     Thread.Sleep(1);
-#else
-                    Thread.Yield ();
+                }
+                else // if ((yieldsSoFar % SLEEP_0_EVERY_HOW_MANY_TIMES) == (SLEEP_0_EVERY_HOW_MANY_TIMES - 1))
+                {
+                    Thread.Sleep(0);
+                }
+                //else
+                //{
+                //    Thread.Yield();
+                //}
+            }
+            else
+            {
+                //
+                // Otherwise, we will spin.
+                //
+                // We do this using the CLR's SpinWait API, which is just a busy loop that
+                // issues YIELD/PAUSE instructions to ensure multi-threaded CPUs can react
+                // intelligently to avoid starving. (These are NOOPs on other CPUs.) We
+                // choose a number for the loop iteration count such that each successive
+                // call spins for longer, to reduce cache contention.  We cap the total
+                // number of spins we are willing to tolerate to reduce delay to the caller,
+                // since we expect most callers will eventually block anyway.
+                //
+                Thread.SpinWait(4 << m_count);
+            }
+
+            // Finally, increment our spin counter.
+            m_count = (m_count == int.MaxValue ? YIELD_THRESHOLD : m_count + 1);
+        }
+
+        /// <summary>
+        /// Resets the spin counter.
+        /// </summary>
+        /// <remarks>
+        /// This makes <see cref="SpinOnce"/> and <see cref="NextSpinWillYield"/> behave as though no calls
+        /// to <see cref="SpinOnce"/> had been issued on this instance. If a <see cref="SpinWait"/> instance
+        /// is reused many times, it may be useful to reset it to avoid yielding too soon.
+        /// </remarks>
+        public void Reset()
+        {
+            m_count = 0;
+        }
+
+        #region Static Methods
+        /// <summary>
+        /// Spins until the specified condition is satisfied.
+        /// </summary>
+        /// <param name="condition">A delegate to be executed over and over until it returns true.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="condition"/> argument is null.</exception>
+        public static void SpinUntil(Func<bool> condition)
+        {
+#if DEBUG
+            bool result =
 #endif
-                else
-                    // Multi-CPU system might be hyper-threaded, let other thread run
-                    Thread.SpinWait (Math.Min (ntime, maxTime) << 1);
-			}
-		}
+            SpinUntil(condition, Timeout.Infinite);
+#if DEBUG
+            // Contract.Assert(result);
+#endif
+        }
 
         /// <summary>
-        ///
+        /// Spins until the specified condition is satisfied or until the specified timeout is expired.
         /// </summary>
-        /// <param name="condition"></param>
-		public static void SpinUntil (Func<bool> condition)
-		{
-			SpinWait sw = new SpinWait ();
-			while (!condition ())
-				sw.SpinOnce ();
-		}
+        /// <param name="condition">A delegate to be executed over and over until it returns true.</param>
+        /// <param name="timeout">
+        /// A <see cref="TimeSpan"/> that represents the number of milliseconds to wait,
+        /// or a TimeSpan that represents -1 milliseconds to wait indefinitely.</param>
+        /// <returns>True if the condition is satisfied within the timeout; otherwise, false</returns>
+        /// <exception cref="ArgumentNullException">The <paramref name="condition"/> argument is null.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
+        /// other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than
+        /// <see cref="System.Int32.MaxValue"/>.</exception>
+        public static bool SpinUntil(Func<bool> condition, TimeSpan timeout)
+        {
+            // Validate the timeout
+            Int64 totalMilliseconds = (Int64)timeout.TotalMilliseconds;
+            if (totalMilliseconds < -1 || totalMilliseconds > Int32.MaxValue)
+            {
+                throw new System.ArgumentOutOfRangeException(
+                    "timeout", timeout, "SpinWait SpinUntil Timeout Wrong");
+            }
+
+            // Call wait with the timeout milliseconds
+            return SpinUntil(condition, (int)timeout.TotalMilliseconds);
+        }
 
         /// <summary>
-        ///
+        /// Spins until the specified condition is satisfied or until the specified timeout is expired.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="timeout"></param>
+        /// <param name="condition">A delegate to be executed over and over until it returns true.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
+        /// cref="System.Threading.Timeout.Infinite"/> (-1) to wait indefinitely.</param>
+        /// <returns>True if the condition is satisfied within the timeout; otherwise, false</returns>
+        /// <exception cref="ArgumentNullException">The <paramref name="condition"/> argument is null.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// negative number other than -1, which represents an infinite time-out.</exception>
+        public static bool SpinUntil(Func<bool> condition, int millisecondsTimeout)
+        {
+            if (millisecondsTimeout < Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException("millisecondsTimeout");
+            }
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
+            uint startTime = 0;
+            if (millisecondsTimeout != 0 && millisecondsTimeout != Timeout.Infinite)
+            {
+                startTime = TimeoutHelper.GetTime();
+            }
+            SpinWait spinner = new SpinWait();
+            while (!condition())
+            {
+                if (millisecondsTimeout == 0)
+                {
+                    return false;
+                }
+
+                spinner.SpinOnce();
+
+                if (millisecondsTimeout != Timeout.Infinite && spinner.NextSpinWillYield)
+                {
+                    if (millisecondsTimeout <= (TimeoutHelper.GetTime() - startTime))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+
+        }
+        #endregion
+
+    }
+
+
+    /// <summary>
+    /// A helper class to get the number of processors, it updates the numbers of processors every sampling interval.
+    /// </summary>
+    internal static class PlatformHelper
+    {
+        private const int PROCESSOR_COUNT_REFRESH_INTERVAL_MS = 30000; // How often to refresh the count, in milliseconds.
+        private static volatile int s_processorCount; // The last count seen.
+        private static volatile int s_lastProcessorCountRefreshTicks; // The last time we refreshed.
+
+        /// <summary>
+        /// Gets the number of available processors
+        /// </summary>
+        [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "Reviewed for thread safety")]
+        internal static int ProcessorCount
+        {
+            get
+            {
+                int now = Environment.TickCount;
+                int procCount = s_processorCount;
+                if (procCount == 0 || (now - s_lastProcessorCountRefreshTicks) >= PROCESSOR_COUNT_REFRESH_INTERVAL_MS)
+                {
+                    s_processorCount = procCount = Environment.ProcessorCount;
+                    s_lastProcessorCountRefreshTicks = now;
+                }
+
+                return procCount;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the current machine has only a single processor.
+        /// </summary>
+        internal static bool IsSingleProcessor
+        {
+            get { return ProcessorCount == 1; }
+        }
+    }
+
+    /// <summary>
+    /// A helper class to capture a start time using Environment.TickCout as a time in milliseconds, also updates a given timeout bu subtracting the current time from
+    /// the start time
+    /// </summary>
+    internal static class TimeoutHelper
+    {
+        /// <summary>
+        /// Returns the Environment.TickCount as a start time in milliseconds as a uint, TickCount tools over from postive to negative every ~ 25 days
+        /// then ~25 days to back to positive again, uint is sued to ignore the sign and double the range to 50 days
+        /// </summary>
         /// <returns></returns>
-		public static bool SpinUntil (Func<bool> condition, TimeSpan timeout)
-		{
-			return SpinUntil (condition, (int)timeout.TotalMilliseconds);
-		}
+        public static uint GetTime()
+        {
+            return (uint)Environment.TickCount;
+        }
 
         /// <summary>
-        ///
+        /// Helper function to measure and update the elapsed time
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="millisecondsTimeout"></param>
-        /// <returns></returns>
-		public static bool SpinUntil (Func<bool> condition, int millisecondsTimeout)
-		{
-			SpinWait sw = new SpinWait ();
-			Stopwatch watch = Stopwatch.StartNew ();
+        /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
+        /// <param name="originalWaitMillisecondsTimeout">The orginal wait timeoutout in milliseconds</param>
+        /// <returns>The new wait time in milliseconds, -1 if the time expired</returns>
+        public static int UpdateTimeOut(uint startTime, int originalWaitMillisecondsTimeout)
+        {
+            uint elapsedMilliseconds = (GetTime() - startTime);
 
-			while (!condition ()) {
-				if (watch.ElapsedMilliseconds > millisecondsTimeout)
-					return false;
-				sw.SpinOnce ();
-			}
+            // Check the elapsed milliseconds is greater than max int because this property is uint
+            if (elapsedMilliseconds > int.MaxValue)
+            {
+                return 0;
+            }
 
-			return true;
-		}
+            // Subtract the elapsed time from the current wait time
+            int currentWaitTimeout = originalWaitMillisecondsTimeout - (int)elapsedMilliseconds; ;
+            if (currentWaitTimeout <= 0)
+            {
+                return 0;
+            }
 
-        /// <summary>
-        ///
-        /// </summary>
-		public void Reset ()
-		{
-			ntime = 0;
-		}
+            return currentWaitTimeout;
+        }
+    }
 
-        /// <summary>
-        ///
-        /// </summary>
-		public bool NextSpinWillYield {
-			get {
-				return isSingleCpu ? true : ntime % step == 0;
-			}
-		}
-
-        /// <summary>
-        ///
-        /// </summary>
-		public int Count {
-			get {
-				return ntime;
-			}
-		}
-	}
 }
 #endif


### PR DESCRIPTION
This is intended to address #2579 by replacing the thread related compatibility classes with the latest copies from Mono. I don't say fix above because I would like to leave #2579 open until we have run in CI for a few weeks without failure.

As commented in #2579, I managed to reproduce some of the errors by running the .NET 3.5 tests at the same time in multiple console windows. After making these changes, I have not been able to reproduce. I will rebuild the AppVeyor build a few times to double check.

My main concern with these changes are licensing. The source originally came from the .NET Framework reference source (via Mono) which is available on GitHub at https://github.com/Microsoft/referencesource. The readme there states that all of the source is now under MIT license unless otherwise noted in the headers of the files. The problem is, as far as I can tell, none of the headers in any of those files say MIT license, they all say Copyright Microsoft. My thinking is that if the source wasn't MIT as the root license and README say, then it would explicitly say so. To back that up, Mono is using the source and Mono is MIT. I also took my copies from Mono.

@jnm2 you've been tapped into the open sourcing of .NET more than I have. What have you read or seen? I can also contact the .NET Foundation.

Back to technical issues, I did make a couple of small changes to the files. I will add inline comments for those.