### PR TITLE
Provide better error message for CollectionOrderedConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -152,12 +152,12 @@ namespace NUnit.Framework.Constraints
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write("  Extra:    ");
-                    writer.WriteCollectionElements(SkipItems(actual, failurePoint.Position), 0, 3);
+                    writer.WriteCollectionElements(actual.Skip(failurePoint.Position), 0, 3);
                 }
                 else
                 {
                     writer.Write("  Missing:  ");
-                    writer.WriteCollectionElements(SkipItems(expected, failurePoint.Position), 0, 3);
+                    writer.WriteCollectionElements(expected.Skip(failurePoint.Position), 0, 3);
                 }
             }
         }
@@ -242,18 +242,6 @@ namespace NUnit.Framework.Constraints
             return null;
         }
 
-        private static IEnumerable SkipItems(IEnumerable enumerable, long skip)
-        {
-            var iterator = enumerable.GetEnumerator();
-            while (skip-- > 0)
-            {
-                iterator.MoveNext();
-            }
-            while (iterator.MoveNext())
-            {
-                yield return iterator.Current;
-            }
-        }
         #endregion
 
         #region DisplayEnumerableDifferences

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2011 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Constraints
         /// Construct an EqualConstraintResult
         /// </summary>
         public EqualConstraintResult(EqualConstraint constraint, object actual, bool hasSucceeded)
-            : base(constraint, actual, hasSucceeded) 
+            : base(constraint, actual, hasSucceeded)
         {
             this.expectedValue = constraint.Arguments[0];
             this.tolerance = constraint.Tolerance;
@@ -152,12 +152,12 @@ namespace NUnit.Framework.Constraints
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write("  Extra:    ");
-                    writer.WriteCollectionElements(actual, failurePoint.Position, 3);
+                    writer.WriteCollectionElements(SkipItems(actual, failurePoint.Position), 0, 3);
                 }
                 else
                 {
                     writer.Write("  Missing:  ");
-                    writer.WriteCollectionElements(expected, failurePoint.Position, 3);
+                    writer.WriteCollectionElements(SkipItems(expected, failurePoint.Position), 0, 3);
                 }
             }
         }
@@ -240,6 +240,19 @@ namespace NUnit.Framework.Constraints
                     return obj;
 
             return null;
+        }
+
+        private static IEnumerable SkipItems(IEnumerable enumerable, long skip)
+        {
+            var iterator = enumerable.GetEnumerator();
+            while (skip-- > 0)
+            {
+                iterator.MoveNext();
+            }
+            while (iterator.MoveNext())
+            {
+                yield return iterator.Current;
+            }
         }
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -22,11 +22,11 @@
 // ***********************************************************************
 
 using System;
-using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
 using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
@@ -146,7 +146,12 @@ namespace NUnit.Framework.Constraints
         {
             int count = 0;
             int index = 0;
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("< ");
+
+            if (start > 0)
+                sb.Append("...");
 
             foreach (object obj in collection)
             {
@@ -154,7 +159,8 @@ namespace NUnit.Framework.Constraints
                 {
                     if (++count > max)
                         break;
-                    sb.Append(count == 1 ? "< " : ", ");
+                    if (count > 1)
+                        sb.Append(", ");
                     sb.Append(FormatValue(obj));
                 }
             }
@@ -318,7 +324,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private static string FormatDecimal(Decimal d)
+        private static string FormatDecimal(decimal d)
         {
             return d.ToString("G29", CultureInfo.InvariantCulture) + "m";
         }

--- a/src/NUnitFramework/framework/Extensions.cs
+++ b/src/NUnitFramework/framework/Extensions.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
@@ -120,5 +121,23 @@ namespace NUnit.Framework
             return ((ICustomAttributeProvider)type.GetTypeInfo()).GetAttributes<T>(inherit);
         }
 #endif
+
+        public static IEnumerable Skip(this IEnumerable enumerable, long skip)
+        {
+            var iterator = enumerable.GetEnumerator();
+            using (iterator as IDisposable)
+            {
+                while (skip-- > 0)
+                {
+                    if (!iterator.MoveNext())
+                        yield break;
+                }
+
+                while (iterator.MoveNext())
+                {
+                    yield return iterator.Current;
+                }
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -680,7 +680,8 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: collection ordered" + Environment.NewLine +
-                "  But was:  < \"x\", \"z\", \"y\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"z\", \"y\" >" + Environment.NewLine +
+                "  Ordering breaks at index [2]:  \"y\"" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.IsOrdered(list));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -23,9 +23,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework.Internal;
-using NUnit.TestUtilities;
 using NUnit.TestUtilities.Comparers;
 
 namespace NUnit.Framework.Constraints
@@ -146,9 +145,25 @@ namespace NUnit.Framework.Constraints
         {
             var expectedMessage =
                 "  Expected: collection ordered" + NL +
-                "  But was:  < \"x\", \"z\", \"y\" >" + NL;
+                "  But was:  < \"x\", \"z\", \"y\" >" + NL +
+                "  Ordering breaks at index [2]:  \"y\"" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(new[] { "x", "z", "y" }, Is.Ordered));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void IsOrdered_DisplaysBreakingItemForHugeCollections()
+        {
+            var actual = Enumerable.Range(0, 100).ToArray();
+            actual[90] = 1000;
+
+            var expectedMessage =
+                "  Expected: collection ordered" + NL +
+                "  But was:  < 83, 84, 85, 86, 87, 88, 89, 1000, 91, 92... >" + NL +
+                "  Ordering breaks at index [91]:  91" + NL;
+
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.Ordered));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -261,7 +276,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void IsOrdered_AtLeastOneArgMustImplementIComparable()
         {
-            Assert.Throws<ArgumentException>(() => Assert.That(new [] { new object(), new object() }, Is.Ordered));
+            Assert.Throws<ArgumentException>(() => Assert.That(new[] { new object(), new object() }, Is.Ordered));
         }
 
         [TestCaseSource(nameof(InvalidOrderedByData))]

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(collection, constraint);
         }
 
-        static readonly object[] OrderedByData = new[]
+        private static readonly object[] OrderedByData = new[]
         {
             // Simple Ordering
             new TestCaseData(
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Constraints
 
             var expectedMessage =
                 "  Expected: collection ordered" + NL +
-                "  But was:  < 83, 84, 85, 86, 87, 88, 89, 1000, 91, 92... >" + NL +
+                "  But was:  < ...83, 84, 85, 86, 87, 88, 89, 1000, 91, 92... >" + NL +
                 "  Ordering breaks at index [91]:  91" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.Ordered));
@@ -285,7 +285,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(() => Assert.That(collection, Is.Ordered.By(property)), Throws.ArgumentException.With.Message.Contain(expectedIndex));
         }
 
-        static readonly object[] InvalidOrderedByData = new[]
+        private static readonly object[] InvalidOrderedByData = new[]
         {
             new TestCaseData(
                 new object [] { "a", "b" },
@@ -320,7 +320,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        class TestClass2
+        private class TestClass2
         {
             public int Value { get; }
 


### PR DESCRIPTION
fixes #2855 

Added line to error message with item at which ordering 
```
Expected: collection ordered
But was:  < "x", "z", "y" >
Ordering breaks at index [2]:  "y"    <----------- ADDED LINE
```

Besides, actual collection logging changed a bit, so it would always show item at which ordering breaks.
So if we have collection of 100 elements, and ordering breaks at index 91, it would look like that:
```
Expected: collection ordered
But was:  < 83, 84, 85, 86, 87, 88, 89, 1000, 91, 92... >
Ordering breaks at index [91]:  91
```

Open questions:
1. `CollectionOrderedConstraint` has `CollectionConstraint` as base class, but currently it's not used at all. I decided to leave it as is (as technically removing that could be a breaking change), but maybe you have other opinion.

2. I would prefer to put ellipsis at the beginning of actual collection, if it starts not from index 0 
(like `< ...83, 84, 85, 86, 87, 88, 89, 1000, 91, 92... >`). 
I could add it to MsgUtils.FormatCollections (if `start` is not 0), but that would require to change Missing/Extra items logging logic for CollectionEquivalent constraint. Do you have any objections or suggestions?