### PR TITLE
Only run AppVeyor PR build against open PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,6 @@ deploy:
     skip_symbols: true
     on:
       branch: master
+      
+# For PRs, skip the branch run and only run against the virtual PR merge.
+skip_branch_with_pr: true


### PR DESCRIPTION
This will cut down on duplicate AppVeyor work. As soon as you open a PR, further pushes to that branch will not be built as branch builds but only as PR (virtual `master` merge) builds.

It's working great at https://github.com/OmerMor/AsyncBridge!