### PR TITLE
Re-enabled teardown abort test

### DIFF
--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -74,6 +74,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "Test never aborts on Mono (tested 5.4–5.12)")]
         public void TearDownTimesOutAndNoFurtherTearDownIsRun()
         {
             TimeoutFixture fixture = new TimeoutFixtureWithTimeoutInTearDown();

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -73,8 +73,7 @@ namespace NUnit.Framework.Attributes
             Assert.That(fixture.TearDownWasRun, "TearDown was not run");
         }
 
-        /* TODO: Uncomment this test when issue #352 is fixed, ignoring causes build warnings
-        [Test, Ignore("Issue #352 - Test with infinite loop in TearDown cannot be aborted")]
+        [Test]
         public void TearDownTimesOutAndNoFurtherTearDownIsRun()
         {
             TimeoutFixture fixture = new TimeoutFixtureWithTimeoutInTearDown();
@@ -85,7 +84,6 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.Message, Does.Contain("50ms"));
             Assert.That(fixture.TearDownWasRun, "Base TearDown should not have been run but was");
         }
-        */
 
         [Test]
         [Platform(Exclude = "Mono", Reason = "Runner hangs at end when this is run")]


### PR DESCRIPTION
Closes #352 by reversing https://github.com/nunit/nunit/commit/f9b4e2d22e99731788bf7609c51ee1bf7fa927dc to bring back the test which validates the fix in https://github.com/nunit/nunit/pull/2920.

I verified that the test still hung before @dukearena's change. It now passes.