### PR TITLE
Avoid treating warnings as errors inside the IDE

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -3,12 +3,16 @@
   <PropertyGroup>
     <LangVersion>6</LangVersion>
     <Features>strict</Features>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <!-- Ideally this is always enabled, but that tends to hurt developer productivity -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change helps improve developer inner loop efficiency by revealing but not _demanding attention_ for warnings that occur during normal iterative development. Anything missed will still be caught by the CI and command line builds.

💡 Please do not rebase or squash this pull request on merge.