### PR TITLE
Use NUnit equality when the element type is not sealed

### DIFF
--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Constraints
             // If IEnumerable<T> is not implemented exit,
             // Otherwise return value is the Type of T
             Type memberType = GetGenericTypeArgument(actual);
-            if (memberType == null || IsHandledSpeciallyByNUnit(memberType))
+            if (memberType == null || !IsSealed(memberType) || IsHandledSpeciallyByNUnit(memberType))
                 return null;
 
             // Special handling for ignore case with strings and chars
@@ -92,6 +92,11 @@ namespace NUnit.Framework.Constraints
             }
 
             return (bool)ItemsUniqueMethod.MakeGenericMethod(memberType).Invoke(null, new object[] { actual });
+        }
+
+        private bool IsSealed(Type type)
+        {
+            return type.GetTypeInfo().IsSealed;
         }
 
         private static readonly MethodInfo ItemsUniqueMethod =

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -123,6 +123,34 @@ namespace NUnit.Framework.Assertions
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
         }
 
+        [Test]
+        public void UniqueFailure_ElementTypeIsObject_NUnitEqualityIsUsed()
+        {
+            var collection = new List<object> { 42, null, 42f };
+            Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
+        }
+
+        [Test]
+        public void UniqueFailure_ElementTypeIsInterface_NUnitEqualityIsUsed()
+        {
+            var collection = new List<IConvertible> { 42, null, 42f };
+            Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
+        }
+
+        [Test]
+        public void UniqueFailure_ElementTypeIsStruct_ImplicitCastAndNewAlgorithmIsUsed()
+        {
+            var collection = new List<float> { 42, 42f };
+            Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
+        }
+
+        [Test]
+        public void UniqueFailure_ElementTypeIsNotSealed_NUnitEqualityIsUsed()
+        {
+            var collection = new List<ValueType> { 42, 42f };
+            Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
+        }
+
         static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
 
         static readonly IEnumerable[] PerformanceData =


### PR DESCRIPTION
Fixes #2627