### PR TITLE
Make tests robust without depending on the order of attributes

### DIFF
--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections;
+using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.TestData.TestCaseAttributeFixture;
@@ -403,14 +404,14 @@ namespace NUnit.Framework.Attributes
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodWithArrayArguments));
 
             Assert.That(suite.TestCaseCount, Is.EqualTo(4));
-
-            Assert.Multiple(() =>
+            var expectedNames = new[]
             {
-                Assert.That(suite.Tests[0].Name, Is.EqualTo(@"MethodWithArrayArguments([])"));
-                Assert.That(suite.Tests[1].Name, Is.EqualTo(@"MethodWithArrayArguments([1, ""text"", null])"));
-                Assert.That(suite.Tests[2].Name, Is.EqualTo(@"MethodWithArrayArguments([1, Int32[], 4])"));
-                Assert.That(suite.Tests[3].Name, Is.EqualTo(@"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"));
-            });
+                @"MethodWithArrayArguments([])",
+                @"MethodWithArrayArguments([1, ""text"", null])",
+                @"MethodWithArrayArguments([1, Int32[], 4])",
+                @"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"
+            };
+            Assert.That(suite.Tests.Select(t => t.Name), Is.EquivalentTo(expectedNames));
         }
 
 

--- a/src/NUnitFramework/tests/Internal/TestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestMethodTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Linq;
 using NUnit.Framework.Internal.Builders;
 using NUnit.TestData.TestFixtureTests;
 
@@ -68,8 +69,9 @@ namespace NUnit.Framework.Internal
             Assert.That(test.Arguments, Is.EqualTo(new object[0]));
             Assert.That(test.Tests[0], Is.TypeOf<TestMethod>());
             Assert.That(test.Tests[1], Is.TypeOf<TestMethod>());
-            Assert.That(test.Tests[0].Arguments, Is.EqualTo(new object[] { 42, "abc" }));
-            Assert.That(test.Tests[1].Arguments, Is.EqualTo(new object[] { 24, "cba" }));
+            var expectedArguments = new[] { new object[] { 42, "abc" }, new object[] { 24, "cba" } };
+            var actualArguments = test.Tests.Select(t => t.Arguments);
+            Assert.That(actualArguments, Is.EquivalentTo(expectedArguments));
         }
     }
 }


### PR DESCRIPTION
Relates to #2326 (perhaps even closes the issue?)