### PR TITLE
ExpectedResult of TestCaseAttribute should support same conversions as method arguments

### DIFF
--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -115,12 +115,30 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(1942, dt.Year);
         }
 
+        [TestCase("1942-10-12")]
+        public void CanConvertIso8601DateStringToDateTime(DateTime dt)
+        {
+            Assert.AreEqual(new DateTime(1942,10,12), dt);
+        }
+
+        [TestCase("1942-10-12", ExpectedResult = "1942-10-12")]
+        public DateTime CanConvertExpectedResultStringToDateTime(DateTime dt)
+        {
+            return dt;
+        }
+
         [TestCase("4:44:15")]
         public void CanConvertStringToTimeSpan(TimeSpan ts)
         {
             Assert.AreEqual(4, ts.Hours);
             Assert.AreEqual(44, ts.Minutes);
             Assert.AreEqual(15, ts.Seconds);
+        }
+
+        [TestCase("4:44:15", ExpectedResult = "4:44:15")]
+        public TimeSpan CanConvertExpectedResultStringToTimeSpan(TimeSpan ts)
+        {
+            return ts;
         }
 
         [TestCase(null)]


### PR DESCRIPTION
This is my suggested fix for #2734.

My goal was to change as little as necessary, therefore ExpectedResult is set a second time after TestCaseParameters instance is created. It's set the first time in the constructor of TestCaseParameters, but I didn't want to touch ITestCaseData.
I simply extracted the actual argument conversion from the existing PerformSpecialConversions (plural) into a new method PerformSpecialConversion (singular) which handles individual arguments.