### PR TITLE
Add NUnitCallContext to clean-up CallContext around FrameworkController actions

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -473,15 +473,21 @@ namespace NUnit.Framework.Api
 
 #endregion
 
+#region Nested Action Classes
+
 #region TestContollerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions
         /// performed against a FrameworkController.
         /// </summary>
-        public abstract class FrameworkControllerAction : LongLivedMarshalByRefObject { }
+        public abstract class FrameworkControllerAction : LongLivedMarshalByRefObject
+        {
+        }
 
-        #region LoadTestsAction
+#endregion
+
+#region LoadTestsAction
 
         /// <summary>
         /// LoadTestsAction loads a test into the FrameworkController

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -483,6 +483,22 @@ namespace NUnit.Framework.Api
         /// </summary>
         public abstract class FrameworkControllerAction : LongLivedMarshalByRefObject
         {
+            /// <summary>
+            /// Wrap in NUnitCallContext executes the action within an NUnitCallContext
+            /// which ensures System.Runtime.Remoting.Messaging.CallContext is cleaned up
+            /// suitably at the end of the test run. This method only has an effect running
+            /// the full .NET Framework.
+            /// </summary>
+            /// <param name="action"></param>
+            protected void WrapInNUnitCallContext(Action action)
+            {
+#if !(NET20 || NET35 || NET40 || NET45)
+                action();
+#else
+                using (new NUnitCallContext())
+                    action();
+#endif
+            }
         }
 
 #endregion
@@ -501,7 +517,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">The callback handler.</param>
             public LoadTestsAction(FrameworkController controller, object handler)
             {
-                controller.LoadTests((ICallbackEventHandler)handler);
+                WrapInNUnitCallContext(() => controller.LoadTests((ICallbackEventHandler)handler));
             }
         }
 
@@ -522,7 +538,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">The callback handler.</param>
             public ExploreTestsAction(FrameworkController controller, string filter, object handler)
             {
-                controller.ExploreTests((ICallbackEventHandler)handler, filter);
+                WrapInNUnitCallContext(() => controller.ExploreTests((ICallbackEventHandler)handler, filter));
             }
         }
 
@@ -544,7 +560,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public CountTestsAction(FrameworkController controller, string filter, object handler)
             {
-                controller.CountTests((ICallbackEventHandler)handler, filter);
+                WrapInNUnitCallContext(() => controller.CountTests((ICallbackEventHandler)handler, filter));
             }
         }
 
@@ -565,7 +581,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public RunTestsAction(FrameworkController controller, string filter, object handler)
             {
-                controller.RunTests((ICallbackEventHandler)handler, filter);
+                WrapInNUnitCallContext(() => controller.RunTests((ICallbackEventHandler)handler, filter));
             }
         }
 
@@ -586,7 +602,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public RunAsyncAction(FrameworkController controller, string filter, object handler)
             {
-                controller.RunAsync((ICallbackEventHandler)handler, filter);
+                WrapInNUnitCallContext(() => controller.RunAsync((ICallbackEventHandler)handler, filter));
             }
         }
 
@@ -609,7 +625,7 @@ namespace NUnit.Framework.Api
             /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
             public StopRunAction(FrameworkController controller, bool force, object handler)
             {
-                controller.StopRun((ICallbackEventHandler)handler, force);
+                WrapInNUnitCallContext(() => controller.StopRun((ICallbackEventHandler)handler, force));
             }
         }
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -473,37 +473,15 @@ namespace NUnit.Framework.Api
 
 #endregion
 
-#region Nested Action Classes
-
 #region TestContollerAction
 
         /// <summary>
         /// FrameworkControllerAction is the base class for all actions
         /// performed against a FrameworkController.
         /// </summary>
-        public abstract class FrameworkControllerAction : LongLivedMarshalByRefObject
-        {
-            /// <summary>
-            /// Wrap in NUnitCallContext executes the action within an NUnitCallContext
-            /// which ensures System.Runtime.Remoting.Messaging.CallContext is cleaned up
-            /// suitably at the end of the test run. This method only has an effect running
-            /// the full .NET Framework.
-            /// </summary>
-            /// <param name="action"></param>
-            protected void WrapInNUnitCallContext(Action action)
-            {
-#if !(NET20 || NET35 || NET40 || NET45)
-                action();
-#else
-                using (new NUnitCallContext())
-                    action();
-#endif
-            }
-        }
+        public abstract class FrameworkControllerAction : LongLivedMarshalByRefObject { }
 
-#endregion
-
-#region LoadTestsAction
+        #region LoadTestsAction
 
         /// <summary>
         /// LoadTestsAction loads a test into the FrameworkController
@@ -517,7 +495,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">The callback handler.</param>
             public LoadTestsAction(FrameworkController controller, object handler)
             {
-                WrapInNUnitCallContext(() => controller.LoadTests((ICallbackEventHandler)handler));
+                controller.LoadTests((ICallbackEventHandler)handler);
             }
         }
 
@@ -538,7 +516,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">The callback handler.</param>
             public ExploreTestsAction(FrameworkController controller, string filter, object handler)
             {
-                WrapInNUnitCallContext(() => controller.ExploreTests((ICallbackEventHandler)handler, filter));
+                controller.ExploreTests((ICallbackEventHandler)handler, filter);
             }
         }
 
@@ -560,7 +538,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public CountTestsAction(FrameworkController controller, string filter, object handler)
             {
-                WrapInNUnitCallContext(() => controller.CountTests((ICallbackEventHandler)handler, filter));
+                controller.CountTests((ICallbackEventHandler)handler, filter);
             }
         }
 
@@ -581,7 +559,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public RunTestsAction(FrameworkController controller, string filter, object handler)
             {
-                WrapInNUnitCallContext(() => controller.RunTests((ICallbackEventHandler)handler, filter));
+                controller.RunTests((ICallbackEventHandler)handler, filter);
             }
         }
 
@@ -602,7 +580,7 @@ namespace NUnit.Framework.Api
             /// <param name="handler">A callback handler used to report results</param>
             public RunAsyncAction(FrameworkController controller, string filter, object handler)
             {
-                WrapInNUnitCallContext(() => controller.RunAsync((ICallbackEventHandler)handler, filter));
+                controller.RunAsync((ICallbackEventHandler)handler, filter);
             }
         }
 
@@ -625,7 +603,7 @@ namespace NUnit.Framework.Api
             /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
             public StopRunAction(FrameworkController controller, bool force, object handler)
             {
-                WrapInNUnitCallContext(() => controller.StopRun((ICallbackEventHandler)handler, force));
+                controller.StopRun((ICallbackEventHandler)handler, force);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
@@ -30,9 +30,9 @@ using System.Security;
 namespace NUnit.Framework.Internal
 {
     /// <summary>
-    /// This class ensures the CallContext is correctly cleared or restored around framework actions.
-    /// This is important if running multiple assemblies within the same process, to ensure no leakage
-    /// from one assembly to the next. See https://github.com/nunit/nunit-console/issues/325
+    /// This class ensures the <see cref="System.Runtime.Remoting.Messaging.CallContext"/> is correctly cleared
+    /// or restored around framework actions. This is important if running multiple assemblies within the same
+    /// process, to ensure no leakage from one assembly to the next. See https://github.com/nunit/nunit-console/issues/325
     /// </summary>
     internal class NUnitCallContext : IDisposable
     {
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Internal
         [SecuritySafeCritical]
         public NUnitCallContext()
         {
-            _oldContext = CallContext.GetData("NUnit.Framework.TestExecutionContext") as TestExecutionContext;
+            _oldContext = CallContext.GetData(TestExecutionContextKey);
         }
 
         [SecuritySafeCritical]

--- a/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
@@ -1,0 +1,61 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if NET20 || NET35 || NET40 || NET45
+using System;
+using System.Runtime.Remoting.Messaging;
+using System.Security;
+
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// This class ensures the CallContext is correctly cleared or restored around framework actions.
+    /// This is important if running multiple assemblies within the same process, to ensure no leakage
+    /// from one assembly to the next. See https://github.com/nunit/nunit-console/issues/325
+    /// </summary>
+    internal class NUnitCallContext : IDisposable
+    {
+        private readonly object _oldContext;
+        public const string TestExecutionContextKey = "NUnit.Framework.TestExecutionContext";
+
+        // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
+        // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
+        // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
+        [SecuritySafeCritical]
+        public NUnitCallContext()
+        {
+            _oldContext = CallContext.GetData("NUnit.Framework.TestExecutionContext") as TestExecutionContext;
+        }
+
+        [SecuritySafeCritical]
+        public void Dispose()
+        {
+            if (_oldContext == null)
+                CallContext.FreeNamedDataSlot(TestExecutionContextKey);
+            else
+                CallContext.SetData(TestExecutionContextKey, _oldContext);
+        }
+    }
+}
+#endif

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -162,39 +162,37 @@ namespace NUnit.Framework.Internal
         }
 #else
         // In all other builds, we use the CallContext
-        private static readonly string CONTEXT_KEY = "NUnit.Framework.TestContext";
-
         /// <summary>
         /// Gets and sets the current context.
         /// </summary>
         public static TestExecutionContext CurrentContext
         {
-            // This getter invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
+            // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
             // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
             // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
             [SecuritySafeCritical]
             get
             {
-                var context = CallContext.GetData(CONTEXT_KEY) as TestExecutionContext;
+                var context = CallContext.GetData(NUnitCallContext.TestExecutionContextKey) as TestExecutionContext;
 
                 if (context == null)
                 {
                     context = new AdhocContext();
-                    CallContext.SetData(CONTEXT_KEY, context);
+                    CallContext.SetData(NUnitCallContext.TestExecutionContextKey, context);
                 }
 
                 return context;
             }
-            // This setter invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
+            // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
             // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
             // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
             [SecuritySafeCritical]
             private set
             {
                 if (value == null)
-                    CallContext.FreeNamedDataSlot(CONTEXT_KEY);
+                    CallContext.FreeNamedDataSlot(NUnitCallContext.TestExecutionContextKey);
                 else
-                    CallContext.SetData(CONTEXT_KEY, value);
+                    CallContext.SetData(NUnitCallContext.TestExecutionContextKey, value);
             }
         }
 #endif

--- a/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Api
                 {
                     { FrameworkPackageSettings.RunOnMainThread, true }
                 };
-                var controller = new FrameworkController(MockAssemblyFile, "ID", settings);
+                var controller = new FrameworkController(MockAssemblyFile, Test.IdPrefix, settings);
                 var handler = new CallbackEventHandler();
                 yield return () => new FrameworkController.LoadTestsAction(controller, handler);
                 yield return () => new FrameworkController.ExploreTestsAction(controller, null, handler);

--- a/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
@@ -1,0 +1,80 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if (NET20 || NET35 || NET40 || NET45)
+using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
+using NUnit.Framework.Internal;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Api
+{
+    class FrameworkControllerCallContextTests
+    {
+        private object _origExecutionContext;
+        private const string MockAssemblyFile = "mock-assembly.dll";
+
+        [SetUp]
+        public void SetUp()
+        {
+            _origExecutionContext = CallContext.GetData(NUnitCallContext.TestExecutionContextKey);
+        }
+
+        [TestCaseSource(nameof(FrameworkActions))]
+        public void CallContextIsRestoredAroundFrameworkActions(Action frameworkAction)
+        {
+            //This test only has value if the CallContext of nunit.framework.tests is first cleared. 
+            //Otherwise no new call context will be created by the framework action
+            CallContext.FreeNamedDataSlot(NUnitCallContext.TestExecutionContextKey);
+            frameworkAction();
+            var actual = CallContext.GetData(NUnitCallContext.TestExecutionContextKey);
+            Assert.That(actual, Is.Null);
+        }
+
+        [TearDown]
+        public void RestoreCallContext()
+        {
+            CallContext.SetData(NUnitCallContext.TestExecutionContextKey, _origExecutionContext);
+        }
+
+        private static IEnumerable<Action> FrameworkActions
+        {
+            get
+            {
+                var settings = new Dictionary<string, object>
+                {
+                    { FrameworkPackageSettings.RunOnMainThread, true }
+                };
+                var controller = new FrameworkController(MockAssemblyFile, "ID", settings);
+                var handler = new CallbackEventHandler();
+                yield return () => new FrameworkController.LoadTestsAction(controller, handler);
+                yield return () => new FrameworkController.ExploreTestsAction(controller, null, handler);
+                yield return () => new FrameworkController.CountTestsAction(controller, null, handler);
+                yield return () => new FrameworkController.RunTestsAction(controller, null, handler);
+                yield return () => new FrameworkController.RunAsyncAction(controller, null, handler);
+            }
+        }
+    }
+}
+#endif

--- a/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerCallContextTests.cs
@@ -30,6 +30,7 @@ using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Api
 {
+    //https://github.com/nunit/nunit/issues/2614
     class FrameworkControllerCallContextTests
     {
         private object _origExecutionContext;
@@ -62,6 +63,10 @@ namespace NUnit.Framework.Api
         {
             get
             {
+                //RunOnMainThread to ensure we're testing worse-case-scenario. The original issue was found
+                //when TestExecutionContext was created in a TestCaseSource,in test exploring code
+                //which always runs on the main thread - however, it could be that the entire test
+                //run is carried out on the main thread - and we should be protecting against that case too.
                 var settings = new Dictionary<string, object>
                 {
                     { FrameworkPackageSettings.RunOnMainThread, true }

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -30,6 +30,7 @@ using System.Web.UI;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+using NUnit.TestUtilities;
 using NUnit.Tests.Assemblies;
 
 namespace NUnit.Framework.Api
@@ -589,25 +590,6 @@ namespace NUnit.Framework.Api
         {
             var propNode = result.SelectSingleNode(string.Format("properties/property[@name='{0}']", PropertyNames.SkipReason));
             return propNode == null ? null : propNode.Attributes["value"];
-        }
-
-#endregion
-
-#region Nested Callback Class
-
-        private class CallbackEventHandler : System.Web.UI.ICallbackEventHandler
-        {
-            private string _result;
-
-            public string GetCallbackResult()
-            {
-                return _result;
-            }
-
-            public void RaiseCallbackEvent(string eventArgument)
-            {
-                _result = eventArgument;
-            }
         }
 
 #endregion

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -60,18 +60,16 @@ namespace NUnit.Framework.Assertions
             TestExecutionContext.CurrentContext = savedContext;
         }
 #else
-        private static readonly string CONTEXT_KEY = "NUnit.Framework.TestContext";
-
         private TestExecutionContext ClearExecutionContext()
         {
             var savedContext = TestExecutionContext.CurrentContext;
-            CallContext.FreeNamedDataSlot(CONTEXT_KEY);
+            CallContext.FreeNamedDataSlot(NUnitCallContext.TestExecutionContextKey);
             return savedContext;
         }
 
         private void RestoreExecutionContext(TestExecutionContext savedContext)
         {
-            CallContext.SetData(CONTEXT_KEY, savedContext);
+            CallContext.SetData(NUnitCallContext.TestExecutionContextKey, savedContext);
         }
 #endif
 

--- a/src/NUnitFramework/tests/TestUtilities/CallbackEventHandler.cs
+++ b/src/NUnitFramework/tests/TestUtilities/CallbackEventHandler.cs
@@ -1,0 +1,40 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.TestUtilities
+{
+    public class CallbackEventHandler : System.Web.UI.ICallbackEventHandler
+    {
+        private string _result;
+
+        public string GetCallbackResult()
+        {
+            return _result;
+        }
+
+        public void RaiseCallbackEvent(string eventArgument)
+        {
+            _result = eventArgument;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2614. This is intended to ensure the Remoting.CallContext is cleaned up correctly after each call to a framework action. The CallContext should be cleared after each run (or other framework call) - remembering the fact that the assembly may be loaded just the once, and multiple calls to it made. This is to ensure that TestExecutionContext objects which are stored in the CallContext can not leak from one run to the next.

Is this the correct level to implement this fix? I've had a look into this - the Engine calls the framework via the `FrameworkController.*Action` methods where I've added the current fix, however NUnitLite and the Xamarin runner both use the NUnitTestAssemblyRunner, which is a level lower. How does this fit into our intended architecture - should we be applying this fix in the NUnitTestAssemblyRunner - or should these two runners not be using the NUnitTestAssembly runner, and instead be using the FrameworkController class? Our [docs](https://github.com/nunit/docs/wiki/Framework-Api) suggest things should be going through the FrameworkController class. (This is more a semantics issue, as the Xamarin runner will never run full framework assemblies, where CallContext is relevant, and NUnitLite rarely runs more that one assembly in the same process.)

@yaakov-h - Would you grab the framework package from the appveyor build, and check this fix does solve your issue reported in https://github.com/nunit/nunit-console/issues/325, and we've diagnosed correctly?