### PR TITLE
Show non-matching item for AllItems/NoItem constraints

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections;
 using NUnit.Framework.Internal;
 
@@ -61,9 +60,16 @@ namespace NUnit.Framework.Constraints
         {
             var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
+            int index = 0;
             foreach (object item in enumerable)
+            {
                 if (!BaseConstraint.ApplyTo(item).IsSuccess)
-                    return new ConstraintResult(this, actual, ConstraintStatus.Failure);
+                {
+                    return new EachItemConstraintResult(this, actual, item, index);
+                }
+
+                index++;
+            }
 
             return new ConstraintResult(this, actual, ConstraintStatus.Success);
         }

--- a/src/NUnitFramework/framework/Constraints/EachItemConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EachItemConstraintResult.cs
@@ -1,0 +1,40 @@
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Provides a <see cref="ConstraintResult"/> for the constraints 
+    /// that are applied to each item in the collection
+    /// </summary>
+    public class EachItemConstraintResult : ConstraintResult
+    {
+        private readonly object _nonMatchingItem;
+        private readonly int _nonMatchingItemIndex;
+
+        /// <summary>
+        /// Constructs a <see cref="EachItemConstraintResult" /> for a particular <see cref="Constraint" />.
+        /// Only used for Failure
+        /// </summary>
+        /// <param name="constraint">The Constraint to which this result applies.</param>
+        /// <param name="actualValue">The actual value to which the Constraint was applied.</param>
+        /// <param name="nonMatchingItem">Actual item that does not match expected condition</param>
+        /// <param name="nonMatchingIndex">Non matching item index</param>
+        public EachItemConstraintResult(IConstraint constraint, object actualValue, object nonMatchingItem, int nonMatchingIndex)
+            : base(constraint, actualValue, false)
+        {
+            _nonMatchingItem = nonMatchingItem;
+            _nonMatchingItemIndex = nonMatchingIndex;
+        }
+
+        /// <summary>
+        /// Write constraint description, actual items, and non-matching item
+        /// </summary>
+        /// <param name="writer">The MessageWriter on which to display the message</param>
+        public override void WriteMessageTo(MessageWriter writer)
+        {
+            base.WriteMessageTo(writer);
+
+            var nonMatchingStr = $"  Non-matching item at index [{_nonMatchingItemIndex}]:  "
+                + MsgUtils.FormatValue(_nonMatchingItem);
+            writer.WriteLine(nonMatchingStr);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EachItemConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EachItemConstraintResult.cs
@@ -1,20 +1,43 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
     /// Provides a <see cref="ConstraintResult"/> for the constraints 
     /// that are applied to each item in the collection
     /// </summary>
-    public class EachItemConstraintResult : ConstraintResult
+    internal sealed class EachItemConstraintResult : ConstraintResult
     {
         private readonly object _nonMatchingItem;
         private readonly int _nonMatchingItemIndex;
 
         /// <summary>
-        /// Constructs a <see cref="EachItemConstraintResult" /> for a particular <see cref="Constraint" />.
+        /// Constructs a <see cref="EachItemConstraintResult" /> for a particular <see cref="Constraint" />
         /// Only used for Failure
         /// </summary>
-        /// <param name="constraint">The Constraint to which this result applies.</param>
-        /// <param name="actualValue">The actual value to which the Constraint was applied.</param>
+        /// <param name="constraint">The Constraint to which this result applies</param>
+        /// <param name="actualValue">The actual value to which the Constraint was applied</param>
         /// <param name="nonMatchingItem">Actual item that does not match expected condition</param>
         /// <param name="nonMatchingIndex">Non matching item index</param>
         public EachItemConstraintResult(IConstraint constraint, object actualValue, object nonMatchingItem, int nonMatchingIndex)
@@ -28,11 +51,9 @@ namespace NUnit.Framework.Constraints
         /// Write constraint description, actual items, and non-matching item
         /// </summary>
         /// <param name="writer">The MessageWriter on which to display the message</param>
-        public override void WriteMessageTo(MessageWriter writer)
+        public override void WriteAdditionalLinesTo(MessageWriter writer)
         {
-            base.WriteMessageTo(writer);
-
-            var nonMatchingStr = $"  Non-matching item at index [{_nonMatchingItemIndex}]:  "
+            var nonMatchingStr = $"  First non-matching item at index [{_nonMatchingItemIndex}]:  "
                 + MsgUtils.FormatValue(_nonMatchingItem);
             writer.WriteLine(nonMatchingStr);
         }

--- a/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections;
 using NUnit.Framework.Internal;
 
@@ -61,9 +60,16 @@ namespace NUnit.Framework.Constraints
         {
             var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
+            int index = 0;
             foreach (object item in enumerable)
+            {
                 if (BaseConstraint.ApplyTo(item).IsSuccess)
-                    return new ConstraintResult(this, actual, ConstraintStatus.Failure);
+                {
+                    return new EachItemConstraintResult(this, actual, item, index);
+                }
+
+                index++;
+            }
 
             return new ConstraintResult(this, actual, ConstraintStatus.Success);
         }

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -25,10 +25,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using NUnit.Compatibility;
-using NUnit.Framework.Constraints;
-using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
 
@@ -55,9 +51,10 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: all items instance of <System.String>" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", <System.Object> >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", <System.Object> >" + Environment.NewLine +
+                "  Non-matching item at index [2]:  <System.Object>" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(collection,typeof(string)));
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(collection, typeof(string)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
         #endregion
@@ -77,7 +74,8 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: all items not null" + Environment.NewLine +
-                "  But was:  < \"x\", null, \"z\" >" + Environment.NewLine;
+                "  But was:  < \"x\", null, \"z\" >" + Environment.NewLine +
+                "  Non-matching item at index [1]:  null" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreNotNull(collection));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: all items instance of <System.String>" + Environment.NewLine +
                 "  But was:  < \"x\", \"y\", <System.Object> >" + Environment.NewLine +
-                "  Non-matching item at index [2]:  <System.Object>" + Environment.NewLine;
+                "  First non-matching item at index [2]:  <System.Object>" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(collection, typeof(string)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: all items not null" + Environment.NewLine +
                 "  But was:  < \"x\", null, \"z\" >" + Environment.NewLine +
-                "  Non-matching item at index [1]:  null" + Environment.NewLine;
+                "  First non-matching item at index [1]:  null" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreNotNull(collection));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items not equal to null" + NL +
                 TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
-                "  Non-matching item at index [2]:  null" + NL;
+                "  First non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new NotConstraint(new EqualConstraint(null)))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items in range (10,100)" + NL +
                 TextMessageWriter.Pfx_Actual + "< 12, 27, 19, 32, 107, 99, 26 >" + NL +
-                "  Non-matching item at index [4]:  107" + NL;
+                "  First non-matching item at index [4]:  107" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new RangeConstraint(10, 100))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -111,7 +111,7 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items instance of <System.Char>" + NL +
                 TextMessageWriter.Pfx_Actual + "< 'a', \"b\", 'c' >" + NL +
-                "  Non-matching item at index [1]:  \"b\"" + NL;
+                "  First non-matching item at index [1]:  \"b\"" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new InstanceOfTypeConstraint(typeof(char)))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -45,7 +45,8 @@ namespace NUnit.Framework.Constraints
             object[] c = new object[] { 1, "hello", null, 3 };
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items not equal to null" + NL +
-                TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL;
+                TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
+                "  Non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new NotConstraint(new EqualConstraint(null)))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -90,7 +91,8 @@ namespace NUnit.Framework.Constraints
             int[] c = new int[] { 12, 27, 19, 32, 107, 99, 26 };
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items in range (10,100)" + NL +
-                TextMessageWriter.Pfx_Actual + "< 12, 27, 19, 32, 107, 99, 26 >" + NL;
+                TextMessageWriter.Pfx_Actual + "< 12, 27, 19, 32, 107, 99, 26 >" + NL +
+                "  Non-matching item at index [4]:  107" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new RangeConstraint(10, 100))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -108,7 +110,8 @@ namespace NUnit.Framework.Constraints
             object[] c = new object[] { 'a', "b", 'c' };
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "all items instance of <System.Char>" + NL +
-                TextMessageWriter.Pfx_Actual + "< 'a', \"b\", 'c' >" + NL;
+                TextMessageWriter.Pfx_Actual + "< 'a', \"b\", 'c' >" + NL +
+                "  Non-matching item at index [1]:  \"b\"" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new InstanceOfTypeConstraint(typeof(char)))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -119,7 +122,7 @@ namespace NUnit.Framework.Constraints
             var c = new NUnit.TestUtilities.Collections.SimpleObjectCollection(1, 2, 3);
             Assert.That(c, Is.All.Not.Null);
         }
-        
+
         [Test]
         public void FailsWhenNotUsedAgainstAnEnumerable()
         {

--- a/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "no item null" + NL +
                 TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
-                "  Non-matching item at index [2]:  null" + NL;
+                "  First non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new NoItemConstraint(Is.Null)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }

--- a/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2007 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -28,9 +28,9 @@ namespace NUnit.Framework.Constraints
 {
     [TestFixture]
     public class NoItemConstraintTests
-    {   
+    {
         private readonly string NL = Environment.NewLine;
-        
+
         [Test]
         public void NoItemsAreNotNull()
         {
@@ -44,11 +44,12 @@ namespace NUnit.Framework.Constraints
             object[] c = new object[] { 1, "hello", null, 3 };
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "no item null" + NL +
-                TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL;
+                TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
+                "  Non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new NoItemConstraint(Is.Null)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
-        
+
         [Test]
         public void FailsWhenNotUsedAgainstAnEnumerable()
         {


### PR DESCRIPTION
Fixes #2854 


Added additional line in message showing non-matching item:
```
Expected: all items instance of <System.Char>
Actual: < 'a', \"b\", 'c' >
Non-matching item at index [1]: "b"      <---- ADDED
```