### PR TITLE
[Do not merge] Cross-cutting tests proof-of-concept

### DIFF
--- a/src/NUnitFramework/tests/Crosscutting/CharComparisons.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CharComparisons.cs
@@ -1,0 +1,29 @@
+namespace NUnit.Framework.Crosscutting
+{
+    public sealed class CharComparisons : CrosscuttingComparisonTests
+    {
+        [Test]
+        public void EqualChars()
+        {
+            AssertEquality((char)4, (char)4);
+        }
+
+        [Test]
+        public void CharEqualToInt()
+        {
+            AssertEquality((char)4, 4);
+        }
+
+        [Test]
+        public void CharGreaterThanInt()
+        {
+            AssertFirstIsGreater((char)4, 2);
+        }
+
+        [Test]
+        public void IntGreaterThanChar()
+        {
+            AssertFirstIsGreater(4, (char)2);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehavior.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehavior.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected struct ComparisonBehavior
+        {
+            private readonly object _first;
+            private readonly object _second;
+            private readonly ValueRelationship _relationship;
+
+            public ComparisonBehavior(object first, object second, ValueRelationship relationship)
+            {
+                _first = first;
+                _second = second;
+                _relationship = relationship;
+            }
+
+            public ComparisonBehavior Verify(Func<object, object, bool> comparer, ComparisonType comparisonType)
+            {
+                If<object>().Verify(comparer, comparisonType);
+                return this;
+            }
+
+            public ComparisonBehaviorIf<T> If<T>()
+            {
+                return new ComparisonBehaviorIf<T>(_first, _second, _relationship);
+            }
+
+            public ComparisonBehaviorWithAssertionException WithAssertionException
+            {
+                get { return new ComparisonBehaviorWithAssertionException(this); }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorIf.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorIf.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected struct ComparisonBehaviorIf<T>
+        {
+            private readonly T _first;
+            private readonly T _second;
+            private readonly ValueRelationship? relationship;
+
+            public ComparisonBehaviorIf(object first, object second, ValueRelationship relationship)
+            {
+                if (first is T && second is T)
+                {
+                    _first = (T)first;
+                    _second = (T)second;
+                    this.relationship = relationship;
+                }
+                else
+                {
+                    this = default(ComparisonBehaviorIf<T>);
+                }
+            }
+
+            public ComparisonBehaviorIf<T> Verify(Func<T, T, bool> comparer, ComparisonType comparisonType)
+            {
+                Guard.ArgumentNotNull(comparer, nameof(comparer));
+
+                if (relationship != null)
+                {
+                    bool result, reverse;
+                    using (new TestExecutionContext.IsolatedContext())
+                    {
+                        result = comparer.Invoke(_first, _second);
+                        reverse = comparer.Invoke(_second, _first);
+                    }
+
+                    switch (comparisonType)
+                    {
+                        case ComparisonType.Equal:
+                            // Comparing eq == eq, greater == lesser, unordered == unordered
+                            Assert.That(result == (relationship.Value == ValueRelationship.Equality));
+                            // Comparing eq == eq, lesser == greater, unordered == unordered
+                            Assert.That(reverse == (relationship.Value == ValueRelationship.Equality));
+                            break;
+                        case ComparisonType.Unequal:
+                            // Comparing eq != eq, greater != lesser, unordered != unordered
+                            Assert.That(result != (relationship.Value == ValueRelationship.Equality));
+                            // Comparing eq != eq, lesser != greater, unordered != unordered
+                            Assert.That(reverse != (relationship.Value == ValueRelationship.Equality));
+                            break;
+                        case ComparisonType.Less:
+                            // Comparing eq < eq, greater < lesser, unordered < unordered
+                            Assert.That(!result);
+                            // Comparing eq < eq, lesser < greater, unordered < unordered
+                            Assert.That(reverse == (relationship.Value == ValueRelationship.FirstIsGreater));
+                            break;
+                        case ComparisonType.Greater:
+                            // Comparing eq > eq, greater > lesser, unordered > unordered
+                            Assert.That(result == (relationship.Value == ValueRelationship.FirstIsGreater));
+                            // Comparing eq > eq, lesser > greater, unordered > unordered
+                            Assert.That(!reverse);
+                            break;
+                        case ComparisonType.LessOrEqual:
+                            // Comparing eq <= eq, greater <= lesser, unordered <= unordered
+                            Assert.That(result == (relationship.Value == ValueRelationship.Equality));
+                            // Comparing eq <= eq, lesser <= greater, unordered <= unordered
+                            Assert.That(reverse == (relationship.Value == ValueRelationship.Equality | relationship.Value == ValueRelationship.FirstIsGreater));
+                            break;
+                        case ComparisonType.GreaterOrEqual:
+                            // Comparing eq >= eq, greater >= lesser, unordered >= unordered
+                            Assert.That(result == (relationship.Value == ValueRelationship.Equality | relationship.Value == ValueRelationship.FirstIsGreater));
+                            // Comparing eq >= eq, lesser >= greater, unordered >= unordered
+                            Assert.That(reverse == (relationship.Value == ValueRelationship.Equality));
+                            break;
+                    }
+                }
+
+                return this;
+            }
+
+            public ComparisonBehaviorIfWithAssertionException<T> WithAssertionException
+            {
+                get { return new ComparisonBehaviorIfWithAssertionException<T>(this); }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorIfWithAssertionException.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorIfWithAssertionException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected struct ComparisonBehaviorIfWithAssertionException<T>
+        {
+            private readonly ComparisonBehaviorIf<T> _comparisonBehavior;
+
+            public ComparisonBehaviorIfWithAssertionException(ComparisonBehaviorIf<T> comparisonBehavior)
+            {
+                _comparisonBehavior = comparisonBehavior;
+            }
+
+            public ComparisonBehaviorIfWithAssertionException<T> Verify(Action<T, T> throwsAssertionExceptionForFalse, ComparisonType comparisonType)
+            {
+                Guard.ArgumentNotNull(throwsAssertionExceptionForFalse, nameof(throwsAssertionExceptionForFalse));
+
+                _comparisonBehavior.Verify((x, y) =>
+                {
+                    try
+                    {
+                        throwsAssertionExceptionForFalse.Invoke(x, y);
+                        return true;
+                    }
+                    catch (AssertionException)
+                    {
+                        return false;
+                    }
+                }, comparisonType);
+
+                return this;
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorWithAssertionException.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonBehaviorWithAssertionException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected struct ComparisonBehaviorWithAssertionException
+        {
+            private readonly ComparisonBehavior _comparisonBehavior;
+
+            public ComparisonBehaviorWithAssertionException(ComparisonBehavior comparisonBehavior)
+            {
+                _comparisonBehavior = comparisonBehavior;
+            }
+
+            public ComparisonBehaviorWithAssertionException Verify(Action<object, object> throwsAssertionExceptionForFalse, ComparisonType comparisonType)
+            {
+                Guard.ArgumentNotNull(throwsAssertionExceptionForFalse, nameof(throwsAssertionExceptionForFalse));
+
+                _comparisonBehavior.Verify((x, y) =>
+                {
+                    try
+                    {
+                        throwsAssertionExceptionForFalse.Invoke(x, y);
+                        return true;
+                    }
+                    catch (AssertionException)
+                    {
+                        return false;
+                    }
+                }, comparisonType);
+
+                return this;
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonType.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ComparisonType.cs
@@ -1,0 +1,15 @@
+﻿namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected enum ComparisonType
+        {
+            Equal,
+            Unequal,
+            Less,
+            LessOrEqual,
+            Greater,
+            GreaterOrEqual
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ValueRelationship.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.ValueRelationship.cs
@@ -1,0 +1,12 @@
+﻿namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected enum ValueRelationship
+        {
+            Equality,
+            FirstIsGreater,
+            UnorderedInequality
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.cs
+++ b/src/NUnitFramework/tests/Crosscutting/CrosscuttingComparisonTests.cs
@@ -1,0 +1,174 @@
+using System;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Crosscutting
+{
+    public abstract partial class CrosscuttingComparisonTests
+    {
+        protected void AssertEquality(object first, object second)
+        {
+            RunComparisons(new ComparisonBehavior(first, second, ValueRelationship.Equality));
+        }
+
+        protected void AssertFirstIsGreater(object first, object second)
+        {
+            RunComparisons(new ComparisonBehavior(first, second, ValueRelationship.FirstIsGreater));
+        }
+
+        protected void AssertUnorderedInequality(object first, object second)
+        {
+            RunComparisons(new ComparisonBehavior(first, second, ValueRelationship.UnorderedInequality));
+        }
+
+        /// <summary>
+        /// Exercises every API to which each test’s specified behavior should apply.
+        /// </summary>
+        protected void RunComparisons(ComparisonBehavior comparisonBehavior)
+        {
+            comparisonBehavior
+                .Verify((x, y) =>
+                {
+                    var tolerance = Tolerance.Default;
+                    return new NUnitEqualityComparer().AreEqual(x, y, ref tolerance);
+                }, ComparisonType.Equal)
+
+                .Verify((x, y) => new NUnitComparer().Compare(x, y) == 0, ComparisonType.Equal)
+                .Verify((x, y) => new NUnitComparer().Compare(x, y) > 0, ComparisonType.Greater);
+
+            comparisonBehavior
+                .WithAssertionException
+                .Verify((x, y) => Assert.That(x, Is.EqualTo(y)), ComparisonType.Equal)
+                .Verify((x, y) => Assert.That(x, Is.LessThan(y)), ComparisonType.Less)
+                .Verify((x, y) => Assert.That(x, Is.LessThanOrEqualTo(y)), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.That(x, Is.AtMost(y)), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.That(x, Is.GreaterThan(y)), ComparisonType.Greater)
+                .Verify((x, y) => Assert.That(x, Is.GreaterThanOrEqualTo(y)), ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.That(x, Is.AtLeast(y)), ComparisonType.GreaterOrEqual)
+
+                .Verify((x, y) => Assert.That(x, Is.AnyOf(y)), ComparisonType.Equal)
+
+                .Verify((x, y) => Assert.That(new[] { y }, Contains.Item(x)), ComparisonType.Equal);
+
+            // TODO: flesh out constraint syntaxes
+
+            var message = string.Empty;
+
+            comparisonBehavior
+                .WithAssertionException
+                .Verify(Assert.AreEqual, ComparisonType.Equal)
+                .Verify(Assert.AreNotEqual, ComparisonType.Unequal)
+                .Verify((x, y) => Assert.AreEqual(x, y, message), ComparisonType.Equal)
+                .Verify((x, y) => Assert.AreNotEqual(x, y, message), ComparisonType.Unequal);
+
+            comparisonBehavior
+                .If<int>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<uint>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<long>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<ulong>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<decimal>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<double>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<float>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .If<IComparable>()
+                .WithAssertionException
+                .Verify(Assert.Less, ComparisonType.Less)
+                .Verify(Assert.LessOrEqual, ComparisonType.LessOrEqual)
+                .Verify(Assert.Greater, ComparisonType.Greater)
+                .Verify(Assert.GreaterOrEqual, ComparisonType.GreaterOrEqual)
+                .Verify((x, y) => Assert.Less(x, y, message), ComparisonType.Less)
+                .Verify((x, y) => Assert.LessOrEqual(x, y, message), ComparisonType.LessOrEqual)
+                .Verify((x, y) => Assert.Greater(x, y, message), ComparisonType.Greater)
+                .Verify((x, y) => Assert.GreaterOrEqual(x, y, message), ComparisonType.GreaterOrEqual);
+
+            comparisonBehavior
+                .WithAssertionException
+                .Verify((x, y) => CollectionAssert.AreEqual(new[] { x }, new[] { y }), ComparisonType.Equal)
+                .Verify((x, y) => CollectionAssert.AreNotEqual(new[] { x }, new[] { y }), ComparisonType.Unequal)
+                .Verify((x, y) => CollectionAssert.AreEquivalent(new[] { x }, new[] { y }), ComparisonType.Equal)
+                .Verify((x, y) => CollectionAssert.AreNotEquivalent(new[] { x }, new[] { y }), ComparisonType.Unequal)
+                .Verify((x, y) => CollectionAssert.Contains(new[] { x }, y), ComparisonType.Equal)
+                .Verify((x, y) => CollectionAssert.DoesNotContain(new[] { x }, y), ComparisonType.Unequal)
+                .Verify((x, y) => CollectionAssert.IsSubsetOf(new[] { x }, new[] { y }), ComparisonType.Equal)
+                .Verify((x, y) => CollectionAssert.IsNotSubsetOf(new[] { x }, new[] { y }), ComparisonType.Unequal)
+                .Verify((x, y) => CollectionAssert.IsSupersetOf(new[] { x }, new[] { y }), ComparisonType.Equal)
+                .Verify((x, y) => CollectionAssert.IsNotSupersetOf(new[] { x }, new[] { y }), ComparisonType.Unequal)
+                .Verify((x, y) => CollectionAssert.IsOrdered(new[] { x, y }), ComparisonType.LessOrEqual);
+        }
+    }
+}


### PR DESCRIPTION
While [adding unit tests](https://github.com/nunit/nunit/pull/2765/files#diff-da11b68293e8c077e88bb97c497712e0R49) on NUnitComparer and then [duplicating the data](https://github.com/nunit/nunit/pull/2765/files#diff-60c7f8eb1c14bc5b8d779475070e614fR55) to keep our duplicated data in sync for NUnitEqualityComparer, I wished we could somehow reduce duplication and be a bit more exhaustive at the same time. I imagined what it would look like if I was able to add the four tests you see in the PR in `CharComparisons`.

This idea might come to nothing, but it was fun enough to play with for a bit and I'm interested in your reactions.

I ran into inconsistent async handling a few times last year and my mind kept going to the idea of cross-cutting guarantees to hold all those details consistent across the various APIs NUnit offers. So, if you end up not liking this for comparison tests, maybe you'd not mind something like this when I do the async PR?
