### PR TITLE
 Enable SetCulture and SetUICulture attributes for .NET-Standard 1.4 and fix tests that are failing in non-english locales

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_4
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -54,10 +53,13 @@ namespace NUnit.Framework
 
         void IApplyToContext.ApplyToContext(TestExecutionContext context)
         {
+#if NETSTANDARD1_4
+            context.CurrentCulture = new System.Globalization.CultureInfo(_culture);
+#else
             context.CurrentCulture = new System.Globalization.CultureInfo(_culture, false);
+#endif
         }
 
         #endregion
     }
 }
-#endif

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_4
 using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -54,10 +53,13 @@ namespace NUnit.Framework
 
         void IApplyToContext.ApplyToContext(TestExecutionContext context)
         {
+#if NETSTANDARD1_4
+            context.CurrentUICulture = new System.Globalization.CultureInfo(_culture);
+#else
             context.CurrentUICulture = new System.Globalization.CultureInfo(_culture, false);
+#endif
         }
 
         #endregion
     }
 }
-#endif

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -382,7 +382,9 @@ namespace NUnit.Framework.Internal
             set
             {
                 _currentCulture = value;
-#if !NETSTANDARD1_4
+#if NETSTANDARD1_4
+                CultureInfo.CurrentCulture = _currentCulture;
+#else
                 Thread.CurrentThread.CurrentCulture = _currentCulture;
 #endif
             }
@@ -397,7 +399,9 @@ namespace NUnit.Framework.Internal
             set
             {
                 _currentUICulture = value;
-#if !NETSTANDARD1_4
+#if NETSTANDARD1_4
+                CultureInfo.CurrentUICulture = _currentUICulture;
+#else
                 Thread.CurrentThread.CurrentUICulture = _currentUICulture;
 #endif
             }
@@ -460,7 +464,10 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public void EstablishExecutionEnvironment()
         {
-#if !NETSTANDARD1_4
+#if NETSTANDARD1_4
+            CultureInfo.CurrentCulture = _currentCulture;
+            CultureInfo.CurrentUICulture = _currentUICulture;
+#else
             Thread.CurrentThread.CurrentCulture = _currentCulture;
             Thread.CurrentThread.CurrentUICulture = _currentUICulture;
             Thread.CurrentPrincipal = _currentPrincipal;

--- a/src/NUnitFramework/testdata/CultureAttributeData.cs
+++ b/src/NUnitFramework/testdata/CultureAttributeData.cs
@@ -38,20 +38,4 @@ namespace NUnit.TestData.CultureAttributeData
         [Test, Culture("fr-CA")]
         public void FrenchCanadaTest() { }
     }
-
-#if !NETCOREAPP1_1
-    [TestFixture, SetCulture("xx-XX")]
-    public class FixtureWithInvalidSetCultureAttribute
-    {
-        [Test]
-        public void SomeTest() { }
-    }
-
-    [TestFixture]
-    public class FixtureWithInvalidSetCultureAttributeOnTest
-    {
-        [Test, SetCulture("xx-XX")]
-        public void InvalidCultureSet() { }
-    }
-#endif
 }

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.TestCaseCount, Is.EqualTo(MockAssembly.Tests));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void Load_FileNotFound_ReturnsNonRunnableSuite()
         {
             var result = _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Api
                 Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void Load_BadFile_ReturnsNonRunnableSuite()
         {
             var result = _runner.Load(BAD_FILE, EMPTY_SETTINGS);
@@ -263,7 +263,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void Run_FileNotFound_ReturnsNonRunnableSuite()
         {
             _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
@@ -315,7 +315,7 @@ namespace NUnit.Framework.Api
             CheckParameterOutput(result);
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void Run_BadFile_ReturnsNonRunnableSuite()
         {
             _runner.Load(BAD_FILE, EMPTY_SETTINGS);
@@ -377,7 +377,7 @@ namespace NUnit.Framework.Api
             Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void RunAsync_FileNotFound_ReturnsNonRunnableSuite()
         {
             _runner.Load(MISSING_FILE, EMPTY_SETTINGS);
@@ -394,7 +394,7 @@ namespace NUnit.Framework.Api
                 Does.StartWith(COULD_NOT_LOAD_MSG));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void RunAsync_BadFile_ReturnsNonRunnableSuite()
         {
             _runner.Load(BAD_FILE, EMPTY_SETTINGS);

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -211,7 +211,7 @@ namespace NUnit.Framework.Assertions
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void DerivedExceptionThrown()
         {
             var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentException));
@@ -222,7 +222,7 @@ namespace NUnit.Framework.Assertions
             CheckForSpuriousAssertionResults();
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void DerivedExceptionThrownAsync()
         {
             var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
@@ -168,7 +168,7 @@ namespace NUnit.Framework.Assertions
             CheckForSpuriousAssertionResults();
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void DerivedExceptionThrown()
         {
             var ex = CatchException(() => 

--- a/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Assertions
             Assert.IsNotInstanceOf<System.Int32>("abc123");
         }
 
-        [Test]
+        [Test, SetUICulture("en-US")]
         public void IsNotInstanceOfFails()
         {
             var expectedMessage =

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -45,7 +45,6 @@ namespace NUnit.Framework.Attributes
             Assert.True(_context.IsSingleThreaded);
         }
 
-#if !NETCOREAPP1_1
         [Test]
         public void SetCultureAttribute()
         {
@@ -61,7 +60,6 @@ namespace NUnit.Framework.Attributes
             attr.ApplyToContext(_context);
             Assert.That(_context.CurrentUICulture, Is.EqualTo(new CultureInfo("fr-FR")));
         }
-#endif
 
 #if THREAD_ABORT
         [Test]

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -528,8 +528,6 @@ namespace NUnit.Framework.Attributes
 
         #endregion
 
-#if PARALLEL
-
         #region SetCultureAttribute
 
         public void SetCultureAttributeSetsSetCultureProperty()
@@ -563,7 +561,5 @@ namespace NUnit.Framework.Attributes
         }
 
         #endregion
-
-#endif
     }
 }

--- a/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
@@ -33,10 +33,8 @@ namespace NUnit.Framework.Attributes
         [TestCase(typeof(LevelOfParallelismAttribute), PropertyNames.LevelOfParallelism, 7)]
         [TestCase(typeof(MaxTimeAttribute), PropertyNames.MaxTime, 50)]
         [TestCase(typeof(ParallelizableAttribute), PropertyNames.ParallelScope, ParallelScope.Fixtures)]
-#if !NETCOREAPP1_1
         [TestCase(typeof(SetCultureAttribute), PropertyNames.SetCulture, "fr-FR")]
         [TestCase(typeof(SetUICultureAttribute), PropertyNames.SetUICulture, "fr-FR")]
-#endif
 #if APARTMENT_STATE
         [TestCase(typeof(ApartmentAttribute), PropertyNames.ApartmentState, ApartmentState.MTA)]
         [TestCase(typeof(ApartmentAttribute), PropertyNames.ApartmentState, ApartmentState.STA)]

--- a/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
 using System;
 using System.Threading;
 using System.Globalization;
@@ -128,4 +127,3 @@ namespace NUnit.Framework.Attributes
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        [Test, TestCaseSource("FailureData")]
+        [Test, TestCaseSource("FailureData"), SetUICulture("en-US")]
         public void FailsWithBadValues(object badValue, string message)
         {
             string NL = Environment.NewLine;

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -112,7 +112,6 @@ namespace NUnit.Framework.Internal
             ExpectFailure( attr, "Not supported under culture fr-FR" );
         }
 
-#if !NETCOREAPP1_1
         [Test,SetCulture("fr-FR")]
         public void LoadWithFrenchCulture()
         {
@@ -158,6 +157,5 @@ namespace NUnit.Framework.Internal
                 Assert.AreEqual( "en-GB", CultureInfo.CurrentCulture.Name );
             }
         }
-#endif
     }
 }


### PR DESCRIPTION
While drafting an initial pull request for #2889 I recognized some tests that are failing on my system due to locale issues (I'm on a de-DE locale).

I looked into it and found that SetCulture/SetUICulture aren't used for NUnits own tests probably because those attributes are disabled for .Net-Standard ~~1.6~~ 1.4.

This isn't really necessary and probably is a leftover from older compatibility requirements (perhaps PORTABLE or NETSTANDARD1_3).

This pull request  enables SetCultureAttribute and SetUICultureAttribute for .NET-Standard ~~1.6~~ 1.4 which means that it now works on every platform that NUnit currently supports.
It also uses those attributes to fix some tests that are currently failing in non-english locales.

As this is pretty trivial I've opted for one pull request but left two separate commits to split the changes into logical units.