### PR TITLE
Concatenate retried tests TestContext Output

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -109,8 +109,12 @@ namespace NUnit.Framework
                     // Clear result for retry
                     if (count > 0)
                     {
+                        var carryOverTestOutput = context.CurrentResult.Output;
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
                         context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
+
+                        context.CurrentResult.OutWriter.Write(carryOverTestOutput);
+                        context.CurrentResult.OutWriter.WriteLine();
                     }
                 }
 

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -177,6 +177,16 @@ namespace NUnit.TestData.RepeatingTests
         }
     }
 
+    public class RetryTestCaseWithPrintFixture : RepeatingTestsFixtureBase
+    {
+        [Test, Retry(3)]
+        public void FailsEveryTimeAndLogsMessage()
+        {
+            TestContext.Write(".");
+            Assert.IsTrue(false);
+        }
+    }
+
     public sealed class RetryWithoutSetUpOrTearDownFixture
     {
         public int Count { get; private set; }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -100,6 +101,15 @@ namespace NUnit.Framework.Attributes
             Assert.IsNotNull(categories);
             Assert.AreEqual(1, categories.Count);
             Assert.AreEqual("SAMPLE", categories[0]);
+        }
+
+        [Test]
+        public void CollectingWritesWorksWithRetry()
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestCaseWithPrintFixture));
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+            var testOutput = result.Children.First().Output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(3, testOutput.Count());
         }
 
         [Test]


### PR DESCRIPTION
Hi all,

So we recently discovered that somewhere between nunit 3.0.0 and the current version of nunit, test output was no longer kept while using retries (instead only the final test output was printed). I decided to dig in and fix it immediately instead of filing an issue, hope that's okay!

As this is the first time contributing, I'm more than happy to accept feedback or proposals for changes. Thanks in advance!