### PR TITLE
Removed accidental call to ValueType.GetHashCode while overriding

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/FixtureMethod.cs
+++ b/src/NUnitFramework/framework/Interfaces/FixtureMethod.cs
@@ -96,7 +96,6 @@ namespace NUnit.Framework.Interfaces
         public override int GetHashCode()
         {
             var hashCode = 662238274;
-            hashCode = hashCode * -1521134295 + base.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(FixtureType);
             hashCode = hashCode * -1521134295 + EqualityComparer<MethodInfo>.Default.GetHashCode(Method);
             return hashCode;


### PR DESCRIPTION
I was sure I had deleted this line. The point of overriding GetHashCode is to avoid incurring the performance hit of ValueType.GetHashCode.