### PR TITLE
Consistent netstandard1.6 behavior (System.Diagnostics.Process)

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -30,6 +30,7 @@ Supported platforms:
       <group targetFramework="net45" />
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Diagnostics.Process" version="4.3.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.0" />

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -42,6 +42,7 @@ How to use this package:
       <group targetFramework="netstandard1.6">
         <dependency id="NUnit" version="[$version$]" />
         <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Diagnostics.Process" version="4.3.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NUnit" version="[$version$]" />

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -273,8 +273,8 @@ namespace NUnit.Framework.Api
 
             testAssembly.ApplyAttributesToTest(assembly);
 
-#if !NETSTANDARD1_6
             testAssembly.Properties.Set(PropertyNames.ProcessID, System.Diagnostics.Process.GetCurrentProcess().Id);
+#if !NETSTANDARD1_6
             testAssembly.Properties.Set(PropertyNames.AppDomain, AppDomain.CurrentDomain.FriendlyName);
 #endif
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -146,11 +146,9 @@ namespace NUnit.Framework.Api
                     var workDirectory = Settings.ContainsKey(FrameworkPackageSettings.WorkDirectory)
                         ? (string)Settings[FrameworkPackageSettings.WorkDirectory]
                         : Directory.GetCurrentDirectory();
-#if NETSTANDARD1_6
-                    var id = DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss");
-#else
+
                     var id = Process.GetCurrentProcess().Id;
-#endif
+
                     var logName = string.Format(LOG_FILE_FORMAT, id, Path.GetFileName(assemblyPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -412,11 +412,7 @@ namespace NUnitLite
                     ? Path.GetFileNameWithoutExtension(_options.InputFile)
                     : "NUnitLite";
 
-#if NETSTANDARD1_6
-            var id = DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss");
-#else
             var id = Process.GetCurrentProcess().Id;
-#endif
 
             return string.Format(LOG_FILE_FORMAT, id, baseName, ext);
         }

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The recommendation from the corefx team is that we should expect .NET Standard platform extensions like System.Diagnostics.Process to just work.