### PR TITLE
Change TestAssembly to only take in assembly name, clean up the usage of path and name

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -81,17 +81,17 @@ namespace NUnit.Framework.Api
 #endif
 
             string assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
-            string assemblyName = assemblyPath.IndexOfAny(Path.GetInvalidPathChars()) == -1
-                ? Path.GetFileName(assemblyPath)
-                : AssemblyHelper.GetAssemblyName(assembly).FullName;
+            string suiteName = assemblyPath.Equals("<Unknown>")
+                ? AssemblyHelper.GetAssemblyName(assembly).FullName
+                : Path.GetFileName(assemblyPath);
 
-            return Build(assembly, assemblyName, options);
+            return Build(assembly, suiteName, options);
         }
 
         /// <summary>
-        /// Build a suite of tests given the filename of an assembly
+        /// Build a suite of tests given the name or the location of an assembly
         /// </summary>
-        /// <param name="assemblyNameOrPath">The filename or path of the assembly from which tests are to be built</param>
+        /// <param name="assemblyNameOrPath">The name or the location of the assembly.</param>
         /// <param name="options">A dictionary of options to use in building the suite</param>
         /// <returns>
         /// A TestSuite containing the tests found in the assembly
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Api
             return testAssembly;
         }
 
-        private TestSuite Build(Assembly assembly, string assemblyName, IDictionary<string, object> options)
+        private TestSuite Build(Assembly assembly, string suiteName, IDictionary<string, object> options)
         {
             TestSuite testAssembly = null;
 
@@ -172,11 +172,11 @@ namespace NUnit.Framework.Api
                     fixtureNames = options[FrameworkPackageSettings.LOAD] as IList;
                 var fixtures = GetFixtures(assembly, fixtureNames);
 
-                testAssembly = BuildTestAssembly(assembly, assemblyName, fixtures);
+                testAssembly = BuildTestAssembly(assembly, suiteName, fixtures);
             }
             catch (Exception ex)
             {
-                testAssembly = new TestAssembly(assemblyName);
+                testAssembly = new TestAssembly(suiteName);
                 testAssembly.MakeInvalid(ExceptionHelper.BuildMessage(ex, true));
             }
 
@@ -258,9 +258,9 @@ namespace NUnit.Framework.Api
         // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
         // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
         [SecuritySafeCritical]
-        private TestSuite BuildTestAssembly(Assembly assembly, string assemblyName, IList<Test> fixtures)
+        private TestSuite BuildTestAssembly(Assembly assembly, string suiteName, IList<Test> fixtures)
         {
-            TestSuite testAssembly = new TestAssembly(assembly, assemblyName);
+            TestSuite testAssembly = new TestAssembly(assembly, suiteName);
 
             if (fixtures.Count == 0)
             {

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -81,42 +81,46 @@ namespace NUnit.Framework.Api
 #endif
 
             string assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
-            return Build(assembly, assemblyPath, options);
+            string assemblyName = assemblyPath.IndexOfAny(Path.GetInvalidPathChars()) == -1
+                ? Path.GetFileName(assemblyPath)
+                : AssemblyHelper.GetAssemblyName(assembly).FullName;
+
+            return Build(assembly, assemblyName, options);
         }
 
         /// <summary>
         /// Build a suite of tests given the filename of an assembly
         /// </summary>
-        /// <param name="assemblyName">The filename of the assembly from which tests are to be built</param>
+        /// <param name="assemblyNameOrPath">The filename or path of the assembly from which tests are to be built</param>
         /// <param name="options">A dictionary of options to use in building the suite</param>
         /// <returns>
         /// A TestSuite containing the tests found in the assembly
         /// </returns>
-        public ITest Build(string assemblyName, IDictionary<string, object> options)
+        public ITest Build(string assemblyNameOrPath, IDictionary<string, object> options)
         {
 #if NETSTANDARD1_4
-            log.Debug("Loading {0}", assemblyName);
+            log.Debug("Loading {0}", assemblyNameOrPath);
 #else
-            log.Debug("Loading {0} in AppDomain {1}", assemblyName, AppDomain.CurrentDomain.FriendlyName);
+            log.Debug("Loading {0} in AppDomain {1}", assemblyNameOrPath, AppDomain.CurrentDomain.FriendlyName);
 #endif
 
             TestSuite testAssembly = null;
 
             try
             {
-                var assembly = AssemblyHelper.Load(assemblyName);
-                testAssembly = Build(assembly, assemblyName, options);
+                var assembly = AssemblyHelper.Load(assemblyNameOrPath);
+                testAssembly = Build(assembly, Path.GetFileName(assemblyNameOrPath), options);
             }
             catch (Exception ex)
             {
-                testAssembly = new TestAssembly(assemblyName);
+                testAssembly = new TestAssembly(Path.GetFileName(assemblyNameOrPath));
                 testAssembly.MakeInvalid(ExceptionHelper.BuildMessage(ex, true));
             }
 
             return testAssembly;
         }
 
-        private TestSuite Build(Assembly assembly, string assemblyPath, IDictionary<string, object> options)
+        private TestSuite Build(Assembly assembly, string assemblyName, IDictionary<string, object> options)
         {
             TestSuite testAssembly = null;
 
@@ -168,11 +172,11 @@ namespace NUnit.Framework.Api
                     fixtureNames = options[FrameworkPackageSettings.LOAD] as IList;
                 var fixtures = GetFixtures(assembly, fixtureNames);
 
-                testAssembly = BuildTestAssembly(assembly, assemblyPath, fixtures);
+                testAssembly = BuildTestAssembly(assembly, assemblyName, fixtures);
             }
             catch (Exception ex)
             {
-                testAssembly = new TestAssembly(assemblyPath);
+                testAssembly = new TestAssembly(assemblyName);
                 testAssembly.MakeInvalid(ExceptionHelper.BuildMessage(ex, true));
             }
 

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -128,9 +128,9 @@ namespace NUnit.Framework.Api
         // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
         // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
         [SecuritySafeCritical]
-        private void Initialize(string assemblyPath, IDictionary settings)
+        private void Initialize(string assemblyNameOrPath, IDictionary settings)
         {
-            AssemblyNameOrPath = assemblyPath;
+            AssemblyNameOrPath = assemblyNameOrPath;
 
             var newSettings = settings as IDictionary<string, object>;
             Settings = newSettings ?? settings.Cast<DictionaryEntry>().ToDictionary(de => (string)de.Key, de => de.Value);
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Api
 #else
                     var id = Process.GetCurrentProcess().Id;
 #endif
-                    var logName = string.Format(LOG_FILE_FORMAT, id, Path.GetFileName(assemblyPath));
+                    var logName = string.Format(LOG_FILE_FORMAT, id, Path.GetFileName(assemblyNameOrPath));
                     InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
                 }
             }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -141,17 +141,17 @@ namespace NUnit.Framework.Api
         /// <summary>
         /// Loads the tests found in an Assembly
         /// </summary>
-        /// <param name="assemblyName">File name of the assembly to load</param>
+        /// <param name="assemblyNameOrPath">File name or path of the assembly to load</param>
         /// <param name="settings">Dictionary of option settings for loading the assembly</param>
         /// <returns>True if the load was successful</returns>
-        public ITest Load(string assemblyName, IDictionary<string, object> settings)
+        public ITest Load(string assemblyNameOrPath, IDictionary<string, object> settings)
         {
             Settings = settings;
 
             if (settings.ContainsKey(FrameworkPackageSettings.RandomSeed))
                 Randomizer.InitialSeed = (int)settings[FrameworkPackageSettings.RandomSeed];
 
-            return LoadedTest = _builder.Build(assemblyName, settings);
+            return LoadedTest = _builder.Build(assemblyNameOrPath, settings);
 
         }
 

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Internal
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAssembly"/> class
-        /// specifying the Assembly and the name of the assembly.
+        /// specifying the Assembly and the suite name.
         /// </summary>
         /// <param name="assembly">The assembly this test represents.</param>
         /// <param name="name">The desired name for the test suite.</param>
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Internal
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAssembly"/> class
-        /// specifying the name of the assembly.
+        /// specifying the suite name for an assembly that could not be loaded.
         /// </summary>
         /// <param name="name">The desired name for the test suite.</param>
         public TestAssembly(string name) : base(name)

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal
         /// specifying the Assembly and the name of the assembly.
         /// </summary>
         /// <param name="assembly">The assembly this test represents.</param>
-        /// <param name="name">The name of the assembly.</param>
+        /// <param name="name">The desired name for the test suite.</param>
         public TestAssembly(Assembly assembly, string name)
             : base(name)
         {
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Internal
         /// Initializes a new instance of the <see cref="TestAssembly"/> class
         /// specifying the name of the assembly.
         /// </summary>
-        /// <param name="name">The name of the assembly.</param>
+        /// <param name="name">The desired name for the test suite.</param>
         public TestAssembly(string name) : base(name)
         {
             this.Name = name;

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -39,25 +39,25 @@ namespace NUnit.Framework.Internal
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAssembly"/> class
-        /// specifying the Assembly and the path from which it was loaded.
+        /// specifying the Assembly and the name of the assembly.
         /// </summary>
         /// <param name="assembly">The assembly this test represents.</param>
-        /// <param name="path">The path used to load the assembly.</param>
-        public TestAssembly(Assembly assembly, string path)
-            : base(path)
+        /// <param name="name">The name of the assembly.</param>
+        public TestAssembly(Assembly assembly, string name)
+            : base(name)
         {
             this.Assembly = assembly;
-            this.Name = Path.GetFileName(path);
+            this.Name = name;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAssembly"/> class
-        /// for a path which could not be loaded.
+        /// specifying the name of the assembly.
         /// </summary>
-        /// <param name="path">The path used to load the assembly.</param>
-        public TestAssembly(string path) : base(path)
+        /// <param name="name">The name of the assembly.</param>
+        public TestAssembly(string name) : base(name)
         {
-            this.Name = Path.GetFileName(path);
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Internal
     public class SetUpFixtureTests
     {
         private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).GetTypeInfo().Assembly);
-        private static readonly string ASSEMBLY_NAME = System.IO.Path.GetFileName(ASSEMBLY_PATH);
+        private static readonly string SUITE_NAME = System.IO.Path.GetFileName(ASSEMBLY_PATH);
 
         ITestAssemblyBuilder builder;
         ITestAssemblyRunner runner;
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Internal
 
             Assert.IsNotNull(suite);
 
-            Assert.AreEqual(ASSEMBLY_NAME, suite.FullName);
+            Assert.AreEqual(SUITE_NAME, suite.FullName);
             Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
 
             string[] nameSpaceBits = nameSpace.Split('.');
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Internal
 
             Assert.IsNotNull(suite);
 
-            Assert.AreEqual(ASSEMBLY_NAME, suite.FullName);
+            Assert.AreEqual(SUITE_NAME, suite.FullName);
             Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
             Assert.AreEqual(RunState.Runnable, suite.RunState);
 

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -16,7 +16,8 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class SetUpFixtureTests
     {
-        private static readonly string testAssembly = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).GetTypeInfo().Assembly);
+        private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(NUnit.TestData.SetupFixture.Namespace1.SomeFixture).GetTypeInfo().Assembly);
+        private static readonly string ASSEMBLY_NAME = System.IO.Path.GetFileName(ASSEMBLY_PATH);
 
         ITestAssemblyBuilder builder;
         ITestAssemblyRunner runner;
@@ -45,7 +46,7 @@ namespace NUnit.Framework.Internal
             // No need for the overhead of parallel execution here
             options["NumberOfTestWorkers"] = 0;
 
-            if (runner.Load(testAssembly, options) != null)
+            if (runner.Load(ASSEMBLY_PATH, options) != null)
                 return runner.Run(TestListener.NULL, filter);
 
             return null;
@@ -63,11 +64,11 @@ namespace NUnit.Framework.Internal
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace1";
             IDictionary<string, object> options = new Dictionary<string, object>();
             options["LOAD"] = new string[] { nameSpace };
-            ITest suite = builder.Build(testAssembly, options);
+            ITest suite = builder.Build(ASSEMBLY_PATH, options);
 
             Assert.IsNotNull(suite);
 
-            Assert.AreEqual(testAssembly, suite.FullName);
+            Assert.AreEqual(ASSEMBLY_NAME, suite.FullName);
             Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
 
             string[] nameSpaceBits = nameSpace.Split('.');
@@ -96,7 +97,7 @@ namespace NUnit.Framework.Internal
         public void AssemblySetUpFixtureFollowsAssemblyNodeInTree()
         {
             IDictionary<string, object> options = new Dictionary<string, object>();
-            var rootSuite = builder.Build(testAssembly, options);
+            var rootSuite = builder.Build(ASSEMBLY_PATH, options);
             Assert.That(rootSuite, Is.TypeOf<TestAssembly>());
             var setupFixture = rootSuite.Tests[0];
             Assert.That(setupFixture, Is.TypeOf<SetUpFixture>());
@@ -112,11 +113,11 @@ namespace NUnit.Framework.Internal
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace6";
             IDictionary<string, object> options = new Dictionary<string, object>();
             options["LOAD"] = new string[] { nameSpace };
-            ITest suite = builder.Build(testAssembly, options);
+            ITest suite = builder.Build(ASSEMBLY_PATH, options);
 
             Assert.IsNotNull(suite);
 
-            Assert.AreEqual(testAssembly, suite.FullName);
+            Assert.AreEqual(ASSEMBLY_NAME, suite.FullName);
             Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
             Assert.AreEqual(RunState.Runnable, suite.RunState);
 


### PR DESCRIPTION
The motivation of this change is to fix #2898 . The assemblyPath of an assembly might be <unknown> when running uwp tests. The fix is to use the assemblyName instead in those cases.
The main improvement is to TestAssembly so that it only takes in assembly name, since that's the only thing it actually uses. It was a bit misleading before, which is probably why assemblyPath and assemblyName are a little misused in multiple classes. Now the caller should only pass in name to TestAssembly.