### PR TITLE
Ensures that exported types are not within System.* namespace.

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Concurrent
     [DebuggerTypeProxy(typeof(SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<>))]
     [HostProtection(Synchronization = true, ExternalThreading = true)]
     [Serializable]
-    public class ConcurrentQueue<T> : IProducerConsumerCollection<T>//, IReadOnlyCollection<T>
+    internal class ConcurrentQueue<T> : IProducerConsumerCollection<T>//, IReadOnlyCollection<T>
     {
         //fields of ConcurrentQueue
         [NonSerialized]

--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
@@ -29,7 +29,7 @@ namespace System.Collections.Concurrent
     /// All implementations of this interface must enable all members of this interface
     /// to be used concurrently from multiple threads.
     /// </remarks>
-    public interface IProducerConsumerCollection<T> : IEnumerable<T>, ICollection
+    internal interface IProducerConsumerCollection<T> : IEnumerable<T>, ICollection
     {
 
         /// <summary>

--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -73,7 +73,7 @@ namespace System.Threading
     /// </para>
     /// </remarks>
     [HostProtection(Synchronization = true, ExternalThreading = true)]
-    public struct SpinWait
+    internal struct SpinWait
     {
 
         // These constants determine the frequency of yields versus spinning. The

--- a/src/NUnitFramework/tests/Internal/NamespaceTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework.Api;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class NamespaceTests
+    {
+        [Test]
+        public void AllExportedNameSpacesAreNotSystem()
+        {
+#if !NETCOREAPP1_1
+            var exportedTypes = Assembly.GetAssembly(typeof(FrameworkController)).GetExportedTypes();
+#else
+            var exportedTypes = typeof(FrameworkController).GetTypeInfo().Assembly.GetExportedTypes();
+#endif
+
+            var exportedTypesWhitelist = new[] 
+            {
+                typeof(System.Web.UI.ICallbackEventHandler)
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var type in exportedTypes.Except(exportedTypesWhitelist))
+                {
+                    Assert.IsFalse(
+                        type.Namespace.StartsWith("System", StringComparison.CurrentCultureIgnoreCase),
+                        $"Type {type.FullName} is in the System namespace but should not be.");
+                }
+            });
+
+
+        }
+    }
+}


### PR DESCRIPTION
Closes #2883 .