### PR TITLE
 Fix for silently missing tests on .NET Standard 1.x

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -198,18 +198,17 @@ namespace NUnit.Framework.Api
             int testcases = 0;
             foreach (Type testType in testTypes)
             {
-                try
+                // Any exceptions from this call are fatal problems in NUnit itself,
+                // since this is always DefaultSuiteBuilder and the current implementation
+                // of DefaultSuiteBuilder.CanBuildFrom cannot invoke any user code.
+                if (_defaultSuiteBuilder.CanBuildFrom(testType))
                 {
-                    if (_defaultSuiteBuilder.CanBuildFrom(testType))
-                    {
-                        Test fixture = _defaultSuiteBuilder.BuildFrom(testType);
-                        fixtures.Add(fixture);
-                        testcases += fixture.TestCaseCount;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    log.Error(ex.ToString());
+                    // Any exceptions from this call are fatal problems in NUnit itself,
+                    // since this is always DefaultSuiteBuilder and the current implementation
+                    // of DefaultSuiteBuilder.BuildFrom handles all exceptions from user code.
+                    Test fixture = _defaultSuiteBuilder.BuildFrom(testType);
+                    fixtures.Add(fixture);
+                    testcases += fixture.TestCaseCount;
                 }
             }
 

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -108,8 +108,20 @@ namespace NUnit.Framework.Internal
         {
             foreach (MethodInfo method in fixtureType.GetMethods(AllMembers | BindingFlags.FlattenHierarchy))
             {
+#if NETSTANDARD1_4
+                // For .NET Standard 1.x, MethodInfo.IsDefined resolves to an extension method,
+                // CustomAttributeExtensions.IsDefined, which delegates to Attribute.IsDefined.
+                // On .NET Core and .NET Framework, Attribute.IsDefined throws ArgumentException
+                // for types which aren’t assignable to System.Attribute (such as interface types).
+                foreach (var attributeData in method.CustomAttributes)
+                {
+                    if (attributeType.IsAssignableFrom(attributeData.AttributeType))
+                        return true;
+                }
+#else
                 if (method.IsDefined(attributeType, false))
                     return true;
+#endif
             }
             return false;
         }

--- a/src/NUnitFramework/testdata/ImpliedFixture.cs
+++ b/src/NUnitFramework/testdata/ImpliedFixture.cs
@@ -1,0 +1,17 @@
+using System;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.TestData
+{
+    public static class ImpliedFixture
+    {
+        [AttributeImplyingFixture]
+        public static void SomeMethod()
+        {
+        }
+
+        private sealed class AttributeImplyingFixture : Attribute, IImplyFixture
+        {
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Compatibility;
+using NUnit.TestData;
+
+namespace NUnit.Framework.Api
+{
+    [TestFixture] // [TestFixture] is needed so that ClassesCanBeImpliedToBeFixtures is effective.
+    public static class DefaultTestAssemblyBuilderTests
+    {
+        [Test]
+        public static void ClassesCanBeImpliedToBeFixtures()
+        {
+            var assemblyTest = new DefaultTestAssemblyBuilder().Build(
+                typeof(ImpliedFixture).GetTypeInfo().Assembly, 
+                options: new Dictionary<string, object>());
+
+            Assert.That(
+                new[] { assemblyTest }.SelectManyRecursive(test => test.Tests),
+                Has.Some.With.Property("Type").EqualTo(typeof(ImpliedFixture)));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Extensions.cs
+++ b/src/NUnitFramework/tests/Extensions.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -51,6 +52,37 @@ namespace NUnit.Framework
         public static FixtureMethod GetFixtureMethod(this Type type, string methodName, BindingFlags bindingAttr)
         {
             return new FixtureMethod(type, type.GetTypeInfo().GetMethod(methodName, bindingAttr));
+        }
+
+        public static IEnumerable<T> SelectManyRecursive<T>(this IEnumerable<T> seed, Func<T, IEnumerable<T>> selector)
+        {
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+            if (seed == null) yield break;
+
+            var stack = new Stack<IEnumerator<T>>();
+            var currentEnumerator = seed.GetEnumerator();
+
+            while (true)
+            {
+                if (currentEnumerator.MoveNext())
+                {
+                    var current = currentEnumerator.Current;
+                    yield return current;
+                    var recursiveEnumerator = selector.Invoke(current)?.GetEnumerator();
+
+                    if (recursiveEnumerator != null)
+                    {
+                        stack.Push(currentEnumerator);
+                        currentEnumerator = recursiveEnumerator;
+                    }
+                }
+                else
+                {
+                    currentEnumerator.Dispose();
+                    if (stack.Count == 0) yield break;
+                    currentEnumerator = stack.Pop();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2896.

The first commit stops swallowing potential fatal errors from NUnit's own implementation. This is just as effective of a test as the failing test added in the second commit, but less direct. As commented, this catch-all could not have caught any user exceptions, only fundamental faults in NUnit.

The second commit directly ensures that IImplyFixture is working. Started a new file since I didn't see existing related tests.

The final commit reverses the regression.
