### PR TITLE
Only introspect one-dimensional arrays

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -221,7 +221,7 @@ namespace NUnit.Framework.Internal
                     : Convert.ToString(arg, System.Globalization.CultureInfo.InvariantCulture);
 
                 var argArray = arg as Array;
-                if (argArray != null)
+                if (argArray != null && argArray.Rank == 1)
                 {
                     if (argArray.Length == 0)
                         display = "[]";

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace NUnit.TestData.TestCaseSourceAttributeFixture
@@ -147,7 +148,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
         }
 
-        [TestCaseSource(nameof(ComplexArrayBasedTestInput))]
+        [TestCaseSource(nameof(ComplexArrayBasedTestInputTestCases))]
         public void MethodWithArrayArguments(object o)
         {
         }
@@ -184,7 +185,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             }
         }
 
-        public static object[] ComplexArrayBasedTestInput = new[]
+        static object[] ComplexArrayBasedTestInput = new[]
         {
             new object[] { 1, "text", new object() },
             new object[0],
@@ -192,5 +193,11 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
             new object[] { new byte[,] { { 1, 2 }, { 2, 3 } } }
         };
+
+        static IEnumerable<TestCaseData> ComplexArrayBasedTestInputTestCases()
+        {
+            foreach (var argumentValue in ComplexArrayBasedTestInput)
+                yield return new TestCaseData(args: new object[] { argumentValue });
+        }
     }
 }

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -189,7 +189,8 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             new object[] { 1, "text", new object() },
             new object[0],
             new object[] { 1, new int[] { 2, 3 }, 4 },
-            new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+            new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+            new object[] { new byte[,] { { 1, 2 }, { 2, 3 } } }
         };
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -349,7 +349,7 @@ namespace NUnit.Framework.Attributes
                 Assert.That(suite.Tests[1].Name, Is.EqualTo(@"MethodWithArrayArguments([])"));
                 Assert.That(suite.Tests[2].Name, Is.EqualTo(@"MethodWithArrayArguments([1, Int32[], 4])"));
                 Assert.That(suite.Tests[3].Name, Is.EqualTo(@"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"));
-                Assert.That(suite.Tests[4].Name, Is.EqualTo(@"MethodWithArrayArguments(System.Byte[,])"));
+                Assert.That(suite.Tests[4].Name, Is.EqualTo(@"MethodWithArrayArguments([System.Byte[,]])"));
             });
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -341,7 +341,7 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithArrayArguments));
 
-            Assert.That(suite.TestCaseCount, Is.EqualTo(4));
+            Assert.That(suite.TestCaseCount, Is.EqualTo(5));
 
             Assert.Multiple(() =>
             {
@@ -349,6 +349,7 @@ namespace NUnit.Framework.Attributes
                 Assert.That(suite.Tests[1].Name, Is.EqualTo(@"MethodWithArrayArguments([])"));
                 Assert.That(suite.Tests[2].Name, Is.EqualTo(@"MethodWithArrayArguments([1, Int32[], 4])"));
                 Assert.That(suite.Tests[3].Name, Is.EqualTo(@"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"));
+                Assert.That(suite.Tests[4].Name, Is.EqualTo(@"MethodWithArrayArguments(System.Byte[,])"));
             });
         }
 

--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -233,7 +233,8 @@ namespace NUnit.Framework.Attributes
             new object[] { 1, "text", new object() },
             new object[0],
             new object[] { 1, new int[] { 2, 3 }, 4 },
-            new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+            new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+            new object[] { new byte[,] { { 1, 2 }, { 2, 3 } } }
         };
 
         [Test]
@@ -242,7 +243,7 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
                 GetType(), nameof(MethodWithArrayArguments));
 
-            Assert.That(suite.TestCaseCount, Is.EqualTo(4));
+            Assert.That(suite.TestCaseCount, Is.EqualTo(5));
 
             Assert.Multiple(() =>
             {
@@ -250,6 +251,7 @@ namespace NUnit.Framework.Attributes
                 Assert.That(suite.Tests[1].Name, Is.EqualTo(@"MethodWithArrayArguments([])"));
                 Assert.That(suite.Tests[2].Name, Is.EqualTo(@"MethodWithArrayArguments([1, Int32[], 4])"));
                 Assert.That(suite.Tests[3].Name, Is.EqualTo(@"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"));
+                Assert.That(suite.Tests[4].Name, Is.EqualTo(@"MethodWithArrayArguments([System.Byte[,]])"));
             });
         }
     }


### PR DESCRIPTION
I've augmented the existing tests even though we do not introspect multi-dimensional arrays, but this keeps the related tests together.

Fixes #2823