### PR TITLE
Update outdated CategoryAttribute xmldoc

### DIFF
--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -40,13 +40,8 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Construct attribute for a given category based on
-        /// a name. The name may not contain the characters ',',
-        /// '+', '-' or '!'. However, this is not checked in the
-        /// constructor since it would cause an error to arise at
-        /// as the test was loaded without giving a clear indication
-        /// of where the problem is located. The error is handled
-        /// in NUnitFramework.cs by marking the test as not
-        /// runnable.
+        /// a name. Category name will be trimmed of any leading
+        /// or trailing white-space.
         /// </summary>
         /// <param name="name">The name of the category</param>
         public CategoryAttribute(string name)


### PR DESCRIPTION
This doc was incorrect as of https://github.com/nunit/nunit/pull/2510/files. As far as I can see, there are no longer any special characters in terms of Category Names.