### PR TITLE
Removed boxing and eager range creation

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Reflection;
+using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -195,6 +196,12 @@ namespace NUnit.Framework
             }
 
             return valueGenerator.GenerateRange(from, to, step);
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        public override string ToString()
+        {
+            return $"{MsgUtils.FormatValue(_from)} .. {MsgUtils.FormatValue(_step)} .. {MsgUtils.FormatValue(_to)}";
         }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -182,15 +182,21 @@ namespace NUnit.Framework
             ValueGenerator.Step step;
             if (!valueGenerator.TryCreateStep(_step, out step))
             {
-                // ValueGenerator.CreateStep is responsible to enable incrementing bytes by (int)(-1),
-                // or perhaps in the future a DateTime by a TimeSpan, but the responsibility to convert
-                // attribute values from Double to Decimal is in ParamAttributeTypeConversions.
-                // (ParamAttributeTypeConversions tries to simulate what would happen in C# if the
-                // literal syntax used for the attribute value had been used as a parameter argument
-                // in a direct call to the test method.)
+                // ValueGenerator.CreateStep has the responsibility to enable Byte values to be incremented
+                // by the Int32 value -1. Or perhaps in the future, DateTime values to be incremented by a TimeSpan.
+                // It handles scenarios where the incrementing type is fundamentally different in its most natural form.
+
+                // However, ParamAttributeTypeConversions has the responsibility to convert attribute arguments
+                // that are only of a different type due to IL limitations or NUnit smoothing over overload differences.
+                // See the XML docs for the ParamAttributeTypeConversions class.
+
                 object stepValueToRequire;
                 if (!ParamAttributeTypeConversions.TryConvert(_step, parameter.ParameterType, out stepValueToRequire))
+                {
+                    // This will cause CreateStep to throw the same exception as it would throw if TryConvert
+                    // succeeded but the value generator still didn’t recognize the step value.
                     stepValueToRequire = _step;
+                }
 
                 step = valueGenerator.CreateStep(stepValueToRequire);
             }

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,8 +24,6 @@
 using System;
 using System.Collections;
 using System.Reflection;
-
-using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -38,36 +36,28 @@ namespace NUnit.Framework
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
     public class RangeAttribute : DataAttribute, IParameterDataSource
     {
-        // We use an object[] so that the individual
-        // elements may have their type changed in GetData
-        // if necessary
-        // TODO: This causes a lot of boxing so we should eliminate it
-        private readonly object[] _data;
+        private readonly object _from;
+        private readonly object _to;
+        private readonly object _step;
+
         #region Ints
 
         /// <summary>
         /// Construct a range of ints using default step of 1
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
         public RangeAttribute(int from, int to) : this(from, to, from > to ? -1 : 1) { }
 
         /// <summary>
-        /// Construct a range of ints specifying the step size 
+        /// Construct a range of ints specifying the step size
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         public RangeAttribute(int from, int to, int step)
         {
             Guard.ArgumentValid(step > 0 && to >= from || step < 0 && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
-            int count = (to - from) / step + 1;
-            _data = new object[count];
-            int index = 0;
-            for (int val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -77,28 +67,21 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a range of unsigned ints using default step of 1
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
         [CLSCompliant(false)]
         public RangeAttribute(uint from, uint to) : this(from, to, 1u) { }
 
         /// <summary>
-        /// Construct a range of unsigned ints specifying the step size 
+        /// Construct a range of unsigned ints specifying the step size
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         [CLSCompliant(false)]
         public RangeAttribute(uint from, uint to, uint step)
         {
             Guard.ArgumentValid(step > 0, "Step must be greater than zero", nameof(step));
             Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", nameof(to));
 
-            uint count = (to - from) / step + 1;
-            _data = new object[count];
-            uint index = 0;
-            for (uint val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -108,26 +91,19 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a range of longs using a default step of 1
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
         public RangeAttribute(long from, long to) : this(from, to, from > to ? -1L : 1L) { }
 
         /// <summary>
         /// Construct a range of longs
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         public RangeAttribute(long from, long to, long step)
         {
             Guard.ArgumentValid(step > 0L && to >= from || step < 0L && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
-            long count = (to - from) / step + 1;
-            _data = new object[count];
-            int index = 0;
-            for (long val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -137,28 +113,21 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a range of unsigned longs using default step of 1
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
         [CLSCompliant(false)]
         public RangeAttribute(ulong from, ulong to) : this(from, to, 1ul) { }
 
         /// <summary>
-        /// Construct a range of unsigned longs specifying the step size 
+        /// Construct a range of unsigned longs specifying the step size
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         [CLSCompliant(false)]
         public RangeAttribute(ulong from, ulong to, ulong step)
         {
             Guard.ArgumentValid(step > 0, "Step must be greater than zero", nameof(step));
             Guard.ArgumentValid(to >= from, "Value of to must be greater than or equal to from", nameof(to));
 
-            ulong count = (to - from) / step + 1;
-            _data = new object[count];
-            ulong index = 0;
-            for (ulong val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -168,21 +137,14 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a range of doubles
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         public RangeAttribute(double from, double to, double step)
         {
             Guard.ArgumentValid(step > 0.0D && to >= from || step < 0.0D && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
-            double aStep = Math.Abs(step);
-            double tol = aStep / 1000;
-            int count = (int)(Math.Abs(to - from) / aStep + tol + 1);
-            _data = new object[count];
-            int index = 0;
-            for (double val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -192,21 +154,14 @@ namespace NUnit.Framework
         /// <summary>
         /// Construct a range of floats
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
-        /// <param name="step"></param>
         public RangeAttribute(float from, float to, float step)
         {
             Guard.ArgumentValid(step > 0.0F && to >= from || step < 0.0F && to <= from,
                 "Step must be positive with to >= from or negative with to <= from", nameof(step));
 
-            float aStep = Math.Abs(step);
-            float tol = aStep / 1000;
-            int count = (int)(Math.Abs(to - from) / aStep + tol + 1);
-            _data = new object[count];
-            int index = 0;
-            for (float val = from; index < count; val += step)
-                _data[index++] = val;
+            _from = from;
+            _to = to;
+            _step = step;
         }
 
         #endregion
@@ -218,7 +173,11 @@ namespace NUnit.Framework
         /// <param name="parameter">The parameter of a parameterized test.</param>
         public IEnumerable GetData(Type fixtureType, ParameterInfo parameter)
         {
-            return ParamAttributeTypeConversions.ConvertData(_data, parameter.ParameterType);
+            var from = ParamAttributeTypeConversions.Convert(_from, parameter.ParameterType);
+            var to = ParamAttributeTypeConversions.Convert(_to, parameter.ParameterType);
+            var step = ParamAttributeTypeConversions.Convert(_step, parameter.ParameterType);
+
+            return ValueGenerator.Create(parameter.ParameterType).GenerateRange(from, to, step);
         }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -44,7 +44,6 @@ namespace NUnit.Framework
         /// elements may have their type changed in GetData
         /// if necessary
         /// </summary>
-        // TODO: This causes a lot of boxing so we should eliminate it
         protected object[] data;
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -30,7 +30,22 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework.Internal
 {
     /// <summary>
-    /// Helper methods for converting parameters to numeric values to supported types
+    /// <para>
+    /// Examines an attribute argument and tries to simulate what that value would have been if the literal syntax
+    /// which might have defined the value in C# had instead been used as an argument to a given method parameter in a direct call.
+    /// </para>
+    /// <para>
+    /// For example, since you can’t apply attributes using <see cref="decimal"/> arguments, we allow the C# syntax
+    /// <c>10</c> (<see cref="int"/> value) or <c>0.1</c> (<see cref="double"/> value) to be specified.
+    /// NUnit then converts it to match the method’s <see cref="decimal"/> parameters, just as if you were actually
+    /// using the syntax <c>TestMethod(10)</c> or <c>TestMethod(0.1)</c>.
+    /// </para>
+    /// <para>
+    /// For another example, you might have written the syntax <c>10</c> and picked up the <see cref="int"/> attribute
+    /// constructor overload; however, the test method for which this value is intended only has a <see cref="byte"/>
+    /// signature. Again, NUnit simulates what would have happened if the inferred C# syntax was transplanted
+    /// and you were actually using the syntax <c>TestMethod(10)</c>.
+    /// </para>
     /// </summary>
     internal static class ParamAttributeTypeConversions
     {

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2017 Charlie Poole, Rob Prouse
+// Copyright (c) 2017–2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -57,46 +57,68 @@ namespace NUnit.Framework.Internal
         {
             for (int i = 0; i < data.Length; i++)
             {
-                object arg = data[i];
-
-                if (arg == null)
-                {
-                    continue;
-                }
-
-                if (targetType.GetTypeInfo().IsInstanceOfType(arg))
-                {
-                    continue;
-                }
-
-                if (arg.GetType().FullName == "System.DBNull")
-                {
-                    data[i] = null;
-                    continue;
-                }
-
-                bool convert = false;
-
-                if (targetType == typeof(short) || targetType == typeof(byte) || targetType == typeof(sbyte))
-                {
-                    convert = arg is int;
-                }
-                else if (targetType == typeof(decimal))
-                {
-                    convert = arg is double || arg is string || arg is int;
-                }
-                else if (targetType == typeof(DateTime) || targetType == typeof(TimeSpan))
-                {
-                    convert = arg is string;
-                }
-
-                if (convert)
-                {
-                    data[i] = Convert.ChangeType(arg, targetType, System.Globalization.CultureInfo.InvariantCulture);
-                }
+                object convertedValue;
+                if (TryConvert(data[i], targetType, out convertedValue))
+                    data[i] = convertedValue;
             }
 
             return data;
+        }
+
+        /// <summary>
+        /// Converts a single value to the <paramref name="targetType"/>, if it is supported.
+        /// </summary>
+        public static object Convert(object value, Type targetType)
+        {
+            object convertedValue;
+            if (TryConvert(value, targetType, out convertedValue))
+                return convertedValue;
+
+            throw new InvalidOperationException(
+                (value == null ? "Null" : $"A value of type {value.GetType()} ({value})")
+                + $" cannot be passed to a parameter of type {targetType}.");
+        }
+
+        /// <summary>
+        /// Converts a single value to the <paramref name="targetType"/>, if it is supported.
+        /// </summary>
+        public static bool TryConvert(object value, Type targetType, out object convertedValue)
+        {
+            if (targetType.GetTypeInfo().IsInstanceOfType(value))
+            {
+                convertedValue = value;
+                return true;
+            }
+
+            if (value == null || value.GetType().FullName == "System.DBNull")
+            {
+                convertedValue = null;
+                return Reflect.IsAssignableFromNull(targetType);
+            }
+
+            bool convert = false;
+
+            if (targetType == typeof(short) || targetType == typeof(byte) || targetType == typeof(sbyte))
+            {
+                convert = value is int;
+            }
+            else if (targetType == typeof(decimal))
+            {
+                convert = value is double || value is string || value is int;
+            }
+            else if (targetType == typeof(DateTime) || targetType == typeof(TimeSpan))
+            {
+                convert = value is string;
+            }
+
+            if (convert)
+            {
+                convertedValue = System.Convert.ChangeType(value, targetType, System.Globalization.CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            convertedValue = null;
+            return false;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007-2012 Charlie Poole, Rob Prouse
+// Copyright (c) 2007-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -349,6 +349,20 @@ namespace NUnit.Framework.Internal
             }
 
             return null;
+        }
+
+        internal static bool IsAssignableFromNull(Type type)
+        {
+            Guard.ArgumentNotNull(type, nameof(type));
+            return !type.GetTypeInfo().IsValueType || IsNullable(type);
+        }
+
+        private static bool IsNullable(Type type)
+        {
+            // Compare with https://github.com/dotnet/coreclr/blob/bb01fb0d954c957a36f3f8c7aad19657afc2ceda/src/mscorlib/src/System/Nullable.cs#L152-L157
+            return type.GetTypeInfo().IsGenericType
+                && !type.GetTypeInfo().IsGenericTypeDefinition
+                && ReferenceEquals(type.GetGenericTypeDefinition(), typeof(Nullable<>));
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
@@ -21,49 +21,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class ByteValueGenerator : ValueGenerator<byte>
         {
-            public override IEnumerable<byte> GenerateRange(byte start, byte end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is byte)
@@ -73,7 +36,7 @@ namespace NUnit.Framework.Internal
                 }
 
                 // ByteValueGenerator is unusual in this regard. We allow byte parameter ranges to start high and end low,
-                // and internally the step is represented as the Int32 value -1 since it can’t be represented as a Byte.
+                // and internally the step is represented as the Int32 value -1 since it canâ€™t be represented as a Byte.
                 // -1 can be converted natively to Int16, SByte and Decimal, so we can fall back on the automatic conversion for them.
                 if (value is int)
                 {

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
@@ -72,6 +72,9 @@ namespace NUnit.Framework.Internal
                     return true;
                 }
 
+                // ByteValueGenerator is unusual in this regard. We allow byte parameter ranges to start high and end low,
+                // and internally the step is represented as the Int32 value -1 since it can’t be represented as a Byte.
+                // -1 can be converted natively to Int16, SByte and Decimal, so we can fall back on the automatic conversion for them.
                 if (value is int)
                 {
                     step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked((byte)(prev + stepValue)));

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
@@ -1,0 +1,60 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class ByteValueGenerator : ValueGenerator<byte>
+        {
+            public override IEnumerable<byte> GenerateRange(byte start, byte end, byte step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked((byte)(current + step));
+
+                        if (end < next) break; // We stepped past the end of the range.
+                        if (next < current) break; // We overflowed which means we tried to step past the end.
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 
 namespace NUnit.Framework.Internal
 {
@@ -30,48 +29,6 @@ namespace NUnit.Framework.Internal
     {
         private sealed class DecimalValueGenerator : ValueGenerator<decimal>
         {
-            public override IEnumerable<decimal> GenerateRange(decimal start, decimal end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        decimal next;
-                        try
-                        {
-                            next = step.Apply(current);
-                        }
-                        catch (OverflowException)
-                        {
-                            break;
-                        }
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next <= current) throw new InvalidOperationException("The step must monotonically increase.");
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current <= next) throw new InvalidOperationException("The step must monotonically increase.");
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is decimal)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class DecimalValueGenerator : ValueGenerator<decimal>
         {
-            public override IEnumerable<decimal> GenerateRange(decimal start, decimal end, decimal step)
+            public override IEnumerable<decimal> GenerateRange(decimal start, decimal end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = current + step;
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is decimal)
+                {
+                    step = new ComparableStep<decimal>((decimal)value, (prev, stepValue) => prev + stepValue);
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class DecimalValueGenerator : ValueGenerator<decimal>
+        {
+            public override IEnumerable<decimal> GenerateRange(decimal start, decimal end, decimal step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = current + step;
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DefaultValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DefaultValueGenerator.cs
@@ -1,0 +1,32 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class DefaultValueGenerator<T> : ValueGenerator<T>
+        {
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class DoubleValueGenerator : ValueGenerator<double>
         {
-            public override IEnumerable<double> GenerateRange(double start, double end, double step)
+            public override IEnumerable<double> GenerateRange(double start, double end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = current + step;
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is double)
+                {
+                    step = new ComparableStep<double>((double)value, (prev, stepValue) => prev + stepValue);
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
@@ -68,7 +68,13 @@ namespace NUnit.Framework.Internal
             {
                 if (value is double)
                 {
-                    step = new ComparableStep<double>((double)value, (prev, stepValue) => prev + stepValue);
+                    step = new ComparableStep<double>((double)value, (prev, stepValue) =>
+                    {
+                        var next = prev + stepValue;
+                        if (stepValue > 0 ? next <= prev : prev <= next)
+                            throw new ArithmeticException($"Not enough precision to represent the next step; {prev:r} + {stepValue:r} = {next:r}.");
+                        return next;
+                    });
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 
 namespace NUnit.Framework.Internal
 {
@@ -30,40 +29,6 @@ namespace NUnit.Framework.Internal
     {
         private sealed class DoubleValueGenerator : ValueGenerator<double>
         {
-            public override IEnumerable<double> GenerateRange(double start, double end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is double)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class DoubleValueGenerator : ValueGenerator<double>
+        {
+            public override IEnumerable<double> GenerateRange(double start, double end, double step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = current + step;
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class Int16ValueGenerator : ValueGenerator<short>
+        {
+            public override IEnumerable<short> GenerateRange(short start, short end, short step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked((short)(current + step));
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class Int16ValueGenerator : ValueGenerator<short>
         {
-            public override IEnumerable<short> GenerateRange(short start, short end, short step)
+            public override IEnumerable<short> GenerateRange(short start, short end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = unchecked((short)(current + step));
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is short)
+                {
+                    step = new ComparableStep<short>((short)value, (prev, stepValue) => unchecked((short)(prev + stepValue)));
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
@@ -21,54 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class Int16ValueGenerator : ValueGenerator<short>
         {
-            public override IEnumerable<short> GenerateRange(short start, short end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is short)
                 {
-                    step = new ComparableStep<short>((short)value, (prev, stepValue) => unchecked((short)(prev + stepValue)));
+                    step = new ComparableStep<short>((short)value, (prev, stepValue) => checked((short)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class Int32ValueGenerator : ValueGenerator<int>
         {
-            public override IEnumerable<int> GenerateRange(int start, int end, int step)
+            public override IEnumerable<int> GenerateRange(int start, int end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = unchecked(current + step);
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is int)
+                {
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class Int32ValueGenerator : ValueGenerator<int>
+        {
+            public override IEnumerable<int> GenerateRange(int start, int end, int step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked(current + step);
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
@@ -21,54 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class Int32ValueGenerator : ValueGenerator<int>
         {
-            public override IEnumerable<int> GenerateRange(int start, int end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is int)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class Int64ValueGenerator : ValueGenerator<long>
+        {
+            public override IEnumerable<long> GenerateRange(long start, long end, long step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked(current + step);
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
@@ -21,54 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class Int64ValueGenerator : ValueGenerator<long>
         {
-            public override IEnumerable<long> GenerateRange(long start, long end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is long)
                 {
-                    step = new ComparableStep<long>((long)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    step = new ComparableStep<long>((long)value, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class Int64ValueGenerator : ValueGenerator<long>
         {
-            public override IEnumerable<long> GenerateRange(long start, long end, long step)
+            public override IEnumerable<long> GenerateRange(long start, long end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = unchecked(current + step);
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is long)
+                {
+                    step = new ComparableStep<long>((long)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class SByteValueGenerator : ValueGenerator<sbyte>
         {
-            public override IEnumerable<sbyte> GenerateRange(sbyte start, sbyte end, sbyte step)
+            public override IEnumerable<sbyte> GenerateRange(sbyte start, sbyte end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = unchecked((sbyte)(current + step));
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is sbyte)
+                {
+                    step = new ComparableStep<sbyte>((sbyte)value, (prev, stepValue) => unchecked((sbyte)(prev + stepValue)));
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
@@ -21,54 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class SByteValueGenerator : ValueGenerator<sbyte>
         {
-            public override IEnumerable<sbyte> GenerateRange(sbyte start, sbyte end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is sbyte)
                 {
-                    step = new ComparableStep<sbyte>((sbyte)value, (prev, stepValue) => unchecked((sbyte)(prev + stepValue)));
+                    step = new ComparableStep<sbyte>((sbyte)value, (prev, stepValue) => checked((sbyte)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class SByteValueGenerator : ValueGenerator<sbyte>
+        {
+            public override IEnumerable<sbyte> GenerateRange(sbyte start, sbyte end, sbyte step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked((sbyte)(current + step));
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
@@ -1,0 +1,68 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class SingleValueGenerator : ValueGenerator<float>
+        {
+            public override IEnumerable<float> GenerateRange(float start, float end, float step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = current + step;
+
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 
 namespace NUnit.Framework.Internal
 {
@@ -30,40 +29,6 @@ namespace NUnit.Framework.Internal
     {
         private sealed class SingleValueGenerator : ValueGenerator<float>
         {
-            public override IEnumerable<float> GenerateRange(float start, float end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is float)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
@@ -68,7 +68,13 @@ namespace NUnit.Framework.Internal
             {
                 if (value is float)
                 {
-                    step = new ComparableStep<float>((float)value, (prev, stepValue) => prev + stepValue);
+                    step = new ComparableStep<float>((float)value, (prev, stepValue) =>
+                    {
+                        var next = prev + stepValue;
+                        if (stepValue > 0 ? next <= prev : prev <= next)
+                            throw new ArithmeticException($"Not enough precision to represent the next step; {prev:r} + {stepValue:r} = {next:r}.");
+                        return next;
+                    });
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class SingleValueGenerator : ValueGenerator<float>
         {
-            public override IEnumerable<float> GenerateRange(float start, float end, float step)
+            public override IEnumerable<float> GenerateRange(float start, float end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start && 0 <= step))
+                else if ((start < end && !step.IsPositive) || (end < start && !step.IsNegative))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = current + step;
+                        var next = step.Apply(current);
 
                         if (start < end)
                         {
@@ -62,6 +62,17 @@ namespace NUnit.Framework.Internal
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is float)
+                {
+                    step = new ComparableStep<float>((float)value, (prev, stepValue) => prev + stepValue);
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
@@ -21,60 +21,23 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class UInt16ValueGenerator : ValueGenerator<ushort>
         {
-            public override IEnumerable<ushort> GenerateRange(ushort start, ushort end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is ushort)
                 {
-                    step = new ComparableStep<ushort>((ushort)value, (prev, stepValue) => unchecked((ushort)(prev + stepValue)));
+                    step = new ComparableStep<ushort>((ushort)value, (prev, stepValue) => checked((ushort)(prev + stepValue)));
                     return true;
                 }
 
                 if (value is int)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked((ushort)(prev + stepValue)));
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((ushort)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
@@ -1,0 +1,60 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class UInt16ValueGenerator : ValueGenerator<ushort>
+        {
+            public override IEnumerable<ushort> GenerateRange(ushort start, ushort end, ushort step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked((ushort)(current + step));
+
+                        if (end < next) break; // We stepped past the end of the range.
+                        if (next < current) break; // We overflowed which means we tried to step past the end.
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
@@ -30,13 +30,13 @@ namespace NUnit.Framework.Internal
     {
         private sealed class UInt32ValueGenerator : ValueGenerator<uint>
         {
-            public override IEnumerable<uint> GenerateRange(uint start, uint end, uint step)
+            public override IEnumerable<uint> GenerateRange(uint start, uint end, Step step)
             {
                 if (start == end)
                 {
                     yield return start;
                 }
-                else if ((start < end && step <= 0) || (end < start))
+                else if ((start < end && !step.IsPositive) || (end < start))
                 {
                     throw new ArgumentException("Step must be in the direction of the end.");
                 }
@@ -46,14 +46,39 @@ namespace NUnit.Framework.Internal
                     {
                         yield return current;
 
-                        var next = unchecked(current + step);
+                        var next = step.Apply(current);
 
-                        if (end < next) break; // We stepped past the end of the range.
-                        if (next < current) break; // We overflowed which means we tried to step past the end.
+                        if (start < end)
+                        {
+                            if (end < next) break; // We stepped past the end of the range.
+                            if (next < current) break; // We overflowed which means we tried to step past the end.
+                        }
+                        else
+                        {
+                            if (next < end) break; // We stepped past the end of the range.
+                            if (current < next) break; // We overflowed which means we tried to step past the end.
+                        }
 
                         current = next;
                     }
                 }
+            }
+
+            public override bool TryCreateStep(object value, out ValueGenerator.Step step)
+            {
+                if (value is uint)
+                {
+                    step = new ComparableStep<uint>((uint)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    return true;
+                }
+
+                if (value is int)
+                {
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked((uint)(prev + stepValue)));
+                    return true;
+                }
+
+                return base.TryCreateStep(value, out step);
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
@@ -1,0 +1,60 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class UInt32ValueGenerator : ValueGenerator<uint>
+        {
+            public override IEnumerable<uint> GenerateRange(uint start, uint end, uint step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked(current + step);
+
+                        if (end < next) break; // We stepped past the end of the range.
+                        if (next < current) break; // We overflowed which means we tried to step past the end.
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
@@ -21,60 +21,23 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class UInt32ValueGenerator : ValueGenerator<uint>
         {
-            public override IEnumerable<uint> GenerateRange(uint start, uint end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is uint)
                 {
-                    step = new ComparableStep<uint>((uint)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    step = new ComparableStep<uint>((uint)value, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 
                 if (value is int)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked((uint)(prev + stepValue)));
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((uint)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
@@ -1,0 +1,60 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    partial class ValueGenerator
+    {
+        private sealed class UInt64ValueGenerator : ValueGenerator<ulong>
+        {
+            public override IEnumerable<ulong> GenerateRange(ulong start, ulong end, ulong step)
+            {
+                if (start == end)
+                {
+                    yield return start;
+                }
+                else if ((start < end && step <= 0) || (end < start))
+                {
+                    throw new ArgumentException("Step must be in the direction of the end.");
+                }
+                else
+                {
+                    for (var current = start;;)
+                    {
+                        yield return current;
+
+                        var next = unchecked(current + step);
+
+                        if (end < next) break; // We stepped past the end of the range.
+                        if (next < current) break; // We overflowed which means we tried to step past the end.
+
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
@@ -21,60 +21,23 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-
 namespace NUnit.Framework.Internal
 {
     partial class ValueGenerator
     {
         private sealed class UInt64ValueGenerator : ValueGenerator<ulong>
         {
-            public override IEnumerable<ulong> GenerateRange(ulong start, ulong end, Step step)
-            {
-                if (start == end)
-                {
-                    yield return start;
-                }
-                else if ((start < end && !step.IsPositive) || (end < start))
-                {
-                    throw new ArgumentException("Step must be in the direction of the end.");
-                }
-                else
-                {
-                    for (var current = start;;)
-                    {
-                        yield return current;
-
-                        var next = step.Apply(current);
-
-                        if (start < end)
-                        {
-                            if (end < next) break; // We stepped past the end of the range.
-                            if (next < current) break; // We overflowed which means we tried to step past the end.
-                        }
-                        else
-                        {
-                            if (next < end) break; // We stepped past the end of the range.
-                            if (current < next) break; // We overflowed which means we tried to step past the end.
-                        }
-
-                        current = next;
-                    }
-                }
-            }
-
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
                 if (value is ulong)
                 {
-                    step = new ComparableStep<ulong>((ulong)value, (prev, stepValue) => unchecked(prev + stepValue));
+                    step = new ComparableStep<ulong>((ulong)value, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 
                 if (value is int)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked(prev + (ulong)stepValue));
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked(prev + (ulong)stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.cs
@@ -47,11 +47,25 @@ namespace NUnit.Framework.Internal
             return GenerateRange((T)start, (T)end, (Step)step);
         }
 
-        public sealed class ComparableStep<TStep> : Step where TStep: IComparable
+        /// <summary>
+        /// Provides a convenient shorthand when <typeparamref name="TStep"/> is <see cref="IComparable{TStep}"/>
+        /// and the default value of <typeparamref name="TStep"/> represents zero.
+        /// </summary>
+        public sealed class ComparableStep<TStep> : Step where TStep : IComparable<TStep>
         {
             private readonly TStep _step;
             private readonly Func<T, TStep, T> _apply;
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ComparableStep{TStep}"/> class.
+            /// </summary>
+            /// <param name="value">The amount by which to increment each time this step is applied.</param>
+            /// <param name="apply">
+            /// Must increment the given value and return the result.
+            /// If the result is outside the range representable by <typeparamref name="T"/>,
+            /// must throw <see cref="OverflowException"/>. If the result does not change due to lack
+            /// of precision representable by <typeparamref name="T"/>, must throw <see cref="ArithmeticException"/>.
+            /// </param>
             public ComparableStep(TStep value, Func<T, TStep, T> apply)
             {
                 if (apply == null) throw new ArgumentNullException(nameof(apply));
@@ -62,14 +76,40 @@ namespace NUnit.Framework.Internal
             public override bool IsPositive => Comparer<TStep>.Default.Compare(default(TStep), _step) < 0;
             public override bool IsNegative => Comparer<TStep>.Default.Compare(_step, default(TStep)) < 0;
 
+            /// <summary>
+            /// Increments the given value and returns the result.
+            /// If the result is outside the range representable by <typeparamref name="T"/>,
+            /// throws <see cref="OverflowException"/>. If the result does not change due to lack
+            /// of precision representable by <typeparamref name="T"/>, throws <see cref="ArithmeticException"/>.
+            /// </summary>
+            /// <exception cref="OverflowException"/>
+            /// <exception cref="ArithmeticException"/>
             public override T Apply(T value) => _apply.Invoke(value, _step);
         }
 
+        /// <summary>
+        /// Encapsulates the ability to increment a <typeparamref name="T"/> value by an amount
+        /// which may be of a different type.
+        /// </summary>
         public new abstract class Step : ValueGenerator.Step
         {
+            /// <summary>
+            /// Increments the given value and returns the result.
+            /// If the result is outside the range representable by <typeparamref name="T"/>,
+            /// throws <see cref="OverflowException"/>. If the result does not change due to lack
+            /// of precision representable by <typeparamref name="T"/>, throws <see cref="ArithmeticException"/>.
+            /// </summary>
+            /// <exception cref="OverflowException"/>
+            /// <exception cref="ArithmeticException"/>
             public abstract T Apply(T value);
         }
 
+        /// <summary>
+        /// Creates a <see cref="Step"/> from the specified value if the current instance is able to
+        /// use it to increment values of type <typeparamref name="T"/>. If the creation fails,
+        /// <see cref="NotSupportedException"/> is thrown.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
         public sealed override ValueGenerator.Step CreateStep(object value)
         {
             ValueGenerator.Step step;
@@ -77,6 +117,11 @@ namespace NUnit.Framework.Internal
             throw CreateNotSupportedException($"creating a step of type {value.GetType()}");
         }
 
+        /// <summary>
+        /// Creates a <see cref="Step"/> from the specified value if the current instance is able to
+        /// use it to increment values of type <typeparamref name="T"/>. A return value indicates
+        /// whether the creation succeeded.
+        /// </summary>
         public override bool TryCreateStep(object value, out ValueGenerator.Step step)
         {
             Guard.ArgumentNotNull(value, nameof(value));
@@ -103,6 +148,9 @@ namespace NUnit.Framework.Internal
 
         public static ValueGenerator<T> Create<T>()
         {
+            // The JIT removes all branches which do not match T since it generates a separate version
+            // of this method at runtime for every value type T.
+
             if (typeof(T) == typeof(sbyte)) return (ValueGenerator<T>)(object)new SByteValueGenerator();
 
             if (typeof(T) == typeof(byte)) return (ValueGenerator<T>)(object)new ByteValueGenerator();
@@ -128,13 +176,28 @@ namespace NUnit.Framework.Internal
             return new DefaultValueGenerator<T>();
         }
 
+        /// <summary>
+        /// Encapsulates the ability to increment a value by an amount which may be of a different type.
+        /// </summary>
         public abstract class Step
         {
             public abstract bool IsPositive { get; }
             public abstract bool IsNegative { get; }
         }
 
+        /// <summary>
+        /// Creates a <see cref="Step"/> from the specified value if the current instance is able to
+        /// use it to increment the on values which it operates. If the creation fails,
+        /// <see cref="NotSupportedException"/> is thrown.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
         public abstract Step CreateStep(object value);
+
+        /// <summary>
+        /// Creates a <see cref="Step"/> from the specified value if the current instance is able to
+        /// use it to increment values on which it operates. A return value indicates
+        /// whether the creation succeeded.
+        /// </summary>
         public abstract bool TryCreateStep(object value, out Step step);
     }
 }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.cs
@@ -1,0 +1,94 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Compatibility;
+
+namespace NUnit.Framework.Internal
+{
+    internal abstract class ValueGenerator<T> : ValueGenerator
+    {
+        private static Exception CreateNotSupportedException(string description)
+        {
+            return new NotSupportedException($"{typeof(T)} is using the default value generator which does not support {description}.");
+        }
+
+        public virtual IEnumerable<T> GenerateRange(T start, T end, T step)
+        {
+            throw CreateNotSupportedException("generating a range");
+        }
+
+        public override IEnumerable GenerateRange(object start, object end, object step)
+        {
+            return GenerateRange((T)start, (T)end, (T)step);
+        }
+    }
+
+    internal abstract partial class ValueGenerator
+    {
+        public abstract IEnumerable GenerateRange(object start, object end, object step);
+
+        private static readonly MethodInfo GenericCreateMethod =
+            typeof(ValueGenerator)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(method => method.Name == nameof(Create) && method.IsGenericMethod);
+
+        public static ValueGenerator Create(Type valueType)
+        {
+            var genericInstantiation = GenericCreateMethod.MakeGenericMethod(valueType);
+            var @delegate = (Func<ValueGenerator>)genericInstantiation.CreateDelegate(typeof(Func<ValueGenerator>));
+            return @delegate.Invoke();
+        }
+
+        public static ValueGenerator<T> Create<T>()
+        {
+            if (typeof(T) == typeof(sbyte)) return (ValueGenerator<T>)(object)new SByteValueGenerator();
+
+            if (typeof(T) == typeof(byte)) return (ValueGenerator<T>)(object)new ByteValueGenerator();
+
+            if (typeof(T) == typeof(short)) return (ValueGenerator<T>)(object)new Int16ValueGenerator();
+
+            if (typeof(T) == typeof(ushort)) return (ValueGenerator<T>)(object)new UInt16ValueGenerator();
+
+            if (typeof(T) == typeof(int)) return (ValueGenerator<T>)(object)new Int32ValueGenerator();
+
+            if (typeof(T) == typeof(uint)) return (ValueGenerator<T>)(object)new UInt32ValueGenerator();
+
+            if (typeof(T) == typeof(long)) return (ValueGenerator<T>)(object)new Int64ValueGenerator();
+
+            if (typeof(T) == typeof(ulong)) return (ValueGenerator<T>)(object)new UInt64ValueGenerator();
+
+            if (typeof(T) == typeof(float)) return (ValueGenerator<T>)(object)new SingleValueGenerator();
+
+            if (typeof(T) == typeof(double)) return (ValueGenerator<T>)(object)new DoubleValueGenerator();
+
+            if (typeof(T) == typeof(decimal)) return (ValueGenerator<T>)(object)new DecimalValueGenerator();
+
+            return new DefaultValueGenerator<T>();
+        }
+    }
+}

--- a/src/NUnitFramework/testdata/RangeTestFixture.cs
+++ b/src/NUnitFramework/testdata/RangeTestFixture.cs
@@ -1,0 +1,33 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+    public static class RangeTestFixture
+    {
+        [Test]
+        public static void MethodWithMultipleRanges([Range(1, 3)] [Range(10, 12)] int x) { }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.ExpectedOutcome.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.ExpectedOutcome.cs
@@ -1,0 +1,89 @@
+// ***********************************************************************
+// Copyright (c) 2009-2015 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework.Constraints;
+
+#if NETCOREAPP1_1
+using System.Linq;
+#endif
+
+namespace NUnit.Framework.Attributes
+{
+    partial class RangeAttributeTests
+    {
+        public struct ExpectedOutcome
+        {
+            private readonly IEnumerable _values;
+
+            private ExpectedOutcome(IEnumerable values)
+            {
+                _values = values;
+            }
+
+            public override string ToString()
+            {
+                return _values == null
+                    ? "Expected: coercion error"
+                    : "Expected: values " + MsgUtils.FormatCollection(_values, 0, int.MaxValue);
+            }
+
+            public static ExpectedOutcome CoercionError => new ExpectedOutcome(null);
+
+            public static ExpectedOutcome Values(IEnumerable expected)
+            {
+                Guard.ArgumentNotNull(expected, nameof(expected));
+                return new ExpectedOutcome(expected);
+            }
+
+            public void Assert(RangeAttribute attribute, Type parameterType)
+            {
+                var param = GetStubParameter(parameterType);
+
+                if (_values != null)
+                {
+                    Framework.Assert.That(attribute.GetData(null, param),
+                        Is.EqualTo(_values).AsCollection.Using((IEqualityComparer)EqualityComparer<object>.Default));
+                }
+                else
+                {
+                    Framework.Assert.That(() => attribute.GetData(null, param),
+                        Throws.Exception.Message.Contains("cannot be passed to a parameter of type"));
+                }
+            }
+
+            private static ParameterInfo GetStubParameter(Type parameterType)
+            {
+                return typeof(ExpectedOutcome)
+                       .GetMethod(nameof(DummyMethod), BindingFlags.Static | BindingFlags.NonPublic)
+                       .MakeGenericMethod(parameterType)
+                       .GetParameters()[0];
+            }
+
+            private static void DummyMethod<T>(T parameter) { }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.RangeWithExpectedConversions.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.RangeWithExpectedConversions.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Attributes
             /// </summary>
             public void AssertCoercionErrorOrMatchingSequence(Type parameterType, IEnumerable valuesToConvert)
             {
-                var param = GetStubParameter(parameterType);
+                var param = StubParameterInfo.OfType(parameterType);
 
                 if (ExpectedConversions.Contains(parameterType))
                 {
@@ -72,16 +72,6 @@ namespace NUnit.Framework.Attributes
                         Throws.Exception.Message.Contains("cannot be passed to a parameter of type"));
                 }
             }
-
-            private static ParameterInfo GetStubParameter(Type parameterType)
-            {
-                return typeof(RangeWithExpectedConversions)
-                       .GetMethod(nameof(DummyMethod), BindingFlags.Static | BindingFlags.NonPublic)
-                       .MakeGenericMethod(parameterType)
-                       .GetParameters()[0];
-            }
-
-            private static void DummyMethod<T>(T parameter) { }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -408,7 +408,7 @@ namespace NUnit.Framework.Attributes
             CheckValuesWithinTolerance(nameof(MethodWithFloatRangeAndNegativeStep_Reversed), 1.2f, 1.0f, 0.8f);
         }
 
-        private void MethodWithFloatRangeAndNegativeStep_Reversed([Range(1.2f, 0.7, -0.2f)] float x) { }
+        private void MethodWithFloatRangeAndNegativeStep_Reversed([Range(1.2f, 0.7f, -0.2f)] float x) { }
 
         [Test]
         public void FloatRangeWithMultipleAttributes()
@@ -433,19 +433,19 @@ namespace NUnit.Framework.Attributes
         private void MethodWithIntRangeAndShortArgument([Range(1, 3)] short x) { }
 
         [Test]
-        public void CanConvertIntRangeToByte() 
+        public void CanConvertIntRangeToByte()
         {
             CheckValues(nameof(MethodWithIntRangeAndByteArgument), (byte)1, (byte)2, (byte)3);
         }
-        
+
         private void MethodWithIntRangeAndByteArgument([Range(1, 3)] byte x) { }
 
         [Test]
-        public void CanConvertIntRangeToSByte() 
+        public void CanConvertIntRangeToSByte()
         {
             CheckValues(nameof(MethodWithIntRangeAndSByteArgument), (sbyte)1, (sbyte)2, (sbyte)3);
         }
-        
+
         private void MethodWithIntRangeAndSByteArgument([Range(1, 3)] sbyte x) { }
 
         [Test]
@@ -453,11 +453,11 @@ namespace NUnit.Framework.Attributes
         {
             CheckValues(nameof(MethodWithIntRangeAndDecimalArgument), 1M, 2M, 3M);
         }
-        
+
         private void MethodWithIntRangeAndDecimalArgument([Range(1, 3)] decimal x) { }
 
         [Test]
-        public void CanConvertDoubleRangeToDecimal() 
+        public void CanConvertDoubleRangeToDecimal()
         {
             CheckValues(nameof(MethodWithDoubleRangeAndDecimalArgument), 1.0M, 1.1M, 1.2M);
         }
@@ -468,7 +468,7 @@ namespace NUnit.Framework.Attributes
         #endregion
 
         #region Helper Methods
-        
+
         private void CheckValues(string methodName, params object[] expected)
         {
             var method = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
@@ -493,7 +493,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(attr.GetData(GetType(), param),
                 Is.EqualTo(expected).Within(0.000001));
         }
-        
+
         #endregion
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -34,6 +34,16 @@ namespace NUnit.Framework.Attributes
 {
     public class RangeAttributeTests
     {
+        [Test]
+        public void MultipleAttributes()
+        {
+            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleRanges));
+
+            Assert.That(test.TestCaseCount, Is.EqualTo(6));
+        }
+
+        private void MethodWithMultipleRanges([Range(1, 3)] [Range(10, 12)] int x) { }
+
         #region Ints
 
         [Test]
@@ -100,16 +110,6 @@ namespace NUnit.Framework.Attributes
 
         private void MethodWithIntRangeAndNegativeStep_Reversed([Range(15, 11, -2)] int x) { }
 
-        [Test]
-        public void IntRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleIntRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleIntRange([Range(1, 3)][Range(10, 12)]int x) { }
-
         #endregion
 
         #region Unsigned Ints
@@ -161,16 +161,6 @@ namespace NUnit.Framework.Attributes
         }
 
         private void MethodWithUintRangeAndStep_Reversed([Range(15u, 11u, 2u)] uint x) { }
-
-        [Test]
-        public void UnsignedIntRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleUnsignedIntRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleUnsignedIntRange([Range(1u, 3u)] [Range(10u, 12u)] uint x) { }
 
         #endregion
 
@@ -240,16 +230,6 @@ namespace NUnit.Framework.Attributes
 
         private void MethodWithLongRangeAndNegativeStep_Reversed([Range(15L, 11L, -2L)] long x) { }
 
-        [Test]
-        public void LongRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleLongRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleLongRange([Range(1L, 3L)] [Range(10L, 12L)] long x) { }
-
         #endregion
 
         #region Unsigned Longs
@@ -302,16 +282,6 @@ namespace NUnit.Framework.Attributes
 
         private void MethodWithUlongRangeAndStep_Reversed([Range(15ul, 11ul, 2ul)] ulong x) { }
 
-        [Test]
-        public void UnsignedLongRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleUnsignedLongRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleUnsignedLongRange([Range(1ul, 3ul)] [Range(10ul, 12ul)] ulong x) { }
-
         #endregion
 
         #region Doubles
@@ -356,16 +326,6 @@ namespace NUnit.Framework.Attributes
 
         private void MethodWithDoubleRangeAndNegativeStep_Reversed([Range(1.2, 0.7, -0.2)] double x) { }
 
-        [Test]
-        public void DoubleRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleDoubleRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleDoubleRange([Range(1.0, 3.0, 1.0)] [Range(10.0, 12.0, 1.0)] double x) { }
-
         #endregion
 
         #region Floats
@@ -409,16 +369,6 @@ namespace NUnit.Framework.Attributes
         }
 
         private void MethodWithFloatRangeAndNegativeStep_Reversed([Range(1.2f, 0.7f, -0.2f)] float x) { }
-
-        [Test]
-        public void FloatRangeWithMultipleAttributes()
-        {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(GetType(), nameof(MethodWithMultipleFloatRange));
-
-            Assert.That(test.TestCaseCount, Is.EqualTo(6));
-        }
-
-        private void MethodWithMultipleFloatRange([Range(1.0f, 3.0f, 1.0f)] [Range(10.0f, 12.0f, 1.0f)] float x) { }
 
         #endregion
 

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -411,15 +411,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public static void MaxValueRange_Decimal()
         {
-            const double step = (double)(((decimal)LargestDoubleConvertibleToDecimal - (decimal)NextLargestDoubleConvertibleToLowerDecimal) / 2);
+            const decimal fromDecimal = (decimal)NextLargestDoubleConvertibleToLowerDecimal;
+            const decimal toDecimal = (decimal)LargestDoubleConvertibleToDecimal;
+            const double step = (double)((toDecimal - fromDecimal) / 2);
 
             Assert.That(
                 GetData(new RangeAttribute(NextLargestDoubleConvertibleToLowerDecimal, LargestDoubleConvertibleToDecimal, step), typeof(decimal)),
                 Is.EqualTo(new[]
                 {
-                    (decimal)NextLargestDoubleConvertibleToLowerDecimal,
-                    (decimal)NextLargestDoubleConvertibleToLowerDecimal + (decimal)step,
-                    (decimal)NextLargestDoubleConvertibleToLowerDecimal + (decimal)step * 2
+                    fromDecimal,
+                    fromDecimal + (decimal)step,
+                    fromDecimal + (decimal)step * 2
                 }));
         }
 
@@ -483,15 +485,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public static void MinValueRange_Decimal()
         {
-            const double step = (double)((-(decimal)LargestDoubleConvertibleToDecimal - -(decimal)NextLargestDoubleConvertibleToLowerDecimal) / 2);
+            const decimal fromDecimal = -(decimal)NextLargestDoubleConvertibleToLowerDecimal;
+            const decimal toDecimal = -(decimal)LargestDoubleConvertibleToDecimal;
+            const double step = (double)((toDecimal - fromDecimal) / 2);
 
             Assert.That(
                 GetData(new RangeAttribute(-NextLargestDoubleConvertibleToLowerDecimal, -LargestDoubleConvertibleToDecimal, step), typeof(decimal)),
                 Is.EqualTo(new[]
                 {
-                    -(decimal)NextLargestDoubleConvertibleToLowerDecimal,
-                    -(decimal)NextLargestDoubleConvertibleToLowerDecimal + (decimal)step,
-                    -(decimal)NextLargestDoubleConvertibleToLowerDecimal + (decimal)step * 2
+                    fromDecimal,
+                    fromDecimal + (decimal)step,
+                    fromDecimal + (decimal)step * 2
                 }));
         }
 

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework.Internal;
@@ -135,6 +136,66 @@ namespace NUnit.Framework.Attributes
         {
             rangeWithExpectedConversions.AssertCoercionErrorOrMatchingSequence(
                 parameterType, new[] { 11 });
+        }
+
+        public static IEnumerable<RangeWithExpectedConversions> DegeneratePositiveStepRangeCases => new[]
+        {
+            new RangeWithExpectedConversions(new RangeAttribute(11, 11, 2), Int32RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11u, 11u, 2u), UInt32RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11L, 11L, 2L), Int64RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11UL, 11UL, 2UL), UInt64RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11f, 11f, 2f), SingleRangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11d, 11d, 2d), DoubleRangeConvertibleToParameterTypes)
+        };
+
+        [Test]
+        public static void DegeneratePositiveStepRangeDisallowed_Int32(
+            [ValueSource(nameof(DegeneratePositiveStepRangeCases))] RangeWithExpectedConversions rangeWithExpectedConversions,
+            [ValueSource(nameof(TestedParameterTypes))] Type parameterType)
+        {
+            rangeWithExpectedConversions.AssertCoercionErrorOrMatchingSequence(
+                parameterType, new[] { 11 });
+        }
+
+        public static IEnumerable<RangeWithExpectedConversions> DegenerateNegativeStepRangeCases => new[]
+        {
+            new RangeWithExpectedConversions(new RangeAttribute(11, 11, -2), Int32RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11L, 11L, -2L), Int64RangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11f, 11f, -2f), SingleRangeConvertibleToParameterTypes),
+            new RangeWithExpectedConversions(new RangeAttribute(11d, 11d, -2d), DoubleRangeConvertibleToParameterTypes)
+        };
+
+        [Test]
+        public static void DegenerateNegativeStepRange(
+            [ValueSource(nameof(DegenerateNegativeStepRangeCases))] RangeWithExpectedConversions rangeWithExpectedConversions,
+            [ValueSource(nameof(TestedParameterTypes))] Type parameterType)
+        {
+            rangeWithExpectedConversions.AssertCoercionErrorOrMatchingSequence(
+                parameterType, new[] { 11 });
+        }
+
+        [Test]
+        public static void DegenerateZeroStepRangeDisallowed_Int32()
+        {
+            Assert.That(() => new RangeAttribute(11, 11, 0), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public static void DegenerateZeroStepRangeDisallowed_Int64()
+        {
+            Assert.That(() => new RangeAttribute(11L, 11L, 0L), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public static void DegenerateZeroStepRangeDisallowed_Single()
+        {
+            Assert.That(() => new RangeAttribute(11f, 11f, 0f), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public static void DegenerateZeroStepRangeDisallowed_Double()
+        {
+            Assert.That(() => new RangeAttribute(11d, 11d, 0d), Throws.InstanceOf<ArgumentException>());
         }
 
         #endregion
@@ -274,5 +335,66 @@ namespace NUnit.Framework.Attributes
         }
 
         #endregion
+
+        #region MaxValue
+
+        [Test]
+        public static void MaxValueRange_Int32()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(int.MaxValue - 2, int.MaxValue), typeof(int)),
+                Is.EqualTo(new[] { int.MaxValue - 2, int.MaxValue - 1, int.MaxValue }));
+        }
+
+        [Test]
+        public static void MaxValueRange_UInt32()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(uint.MaxValue - 2, uint.MaxValue), typeof(uint)),
+                Is.EqualTo(new[] { uint.MaxValue - 2, uint.MaxValue - 1, uint.MaxValue }));
+        }
+
+        [Test]
+        public static void MaxValueRange_Int64()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(long.MaxValue - 2, long.MaxValue), typeof(long)),
+                Is.EqualTo(new[] { long.MaxValue - 2, long.MaxValue - 1, long.MaxValue }));
+        }
+
+        [Test]
+        public static void MaxValueRange_UInt64()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(ulong.MaxValue - 2, ulong.MaxValue), typeof(ulong)),
+                Is.EqualTo(new[] { ulong.MaxValue - 2, ulong.MaxValue - 1, ulong.MaxValue }));
+        }
+
+        #endregion
+
+        #region MinValue
+
+        [Test]
+        public static void MinValueRange_Int32()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(int.MinValue + 2, int.MinValue), typeof(int)),
+                Is.EqualTo(new[] { int.MinValue + 2, int.MinValue + 1, int.MinValue }));
+        }
+
+        [Test]
+        public static void MinValueRange_Int64()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(long.MinValue + 2, long.MinValue), typeof(long)),
+                Is.EqualTo(new[] { long.MinValue + 2, long.MinValue + 1, long.MinValue }));
+        }
+
+        #endregion
+
+        private static IEnumerable GetData(RangeAttribute rangeAttribute, Type parameterType)
+        {
+            return rangeAttribute.GetData(null, StubParameterInfo.OfType(parameterType));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -49,6 +49,7 @@ namespace NUnit.Framework.Attributes
             typeof(decimal)
         };
 
+        // See XML docs for the ParamAttributeTypeConversions class.
         private static readonly Type[] Int32RangeConvertibleToParameterTypes = { typeof(int), typeof(sbyte), typeof(byte), typeof(short), typeof(decimal) };
         private static readonly Type[] UInt32RangeConvertibleToParameterTypes = { typeof(uint) };
         private static readonly Type[] Int64RangeConvertibleToParameterTypes = { typeof(long) };
@@ -337,6 +338,7 @@ namespace NUnit.Framework.Attributes
 
         // The smallest distance from MaxValue or MinValue which results in a different number,
         // overcoming loss of precision.
+        // Calculated by hand by flipping bits. Used the round-trip format and double-checked.
         private const float SingleExtremaEpsilon = 2.028241E+31f;
         private const double DoubleExtremaEpsilon = 1.99584030953472E+292;
         private const double LargestDoubleConvertibleToDecimal = 7.9228162514264329E+28;

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities;
@@ -32,7 +33,7 @@ using System.Linq;
 
 namespace NUnit.Framework.Attributes
 {
-    public class RangeAttributeTests
+    public partial class RangeAttributeTests
     {
         [Test]
         public void MultipleAttributes()
@@ -46,69 +47,123 @@ namespace NUnit.Framework.Attributes
 
         #region Ints
 
-        [Test]
-        public void IntRange()
+        public static IEnumerable<TestCaseData> IntRangeCases() => new[]
         {
-            CheckValues(nameof(MethodWithIntRange), 11, 12, 13, 14, 15);
+            new TestCaseData(typeof(sbyte), ExpectedOutcome.Values(new sbyte[] { 11, 12, 13, 14, 15 })),
+            new TestCaseData(typeof(byte), ExpectedOutcome.Values(new byte[] { 11, 12, 13, 14, 15 })),
+            new TestCaseData(typeof(short), ExpectedOutcome.Values(new short[] { 11, 12, 13, 14, 15 })),
+            new TestCaseData(typeof(ushort), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(int), ExpectedOutcome.Values(new int[] { 11, 12, 13, 14, 15 })),
+            new TestCaseData(typeof(uint), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(long), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(ulong), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(float), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(double), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(decimal), ExpectedOutcome.Values(new decimal[] { 11, 12, 13, 14, 15 }))
+        };
+        [TestCaseSource(nameof(IntRangeCases))]
+        public static void IntRange(Type parameterType, ExpectedOutcome outcome)
+        {
+            outcome.Assert(new RangeAttribute(11, 15), parameterType);
         }
 
-        private void MethodWithIntRange([Range(11, 15)] int x) { }
-
-        [Test]
-        public void IntRange_Reversed()
+        public static IEnumerable<TestCaseData> IntRange_ReversedCases() => new[]
         {
-            CheckValues(nameof(MethodWithIntRange_Reversed), 15, 14, 13, 12, 11);
+            new TestCaseData(typeof(sbyte), ExpectedOutcome.Values(new sbyte[] { 15, 14, 13, 12, 11 })),
+            new TestCaseData(typeof(byte), ExpectedOutcome.Values(new byte[] { 15, 14, 13, 12, 11 })),
+            new TestCaseData(typeof(short), ExpectedOutcome.Values(new short[] { 15, 14, 13, 12, 11 })),
+            new TestCaseData(typeof(ushort), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(int), ExpectedOutcome.Values(new int[] { 15, 14, 13, 12, 11 })),
+            new TestCaseData(typeof(uint), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(long), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(ulong), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(float), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(double), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(decimal), ExpectedOutcome.Values(new decimal[] { 15, 14, 13, 12, 11 }))
+        };
+        [TestCaseSource(nameof(IntRange_ReversedCases))]
+        public static void IntRange_Reversed(Type parameterType, ExpectedOutcome outcome)
+        {
+            outcome.Assert(new RangeAttribute(15, 11), parameterType);
         }
 
-        private void MethodWithIntRange_Reversed([Range(15, 11)] int x) { }
-
-        [Test]
-        public void IntRange_FromEqualsTo()
+        public static IEnumerable<TestCaseData> IntRange_FromEqualsToCases() => new[]
         {
-            CheckValues(nameof(MethodWithIntRange_FromEqualsTo), 11);
+            new TestCaseData(typeof(sbyte), ExpectedOutcome.Values(new sbyte[] { 11 })),
+            new TestCaseData(typeof(byte), ExpectedOutcome.Values(new byte[] { 11 })),
+            new TestCaseData(typeof(short), ExpectedOutcome.Values(new short[] { 11 })),
+            new TestCaseData(typeof(ushort), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(int), ExpectedOutcome.Values(new int[] { 11 })),
+            new TestCaseData(typeof(uint), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(long), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(ulong), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(float), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(double), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(decimal), ExpectedOutcome.Values(new decimal[] { 11 }))
+        };
+        [TestCaseSource(nameof(IntRange_FromEqualsToCases))]
+        public static void IntRange_FromEqualsTo(Type parameterType, ExpectedOutcome outcome)
+        {
+            outcome.Assert(new RangeAttribute(11, 11), parameterType);
         }
 
-        private void MethodWithIntRange_FromEqualsTo([Range(11, 11)] int x) { }
-
-        [Test]
-        public void IntRangeAndStep()
+        public static IEnumerable<TestCaseData> IntRangeAndStepCases() => new[]
         {
-            CheckValues(nameof(MethodWithIntRangeAndStep), 11, 13, 15);
+            new TestCaseData(typeof(sbyte), ExpectedOutcome.Values(new sbyte[] { 11, 13, 15 })),
+            new TestCaseData(typeof(byte), ExpectedOutcome.Values(new byte[] { 11, 13, 15 })),
+            new TestCaseData(typeof(short), ExpectedOutcome.Values(new short[] { 11, 13, 15 })),
+            new TestCaseData(typeof(ushort), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(int), ExpectedOutcome.Values(new int[] { 11, 13, 15 })),
+            new TestCaseData(typeof(uint), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(long), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(ulong), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(float), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(double), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(decimal), ExpectedOutcome.Values(new decimal[] { 11, 13, 15 }))
+        };
+        [TestCaseSource(nameof(IntRangeAndStepCases))]
+        public static void IntRangeAndStep(Type parameterType, ExpectedOutcome outcome)
+        {
+            outcome.Assert(new RangeAttribute(11, 15, 2), parameterType);
         }
 
-        private void MethodWithIntRangeAndStep([Range(11, 15, 2)] int x) { }
-
         [Test]
-        public void IntRangeAndZeroStep()
+        public static void IntRangeAndZeroStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndZeroStep), 11, 12, 13));
+            Assert.That(() => new RangeAttribute(11, 15, 0), Throws.InstanceOf<ArgumentException>());
         }
 
-        private void MethodWithIntRangeAndZeroStep([Range(11, 15, 0)] int x) { }
-
         [Test]
-        public void IntRangeAndStep_Reversed()
+        public static void IntRangeAndStep_Reversed()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndStep_Reversed), 11, 13, 15));
+            Assert.That(() => new RangeAttribute(15, 11, 2), Throws.InstanceOf<ArgumentException>());
         }
 
-        private void MethodWithIntRangeAndStep_Reversed([Range(15, 11, 2)] int x) { }
-
         [Test]
-        public void IntRangeAndNegativeStep()
+        public static void IntRangeAndNegativeStep()
         {
-            Assert.Throws<ArgumentException>(() => CheckValues(nameof(MethodWithIntRangeAndNegativeStep), 11, 13, 15));
+            Assert.That(() => new RangeAttribute(11, 15, -2), Throws.InstanceOf<ArgumentException>());
         }
 
-        private void MethodWithIntRangeAndNegativeStep([Range(11, 15, -2)] int x) { }
-
-        [Test]
-        public void IntRangeAndNegativeStep_Reversed()
+        public static IEnumerable<TestCaseData> IntRangeAndNegativeStep_ReversedCases() => new[]
         {
-            CheckValues(nameof(MethodWithIntRangeAndNegativeStep_Reversed), 15, 13, 11);
+            new TestCaseData(typeof(sbyte), ExpectedOutcome.Values(new sbyte[] { 15, 13, 11 })),
+            new TestCaseData(typeof(byte), ExpectedOutcome.Values(new byte[] { 15, 13, 11 })),
+            new TestCaseData(typeof(short), ExpectedOutcome.Values(new short[] { 15, 13, 11 })),
+            new TestCaseData(typeof(ushort), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(int), ExpectedOutcome.Values(new int[] { 15, 13, 11 })),
+            new TestCaseData(typeof(uint), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(long), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(ulong), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(float), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(double), ExpectedOutcome.CoercionError),
+            new TestCaseData(typeof(decimal), ExpectedOutcome.Values(new decimal[] { 15, 13, 11 }))
+        };
+        [TestCaseSource(nameof(IntRangeAndNegativeStep_ReversedCases))]
+        public static void IntRangeAndNegativeStep_Reversed(Type parameterType, ExpectedOutcome outcome)
+        {
+            outcome.Assert(new RangeAttribute(15, 11, -2), parameterType);
         }
-
-        private void MethodWithIntRangeAndNegativeStep_Reversed([Range(15, 11, -2)] int x) { }
 
         #endregion
 
@@ -373,38 +428,6 @@ namespace NUnit.Framework.Attributes
         #endregion
 
         #region Conversions
-
-        [Test]
-        public void CanConvertIntRangeToShort()
-        {
-            CheckValues(nameof(MethodWithIntRangeAndShortArgument), (short)1, (short)2, (short)3);
-        }
-
-        private void MethodWithIntRangeAndShortArgument([Range(1, 3)] short x) { }
-
-        [Test]
-        public void CanConvertIntRangeToByte()
-        {
-            CheckValues(nameof(MethodWithIntRangeAndByteArgument), (byte)1, (byte)2, (byte)3);
-        }
-
-        private void MethodWithIntRangeAndByteArgument([Range(1, 3)] byte x) { }
-
-        [Test]
-        public void CanConvertIntRangeToSByte()
-        {
-            CheckValues(nameof(MethodWithIntRangeAndSByteArgument), (sbyte)1, (sbyte)2, (sbyte)3);
-        }
-
-        private void MethodWithIntRangeAndSByteArgument([Range(1, 3)] sbyte x) { }
-
-        [Test]
-        public void CanConvertIntRangeToDecimal()
-        {
-            CheckValues(nameof(MethodWithIntRangeAndDecimalArgument), 1M, 2M, 3M);
-        }
-
-        private void MethodWithIntRangeAndDecimalArgument([Range(1, 3)] decimal x) { }
 
         [Test]
         public void CanConvertDoubleRangeToDecimal()

--- a/src/NUnitFramework/tests/TestUtilities/StubParameterInfo.cs
+++ b/src/NUnitFramework/tests/TestUtilities/StubParameterInfo.cs
@@ -1,0 +1,57 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Reflection;
+
+namespace NUnit.TestUtilities
+{
+    public static class StubParameterInfo
+    {
+        public static ParameterInfo OfType(Type parameterType)
+        {
+#if NETCOREAPP1_1
+            return typeof(StubParameterInfo)
+                   .GetMethod(nameof(DummyMethod), BindingFlags.Static | BindingFlags.NonPublic)
+                   .MakeGenericMethod(parameterType)
+                   .GetParameters()[0];
+#else
+            return new Impl(parameterType);
+#endif
+        }
+
+#if NETCOREAPP1_1
+        private static void DummyMethod<T>(T parameter) { }
+#else
+        private sealed class Impl : ParameterInfo
+        {
+            public Impl(Type parameterType)
+            {
+                ParameterType = parameterType;
+            }
+
+            public override Type ParameterType { get; }
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/nunit/nunit/blob/b648b8a32f8641452a13103f06a6924b8a39c385/src/NUnitFramework/framework/Attributes/RangeAttribute.cs#L44-L45

Rather than building up an array of boxed values and then converting the values (reboxing them), values are now only generated on demand *and* now generated natively matching the parameter type rather than having to convert each value in the sequence.

I structured it this way so that other things can be moved here in the future, such as [RandomAttribute's generic specializations](https://github.com/nunit/nunit/blob/d4686bbfba471337c646ab2592a60d2713e59109/src/NUnitFramework/framework/Attributes/RandomAttribute.cs#L168-L193).
