### PR TITLE
Scoped the modifiers to convey intended uses (NUnit.Framework.Constraints)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -279,7 +279,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// An OrderingStep represents one stage of the sort
         /// </summary>
-        private class OrderingStep
+        private sealed class OrderingStep
         {
             public OrderingStep(string propertyName)
             {

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -28,10 +28,10 @@ namespace NUnit.Framework.Constraints
 {
     /// <summary><see cref="CollectionTally"/> counts (tallies) the number of occurrences 
     /// of each object in one or more enumerations.</summary>
-    public class CollectionTally
+    public sealed class CollectionTally
     {
         /// <summary>The result of a <see cref="CollectionTally"/>.</summary>
-        public class CollectionTallyResult
+        public sealed class CollectionTallyResult
         {
             /// <summary>Items that were not in the expected collection.</summary>
             public List<object> ExtraItems { get; set; }

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -34,16 +34,16 @@ namespace NUnit.Framework.Constraints
         public sealed class CollectionTallyResult
         {
             /// <summary>Items that were not in the expected collection.</summary>
-            public List<object> ExtraItems { get; set; }
+            public List<object> ExtraItems { get; }
 
             /// <summary>Items that were not accounted for in the expected collection.</summary>
-            public List<object> MissingItems { get; set; }
+            public List<object> MissingItems { get; }
 
-            /// <summary>Constructs an empty <see cref="CollectionTallyResult"/>.</summary>
-            public CollectionTallyResult()
+            /// <summary>Initializes a new instance of the <see cref="CollectionTallyResult"/> class with the given fields.</summary>
+            public CollectionTallyResult(List<object> missingItems, List<object> extraItems)
             {
-                ExtraItems = new List<object>();
-                MissingItems = new List<object>();
+                MissingItems = missingItems;
+                ExtraItems = extraItems;
             }
         }
 
@@ -54,11 +54,9 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-                return new CollectionTallyResult()
-                {
-                    MissingItems = new List<object>(_missingItems),
-                    ExtraItems = new List<object>(_extraItems)
-                };
+                return new CollectionTallyResult(
+                    new List<object>(_missingItems),
+                    new List<object>(_extraItems));
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="Array"/>s.
     /// </summary>
-    internal class ArraysComparer : IChainComparer
+    internal sealed class ArraysComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
         private readonly EnumerablesComparer _enumerablesComparer;

--- a/src/NUnitFramework/framework/Constraints/Comparers/CharsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/CharsComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="Char"/>s.
     /// </summary>
-    internal class CharsComparer : IChainComparer
+    internal sealed class CharsComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="DateTimeOffset"/>s.
     /// </summary>
-    internal class DateTimeOffsetsComparer : IChainComparer
+    internal sealed class DateTimeOffsetsComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="IDictionary"/>s.
     /// </summary>
-    internal class DictionariesComparer : IChainComparer
+    internal sealed class DictionariesComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionaryEntriesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionaryEntriesComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="DictionaryEntry"/>s.
     /// </summary>
-    internal class DictionaryEntriesComparer : IChainComparer
+    internal sealed class DictionaryEntriesComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/DirectoriesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DirectoriesComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="DirectoryInfo"/>s.
     /// </summary>
-    internal class DirectoriesComparer : IChainComparer
+    internal sealed class DirectoriesComparer : IChainComparer
     {
         public bool? Equal(object x, object y, ref Tolerance tolerance, bool topLevelComparison = true)
         {

--- a/src/NUnitFramework/framework/Constraints/Comparers/EnumerablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EnumerablesComparer.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="IEnumerable"/>s.
     /// </summary>
-    internal class EnumerablesComparer : IChainComparer
+    internal sealed class EnumerablesComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two types related by <see cref="IEquatable{T}"/>.
     /// </summary>
-    internal class EquatablesComparer : IChainComparer
+    internal sealed class EquatablesComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/KeyValuePairsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/KeyValuePairsComparer.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="KeyValuePair{TKey, TValue}"/>s.
     /// </summary>
-    internal class KeyValuePairsComparer : IChainComparer
+    internal sealed class KeyValuePairsComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="Numerics"/>s.
     /// </summary>
-    internal class NumericsComparer : IChainComparer
+    internal sealed class NumericsComparer : IChainComparer
     {
         public bool? Equal(object x, object y, ref Tolerance tolerance, bool topLevelComparison = true)
         {

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="Stream"/>s.
     /// </summary>
-    internal class StreamsComparer : IChainComparer
+    internal sealed class StreamsComparer : IChainComparer
     {
         private static readonly int BUFFER_SIZE = 4096;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="String"/>s.
     /// </summary>
-    internal class StringsComparer : IChainComparer
+    internal sealed class StringsComparer : IChainComparer
     {
         private readonly NUnitEqualityComparer _equalityComparer;
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/TimeSpanToleranceComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TimeSpanToleranceComparer.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <see cref="DateTime"/>s or <see cref="TimeSpan"/>s.
     /// </summary>
-    internal class TimeSpanToleranceComparer : IChainComparer
+    internal sealed class TimeSpanToleranceComparer : IChainComparer
     {
         public bool? Equal(object x, object y, ref Tolerance tolerance, bool topLevelComparison = true)
         {

--- a/src/NUnitFramework/framework/Constraints/Comparers/TupleComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TupleComparer.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <c>Tuple</c>s.
     /// </summary>
-    internal class TupleComparer : TupleComparerBase
+    internal sealed class TupleComparer : TupleComparerBase
     {
         internal TupleComparer(NUnitEqualityComparer equalityComparer)
             : base(equalityComparer)

--- a/src/NUnitFramework/framework/Constraints/Comparers/ValueTupleComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ValueTupleComparer.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints.Comparers
     /// <summary>
     /// Comparator for two <c>ValueTuple</c>s.
     /// </summary>
-    internal class ValueTupleComparer : TupleComparerBase
+    internal sealed class ValueTupleComparer : TupleComparerBase
     {
         internal ValueTupleComparer(NUnitEqualityComparer equalityComparer)
             : base(equalityComparer)

--- a/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,18 +30,18 @@ namespace NUnit.Framework.Constraints
     /// ConstraintBuilder maintains the stacks that are used in
     /// processing a ConstraintExpression. An OperatorStack
     /// is used to hold operators that are waiting for their
-    /// operands to be reorganized. a ConstraintStack holds 
+    /// operands to be reorganized. a ConstraintStack holds
     /// input constraints as well as the results of each
     /// operator applied.
     /// </summary>
-    public class ConstraintBuilder : IResolveConstraint
+    public sealed class ConstraintBuilder : IResolveConstraint
     {
         #region Nested Operator Stack Class
 
         /// <summary>
         /// OperatorStack is a type-safe stack for holding ConstraintOperators
         /// </summary>
-        public class OperatorStack
+        private sealed class OperatorStack
         {
             private readonly Stack<ConstraintOperator> stack = new Stack<ConstraintOperator>();
 
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// ConstraintStack is a type-safe stack for holding Constraints
         /// </summary>
-        public class ConstraintStack
+        public sealed class ConstraintStack
         {
             private readonly Stack<IConstraint> stack = new Stack<IConstraint>();
             private readonly ConstraintBuilder builder;
@@ -121,7 +121,7 @@ namespace NUnit.Framework.Constraints
 
             /// <summary>
             /// Pushes the specified constraint. As a side effect,
-            /// the constraint's Builder field is set to the 
+            /// the constraint's Builder field is set to the
             /// ConstraintBuilder owning this stack.
             /// </summary>
             /// <param name="constraint">The constraint to put onto the stack</param>
@@ -186,7 +186,7 @@ namespace NUnit.Framework.Constraints
 
             // Reduce any lower precedence operators
             ReduceOperatorStack(op.LeftPrecedence);
-            
+
             ops.Push(op);
             lastPushed = op;
         }

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// The ConstraintBuilder holding the elements recognized so far
         /// </summary>
-        protected ConstraintBuilder builder;
+        protected readonly ConstraintBuilder builder;
 
         #endregion
 
@@ -54,9 +54,8 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstraintExpression"/> class.
         /// </summary>
-        public ConstraintExpression()
+        public ConstraintExpression() : this(new ConstraintBuilder())
         {
-            this.builder = new ConstraintBuilder();
         }
 
         /// <summary>
@@ -66,6 +65,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="builder">The builder.</param>
         public ConstraintExpression(ConstraintBuilder builder)
         {
+            Guard.ArgumentNotNull(builder, nameof(builder));
             this.builder = builder;
         }
 

--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -125,7 +125,7 @@ namespace NUnit.Framework.Constraints
             return new PredicateEqualityAdapter<TExpected, TActual>(comparison);
         }
 
-        internal class PredicateEqualityAdapter<TActual, TExpected> : EqualityAdapter
+        internal sealed class PredicateEqualityAdapter<TActual, TExpected> : EqualityAdapter
         {
             private readonly Func<TActual, TExpected, bool> _comparison;
 

--- a/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
+++ b/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
@@ -26,7 +26,6 @@ using System.Runtime.InteropServices;
 
 namespace NUnit.Framework.Constraints
 {
-
     /// <summary>Helper routines for working with floating point numbers</summary>
     /// <remarks>
     ///   <para>
@@ -45,9 +44,8 @@ namespace NUnit.Framework.Constraints
     ///     as low as 0.0000001 for small numbers or as high as 10.0 for large numbers.
     ///   </para>
     /// </remarks>
-    public class FloatingPointNumerics
+    internal static class FloatingPointNumerics
     {
-
         #region struct FloatIntUnion
 
         /// <summary>Union of a floating point variable and an integer</summary>
@@ -256,10 +254,6 @@ namespace NUnit.Framework.Constraints
             DoubleLongUnion union = new DoubleLongUnion();
             union.Long = value;
             return union.Double;
-        }
-
-        private FloatingPointNumerics()
-        {
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
+++ b/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -190,70 +190,6 @@ namespace NUnit.Framework.Constraints
 
             // Either they have the same sign or both are very close to zero
             return Math.Abs(leftUnion.Long - rightUnion.Long) <= maxUlps;
-        }
-
-        /// <summary>
-        ///   Reinterprets the memory contents of a floating point value as an integer value
-        /// </summary>
-        /// <param name="value">
-        ///   Floating point value whose memory contents to reinterpret
-        /// </param>
-        /// <returns>
-        ///   The memory contents of the floating point value interpreted as an integer
-        /// </returns>
-        public static int ReinterpretAsInt(float value)
-        {
-            FloatIntUnion union = new FloatIntUnion();
-            union.Float = value;
-            return union.Int;
-        }
-
-        /// <summary>
-        ///   Reinterprets the memory contents of a double precision floating point
-        ///   value as an integer value
-        /// </summary>
-        /// <param name="value">
-        ///   Double precision floating point value whose memory contents to reinterpret
-        /// </param>
-        /// <returns>
-        ///   The memory contents of the double precision floating point value
-        ///   interpreted as an integer
-        /// </returns>
-        public static long ReinterpretAsLong(double value)
-        {
-            DoubleLongUnion union = new DoubleLongUnion();
-            union.Double = value;
-            return union.Long;
-        }
-
-        /// <summary>
-        ///   Reinterprets the memory contents of an integer as a floating point value
-        /// </summary>
-        /// <param name="value">Integer value whose memory contents to reinterpret</param>
-        /// <returns>
-        ///   The memory contents of the integer value interpreted as a floating point value
-        /// </returns>
-        public static float ReinterpretAsFloat(int value)
-        {
-            FloatIntUnion union = new FloatIntUnion();
-            union.Int = value;
-            return union.Float;
-        }
-
-        /// <summary>
-        ///   Reinterprets the memory contents of an integer value as a double precision
-        ///   floating point value
-        /// </summary>
-        /// <param name="value">Integer whose memory contents to reinterpret</param>
-        /// <returns>
-        ///   The memory contents of the integer interpreted as a double precision
-        ///   floating point value
-        /// </returns>
-        public static double ReinterpretAsDouble(long value)
-        {
-            DoubleLongUnion union = new DoubleLongUnion();
-            union.Long = value;
-            return union.Double;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Interval.cs
+++ b/src/NUnitFramework/framework/Constraints/Interval.cs
@@ -6,7 +6,7 @@ namespace NUnit.Framework.Constraints
     /// Keeps track of an interval time which can be represented in
     /// Minutes, Seconds or Milliseconds
     /// </summary>
-    public class Interval
+    public sealed class Interval
     {
         private readonly int _value;
         private IntervalUnit _mode;

--- a/src/NUnitFramework/framework/Constraints/NUnitComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitComparer.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
     /// NUnitComparer encapsulates NUnit's default behavior
     /// in comparing two objects.
     /// </summary>
-    public class NUnitComparer : IComparer
+    public sealed class NUnitComparer : IComparer
     {
         /// <summary>
         /// Returns the default NUnitComparer.

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
     /// NUnitEqualityComparer encapsulates NUnit's handling of
     /// equality tests between objects.
     /// </summary>
-    public class NUnitEqualityComparer
+    public sealed class NUnitEqualityComparer
     {
         #region Static and Instance Fields
         /// <summary>
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Constraints
         /// FailurePoint class represents one point of failure
         /// in an equality test.
         /// </summary>
-        public class FailurePoint
+        public sealed class FailurePoint
         {
             /// <summary>
             /// The location of the failure

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Constraints
 
         #region Nested Result Class
 
-        private class ThrowsConstraintResult : ConstraintResult
+        private sealed class ThrowsConstraintResult : ConstraintResult
         {
             private readonly ConstraintResult baseResult;
 
@@ -148,7 +148,7 @@ namespace NUnit.Framework.Constraints
 
         #region ExceptionInterceptor
 
-        internal class ExceptionInterceptor
+        internal sealed class ExceptionInterceptor
         {
             private ExceptionInterceptor() { }
 
@@ -230,7 +230,7 @@ namespace NUnit.Framework.Constraints
 
 #region InvocationDescriptor
 
-        internal class GenericInvocationDescriptor<T> : IInvocationDescriptor
+        internal sealed class GenericInvocationDescriptor<T> : IInvocationDescriptor
         {
             private readonly ActualValueDelegate<T> _del;
 
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Constraints
             object Invoke();
         }
 
-        private class VoidInvocationDescriptor : IInvocationDescriptor
+        private sealed class VoidInvocationDescriptor : IInvocationDescriptor
         {
             private readonly TestDelegate _del;
 

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Constraints
 #if !NETSTANDARD1_6
     [Serializable]
 #endif
-    public class Tolerance
+    public sealed class Tolerance
     {
         #region Constants and Static Properties
 
@@ -324,7 +324,7 @@ namespace NUnit.Framework.Constraints
         /// Tolerance.Range represents the range of values that match
         /// a specific tolerance, when applied to a specific value.
         /// </summary>
-        public class Range
+        public struct Range
         {
             /// <summary>
             /// The lower bound of the range
@@ -332,12 +332,12 @@ namespace NUnit.Framework.Constraints
             public readonly object LowerBound;
 
             /// <summary>
-            /// The Upper bound of the range
+            /// The upper bound of the range
             /// </summary>
             public readonly object UpperBound;
 
             /// <summary>
-            ///  Construct a Range
+            /// Constructs a range
             /// </summary>
             public Range(object lowerBound, object upperBound)
             {

--- a/src/NUnitFramework/tests/Constraints/FloatingPointNumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/FloatingPointNumericsTest.cs
@@ -73,57 +73,5 @@ namespace NUnit.Framework.Constraints
                 FloatingPointNumerics.AreAlmostEqualUlps(2.0, -2.0, 1)
             );
         }
-
-        /// <summary>Tests the integer reinterpretation functions</summary>
-        [Test]
-        public void MirroredIntegerReinterpretation()
-        {
-            Assert.AreEqual(
-                12345.0f,
-                FloatingPointNumerics.ReinterpretAsFloat(
-                    FloatingPointNumerics.ReinterpretAsInt(12345.0f)
-                )
-            );
-        }
-
-        /// <summary>Tests the long reinterpretation functions</summary>
-        [Test]
-        public void MirroredLongReinterpretation()
-        {
-            Assert.AreEqual(
-                12345.67890,
-                FloatingPointNumerics.ReinterpretAsDouble(
-                    FloatingPointNumerics.ReinterpretAsLong(12345.67890)
-                )
-            );
-        }
-
-        /// <summary>Tests the floating point reinterpretation functions</summary>
-        [Test]
-        public void MirroredFloatReinterpretation()
-        {
-            Assert.AreEqual(
-                12345,
-                FloatingPointNumerics.ReinterpretAsInt(
-                    FloatingPointNumerics.ReinterpretAsFloat(12345)
-                )
-            );
-        }
-
-
-        /// <summary>
-        ///   Tests the double prevision floating point reinterpretation functions
-        /// </summary>
-        [Test]
-        public void MirroredDoubleReinterpretation()
-        {
-            Assert.AreEqual(
-                1234567890,
-                FloatingPointNumerics.ReinterpretAsLong(
-                    FloatingPointNumerics.ReinterpretAsDouble(1234567890)
-                )
-            );
-        }
-
-  }
+    }
 }


### PR DESCRIPTION
In the same vein as https://github.com/nunit/nunit/pull/2804.

ℹ This is not why I think `sealed` is important, but a side effect of this is that recent JITs generate faster code when calling methods of sealed classes.