### PR TITLE
Assert.That with a Throws constraint provide more information

### DIFF
--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -61,6 +61,10 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             actualType = actual == null ? null : actual.GetType();
+
+            if (actual is Exception)
+                return new ConstraintResult(this, actual, this.Matches(actual));
+
             return new ConstraintResult(this, actualType, this.Matches(actual));
         }
 

--- a/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
@@ -76,8 +76,8 @@ namespace NUnit.Framework.Assertions
         public void IsNotInstanceOfFails()
         {
             var expectedMessage =
-                "  Expected: not instance of <System.Exception>" + System.Environment.NewLine + 
-                "  But was:  <System.ArgumentException>" + System.Environment.NewLine;
+                "  Expected: not instance of <System.Exception>" + System.Environment.NewLine +
+                "  But was:  <System.ArgumentException: Value does not fall within the expected range.>" + System.Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.IsNotInstanceOf( typeof(System.Exception), new ArgumentException() ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Constraints
     }
 
     [TestFixture]
-    public class ThrowsConstraintTest_InstanceOfType : ConstraintTestBase
+    public class ThrowsConstraintTest_InstanceOfType : ThrowsConstraintTestBase
     {
         [SetUp]
         public void SetUp()
@@ -72,9 +72,9 @@ namespace NUnit.Framework.Constraints
 
         static object[] FailureData = new object[]
         {
-            new TestCaseData( new TestDelegate( TestDelegates.ThrowsArgumentException ), "<System.ArgumentException>" ),
+            new TestCaseData( new TestDelegate( TestDelegates.ThrowsArgumentException ), $"<System.ArgumentException: myMessage{Environment.NewLine}Parameter name: myParam" ),
             new TestCaseData( new TestDelegate( TestDelegates.ThrowsNothing ), "no exception thrown" ),
-            new TestCaseData( new TestDelegate( TestDelegates.ThrowsNullReferenceException ), "<System.NullReferenceException>" )
+            new TestCaseData( new TestDelegate( TestDelegates.ThrowsNullReferenceException ), "<System.NullReferenceException: my message" )
         };
     }
 

--- a/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Syntax
@@ -143,6 +144,44 @@ namespace NUnit.Framework.Syntax
                 () => new MyClass(null),
                 Throws.InstanceOf<ArgumentNullException>()
                 .And.Message.EqualTo(expectedExceptionMessage));
+        }
+
+        [Test]
+        public void LambdaThrowsException_TestOutput()
+        {
+            var ex = CatchException(() =>
+                Assert.That(TestDelegates.ThrowsNullReferenceException, Throws.TypeOf<ArgumentException>()));
+
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: <System.ArgumentException>" + Environment.NewLine +
+                "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
+        }
+
+        [Test]
+        public void LambdaThrowsExceptionInstanceOf_TestOutput()
+        {
+            var ex = CatchException(() =>
+                Assert.That(TestDelegates.ThrowsNullReferenceException, Throws.InstanceOf<ArgumentException>()));
+
+            Assert.That(ex.Message, Does.StartWith(
+                "  Expected: instance of <System.ArgumentException>" + Environment.NewLine +
+                "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
+        }
+
+        private Exception CatchException(TestDelegate del)
+        {
+            using (new TestExecutionContext.IsolatedContext())
+            {
+                try
+                {
+                    del();
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            }
         }
 
         internal class MyClass


### PR DESCRIPTION
Fix issue by checking the type of object in TypeConstraint.ApplyTo, if it is an exception, set the actual value to the exception object instead of the type.
Fix broken unit tests and add a couple of extra tests

Fixes #2146