### PR TITLE
Fixed deadlocks on known synchronization contexts

### DIFF
--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -1,0 +1,114 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if ASYNC
+using System;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Threading.Tasks;
+
+namespace NUnit.Framework.Internal
+{
+    internal abstract class AwaitAdapter
+    {
+        public abstract bool IsCompleted { get; }
+        public abstract void OnCompleted(Action action);
+        public abstract void BlockUntilCompleted();
+
+        public static AwaitAdapter FromAwaitable(object awaitable)
+        {
+            if (awaitable == null) throw new ArgumentNullException(nameof(awaitable));
+
+            var task = awaitable as Task;
+            if (task == null)
+                throw new NotImplementedException("Proper awaitable implementation to follow.");
+
+#if NET40
+            // TODO: use the general reflection-based awaiter if net40 build is running against a newer BCL
+            return new Net40BclTaskAwaitAdapter(task);
+#else
+            return new TaskAwaitAdapter(task);
+#endif
+        }
+
+#if NET40
+        private sealed class Net40BclTaskAwaitAdapter : AwaitAdapter
+        {
+            private readonly Task _task;
+
+            public Net40BclTaskAwaitAdapter(Task task)
+            {
+                _task = task;
+            }
+
+            public override bool IsCompleted => _task.IsCompleted;
+
+            public override void OnCompleted(Action action)
+            {
+                if (action == null) return;
+
+                // Normally we would call TaskAwaiter.UnsafeOnCompleted (https://source.dot.net/#System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs)
+                // We will have to polyfill on top of the TPL API.
+                // Compare TaskAwaiter.OnCompletedInternal from Microsoft.Threading.Tasks.dll in Microsoft.Bcl.Async.nupkg.
+
+                _task.ContinueWith(_ => action.Invoke(), TaskScheduler.FromCurrentSynchronizationContext());
+            }
+
+            public override void BlockUntilCompleted()
+            {
+                // Normally we would call TaskAwaiter.GetResult (https://source.dot.net/#System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs)
+                // We will have to polyfill on top of the TPL API.
+                // Compare TaskAwaiter.ValidateEnd from Microsoft.Threading.Tasks.dll in Microsoft.Bcl.Async.nupkg.
+
+                try
+                {
+                    _task.Wait(); // Wait even if the task is completed so that an exception is thrown for cancellation or failure.
+                }
+                catch (AggregateException ex) when (ex.InnerExceptions.Count == 1) // Task.Wait wraps every exception
+                {
+                    ExceptionHelper.Rethrow(ex.InnerException);
+                }
+            }
+        }
+#else
+        private sealed class TaskAwaitAdapter : AwaitAdapter
+        {
+            private readonly TaskAwaiter _awaiter;
+
+            public TaskAwaitAdapter(Task task)
+            {
+                _awaiter = task.GetAwaiter();
+            }
+
+            public override bool IsCompleted => _awaiter.IsCompleted;
+
+            [SecuritySafeCritical]
+            public override void OnCompleted(Action action) => _awaiter.UnsafeOnCompleted(action);
+
+            // Assumption that GetResult blocks until complete is only valid for System.Threading.Tasks.Task.
+            public override void BlockUntilCompleted() => _awaiter.GetResult();
+        }
+#endif
+    }
+}
+#endif

--- a/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
@@ -1,0 +1,136 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if ASYNC
+using System;
+using System.Threading;
+
+#if NET40 || NET45
+using System.Windows.Forms;
+using System.Windows.Threading;
+#endif
+
+namespace NUnit.Framework.Internal
+{
+    internal abstract class MessagePumpStrategy
+    {
+        public abstract void WaitForCompletion(AwaitAdapter awaitable);
+
+        public static MessagePumpStrategy FromCurrentSynchronizationContext()
+        {
+#if NET40 || NET45
+            var context = SynchronizationContext.Current;
+
+            if (context is WindowsFormsSynchronizationContext)
+                return WindowsFormsMessagePumpStrategy.Instance;
+
+            if (context is DispatcherSynchronizationContext)
+                return WpfMessagePumpStrategy.Instance;
+#endif
+
+            return NoMessagePumpStrategy.Instance;
+        }
+
+        private sealed class NoMessagePumpStrategy : MessagePumpStrategy
+        {
+            public static readonly NoMessagePumpStrategy Instance = new NoMessagePumpStrategy();
+            private NoMessagePumpStrategy() { }
+
+            public override void WaitForCompletion(AwaitAdapter awaitable)
+            {
+                awaitable.BlockUntilCompleted();
+            }
+        }
+
+#if NET40 || NET45
+        private sealed class WindowsFormsMessagePumpStrategy : MessagePumpStrategy
+        {
+            public static readonly WindowsFormsMessagePumpStrategy Instance = new WindowsFormsMessagePumpStrategy();
+            private WindowsFormsMessagePumpStrategy() { }
+
+            public override void WaitForCompletion(AwaitAdapter awaitable)
+            {
+                var context = SynchronizationContext.Current;
+
+                if (!(context is WindowsFormsSynchronizationContext))
+                    throw new InvalidOperationException("This strategy must only be used from a WindowsFormsSynchronizationContext.");
+
+                if (awaitable.IsCompleted) return;
+
+                // Wait for a post rather than scheduling the continuation now. If there has been a race condition
+                // and it completed after the IsCompleted check, it will wait until the application runs *before*
+                // shutting it down. Otherwise Application.Exit is a no-op and we would then proceed to do
+                // Application.Run and never return.
+                context.Post(
+                    state => ContinueOnSameSynchronizationContext((AwaitAdapter)state, Application.Exit),
+                    state: awaitable);
+
+                Application.Run();
+            }
+        }
+
+        private sealed class WpfMessagePumpStrategy : MessagePumpStrategy
+        {
+            public static readonly WpfMessagePumpStrategy Instance = new WpfMessagePumpStrategy();
+            private WpfMessagePumpStrategy() { }
+
+            public override void WaitForCompletion(AwaitAdapter awaitable)
+            {
+                var context = SynchronizationContext.Current;
+
+                if (!(context is DispatcherSynchronizationContext))
+                    throw new InvalidOperationException("This strategy must only be used from a DispatcherSynchronizationContext.");
+
+                if (awaitable.IsCompleted) return;
+
+                // Wait for a post rather than scheduling the continuation now. If there has been a race condition
+                // and it completed after the IsCompleted check, it will wait until the application runs *before*
+                // shutting it down. Otherwise Dispatcher.ExitAllFrames is a no-op and we would then proceed to do
+                // Dispatcher.Run and never return.
+                context.Post(
+                    state => ContinueOnSameSynchronizationContext((AwaitAdapter)state, Dispatcher.ExitAllFrames),
+                    state: awaitable);
+
+                Dispatcher.Run();
+            }
+        }
+
+        private static void ContinueOnSameSynchronizationContext(AwaitAdapter adapter, Action continuation)
+        {
+            if (adapter == null) throw new ArgumentNullException(nameof(adapter));
+            if (continuation == null) throw new ArgumentNullException(nameof(continuation));
+
+            var context = SynchronizationContext.Current;
+
+            adapter.OnCompleted(() =>
+            {
+                if (SynchronizationContext.Current == context)
+                    continuation.Invoke();
+                else
+                    context.Post(state => ((Action)state).Invoke(), state: continuation);
+            });
+        }
+#endif
+    }
+}
+#endif

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -13,6 +13,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" Condition="'$(TargetFramework)' != 'net20'" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnitFramework/testdata/On.cs
+++ b/src/NUnitFramework/testdata/On.cs
@@ -1,0 +1,59 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Threading;
+
+namespace NUnit.TestData
+{
+    /// <summary>
+    /// Enables the <see cref="On.Dispose"/> syntax.
+    /// </summary>
+    public static class On
+    {
+        /// <summary>
+        /// Wraps an action so that it is executed when the returned object is disposed.
+        /// This disposal is thread-safe and the action will be executed at most once.
+        /// </summary>
+        public static IDisposable Dispose(Action action)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+            return new DisposableAction(action);
+        }
+
+        private sealed class DisposableAction : IDisposable
+        {
+            private Action action;
+
+            public DisposableAction(Action action)
+            {
+                this.action = action;
+            }
+
+            public void Dispose()
+            {
+                Interlocked.Exchange(ref action, null)?.Invoke();
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/testdata/SynchronizationContextFixture.cs
+++ b/src/NUnitFramework/testdata/SynchronizationContextFixture.cs
@@ -55,13 +55,15 @@ namespace NUnit.TestData
 
 #if ASYNC
         [Test]
-        public async Task YieldingTestMethod()
+        public async Task YieldAndAssertSameThread()
         {
+            var originalThread = Thread.CurrentThread;
 #if NET40
             await TaskEx.Yield();
 #else
             await Task.Yield();
 #endif
+            Assert.That(Thread.CurrentThread, Is.SameAs(originalThread));
         }
 #endif
 

--- a/src/NUnitFramework/testdata/SynchronizationContextFixture.cs
+++ b/src/NUnitFramework/testdata/SynchronizationContextFixture.cs
@@ -1,0 +1,75 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+
+#if ASYNC
+using System.Threading.Tasks;
+#endif
+
+namespace NUnit.TestData
+{
+    public sealed class SynchronizationContextFixture : IDisposable
+    {
+        private readonly SynchronizationContext _synchronizationContext;
+        private IDisposable installation;
+
+        public SynchronizationContextFixture(SynchronizationContext synchronizationContext)
+        {
+            _synchronizationContext = synchronizationContext;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            installation = TemporarySynchronizationContext(_synchronizationContext);
+        }
+
+        public void Dispose()
+        {
+            // Make sure this gets cleaned up even if the tests fail!
+            installation.Dispose();
+        }
+
+#if ASYNC
+        [Test]
+        public async Task YieldingTestMethod()
+        {
+#if NET40
+            await TaskEx.Yield();
+#else
+            await Task.Yield();
+#endif
+        }
+#endif
+
+        private static IDisposable TemporarySynchronizationContext(SynchronizationContext synchronizationContext)
+        {
+            var originalContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            return On.Dispose(() => SynchronizationContext.SetSynchronizationContext(originalContext));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Extensions.cs
+++ b/src/NUnitFramework/tests/Extensions.cs
@@ -1,0 +1,44 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Contains this assembly's general extension methods.
+    /// </summary>
+    internal static class Extensions
+    {
+        /// <summary>
+        /// Asserts that the result state has <see cref="TestStatus.Passed"/>.
+        /// </summary>
+        public static void AssertPassed(this ITestResult result)
+        {
+            if (result == null) throw new ArgumentNullException(nameof(result));
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -36,6 +36,9 @@ namespace NUnit.Framework
     public static class SynchronizationContextTests
     {
 #if NET40 || NET45
+        // TODO: test a custom awaitable type whose awaiter executes continuations on a brand new thread
+        // to ensure that the message pump is shut down on the correct thread.
+
         public static readonly IEnumerable<Type> KnownSynchronizationContextTypes = new[]
         {
             typeof(System.Windows.Forms.WindowsFormsSynchronizationContext),

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -1,0 +1,134 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.TestData;
+using NUnit.TestUtilities;
+
+#if ASYNC
+using System.Threading.Tasks;
+#endif
+
+namespace NUnit.Framework
+{
+    public static class SynchronizationContextTests
+    {
+#if NET40 || NET45
+        public static readonly IEnumerable<Type> KnownSynchronizationContextTypes = new[]
+        {
+            typeof(System.Windows.Forms.WindowsFormsSynchronizationContext),
+            typeof(System.Windows.Threading.DispatcherSynchronizationContext)
+        };
+
+        [Timeout(10000)]
+        [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
+        public static void TestMethodContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
+        {
+            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+
+            using (var fixture = new SynchronizationContextFixture(createdOnThisThread))
+            {
+                TestBuilder
+                    .RunTestCase(fixture, nameof(fixture.YieldingTestMethod))
+                    .AssertPassed();
+            }
+        }
+
+        [Timeout(10000)]
+        [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
+        public static void AssertThatContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
+        {
+            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+
+            using (TemporarySynchronizationContext(createdOnThisThread))
+            {
+                Assert.That(Yields, Throws.Nothing);
+            }
+        }
+
+        [Timeout(10000)]
+        [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
+        public static void AssertDoesNotThrowAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
+        {
+            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+
+            using (TemporarySynchronizationContext(createdOnThisThread))
+            {
+                Assert.DoesNotThrowAsync(Yields);
+            }
+        }
+
+        [Timeout(10000)]
+        [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
+        public static void AssertThrowsAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
+        {
+            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+
+            using (TemporarySynchronizationContext(createdOnThisThread))
+            {
+                Assert.ThrowsAsync<Exception>(ThrowsAfterYield);
+            }
+        }
+
+        [Timeout(10000)]
+        [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
+        public static void AssertCatchAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
+        {
+            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+
+            using (TemporarySynchronizationContext(createdOnThisThread))
+            {
+                Assert.CatchAsync(ThrowsAfterYield);
+            }
+        }
+
+        public static async Task Yields()
+        {
+#if NET40
+            await TaskEx.Yield();
+#else
+            await Task.Yield();
+#endif
+        }
+
+        public static async Task ThrowsAfterYield()
+        {
+#if NET40
+            await TaskEx.Yield();
+#else
+            await Task.Yield();
+#endif
+            throw new Exception();
+        }
+#endif
+
+        private static IDisposable TemporarySynchronizationContext(SynchronizationContext synchronizationContext)
+        {
+            var originalContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            return On.Dispose(() => SynchronizationContext.SetSynchronizationContext(originalContext));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using NUnit.Framework.Internal;
 using NUnit.TestData;
 using NUnit.TestUtilities;
 
@@ -45,11 +46,31 @@ namespace NUnit.Framework
             typeof(System.Windows.Threading.DispatcherSynchronizationContext)
         };
 
+        private static SynchronizationContext CreateSynchronizationContext(Type knownSynchronizationContextType)
+        {
+            if (new PlatformHelper().IsPlatformSupported("Mono"))
+            {
+                if (knownSynchronizationContextType == typeof(System.Windows.Threading.DispatcherSynchronizationContext))
+                {
+                    Assert.Ignore("DispatcherSynchronizationContext throws NotImplementedException on Mono.");
+                }
+                else if (knownSynchronizationContextType == typeof(System.Windows.Forms.WindowsFormsSynchronizationContext))
+                {
+                    if (!Environment.UserInteractive)
+                    {
+                        Assert.Inconclusive("WindowsFormsSynchronizationContext throws ArgumentNullException on Mono when not running interactively.");
+                    }
+                }
+            }
+
+            return (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+        }
+
         [Timeout(10000)]
         [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
         public static void TestMethodContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
         {
-            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+            var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
             using (var fixture = new SynchronizationContextFixture(createdOnThisThread))
             {
@@ -63,7 +84,7 @@ namespace NUnit.Framework
         [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
         public static void AssertThatContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
         {
-            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+            var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
             using (TemporarySynchronizationContext(createdOnThisThread))
             {
@@ -75,7 +96,7 @@ namespace NUnit.Framework
         [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
         public static void AssertDoesNotThrowAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
         {
-            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+            var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
             using (TemporarySynchronizationContext(createdOnThisThread))
             {
@@ -87,7 +108,7 @@ namespace NUnit.Framework
         [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
         public static void AssertThrowsAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
         {
-            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+            var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
             using (TemporarySynchronizationContext(createdOnThisThread))
             {
@@ -99,7 +120,7 @@ namespace NUnit.Framework
         [TestCaseSource(nameof(KnownSynchronizationContextTypes))]
         public static void AssertCatchAsyncContinuationDoesNotDeadlock(Type knownSynchronizationContextType)
         {
-            var createdOnThisThread = (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
+            var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
             using (TemporarySynchronizationContext(createdOnThisThread))
             {

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35' and '$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -34,6 +34,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" Condition="'$(TargetFramework)' != 'net20'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #2123, re: https://github.com/nunit/nunit/issues/2774

The first commit enabled me to quickly test because I was without internet, so build.cake couldn't pull the console runner from NuGet, and VS required my license to be refreshed.

I left some notes in the source about the later general-awaitable PR.

All reviews welcome, as usual. @sharwell, since you're knowledgeable in this area and you hit the bug, would you please review?