### PR TITLE
Implement prefiltering in NUnitLite

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -48,9 +48,6 @@ namespace NUnit.Framework.Api
         /// </summary>
         readonly ISuiteBuilder _defaultSuiteBuilder;
 
-        /// <summary>
-        /// The PreFilter used by this builder
-        /// </summary>
         private PreFilter _filter;
 
         #endregion
@@ -174,7 +171,7 @@ namespace NUnit.Framework.Api
 
                 _filter = new PreFilter();
                 if (options.ContainsKey(FrameworkPackageSettings.LOAD))
-                    foreach (string filterText in (IList<string>)options[FrameworkPackageSettings.LOAD])
+                    foreach (string filterText in (IList)options[FrameworkPackageSettings.LOAD])
                         _filter.Add(filterText);
 
                 var fixtures = GetFixtures(assembly);
@@ -238,7 +235,7 @@ namespace NUnit.Framework.Api
             var result = new List<Type>();
 
             foreach (Type type in assembly.GetTypes())
-                if (_filter.Match(type))
+                if (_filter.IsMatch(type))
                     result.Add(type);
 
             return result;

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -234,20 +234,13 @@ namespace NUnit.Framework.Api
 
             var result = new List<Type>();
 
-            foreach (string name in names)
-            {
-                Type fixtureType = assembly.GetType(name);
-                if (fixtureType != null)
-                    result.Add(fixtureType);
-                else
-                {
-                    string prefix = name + ".";
-
-                    foreach (Type type in types)
-                        if (type.FullName.StartsWith(prefix))
-                            result.Add(type);
-                }
-            }
+            foreach (Type type in types)
+                foreach (string name in names)
+                    if (type.FullName == name || type.FullName.StartsWith(name + "."))
+                    {
+                        result.Add(type);
+                        break;
+                    }
 
             return result;
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -234,7 +234,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="type">The type to be used as a fixture.</param>
         /// <param name="filter">Filter used to select methods as tests.</param>
-        public IEnumerable<TestSuite> BuildFrom(Type type, PreFilter filter)
+        public IEnumerable<TestSuite> BuildFrom(Type type, IPreFilter filter)
         {
             yield return _builder.BuildFrom(type, filter, this);
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework
     /// TestFixtureAttribute is used to mark a class that represents a TestFixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
-    public class TestFixtureAttribute : NUnitAttribute, IFixtureBuilder, ITestFixtureData
+    public class TestFixtureAttribute : NUnitAttribute, IFixtureBuilder2, ITestFixtureData
     {
         private readonly NUnitTestFixtureBuilder _builder = new NUnitTestFixtureBuilder();
 
@@ -222,7 +222,21 @@ namespace NUnit.Framework
         /// <param name="type">The type to be used as a fixture.</param>
         public IEnumerable<TestSuite> BuildFrom(Type type)
         {
-            yield return _builder.BuildFrom(type, this);
+            yield return _builder.BuildFrom(type, PreFilter.Empty, this);
+        }
+
+        #endregion
+
+        #region IFixtureBuilder2 Members
+
+        /// <summary>
+        /// Builds a single test fixture from the specified type.
+        /// </summary>
+        /// <param name="type">The type to be used as a fixture.</param>
+        /// <param name="filter">Filter used to select methods as tests.</param>
+        public IEnumerable<TestSuite> BuildFrom(Type type, PreFilter filter)
+        {
+            yield return _builder.BuildFrom(type, filter, this);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -122,7 +122,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="type">The type to be used as a fixture.</param>
         /// <param name="filter">PreFilter used to select methods as tests.</param>
-        public IEnumerable<TestSuite> BuildFrom(Type type, PreFilter filter)
+        public IEnumerable<TestSuite> BuildFrom(Type type, IPreFilter filter)
         {
             Type sourceType = SourceType ?? type;
 

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework
     /// provide test fixture instances for a test class.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public class TestFixtureSourceAttribute : NUnitAttribute, IFixtureBuilder
+    public class TestFixtureSourceAttribute : NUnitAttribute, IFixtureBuilder2
     {
         private readonly NUnitTestFixtureBuilder _builder = new NUnitTestFixtureBuilder();
 
@@ -110,7 +110,24 @@ namespace NUnit.Framework
             Type sourceType = SourceType ?? type;
 
             foreach (TestFixtureParameters parms in GetParametersFor(sourceType))
-                yield return _builder.BuildFrom(type, parms);
+                yield return _builder.BuildFrom(type, PreFilter.Empty, parms);
+        }
+
+        #endregion
+
+        #region IFixtureBuilder2 Members
+
+        /// <summary>
+        /// Builds any number of test fixtures from the specified type.
+        /// </summary>
+        /// <param name="type">The type to be used as a fixture.</param>
+        /// <param name="filter">PreFilter used to select methods as tests.</param>
+        public IEnumerable<TestSuite> BuildFrom(Type type, PreFilter filter)
+        {
+            Type sourceType = SourceType ?? type;
+
+            foreach (TestFixtureParameters parms in GetParametersFor(sourceType))
+                yield return _builder.BuildFrom(type, filter, parms);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Interfaces/IFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/IFixtureBuilder.cs
@@ -28,6 +28,9 @@ namespace NUnit.Framework.Interfaces
 {
     using Internal;
 
+    // TODO: These methods should really return IEnumerable<TestFixture>, 
+    // but that requires changes to the Test hierarchy.
+
     /// <summary>
     /// The IFixtureBuilder interface is exposed by a class that knows how to
     /// build test fixtures from a specified type. In general, it is exposed
@@ -40,7 +43,20 @@ namespace NUnit.Framework.Interfaces
         /// Builds any number of test fixtures from the specified type.
         /// </summary>
         /// <param name="type">The type to be used as a fixture.</param>
-        // TODO: This should really return a TestFixture, but that requires changes to the Test hierarchy.
         IEnumerable<TestSuite> BuildFrom(Type type);
+    }
+
+    /// <summary>
+    /// The IFixtureBuilder2 interface extends IFixtureBuilder by allowing
+    /// use of a PreFilter, which is used to select methods as test cases.
+    /// </summary>
+    public interface IFixtureBuilder2 : IFixtureBuilder
+    {
+        /// <summary>
+        /// Builds any number of test fixtures from the specified type.
+        /// </summary>
+        /// <param name="type">The type to be used as a fixture.</param>
+        /// <param name="filter">PreFilter to be used to select methods.</param>
+        IEnumerable<TestSuite> BuildFrom(Type type, PreFilter filter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/IPreFilter.cs
+++ b/src/NUnitFramework/framework/Interfaces/IPreFilter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014–2018 Charlie Poole, Rob Prouse
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,41 +22,26 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
+using System.Reflection;
 
 namespace NUnit.Framework.Interfaces
 {
-    using Internal;
-
-    // TODO: These methods should really return IEnumerable<TestFixture>, 
-    // but that requires changes to the Test hierarchy.
-
     /// <summary>
-    /// The IFixtureBuilder interface is exposed by a class that knows how to
-    /// build test fixtures from a specified type. In general, it is exposed
-    /// by an attribute, but it may be implemented in a helper class used by the
-    /// attribute in some cases.
+    /// Implemented by filters for use in deciding which
+    /// Types and Methods should be used to generate tests.
     /// </summary>
-    public interface IFixtureBuilder
+    public interface IPreFilter
     {
         /// <summary>
-        /// Builds any number of test fixtures from the specified type.
+        /// Use the filter on a Type, returning true if the type matches the filter
+        /// and should therefore be included in the discovery process.
         /// </summary>
-        /// <param name="type">The type to be used as a fixture.</param>
-        IEnumerable<TestSuite> BuildFrom(Type type);
-    }
+        bool IsMatch(Type type);
 
-    /// <summary>
-    /// The IFixtureBuilder2 interface extends IFixtureBuilder by allowing
-    /// use of a PreFilter, which is used to select methods as test cases.
-    /// </summary>
-    public interface IFixtureBuilder2 : IFixtureBuilder
-    {
         /// <summary>
-        /// Builds any number of test fixtures from the specified type.
+        /// Use the filter on a Type, returning true if the type matches the filter
+        /// and should therefore be included in the discovery process.
         /// </summary>
-        /// <param name="type">The type to be used as a fixture.</param>
-        /// <param name="filter">PreFilter to be used to select methods.</param>
-        IEnumerable<TestSuite> BuildFrom(Type type, IPreFilter filter);
+        bool IsMatch(Type type, MethodInfo method);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
@@ -57,6 +57,6 @@ namespace NUnit.Framework.Interfaces
         /// <param name="type">The Type to be used as a suite.</param>
         /// <param name="filter">A PreFilter for selecting methods.</param>
         /// <returns></returns>
-        TestSuite BuildFrom(Type type, PreFilter filter);
+        TestSuite BuildFrom(Type type, IPreFilter filter);
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Interfaces/ISuiteBuilder.cs
@@ -49,5 +49,14 @@ namespace NUnit.Framework.Interfaces
         /// </summary>
         /// <param name="type">The type to be used as a suite.</param>
         TestSuite BuildFrom(Type type);
+
+        /// <summary>
+        /// Builds a single test suite from the specified type, subject
+        /// to a filter that decides which methods are included.
+        /// </summary>
+        /// <param name="type">The Type to be used as a suite.</param>
+        /// <param name="filter">A PreFilter for selecting methods.</param>
+        /// <returns></returns>
+        TestSuite BuildFrom(Type type, PreFilter filter);
     }
 }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -83,7 +83,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="type">The Type to be used as a suite.</param>
         /// <param name="filter">A PreFilter for selecting methods.</param>
         /// <returns></returns>
-        public TestSuite BuildFrom(Type type, PreFilter filter)
+        public TestSuite BuildFrom(Type type, IPreFilter filter)
         {
             var fixtures = new List<TestSuite>();
 

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -73,6 +73,18 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="type">The type to be used as a suite.</param>
         public TestSuite BuildFrom(Type type)
         {
+            return BuildFrom(type, PreFilter.Empty);
+        }
+
+        /// <summary>
+        /// Builds a single test suite from the specified type, subject
+        /// to a filter that decides which methods are included.
+        /// </summary>
+        /// <param name="type">The Type to be used as a suite.</param>
+        /// <param name="filter">A PreFilter for selecting methods.</param>
+        /// <returns></returns>
+        public TestSuite BuildFrom(Type type, PreFilter filter)
+        {
             var fixtures = new List<TestSuite>();
 
             try
@@ -80,8 +92,13 @@ namespace NUnit.Framework.Internal.Builders
                 IFixtureBuilder[] builders = GetFixtureBuilderAttributes(type);
 
                 foreach (var builder in builders)
-                    foreach (var fixture in builder.BuildFrom(type))
+                {
+                    // See if this is an enhanced attribute, accepting a filter
+                    var builder2 = builder as IFixtureBuilder2;
+
+                    foreach (var fixture in builder2?.BuildFrom(type, filter) ?? builder.BuildFrom(type))
                         fixtures.Add(fixture);
+                }
 
                 if (type.GetTypeInfo().IsGenericType)
                     return BuildMultipleFixtures(type, fixtures);
@@ -89,7 +106,7 @@ namespace NUnit.Framework.Internal.Builders
                 switch (fixtures.Count)
                 {
                     case 0:
-                        return _defaultBuilder.BuildFrom(type);
+                        return _defaultBuilder.BuildFrom(type, filter);
                     case 1:
                         return fixtures[0];
                     default:
@@ -107,6 +124,7 @@ namespace NUnit.Framework.Internal.Builders
                 return fixture;
             }
         }
+
         #endregion
 
         #region Helper Methods

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="filter">Filter used to select methods as tests.</param>
         /// <returns>A TestSuite object or one derived from TestSuite.</returns>
         // TODO: This should really return a TestFixture, but that requires changes to the Test hierarchy.
-        public TestSuite BuildFrom(Type type, PreFilter filter)
+        public TestSuite BuildFrom(Type type, IPreFilter filter)
         {
             var fixture = new TestFixture(type);
 
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="filter">Filter used to select methods as tests.</param>
         /// <param name="testFixtureData">An object implementing ITestFixtureData or null.</param>
         /// <returns></returns>
-        public TestSuite BuildFrom(Type type, PreFilter filter, ITestFixtureData testFixtureData)
+        public TestSuite BuildFrom(Type type, IPreFilter filter, ITestFixtureData testFixtureData)
         {
             Guard.ArgumentNotNull(testFixtureData, nameof(testFixtureData));
 
@@ -167,7 +167,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <summary>
         /// Method to add test cases to the newly constructed fixture.
         /// </summary>
-        private void AddTestCasesToFixture(TestFixture fixture, PreFilter filter)
+        private void AddTestCasesToFixture(TestFixture fixture, IPreFilter filter)
         {
             // TODO: Check this logic added from Neil's build.
             if (fixture.Type.GetTypeInfo().ContainsGenericParameters)
@@ -181,7 +181,7 @@ namespace NUnit.Framework.Internal.Builders
 
             foreach (MethodInfo method in methods)
             {
-                if (filter.Match(fixture.Type, method))
+                if (filter.IsMatch(fixture.Type, method))
                 {
                     Test test = BuildTestCase(new FixtureMethod(fixture.Type, method), fixture);
 

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -64,9 +64,10 @@ namespace NUnit.Framework.Internal.Builders
         /// be returned nonetheless, labelled as non-runnable.
         /// </summary>
         /// <param name="type">An Type for the fixture to be used.</param>
+        /// <param name="filter">Filter used to select methods as tests.</param>
         /// <returns>A TestSuite object or one derived from TestSuite.</returns>
         // TODO: This should really return a TestFixture, but that requires changes to the Test hierarchy.
-        public TestSuite BuildFrom(Type type)
+        public TestSuite BuildFrom(Type type, PreFilter filter)
         {
             var fixture = new TestFixture(type);
 
@@ -75,7 +76,7 @@ namespace NUnit.Framework.Internal.Builders
 
             fixture.ApplyAttributesToTest(type.GetTypeInfo());
 
-            AddTestCasesToFixture(fixture);
+            AddTestCasesToFixture(fixture, filter);
 
             return fixture;
         }
@@ -86,9 +87,10 @@ namespace NUnit.Framework.Internal.Builders
         /// in the ITestFixtureData object.
         /// </summary>
         /// <param name="type">The Type for which to construct a fixture.</param>
+        /// <param name="filter">Filter used to select methods as tests.</param>
         /// <param name="testFixtureData">An object implementing ITestFixtureData or null.</param>
         /// <returns></returns>
-        public TestSuite BuildFrom(Type type, ITestFixtureData testFixtureData)
+        public TestSuite BuildFrom(Type type, PreFilter filter, ITestFixtureData testFixtureData)
         {
             Guard.ArgumentNotNull(testFixtureData, nameof(testFixtureData));
 
@@ -153,7 +155,7 @@ namespace NUnit.Framework.Internal.Builders
 
             fixture.ApplyAttributesToTest(type.GetTypeInfo());
 
-            AddTestCasesToFixture(fixture);
+            AddTestCasesToFixture(fixture, filter);
 
             return fixture;
         }
@@ -165,8 +167,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <summary>
         /// Method to add test cases to the newly constructed fixture.
         /// </summary>
-        /// <param name="fixture">The fixture to which cases should be added</param>
-        private void AddTestCasesToFixture(TestFixture fixture)
+        private void AddTestCasesToFixture(TestFixture fixture, PreFilter filter)
         {
             // TODO: Check this logic added from Neil's build.
             if (fixture.Type.GetTypeInfo().ContainsGenericParameters)
@@ -180,13 +181,16 @@ namespace NUnit.Framework.Internal.Builders
 
             foreach (MethodInfo method in methods)
             {
-                Test test = BuildTestCase(new FixtureMethod(fixture.Type, method), fixture);
+                if (filter.Match(fixture.Type, method))
+                {
+                    Test test = BuildTestCase(new FixtureMethod(fixture.Type, method), fixture);
 
-                if (test != null)
-                    fixture.Add(test);
-                else // it's not a test, check for disallowed attributes
-                    if (method.HasAttribute<ParallelizableAttribute>(false))
+                    if (test != null)
+                        fixture.Add(test);
+                    else // it's not a test, check for disallowed attributes
+                        if (method.HasAttribute<ParallelizableAttribute>(false))
                         fixture.MakeInvalid(PARALLEL_NOT_ALLOWED_MSG);
+                }
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -1,0 +1,208 @@
+// ***********************************************************************
+// Copyright (c) 2014-2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// The PreFilter class implements a simplified filter for use in deciding which
+    /// Types and Methods should be used to generate tests. It is consructed with a 
+    /// list of strings, each of which may end up being interpreted in various ways.
+    /// </summary>
+    public class PreFilter
+    {
+        private static readonly char[] ARG_START = new char[] { '(', '<' };
+
+        private List<FilterElement> _filters = new List<FilterElement>();
+
+        /// <summary>
+        /// Return a new PreFilter, without elements, which is considered
+        /// empty and always matches.
+        /// </summary>
+        public static PreFilter Empty
+        {
+            get { return new PreFilter(); }
+        }
+
+        /// <summary>
+        /// Return true if the filer is empty, in which case it
+        /// always succeeds. Technically, this is just a filter and
+        /// you can add elements but it's best to use Empty when
+        /// you need an empty filter and new when you plan to add.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get { return _filters.Count == 0; }
+        }
+
+        /// <summary>
+        /// Add a new filter element to the filter
+        /// </summary>
+        /// <param name="filterText"></param>
+        public void Add(string filterText)
+        {
+            _filters.Add(new FilterElement(filterText));
+        }
+
+        /// <summary>
+        /// Use the filter on a Type, returning true if the type matches the filter
+        /// and should therefore be included in the discovery process.
+        /// </summary>
+        public bool Match(Type type)
+        {
+            if (IsEmpty)
+                return true;
+
+            string typeName = type.FullName;
+
+            foreach (FilterElement filter in _filters)
+            {
+                if (filter.Match(type))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Use the filter on a Type, returning true if the type matches the filter
+        /// and should therefore be included in the discovery process.
+        /// </summary>
+        public bool Match(Type type, MethodInfo method)
+        {
+            if (IsEmpty)
+                return true;
+
+            int filterCount = 0;
+            foreach (FilterElement filter in _filters)
+            {
+                if (type.FullName == filter.ClassName)
+                {
+                    ++filterCount;
+                    if (method.Name == filter.MethodName)
+                        return true;
+                }
+            }
+
+            // If no match, we succeed only if there were no method filters for this fixture
+            return filterCount == 0;
+        }
+
+        #region Nested FilterElementType Enumeration
+
+        private enum FilterElementType
+        {
+            Unknown,
+            Namespace,
+            Fixture,
+            Method
+        }
+
+        #endregion
+
+        #region Nested FilterElement Class
+
+        private class FilterElement
+        {
+            public FilterElementType ElementType = FilterElementType.Unknown;
+            public string Text;
+            public string ClassName;
+            public string MethodName;
+
+            public FilterElement(string text)
+            {
+                int argStart = text.IndexOfAny(ARG_START);
+                Text = argStart > 0
+                    ? text.Substring(0, argStart)
+                    : text;
+
+                // Filter may be the fullname of a test method, if so extract class name
+                int lastdot = Text.LastIndexOf('.');
+                if (lastdot > 0)
+                {
+                    ClassName = Text.Substring(0, lastdot);
+                    MethodName = Text.Substring(lastdot + 1);
+                }
+            }
+
+            public bool Match(Type type)
+            {
+                switch(ElementType)
+                {
+                    default:
+                    case FilterElementType.Unknown:
+                        return MatchUnknownElement(type);
+                    case FilterElementType.Fixture:
+                        return MatchFixtureElement(type);
+                    case FilterElementType.Namespace:
+                        return MatchNamespaceElement(type);
+                    case FilterElementType.Method:
+                        return MatchMethodElement(type);
+                }
+            }
+
+            private bool MatchUnknownElement(Type type)
+            {
+                if (MatchFixtureElement(type))
+                {
+                    ElementType = FilterElementType.Fixture;
+                    return true;
+                }
+
+                if (MatchNamespaceElement(type))
+                {
+                    ElementType = FilterElementType.Namespace;
+                    return true;
+                }
+
+                if (MatchMethodElement(type))
+                {
+                    ElementType = FilterElementType.Method;
+                    return true;
+                }
+
+                return false;
+            }
+
+            private bool MatchFixtureElement(Type type)
+            {
+                return type.FullName == Text;
+            }
+
+            private bool MatchNamespaceElement(Type type)
+            {
+                return type.FullName.StartsWith(Text + ".");
+            }
+
+            private bool MatchMethodElement(Type type)
+            {
+                return type.FullName == ClassName;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -6,6 +6,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net20|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
   </ItemGroup>

--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -286,6 +286,22 @@ namespace NUnitLite.Tests
             }
         }
 
+        [TestCase("TestList", "--test=Some.Name.Space.TestFixture", "Some.Name.Space.TestFixture")]
+        [TestCase("TestList", "--test=A.B.C,E.F.G", "A.B.C", "E.F.G")]
+        [TestCase("TestList", "--test=A.B.C|--test=E.F.G", "A.B.C", "E.F.G")]
+        [TestCase("PreFilters", "--prefilter=Some.Name.Space.TestFixture", "Some.Name.Space.TestFixture")]
+        [TestCase("PreFilters", "--prefilter=A.B.C,E.F.G", "A.B.C", "E.F.G")]
+        [TestCase("PreFilters", "--prefilter=A.B.C|--prefilter=E.F.G", "A.B.C", "E.F.G")]
+        public void CanRecognizeTestSelectionOptions(string propertyName, string args, params string[] expected)
+        {
+            var property = GetPropertyInfo(propertyName);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(IList<string>)));
+
+            var options = new NUnitLiteOptions(args.Split(new char[] { '|' }));
+            var list = (IList<string>)property.GetValue(options, null);
+            Assert.That(list, Is.EqualTo(expected));
+        }
+
         // [TestCase("InternalTraceLevel", "trace", typeof(InternalTraceLevel))]
         // public void CanRecognizeEnumOptions(string propertyName, string pattern, Type enumType)
         // {
@@ -313,6 +329,8 @@ namespace NUnitLite.Tests
         [TestCase("--err")]
         [TestCase("--work")]
         [TestCase("--trace")]
+        [TestCase("--test")]
+        [TestCase("--prefilter")]
 #if !NETCOREAPP1_1
         [TestCase("--timeout")]
 #endif

--- a/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
@@ -70,5 +70,15 @@ namespace NUnitLite.Tests
             Assert.That(settings.ContainsKey("NumberOfTestWorkers"));
             Assert.AreEqual(8, settings["NumberOfTestWorkers"]);
         }
+
+        [Test]
+        public void WhenLoadIsSpecified_RunSettingsIncludeIt()
+        {
+            var options = new NUnitLiteOptions("test.dll", "--prefilter=A.B.C");
+            var settings = TextRunner.MakeRunSettings(options);
+
+            Assert.That(settings.ContainsKey("LOAD"));
+            Assert.AreEqual(new string[] { "A.B.C" }, settings["LOAD"]);
+        }
     }
 }

--- a/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
@@ -29,56 +29,31 @@ namespace NUnitLite.Tests
 {
     public class MakeRunSettingsTests
     {
+        private static TestCaseData[] SettingsData =
+        {
 #if !NETCOREAPP1_1
-        [Test]
-        public void WhenTimeoutIsSpecified_RunSettingsIncludeIt()
-        {
-            var options = new NUnitLiteOptions("test.dll", "--timeout=50");
-            var settings = TextRunner.MakeRunSettings(options);
-
-            Assert.That(settings.ContainsKey("DefaultTimeout"));
-            Assert.AreEqual(50, settings["DefaultTimeout"]);
-        }
+            new TestCaseData("--timeout=50", "DefaultTimeout", 50),
 #endif
+            new TestCaseData("--work=results", "WorkDirectory", Path.GetFullPath("results")),
+            new TestCaseData("--seed=1234", "RandomSeed", 1234),
+            new TestCaseData("--workers=8", "NumberOfTestWorkers", 8),
+            new TestCaseData("--prefilter=A.B.C", "LOAD", new string[] { "A.B.C" }),
+            new TestCaseData("--test=A.B.C", "LOAD", new string[] { "A.B.C" }),
+            new TestCaseData("--test=A.B.C(arg)", "LOAD", new string[] { "A.B.C" }),
+            new TestCaseData("--test=A.B<type>.C(arg)", "LOAD", new string[] { "A.B" })
+       };
 
-        [Test]
-        public void WhenWorkDirectoryIsSpecified_RunSettingsIncludeIt()
+        [TestCaseSource(nameof(SettingsData))]
+        public void CheckSetting(string option, string key, object value)
         {
-            var options = new NUnitLiteOptions("test.dll", "--work=results");
+            var options = new NUnitLiteOptions("test.dll", option);
             var settings = TextRunner.MakeRunSettings(options);
 
-            Assert.That(settings.ContainsKey("WorkDirectory"));
-            Assert.AreEqual(Path.GetFullPath("results"), settings["WorkDirectory"]);
+            Assert.That(settings.ContainsKey(key));
+            Assert.AreEqual(value, settings[key]);
         }
 
-        [Test]
-        public void WhenSeedIsSpecified_RunSettingsIncludeIt()
-        {
-            var options = new NUnitLiteOptions("test.dll", "--seed=1234");
-            var settings = TextRunner.MakeRunSettings(options);
-
-            Assert.That(settings.ContainsKey("RandomSeed"));
-            Assert.AreEqual(1234, settings["RandomSeed"]);
-        }
-
-        [Test]
-        public void WhenWorkersIsSpecified_RunSettingsIncludeIt()
-        {
-            var options = new NUnitLiteOptions("test.dll", "--workers=8");
-            var settings = TextRunner.MakeRunSettings(options);
-
-            Assert.That(settings.ContainsKey("NumberOfTestWorkers"));
-            Assert.AreEqual(8, settings["NumberOfTestWorkers"]);
-        }
-
-        [Test]
-        public void WhenLoadIsSpecified_RunSettingsIncludeIt()
-        {
-            var options = new NUnitLiteOptions("test.dll", "--prefilter=A.B.C");
-            var settings = TextRunner.MakeRunSettings(options);
-
-            Assert.That(settings.ContainsKey("LOAD"));
-            Assert.AreEqual(new string[] { "A.B.C" }, settings["LOAD"]);
-        }
+        //[Test]
+        //public void WhenTestFixtureIsSpecified_RunSettingsIncludeIt)
     }
 }

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -169,6 +169,7 @@ namespace NUnit.Common
         public string InputFile { get; private set; }
 
         public IList<string> TestList { get; } = new List<string>();
+        public IList<string> PreFilters { get; } = new List<string>();
 
         public IDictionary<string, string> TestParameters { get; } = new Dictionary<string, string>();
 
@@ -352,6 +353,9 @@ namespace NUnit.Common
                         }
                     }
                 });
+
+            this.Add("prefilter=", "Comma-separated list of {NAMES} of test classes or namespaces to be loaded. This option may be repeated.",
+                v => ((List<string>)PreFilters).AddRange(TestNameParser.Parse(RequiredValue(v, "--prefilter"))));
 
             this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
+// Copyright (c) 2015-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -254,13 +254,11 @@ namespace NUnitLite
 
         private void LoadTests(IDictionary<string, object> runSettings)
         {
-            DateTime startTime = DateTime.UtcNow;
-            long startTicks = Stopwatch.GetTimestamp();
+            TimeStamp startTime = new TimeStamp();
             _runner.Load(_testAssembly, runSettings);
-            DateTime endTime = DateTime.UtcNow;
-            double duration = (double)(Stopwatch.GetTimestamp() - startTicks) / Stopwatch.Frequency;
+            TimeStamp endTime = new TimeStamp();
 
-            _textUI.DisplayDiscoveryReport(startTime, endTime, duration);
+            _textUI.DisplayDiscoveryReport(startTime, endTime);
         }
 
         public int RunTests(TestFilter filter, IDictionary<string, object> runSettings)

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -221,6 +221,7 @@ namespace NUnitLite
                     _textUI.DisplayWarning("Ignoring /wait option - only valid for Console");
 
                 var runSettings = MakeRunSettings(_options);
+                LoadTests(runSettings);
 
                 // We display the filters at this point so that any exception message
                 // thrown by CreateTestFilter will be understandable.
@@ -228,7 +229,6 @@ namespace NUnitLite
 
                 TestFilter filter = CreateTestFilter(_options);
 
-                _runner.Load(_testAssembly, runSettings);
                 return _options.Explore ? ExploreTests(filter) : RunTests(filter, runSettings);
             }
             catch (FileNotFoundException ex)
@@ -251,6 +251,17 @@ namespace NUnitLite
         #endregion
 
         #region Helper Methods
+
+        private void LoadTests(IDictionary<string, object> runSettings)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            long startTicks = Stopwatch.GetTimestamp();
+            _runner.Load(_testAssembly, runSettings);
+            DateTime endTime = DateTime.UtcNow;
+            double duration = (double)(Stopwatch.GetTimestamp() - startTicks) / Stopwatch.Frequency;
+
+            _textUI.DisplayDiscoveryReport(startTime, endTime, duration);
+        }
 
         public int RunTests(TestFilter filter, IDictionary<string, object> runSettings)
         {
@@ -319,6 +330,9 @@ namespace NUnitLite
         {
             // Transfer command line options to run settings
             var runSettings = new Dictionary<string, object>();
+
+            if (options.PreFilters != null)
+                runSettings[FrameworkPackageSettings.LOAD] = options.PreFilters;
 
             if (options.NumberOfTestWorkers >= 0)
                 runSettings[FrameworkPackageSettings.NumberOfTestWorkers] = options.NumberOfTestWorkers;

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -331,8 +331,23 @@ namespace NUnitLite
             // Transfer command line options to run settings
             var runSettings = new Dictionary<string, object>();
 
-            if (options.PreFilters != null)
+            if (options.PreFilters.Count > 0)
                 runSettings[FrameworkPackageSettings.LOAD] = options.PreFilters;
+            else if (options.TestList.Count > 0)
+            {
+                var prefilters = new List<string>();
+
+                foreach (var testName in options.TestList)
+                {
+                    int end = testName.IndexOfAny(new char[] { '(', '<' });
+                    if (end > 0)
+                        prefilters.Add(testName.Substring(0, end));
+                    else
+                        prefilters.Add(testName);
+                }
+
+                runSettings[FrameworkPackageSettings.LOAD] = prefilters;
+            }
 
             if (options.NumberOfTestWorkers >= 0)
                 runSettings[FrameworkPackageSettings.NumberOfTestWorkers] = options.NumberOfTestWorkers;

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
+// Copyright (c) 2015-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -183,16 +183,17 @@ namespace NUnitLite
 
         #region Test Discovery Report
 
-        public void DisplayDiscoveryReport(DateTime startTime, DateTime endTime, double duration)
+        public void DisplayDiscoveryReport(TimeStamp startTime, TimeStamp endTime)
         {
             WriteSectionHeader("Test Discovery");
 
             foreach (string filter in _options.PreFilters)
                 Writer.WriteLabelLine("  Pre-Filter: ", filter);
 
-            Writer.WriteLabelLine("  Start time: ", startTime.ToString("u"));
-            Writer.WriteLabelLine("    End time: ", endTime.ToString("u"));
-            Writer.WriteLabelLine("    Duration: ", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000} seconds", duration));
+            Writer.WriteLabelLine("  Start time: ", startTime.DateTime.ToString("u"));
+            Writer.WriteLabelLine("    End time: ", endTime.DateTime.ToString("u"));
+            double elapsedSeconds = TimeStamp.TicksToSeconds(endTime.Ticks - startTime.Ticks);
+            Writer.WriteLabelLine("    Duration: ", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000} seconds", elapsedSeconds));
 
             Writer.WriteLine();
         }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -181,6 +181,24 @@ namespace NUnitLite
 
         #endregion
 
+        #region Test Discovery Report
+
+        public void DisplayDiscoveryReport(DateTime startTime, DateTime endTime, double duration)
+        {
+            WriteSectionHeader("Test Discovery");
+
+            foreach (string filter in _options.PreFilters)
+                Writer.WriteLabelLine("  Pre-Filter: ", filter);
+
+            Writer.WriteLabelLine("  Start time: ", startTime.ToString("u"));
+            Writer.WriteLabelLine("    End time: ", endTime.ToString("u"));
+            Writer.WriteLabelLine("    Duration: ", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000} seconds", duration));
+
+            Writer.WriteLine();
+        }
+
+        #endregion
+
         #region DisplayTestFilters
 
         public void DisplayTestFilters()
@@ -189,9 +207,8 @@ namespace NUnitLite
             {
                 WriteSectionHeader("Test Filters");
 
-                if (_options.TestList.Count > 0)
-                    foreach (string testName in _options.TestList)
-                        Writer.WriteLabelLine("    Test: ", testName);
+                foreach (string testName in _options.TestList)
+                    Writer.WriteLabelLine("    Test: ", testName);
 
                 if (_options.WhereClauseSpecified)
                     Writer.WriteLabelLine("    Where: ", _options.WhereClause.Trim());

--- a/src/NUnitFramework/nunitlite/TimeStamp.cs
+++ b/src/NUnitFramework/nunitlite/TimeStamp.cs
@@ -1,0 +1,45 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Diagnostics;
+
+namespace NUnitLite
+{
+    public class TimeStamp
+    {
+        public TimeStamp()
+        {
+            DateTime = DateTime.UtcNow;
+            Ticks = Stopwatch.GetTimestamp();
+        }
+
+        public DateTime DateTime { get; }
+        public long Ticks { get; }
+
+        public static double TicksToSeconds(long ticks)
+        {
+            return (double)ticks / Stopwatch.Frequency;
+        }
+    }
+}

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -5,6 +5,11 @@
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net20|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -83,6 +83,9 @@ namespace NUnit.Framework.Api
         // Mixed filters
         [TestCase("NUnit.Tests.Assemblies", "NUnit.Tests.Singletons", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests + OneTestCase.Tests)]
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.Assemblies", ExpectedResult = MockTestFixture.Tests)]
+        // Nested Filters (highest level one should be used)
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.Assemblies.MockTestFixture.TestWithException", ExpectedResult = MockTestFixture.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", "NUnit.Tests.Assemblies.MockTestFixture", ExpectedResult = MockTestFixture.Tests)]
         public int LoadWithPreFilter(params string[] filters)
         {
             var settings = new Dictionary<string, object>();

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -1,23 +1,93 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
+using NUnit.Framework.Internal;
+using NUnit.Tests;
+using NUnit.Tests.Assemblies;
+using NUnit.Tests.Singletons;
 using NUnit.Compatibility;
 using NUnit.TestData;
 
 namespace NUnit.Framework.Api
 {
     [TestFixture] // [TestFixture] is needed so that ClassesCanBeImpliedToBeFixtures is effective.
-    public static class DefaultTestAssemblyBuilderTests
+    public static class ImpliedFixtureTests
     {
         [Test]
         public static void ClassesCanBeImpliedToBeFixtures()
         {
             var assemblyTest = new DefaultTestAssemblyBuilder().Build(
-                typeof(ImpliedFixture).GetTypeInfo().Assembly, 
+                typeof(ImpliedFixture).GetTypeInfo().Assembly,
                 options: new Dictionary<string, object>());
 
             Assert.That(
                 new[] { assemblyTest }.SelectManyRecursive(test => test.Tests),
                 Has.Some.With.Property("Type").EqualTo(typeof(ImpliedFixture)));
+        }
+    }
+
+    public class DefaultTestAssemblyBuilderTests
+    {
+        private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";
+
+        private string _mockAssemblyPath;
+        private DefaultTestAssemblyBuilder _builder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE);
+            _builder = new DefaultTestAssemblyBuilder();
+        }
+
+        [TestCase(ExpectedResult = MockAssembly.Tests)]
+        [TestCase("NUnit", ExpectedResult = MockAssembly.Tests)]
+        [TestCase("NUnit.Tests", ExpectedResult = MockAssembly.Tests)]
+        [TestCase("NUnit.Tests.Assemblies", ExpectedResult = MockTestFixture.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", ExpectedResult = MockTestFixture.Tests)]
+        [TestCase("NUnit.Tests.FixtureWithTestCases", ExpectedResult = FixtureWithTestCases.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests)]
+        [TestCase("NUnit.Tests.Singletons", ExpectedResult = OneTestCase.Tests)]
+        [TestCase("NUnit.Tests.Singletons.OneTestCase", ExpectedResult = OneTestCase.Tests)]
+        [TestCase("NUnit.Tests.Assemblies", "NUnit.Tests.Singletons", ExpectedResult = MockTestFixture.Tests + OneTestCase.Tests)]
+        [TestCase("NUnit.Tests.Assemblies", "NUnit.Tests.Singletons", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests + OneTestCase.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.Assemblies", ExpectedResult = MockTestFixture.Tests)]
+        public int LoadWithSinglePreFilter(params string[] filters)
+        {
+            var settings = new Dictionary<string, object>();
+            settings.Add("LOAD", filters);
+            var result = _builder.Build(_mockAssemblyPath, settings);
+
+            Assert.That(result.IsSuite);
+            Assert.That(result, Is.TypeOf<TestAssembly>());
+            Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY_FILE));
+            Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.Runnable));
+
+            return result.TestCaseCount;
         }
     }
 }

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -24,32 +24,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using NUnit.Framework.Internal;
 using NUnit.Tests;
 using NUnit.Tests.Assemblies;
 using NUnit.Tests.Singletons;
-using NUnit.Compatibility;
-using NUnit.TestData;
 
 namespace NUnit.Framework.Api
 {
-    [TestFixture] // [TestFixture] is needed so that ClassesCanBeImpliedToBeFixtures is effective.
-    public static class ImpliedFixtureTests
-    {
-        [Test]
-        public static void ClassesCanBeImpliedToBeFixtures()
-        {
-            var assemblyTest = new DefaultTestAssemblyBuilder().Build(
-                typeof(ImpliedFixture).GetTypeInfo().Assembly,
-                options: new Dictionary<string, object>());
-
-            Assert.That(
-                new[] { assemblyTest }.SelectManyRecursive(test => test.Tests),
-                Has.Some.With.Property("Type").EqualTo(typeof(ImpliedFixture)));
-        }
-    }
-
     public class DefaultTestAssemblyBuilderTests
     {
         private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -64,19 +64,26 @@ namespace NUnit.Framework.Api
             _builder = new DefaultTestAssemblyBuilder();
         }
 
+        // No filter
         [TestCase(ExpectedResult = MockAssembly.Tests)]
+        // Namespace filters
         [TestCase("NUnit", ExpectedResult = MockAssembly.Tests)]
         [TestCase("NUnit.Tests", ExpectedResult = MockAssembly.Tests)]
         [TestCase("NUnit.Tests.Assemblies", ExpectedResult = MockTestFixture.Tests)]
-        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", ExpectedResult = MockTestFixture.Tests)]
-        [TestCase("NUnit.Tests.FixtureWithTestCases", ExpectedResult = FixtureWithTestCases.Tests)]
-        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests)]
         [TestCase("NUnit.Tests.Singletons", ExpectedResult = OneTestCase.Tests)]
+        // Fixture filters
+        [TestCase("NUnit.Tests.FixtureWithTestCases", ExpectedResult = FixtureWithTestCases.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", ExpectedResult = MockTestFixture.Tests)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests)]
         [TestCase("NUnit.Tests.Singletons.OneTestCase", ExpectedResult = OneTestCase.Tests)]
-        [TestCase("NUnit.Tests.Assemblies", "NUnit.Tests.Singletons", ExpectedResult = MockTestFixture.Tests + OneTestCase.Tests)]
+        // Method filters
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", ExpectedResult = 1)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", "NUnit.Tests.Singletons.OneTestCase.TestCase", ExpectedResult = 2)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", "NUnit.Tests.Assemblies.MockTestFixture.WarningTest", "NUnit.Tests.Assemblies.MockTestFixture.FailingTest", ExpectedResult = 3)]
+        // Mixed filters
         [TestCase("NUnit.Tests.Assemblies", "NUnit.Tests.Singletons", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests + OneTestCase.Tests)]
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.Assemblies", ExpectedResult = MockTestFixture.Tests)]
-        public int LoadWithSinglePreFilter(params string[] filters)
+        public int LoadWithPreFilter(params string[] filters)
         {
             var settings = new Dictionary<string, object>();
             settings.Add("LOAD", filters);
@@ -85,7 +92,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.IsSuite);
             Assert.That(result, Is.TypeOf<TestAssembly>());
             Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY_FILE));
-            Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.Runnable));
+            Assert.That(result.RunState, Is.EqualTo(Interfaces.RunState.Runnable), (string)result.Properties.Get(PropertyNames.SkipReason));
 
             return result.TestCaseCount;
         }

--- a/src/NUnitFramework/tests/AsyncExecutionApiAdapter.Fixture-based.cs
+++ b/src/NUnitFramework/tests/AsyncExecutionApiAdapter.Fixture-based.cs
@@ -23,6 +23,7 @@
 
 #if ASYNC
 using System;
+using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
 using NUnit.TestUtilities;
 
@@ -33,7 +34,7 @@ namespace NUnit.Framework
         private static void ExecuteFixture(Type fixtureType, AsyncTestDelegate asyncUserCode)
         {
             TestBuilder.RunTest(
-                new NUnitTestFixtureBuilder().BuildFrom(fixtureType, new TestFixtureData(asyncUserCode))
+                new NUnitTestFixtureBuilder().BuildFrom(fixtureType, PreFilter.Empty, new TestFixtureData(asyncUserCode))
             ).AssertPassed();
         }
 

--- a/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
@@ -22,16 +22,30 @@
 // ***********************************************************************
 
 using NUnit.TestData;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
+    using Builders;
+
+    // NOTE: Because this fixture tests the IImplyFIxture interface, the attribute must be
+    // present. Otherwise, if implied fixture recognition did not work, the tests would not run.
     [TestFixture]
     public static class DefaultSuiteBuilderTests
     {
         [Test]
-        public static void ClassesCanBeImpliedToBeFixtures()
+        public static void CanBuildFromReturnsTrueForImpliedFixture()
         {
-            Assert.That(new Internal.Builders.DefaultSuiteBuilder().CanBuildFrom(typeof(ImpliedFixture)));
+            Assert.That(new DefaultSuiteBuilder().CanBuildFrom(typeof(ImpliedFixture)));
+        }
+
+        [Test]
+        public static void BuildFromReturnsImpliedFixture()
+        {
+            var suite = new DefaultSuiteBuilder().BuildFrom(typeof(ImpliedFixture)) as TestFixture;
+
+            Assert.NotNull(suite, "No test fixture was built");
+            Assert.That(suite.Name, Is.EqualTo(nameof(ImpliedFixture)));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
@@ -1,0 +1,37 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.TestData;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public static class DefaultSuiteBuilderTests
+    {
+        [Test]
+        public static void ClassesCanBeImpliedToBeFixtures()
+        {
+            Assert.That(new Internal.Builders.DefaultSuiteBuilder().CanBuildFrom(typeof(ImpliedFixture)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2876

Allows use of pre-filters that apply before the tests are discovered.
