### PR TITLE
Include type in invalid PropertyConstraint error message.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Constraints
 
             // TODO: Use an error result here
             if (property == null)
-                throw new ArgumentException(string.Format("Property {0} was not found", name), "name");
+                throw new ArgumentException($"Property {name} was not found on {actualType}.", "name");
 
             propValue = property.GetValue(actual, null);
             var baseResult = BaseConstraint.ApplyTo(propValue);

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -112,10 +112,18 @@ namespace NUnit.Framework.Constraints
             object value = null;
             Assert.Throws<ArgumentNullException>(() => theConstraint.ApplyTo(value));
         }
+
         [Test]
         public void InvalidDataThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => theConstraint.ApplyTo(42));
+        }
+
+        [Test]
+        public void InvalidPropertyExceptionMessageContainsTypeName()
+        {
+            Assert.That(() => theConstraint.ApplyTo(42),
+                Throws.ArgumentException.With.Message.Contains("System.Int32"));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #2405 

We talked a lot about this issue, but I think got a bit lost in the semantics. This simple string change is all I needed to fix my issue of not being sure what type I am testing against.

Personally, I have no concern as to whether this is reported as an error or failure - although think the current behaviour here is perhaps 'more semantically accurate' with our current architecture, so don't feel the need to rewrite anything! 😄 