### PR TITLE
Corrects the failure message

### DIFF
--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -310,7 +310,7 @@ namespace NUnit.Framework.Assertions
                 Assert.Fail(
                     $"Expected the number of lines to be no more than {maxLineCount}, but it was {lines.Length}:" + Environment.NewLine
                     + Environment.NewLine
-                    + string.Concat(lines.Select((line, i) => $" {i + 1}. {line.Trim()}" + Environment.NewLine))
+                    + string.Concat(lines.Select((line, i) => $" {i + 1}. {line.Trim()}" + Environment.NewLine).ToArray())
                     + "(end)");
 
                  // ^ Most of that is to differentiate it from the current method's stack trace


### PR DESCRIPTION
Calling ToArray to force the right overload of `string.Concat`.

Without this change I get something like (as we just "ToString" the IEnumerable instead of the individual elements) as the failure message.
```
...
Multiple failures or warnings in test:
  1) (Warning message)
  2) Expected the number of lines to be no more than 4, but it was 5:

System.Linq.Enumerable+<CreateSelectIterator>d__147`2[System.String,System.String](end)
```

With the change I get
```
...
Multiple failures or warnings in test:
  1) (Warning message)
  2) Expected the number of lines to be no more than 4, but it was 5:

 1. at NUnit.TestData.WarningFixture.<>c__DisplayClass45_0.<WarningInBeginInvoke>b__0()
 2. at System.Runtime.Remoting.Messaging.StackBuilderSink._PrivateProcessMessage(IntPtr md, Object[] args, Object server, Object[]& outArgs)
 3. at System.Runtime.Remoting.Messaging.StackBuilderSink.AsyncProcessMessage(IMessage msg, IMessageSink replySink)
 4. at System.Runtime.Remoting.Proxies.AgileAsyncWorkerItem.ThreadPoolCallBack(Object o)
 5. at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
(end)
```