### PR TITLE
Make DataAttribute obsolete and unnecessary

### DIFF
--- a/src/NUnitFramework/framework/Attributes/AttributeHierarchy.txt
+++ b/src/NUnitFramework/framework/Attributes/AttributeHierarchy.txt
@@ -5,10 +5,10 @@ NUnitAttribute
 		TestCaseActionAttribute       : 
 		TestSuiteActionAttribute      : 
 	DataAttribute
-		ValuesAttribute               : IParameterDataSource
-			RandomAttribute           : IParameterDataSource
-		RangeAttribute                : IParameterDataSource
-		ValueSourceAttribute          : IParameterDataSource
+	ValuesAttribute                   : IParameterDataSource
+	RandomAttribute                   : IParameterDataSource
+	RangeAttribute                    : IParameterDataSource
+	ValueSourceAttribute              : IParameterDataSource
 	DatapointAttribute
 	DatapointSourceAttribute
 		DatapointsAttribute

--- a/src/NUnitFramework/framework/Attributes/DataAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DataAttribute.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework
 {
@@ -30,6 +31,8 @@ namespace NUnit.Framework
     /// defined by NUnit. Used to select all data sources for a 
     /// method, class or parameter.
     /// </summary>
+    [Obsolete("Holdover from NUnit v2. Please implement " + nameof(IParameterDataSource) +
+              " for your attribute instead.")]
     public abstract class DataAttribute : NUnitAttribute
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework
     /// to a single parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public class RandomAttribute : DataAttribute, IParameterDataSource
+    public class RandomAttribute : NUnitAttribute, IParameterDataSource
     {
         private RandomDataSource _source;
         private readonly int _count;

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework
     /// individual parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
-    public class RangeAttribute : DataAttribute, IParameterDataSource
+    public class RangeAttribute : NUnitAttribute, IParameterDataSource
     {
         private readonly object _from;
         private readonly object _to;

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework
     /// provide data for one parameter of a test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
-    public class ValueSourceAttribute : DataAttribute, IParameterDataSource
+    public class ValueSourceAttribute : NUnitAttribute, IParameterDataSource
     {
         #region Constructors
 

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework
     /// an individual parameter of a test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public class ValuesAttribute : DataAttribute, IParameterDataSource
+    public class ValuesAttribute : NUnitAttribute, IParameterDataSource
     {
         /// <summary>
         /// The collection of data to be returned. Must

--- a/src/NUnitFramework/tests/Attributes/ParameterDataSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterDataSourceTests.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Attributes
             Assert.Fail("Test Should Not Run By Design.");
         }
 
-        #region DataAttribute TestClass
+        #region IParameterDataSource Attribute
 
         public enum ValuesEnum
         {


### PR DESCRIPTION
Close #2829.

I've found and edited all usages of `DataAttribute` in this repository. However I it is mentioned in https://github.com/nunit/docs/wiki/Active-Attributes and https://github.com/nunit/docs/wiki/Addin-Replacement-in-the-Framework as well. Should we updated these documentation pages too or not?