### PR TITLE
Attribute Summary Consistency Changes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ApartmentAttribute"/> marks a test that must run in a particular threading apartment state, causing it
+    /// Marks a test as needing to be run in a particular threading apartment state. This will cause it
     /// to run in a separate thread if necessary.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ApartmentAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test that must run in a particular threading apartment state, causing it
+    /// <see cref="ApartmentAttribute"/> marks a test that must run in a particular threading apartment state, causing it
     /// to run in a separate thread if necessary.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Attributes/AuthorAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/AuthorAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Provides the Author of a test or test fixture. 
+    /// <see cref="AuthorAttribute"/> provides the Author of a test or test fixture. 
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]
     public class AuthorAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/AuthorAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/AuthorAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="AuthorAttribute"/> provides the Author of a test or test fixture. 
+    /// Provides the author of a test or test fixture. 
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]
     public class AuthorAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Attribute used to apply a category to a test
+    /// <see cref="CategoryAttribute"/> applies a category to a test
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class CategoryAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="CategoryAttribute"/> applies a category to a test
+    /// Applies a category to a test
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class CategoryAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
@@ -29,9 +29,9 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test to use a combinatorial join of any argument 
-    /// data provided. Since this is the default, the attribute is
-    /// optional.
+    /// <see cref="CombinatorialAttribute"/> marks a test to use a combinatorial 
+    /// join of any argument data provided. Since this is the default, the 
+    /// attribute is optional.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class CombinatorialAttribute : CombiningStrategyAttribute

--- a/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombinatorialAttribute.cs
@@ -29,9 +29,8 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="CombinatorialAttribute"/> marks a test to use a combinatorial 
-    /// join of any argument data provided. Since this is the default, the 
-    /// attribute is optional.
+    /// Marks a test to use a combinatorial join of any argument data provided. 
+    /// Since this is the default, the attribute is optional.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class CombinatorialAttribute : CombiningStrategyAttribute

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -33,9 +33,8 @@ namespace NUnit.Framework
     using Internal.Builders;
 
     /// <summary>
-    /// <see cref="CombiningStrategyAttribute"/> marks a test to use a particular
-    /// CombiningStrategy to join any parameter data provided. Since this is the 
-    /// default, the attribute is optional.
+    /// Marks a test as using a particular CombiningStrategy to join any supplied parameter data. 
+    /// Since this is the default, the attribute is optional.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public abstract class CombiningStrategyAttribute : NUnitAttribute, ITestBuilder, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -33,9 +33,9 @@ namespace NUnit.Framework
     using Internal.Builders;
 
     /// <summary>
-    /// Marks a test to use a particular CombiningStrategy to join
-    /// any parameter data provided. Since this is the default, the
-    /// attribute is optional.
+    /// <see cref="CombiningStrategyAttribute"/> marks a test to use a particular
+    /// CombiningStrategy to join any parameter data provided. Since this is the 
+    /// default, the attribute is optional.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public abstract class CombiningStrategyAttribute : NUnitAttribute, ITestBuilder, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test fixture or method as applying to a specific Culture.
+    /// Marks an assembly, test fixture or test method as applying to a specific Culture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class CultureAttribute : IncludeExcludeAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// CultureAttribute is used to mark a test fixture or an
+    /// <see cref="CultureAttribute"/> marks a test fixture or an
     /// individual method as applying to a particular Culture only.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -29,8 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="CultureAttribute"/> marks a test fixture or an
-    /// individual method as applying to a particular Culture only.
+    /// Marks a test fixture or method as applying to a specific Culture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class CultureAttribute : IncludeExcludeAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/DataAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DataAttribute.cs
@@ -27,9 +27,9 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// The abstract base class for all data-providing attributes 
-    /// defined by NUnit. Used to select all data sources for a 
-    /// method, class or parameter.
+    /// <see cref="DataAttribute"/> is the abstract base class for all 
+    /// data-providing attributes defined by NUnit. Used to select all data 
+    /// sources for a method, class or parameter.
     /// </summary>
     [Obsolete("Holdover from NUnit v2. Please implement " + nameof(IParameterDataSource) +
               " for your attribute instead.")]

--- a/src/NUnitFramework/framework/Attributes/DataAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DataAttribute.cs
@@ -27,9 +27,8 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DataAttribute"/> is the abstract base class for all 
-    /// data-providing attributes defined by NUnit. Used to select all data 
-    /// sources for a method, class or parameter.
+    /// Abstract base class for all data-providing attributes defined by NUnit. 
+    /// Used to select all data sources for a method, class or parameter.
     /// </summary>
     [Obsolete("Holdover from NUnit v2. Please implement " + nameof(IParameterDataSource) +
               " for your attribute instead.")]

--- a/src/NUnitFramework/framework/Attributes/DatapointAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointAttribute.cs
@@ -26,9 +26,8 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DatapointAttribute"/> marks a field for use as a datapoint 
-    /// when executing a theory within the same fixture that requires an 
-    /// argument of the field's Type.
+    /// Marks a field for use as a datapoint when executing a theory within 
+    /// the same fixture that requires an argument of the field's Type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class DatapointAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/DatapointAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointAttribute.cs
@@ -26,8 +26,9 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Used to mark a field for use as a datapoint when executing a theory
-    /// within the same fixture that requires an argument of the field's Type.
+    /// <see cref="DatapointAttribute"/> marks a field for use as a datapoint 
+    /// when executing a theory within the same fixture that requires an 
+    /// argument of the field's Type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class DatapointAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
@@ -27,11 +27,11 @@ using System.Collections.Generic;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Used to mark a field, property or method providing a set of datapoints to 
-    /// be used in executing any theories within the same fixture that require an 
-    /// argument of the Type provided. The data source may provide an array of
+    /// <see cref="DatapointSourceAttribute"/> marks a field, property or method as providing 
+    /// a set of datapoints to be used in executing any theories within the same fixture that 
+    /// require an argument of the Type provided. The data source may provide an array of
     /// the required Type or an <see cref="IEnumerable{T}"/>.
-    /// Synonymous with DatapointsAttribute.
+    /// Synonymous with <see cref="DatapointsAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DatapointSourceAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
@@ -27,11 +27,10 @@ using System.Collections.Generic;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DatapointSourceAttribute"/> marks a field, property or method as providing 
-    /// a set of datapoints to be used in executing any theories within the same fixture that 
-    /// require an argument of the Type provided. The data source may provide an array of
-    /// the required Type or an <see cref="IEnumerable{T}"/>.
-    /// Synonymous with <see cref="DatapointsAttribute"/>.
+    /// Marks a field, property or method as providing a set of datapoints for use 
+    /// in executing any theories within the same fixture that require an argument 
+    /// of the Type provided. The data source may provide an array of the required 
+    /// Type or an <see cref="IEnumerable{T}"/>. Synonymous with <see cref="DatapointsAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DatapointSourceAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointSourceAttribute.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Marks a field, property or method as providing a set of datapoints for use 
     /// in executing any theories within the same fixture that require an argument 
-    /// of the Type provided. The data source may provide an array of the required 
+    /// of the provided type. The data source may provide an array of the required 
     /// Type or an <see cref="IEnumerable{T}"/>. Synonymous with <see cref="DatapointsAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
@@ -27,11 +27,11 @@ using System.Collections.Generic;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Used to mark a field, property or method providing a set of datapoints to 
-    /// be used in executing any theories within the same fixture that require an 
-    /// argument of the Type provided. The data source may provide an array of
-    /// the required Type or an <see cref="IEnumerable{T}"/>.
-    /// Synonymous with DatapointSourceAttribute.
+    /// <see cref="DatapointsAttribute"/> marks a field, property or method as providing 
+    /// a set of datapoints to be used in executing any theories within the same 
+    /// fixture that require an argument of the Type provided. The data source may 
+    /// provide an array of the required Type or an <see cref="IEnumerable{T}"/>.
+    /// Synonymous with <see cref="DatapointSourceAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DatapointsAttribute : DatapointSourceAttribute

--- a/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DatapointsAttribute.cs
@@ -27,11 +27,10 @@ using System.Collections.Generic;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DatapointsAttribute"/> marks a field, property or method as providing 
-    /// a set of datapoints to be used in executing any theories within the same 
-    /// fixture that require an argument of the Type provided. The data source may 
-    /// provide an array of the required Type or an <see cref="IEnumerable{T}"/>.
-    /// Synonymous with <see cref="DatapointSourceAttribute"/>.
+    /// Marks a field, property or method as providing a set of datapoints for use
+    /// in executing any theories within the same fixture that require an argument of 
+    /// the provided Type. The data source may provide an array of the required Type 
+    /// or an <see cref="IEnumerable{T}"/>. Synonymous with <see cref="DatapointSourceAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DatapointsAttribute : DatapointSourceAttribute

--- a/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
@@ -29,8 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DefaultFloatingPointToleranceAttribute"/> sets the tolerance used
-    /// by default when checking the equality of floating point values.
+    /// Sets the tolerance used by default when checking the equality of floating point values.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DefaultFloatingPointToleranceAttribute : NUnitAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// DefaultFloatingPointToleranceAttribute sets the tolerance used
+    /// <see cref="DefaultFloatingPointToleranceAttribute"/> sets the tolerance used
     /// by default when checking the equality of floating point values.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
@@ -27,8 +27,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="DescriptionAttribute"/> provides the descriptive text about a 
-    /// test case or fixture.
+    /// Provides the descriptive text relating to the test case or fixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public sealed class DescriptionAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
@@ -27,7 +27,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Provides the descriptive text relating to the test case or fixture.
+    /// Provides the descriptive text relating to the assembly, test fixture or test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public sealed class DescriptionAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DescriptionAttribute.cs
@@ -27,7 +27,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Attribute used to provide descriptive text about a 
+    /// <see cref="DescriptionAttribute"/> provides the descriptive text about a 
     /// test case or fixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// ExplicitAttribute marks a test or test fixture so that it will
+    /// <see cref="ExplicitAttribute"/> marks a test or test fixture so that it will
     /// only be run if explicitly executed from the GUI or command line
     /// or if it is included by use of a filter. The test will not be
     /// run simply because an enclosing suite is run.

--- a/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
@@ -28,10 +28,9 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ExplicitAttribute"/> marks a test or test fixture so that it will
-    /// only be run if explicitly executed from the GUI or command line
-    /// or if it is included by use of a filter. The test will not be
-    /// run simply because an enclosing suite is run.
+    /// Marks a test or test fixture such that it will only run if explicitly 
+    /// executed from the GUI, command line or included within a test filter. 
+    /// The test will not be run simply because an enclosing suite is run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class ExplicitAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExplicitAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test or test fixture such that it will only run if explicitly 
+    /// Marks an assembly, test fixture or test method such that it will only run if explicitly 
     /// executed from the GUI, command line or included within a test filter. 
     /// The test will not be run simply because an enclosing suite is run.
     /// </summary>

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test as being ignored. Ignored tests result in a warning message when the tests are run.
+    /// Marks an assembly, test fixture or test method as being ignored. Ignored tests result in a warning message when the tests are run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class IgnoreAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test as being ignored.  Ignored tests result in a warning message when the tests are run.
+    /// Marks a test as being ignored. Ignored tests result in a warning message when the tests are run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class IgnoreAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -29,8 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="IgnoreAttribute"/> marks a test that is to be ignored.
-    /// Ignored tests result in a warning message when the tests are run.
+    /// Marks a test as being ignored.  Ignored tests result in a warning message when the tests are run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class IgnoreAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -29,9 +29,8 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Attribute used to mark a test that is to be ignored.
-    /// Ignored tests result in a warning message when the
-    /// tests are run.
+    /// <see cref="IgnoreAttribute"/> marks a test that is to be ignored.
+    /// Ignored tests result in a warning message when the tests are run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method|AttributeTargets.Class|AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class IgnoreAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
@@ -26,8 +26,9 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Abstract base for Attributes that are used to include tests
-    /// in the test run based on environmental settings.
+    /// <see cref="IncludeExcludeAttribute"/> is the abstract base for Attributes 
+    /// that are used to include tests in the test run based on environmental 
+    /// settings.
     /// </summary>
     public abstract class IncludeExcludeAttribute : NUnitAttribute
     {

--- a/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
@@ -26,9 +26,8 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="IncludeExcludeAttribute"/> is the abstract base for Attributes 
-    /// that are used to include tests in the test run based on environmental 
-    /// settings.
+    /// Abstract base for attributes that are used to include tests in 
+    /// the test run based on environmental settings.
     /// </summary>
     public abstract class IncludeExcludeAttribute : NUnitAttribute
     {

--- a/src/NUnitFramework/framework/Attributes/LevelOfParallelismAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/LevelOfParallelismAttribute.cs
@@ -26,8 +26,8 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="LevelOfParallelismAttribute"/> sets the number of worker threads
-    /// that may be allocated by the framework for running tests.
+    /// Sets the number of worker threads that may be allocated by the framework 
+    /// for running tests.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly, AllowMultiple=false, Inherited=false )]
     public sealed class LevelOfParallelismAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/LevelOfParallelismAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/LevelOfParallelismAttribute.cs
@@ -26,7 +26,7 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// LevelOfParallelismAttribute is used to set the number of worker threads
+    /// <see cref="LevelOfParallelismAttribute"/> sets the number of worker threads
     /// that may be allocated by the framework for running tests.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly, AllowMultiple=false, Inherited=false )]

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Specifies the maximum time for a test case to succeed.
+    /// Specifies the maximum time (in milliseconds) for a test case to succeed.
     /// </summary>
     [AttributeUsage( AttributeTargets.Method, AllowMultiple=false, Inherited=false )]
     public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="MaxTimeAttribute"/> specifies the maximum time (in milliseconds) for a test case to succeed.
+    /// Specifies the maximum time for a test case to succeed.
     /// </summary>
     [AttributeUsage( AttributeTargets.Method, AllowMultiple=false, Inherited=false )]
     public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Specifies the maximum time (in milliseconds) for a test case to succeed.
+    /// <see cref="MaxTimeAttribute"/> specifies the maximum time (in milliseconds) for a test case to succeed.
     /// </summary>
     [AttributeUsage( AttributeTargets.Method, AllowMultiple=false, Inherited=false )]
     public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/NUnitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NUnitAttribute.cs
@@ -26,7 +26,8 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// The abstract base class for all custom attributes defined by NUnit.
+    /// <see cref="NUnitAttribute"/> is the abstract base class for all custom 
+    /// attributes defined by NUnit.
     /// </summary>
     public abstract class NUnitAttribute : Attribute
     {

--- a/src/NUnitFramework/framework/Attributes/NUnitAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NUnitAttribute.cs
@@ -26,8 +26,7 @@ using System;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="NUnitAttribute"/> is the abstract base class for all custom 
-    /// attributes defined by NUnit.
+    /// Abstract base class for all custom attributes defined by NUnit.
     /// </summary>
     public abstract class NUnitAttribute : Attribute
     {

--- a/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Execution;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// NonParallelizableAttribute is used to mark tests that should NOT be run in parallel.
+    /// <see cref="NonParallelizableAttribute"/> marks tests that should NOT be run in parallel.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple=false, Inherited=true )]
     public sealed class NonParallelizableAttribute : ParallelizableAttribute

--- a/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonParallelizableAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Execution;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="NonParallelizableAttribute"/> marks tests that should NOT be run in parallel.
+    /// Marks tests that should NOT be run in parallel.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple=false, Inherited=true )]
     public sealed class NonParallelizableAttribute : ParallelizableAttribute

--- a/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework
 {
     /// <summary>
     /// Used by third-party frameworks, or other software, that reference 
-    /// the NUnit framework but does not contain any tests. Applying the 
+    /// the NUnit framework but do not contain any tests. Applying the 
     /// attribute indicates that the assembly is not a test assembly and 
     /// may prevent errors if certain runners attempt to load the assembly. 
     /// Note that recognition of the attribute depends on each individual runner.

--- a/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
@@ -27,12 +27,11 @@ using System.ComponentModel;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="NonTestAssemblyAttribute"/> may be used by third-party frameworks
-    /// or other software that references the NUnit framework but does not
-    /// contain tests. Applying the attribute indicates that the assembly
-    /// is not a test assembly and may prevent errors if certain runners
-    /// attempt to load the assembly. Note that recognition of the attribute
-    /// depends on each individual runner.
+    /// Used by third-party frameworks, or other software, that reference 
+    /// the NUnit framework but does not contain any tests. Applying the 
+    /// attribute indicates that the assembly is not a test assembly and 
+    /// may prevent errors if certain runners attempt to load the assembly. 
+    /// Note that recognition of the attribute depends on each individual runner.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/NonTestAssemblyAttribute.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// The NonTestAssemblyAttribute may be used by third-party frameworks
+    /// <see cref="NonTestAssemblyAttribute"/> may be used by third-party frameworks
     /// or other software that references the NUnit framework but does not
     /// contain tests. Applying the attribute indicates that the assembly
     /// is not a test assembly and may prevent errors if certain runners

--- a/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
@@ -26,8 +26,8 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// Attribute used to identify a method that is called once
-	/// to perform setup before any child tests are run.
+	/// <see cref="OneTimeSetUpAttribute"/> identifies a method 
+	/// that is called once to perform setup before any child tests are run.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
 	public class OneTimeSetUpAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
@@ -26,8 +26,7 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// Identifies a method to be called once, prior to the child tests executing, 
-	/// to perform any setup requirements for the proceding tests.
+	/// Identifies a method that is called once to perform setup before any child tests are run.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
 	public class OneTimeSetUpAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OneTimeSetUpAttribute.cs
@@ -26,8 +26,8 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// <see cref="OneTimeSetUpAttribute"/> identifies a method 
-	/// that is called once to perform setup before any child tests are run.
+	/// Identifies a method to be called once, prior to the child tests executing, 
+	/// to perform any setup requirements for the proceding tests.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
 	public class OneTimeSetUpAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/OneTimeTearDownAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OneTimeTearDownAttribute.cs
@@ -26,9 +26,8 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// <see cref="OneTimeTearDownAttribute"/> identifies a method 
-	/// that is called once after all the child tests have run. The method is 
-	/// guaranteed to be called, even if an exception is thrown.
+	/// Identifies a method to be called once after all the child tests have run. 
+	/// The method is guaranteed to be called, even if an exception is thrown.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
 	public class OneTimeTearDownAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/OneTimeTearDownAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OneTimeTearDownAttribute.cs
@@ -26,8 +26,8 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// Attribute used to identify a method that is called once
-	/// after all the child tests have run. The method is 
+	/// <see cref="OneTimeTearDownAttribute"/> identifies a method 
+	/// that is called once after all the child tests have run. The method is 
 	/// guaranteed to be called, even if an exception is thrown.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Defines the order that the test will run in
+    /// <see cref="OrderAttribute"/> defines the order that the test will run in
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="OrderAttribute"/> defines the order that the test will run in
+    /// Defines the order that the test will run in
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
@@ -29,8 +29,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="PairwiseAttribute"/> marks a test to use a 
-    /// pairwise join of any argument data provided. Arguments will be 
+    /// Marks a test as using a pairwise join of any supplied argument data. Arguments will be 
     /// combined in such a way that all possible pairs of arguments are used.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PairwiseAttribute.cs
@@ -29,9 +29,9 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test to use a pairwise join of any argument 
-    /// data provided. Arguments will be combined in such a
-    /// way that all possible pairs of arguments are used.
+    /// <see cref="PairwiseAttribute"/> marks a test to use a 
+    /// pairwise join of any argument data provided. Arguments will be 
+    /// combined in such a way that all possible pairs of arguments are used.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=false)]
     public class PairwiseAttribute : CombiningStrategyAttribute

--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Enumeration specifying the degree to which a test and its descendants 
+    /// Specifies the degree to which a test, and its descendants, 
     /// may be run in parallel.
     /// </summary>
     [Flags]

--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -27,8 +27,8 @@ using System.ComponentModel;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ParallelScope"/> enumeration permits specifying the degree to
-    /// which a test and its descendants may be run in parallel.
+    /// Enumeration specifying the degree to which a test and its descendants 
+    /// may be run in parallel.
     /// </summary>
     [Flags]
     public enum ParallelScope

--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// The ParallelScope enumeration permits specifying the degree to
+    /// <see cref="ParallelScope"/> enumeration permits specifying the degree to
     /// which a test and its descendants may be run in parallel.
     /// </summary>
     [Flags]

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Execution;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ParallelizableAttribute"/> marks tests that may be run in parallel.
+    /// Marks tests that may be run in parallel.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple=false, Inherited=true )]
     public class ParallelizableAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Execution;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// ParallelizableAttribute is used to mark tests that may be run in parallel.
+    /// <see cref="ParallelizableAttribute"/> marks tests that may be run in parallel.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple=false, Inherited=true )]
     public class ParallelizableAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test fixture or method as applying to a specific platform.
+    /// Marks an assembly, test fixture or test method as applying to a specific platform.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]
     public class PlatformAttribute : IncludeExcludeAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// PlatformAttribute is used to mark a test fixture or an
+    /// <see cref="PlatformAttribute"/> marks a test fixture or an
     /// individual method as applying to a particular platform only.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -29,8 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="PlatformAttribute"/> marks a test fixture or an
-    /// individual method as applying to a particular platform only.
+    /// Marks a test fixture or method as applying to a specific platform.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]
     public class PlatformAttribute : IncludeExcludeAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// PropertyAttribute is used to attach information to a test as a name/value pair..
+    /// <see cref="PropertyAttribute"/> attaches information to a test as a name/value pair..
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class PropertyAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="PropertyAttribute"/> attaches information to a test as a name/value pair..
+    /// Attaches information to a test as a name/value pair..
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class PropertyAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Attaches information to a test as a name/value pair..
+    /// Attaches information to a test as a name/value pair.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class PropertyAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -34,8 +34,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RandomAttribute"/> supplies a set of random values
-    /// to a single parameter of a parameterized test.
+    /// Supplies a set of random values to a single parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public class RandomAttribute : NUnitAttribute, IParameterDataSource

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -34,7 +34,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// RandomAttribute is used to supply a set of random values
+    /// <see cref="RandomAttribute"/> supplies a set of random values
     /// to a single parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -31,7 +31,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// RangeAttribute is used to supply a range of values to an
+    /// <see cref="RangeAttribute"/> supplies a range of values to an
     /// individual parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -31,8 +31,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RangeAttribute"/> supplies a range of values to an
-    /// individual parameter of a parameterized test.
+    /// Supplies a range of values to an individual parameter of a parameterized test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
     public class RangeAttribute : NUnitAttribute, IParameterDataSource

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -36,8 +36,7 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RepeatAttribute"/> may be applied to test case in order
-    /// to run it multiple times.
+    /// Specified that a test should be run multiple times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class RepeatAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -36,7 +36,7 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Specified that a test should be run multiple times.
+    /// Specifies that a test should be run multiple times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class RepeatAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -36,7 +36,7 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// RepeatAttribute may be applied to test case in order
+    /// <see cref="RepeatAttribute"/> may be applied to test case in order
     /// to run it multiple times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test that must run on a separate thread.
+    /// <see cref="RequiresThreadAttribute"/> marks a test that must run on a separate thread.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=true)]
     public class RequiresThreadAttribute : PropertyAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RequiresThreadAttribute"/> marks a test that must run on a separate thread.
+    /// Marks a test that must run on a separate thread.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=true)]
     public class RequiresThreadAttribute : PropertyAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RetryAttribute" /> specified that a test method should
+    /// <see cref="RetryAttribute" /> specifies that a test method should
     /// be rerun if it fails, up to a maximum number of times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RetryAttribute" /> is used on a test method to specify that it should
+    /// <see cref="RetryAttribute" /> specified that a test method should
     /// be rerun if it fails, up to a maximum number of times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -29,8 +29,8 @@ using NUnit.Framework.Internal.Commands;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="RetryAttribute" /> specifies that a test method should
-    /// be rerun if it fails, up to a maximum number of times.
+    /// Specifies that a test method should be rerun on failure up to the specified 
+    /// maximum number of times.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class RetryAttribute : PropertyAttribute, IWrapSetUpTearDown

--- a/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
@@ -29,9 +29,9 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="SequentialAttribute"/> marks a test to use a Sequential join of any argument 
-    /// data provided. Arguments will be combined into test cases,
-    /// taking the next value of each argument until all are used.
+    /// Marks a test to use a sequential join of any provided argument data. 
+    /// Arguments will be combined into test cases, taking the next value of 
+    /// each argument until all are used.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=false)]
     public class SequentialAttribute : CombiningStrategyAttribute

--- a/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SequentialAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test to use a Sequential join of any argument 
+    /// <see cref="SequentialAttribute"/> marks a test to use a Sequential join of any argument 
     /// data provided. Arguments will be combined into test cases,
     /// taking the next value of each argument until all are used.
     /// </summary>

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Sets the current Culture for the duration of a test.
+    /// <see cref="SetCultureAttribute"/> sets the current Culture for the duration of a test.
     /// <para>
     /// It may be specified at the level of a test or a fixture.
     /// The culture remains set until the test or fixture completes and is then reset to its original value.

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -28,9 +28,9 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Sets the current Culture for the duration of a test. The culture remains set until 
-    /// the test or fixture completes and is then reset to its original value.
-    /// It may be specified at either the test or fixture level. 
+    /// Sets the current Culture on an assembly, test fixture or test method for 
+    /// the duration of a test. The culture remains set until the test or fixture
+    /// completes and is then reset to its original value.    
     /// </summary>
     /// <seealso cref="SetUICultureAttribute"/>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetCultureAttribute.cs
@@ -28,11 +28,9 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="SetCultureAttribute"/> sets the current Culture for the duration of a test.
-    /// <para>
-    /// It may be specified at the level of a test or a fixture.
-    /// The culture remains set until the test or fixture completes and is then reset to its original value.
-    /// </para>
+    /// Sets the current Culture for the duration of a test. The culture remains set until 
+    /// the test or fixture completes and is then reset to its original value.
+    /// It may be specified at either the test or fixture level. 
     /// </summary>
     /// <seealso cref="SetUICultureAttribute"/>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -28,9 +28,9 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Sets the current UI Culture for the duration of a test. The UI culture remains set until
-    /// the test or fixture completes and is then reset to its original value.
-    /// It may be specified either at the test or fixture level.
+    /// Sets the current UI Culture on an assembly, test fixture or test method 
+    /// for the duration of a test. The UI culture remains set until the test or
+    /// fixture completes and is then reset to its original value.    
     /// </summary>
     /// <seealso cref="SetCultureAttribute"/>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -28,11 +28,9 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="SetUICultureAttribute"/> sets the current UI Culture for the duration of a test.
-    /// <para>
-    /// It may be specified at the level of a test or a fixture.
-    /// The UI culture remains set until the test or fixture completes and is then reset to its original value.
-    /// </para>
+    /// Sets the current UI Culture for the duration of a test. The UI culture remains set until
+    /// the test or fixture completes and is then reset to its original value.
+    /// It may be specified either at the test or fixture level.
     /// </summary>
     /// <seealso cref="SetCultureAttribute"/>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUICultureAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Sets the current UI Culture for the duration of a test.
+    /// <see cref="SetUICultureAttribute"/> sets the current UI Culture for the duration of a test.
     /// <para>
     /// It may be specified at the level of a test or a fixture.
     /// The UI culture remains set until the test or fixture completes and is then reset to its original value.

--- a/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework
     using System;
 
     /// <summary>
-    /// Identifies a method to be called prior to the running of each test.
+    /// Identifies a method to be called immediately before each test is run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=true)]
     public class SetUpAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework
     using System;
 
     /// <summary>
-    /// Attribute used to identify a method that is called 
+    /// <see cref="SetUpAttribute"/> identifies a method that is called 
     /// immediately before each test is run.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=true)]

--- a/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpAttribute.cs
@@ -26,8 +26,7 @@ namespace NUnit.Framework
     using System;
 
     /// <summary>
-    /// <see cref="SetUpAttribute"/> identifies a method that is called 
-    /// immediately before each test is run.
+    /// Identifies a method to be called prior to the running of each test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited=true)]
     public class SetUpAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -32,9 +32,9 @@ namespace NUnit.Framework
     using Internal;
 
     /// <summary>
-    /// <see cref="SetUpFixtureAttribute"/> identifies a class that contains
-    /// <see cref="OneTimeSetUpAttribute" /> or <see cref="OneTimeTearDownAttribute" />
-    /// methods for all the test fixtures under a given namespace.
+    /// Identifies a class as containing <see cref="OneTimeSetUpAttribute" /> or 
+    /// <see cref="OneTimeTearDownAttribute" /> methods for all the test fixtures
+    /// under a given namespace.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
     public class SetUpFixtureAttribute : NUnitAttribute, IFixtureBuilder

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework
     using Internal;
 
     /// <summary>
-    /// Attribute used to identify a class that contains
+    /// <see cref="SetUpFixtureAttribute"/> identifies a class that contains
     /// <see cref="OneTimeSetUpAttribute" /> or <see cref="OneTimeTearDownAttribute" />
     /// methods for all the test fixtures under a given namespace.
     /// </summary>

--- a/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
@@ -28,11 +28,11 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// SingleThreadedAttribute applies to a test fixture and indicates
-    /// that all the child tests must be run on the same thread as the
-    /// OneTimeSetUp and OneTimeTearDown. It sets a flag in the
-    /// TestExecutionContext and forces all tests to be run sequentially
-    /// on the current thread. Any ParallelScope setting is ignored.
+    /// <see cref="SingleThreadedAttribute"/> applies to a test fixture and indicates
+    /// that all child tests must be run on the same thread as the
+    /// <see cref="OneTimeSetUp"/> and <see cref="OneTimeTearDown"/>. A flag in the
+    /// <see cref="TestExecutionContext"/> is set and forces all tests to be run sequentially
+    /// on the current thread. Any <see cref="ParallelScope"/> setting is ignored.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
     public class SingleThreadedAttribute : NUnitAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     /// <summary>
     /// <see cref="SingleThreadedAttribute"/> applies to a test fixture and indicates
     /// that all child tests must be run on the same thread as the
-    /// <see cref="OneTimeSetUp"/> and <see cref="OneTimeTearDown"/>. A flag in the
+    /// OneTimeSetUp and OneTimeTearDown. A flag in the
     /// <see cref="TestExecutionContext"/> is set and forces all tests to be run sequentially
     /// on the current thread. Any <see cref="ParallelScope"/> setting is ignored.
     /// </summary>

--- a/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
@@ -28,11 +28,11 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="SingleThreadedAttribute"/> applies to a test fixture and indicates
-    /// that all child tests must be run on the same thread as the
-    /// OneTimeSetUp and OneTimeTearDown. A flag in the
-    /// <see cref="TestExecutionContext"/> is set and forces all tests to be run sequentially
-    /// on the current thread. Any <see cref="ParallelScope"/> setting is ignored.
+    /// Marks a test fixture as requiring all child tests must be run on the 
+    /// same thread as the OneTimeSetUp and OneTimeTearDown. A flag in the
+    /// <see cref="TestExecutionContext"/> is set and forces all tests to be run 
+    /// sequentially on the current thread. Any <see cref="ParallelScope"/> 
+    /// setting is ignored.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
     public class SingleThreadedAttribute : NUnitAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SingleThreadedAttribute.cs
@@ -28,11 +28,11 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a test fixture as requiring all child tests must be run on the 
+    /// Marks a test fixture as requiring all child tests to be run on the 
     /// same thread as the OneTimeSetUp and OneTimeTearDown. A flag in the
-    /// <see cref="TestExecutionContext"/> is set and forces all tests to be run 
-    /// sequentially on the current thread. Any <see cref="ParallelScope"/> 
-    /// setting is ignored.
+    /// <see cref="TestExecutionContext"/> is set forcing all child tests 
+    /// to be run sequentially on the current thread. 
+    /// Any <see cref="ParallelScope"/> setting is ignored.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
     public class SingleThreadedAttribute : NUnitAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/TearDownAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TearDownAttribute.cs
@@ -26,9 +26,8 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// <see cref="TearDownAttribute"/> identifies a method that is called 
-	/// immediately after each test is run. The method is 
-	/// guaranteed to be called, even if an exception is thrown.
+	/// Identifies a method to be called immediately after each test is run. 
+	/// The method is guaranteed to be called, even if an exception is thrown.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
 	public class TearDownAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/TearDownAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TearDownAttribute.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework
 	using System;
 
 	/// <summary>
-	/// Attribute used to identify a method that is called 
+	/// <see cref="TearDownAttribute"/> identifies a method that is called 
 	/// immediately after each test is run. The method is 
 	/// guaranteed to be called, even if an exception is thrown.
 	/// </summary>

--- a/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     using Interfaces;
 
     /// <summary>
-    /// <see cref="TestActionAttribute"/> provide actions to execute before and after tests.
+    /// <see cref="TestActionAttribute"/> provides actions to execute before and after tests.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public abstract class TestActionAttribute : Attribute, ITestAction

--- a/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     using Interfaces;
 
     /// <summary>
-    /// <see cref="TestActionAttribute"/> provides actions to execute before and after tests.
+    /// Abstract attribute providing actions to execute before and after tests.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public abstract class TestActionAttribute : Attribute, ITestAction

--- a/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestActionAttribute.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework
     using Interfaces;
 
     /// <summary>
-    /// Provide actions to execute before and after tests.
+    /// <see cref="TestActionAttribute"/> provide actions to execute before and after tests.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public abstract class TestActionAttribute : Attribute, ITestAction

--- a/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
@@ -28,7 +28,7 @@ using System.Text;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// TestAssemblyDirectoryResolveAttribute is used to mark a test assembly as needing a
+    /// <see cref="TestAssemblyDirectoryResolveAttribute"/> is used to mark a test assembly as needing a
     /// special assembly resolution hook that will explicitly search the test assembly's
     /// directory for dependent assemblies. This works around a conflict between mixed-mode
     /// assembly initialization and tests running in their own AppDomain in some cases.

--- a/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
@@ -28,10 +28,10 @@ using System.Text;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestAssemblyDirectoryResolveAttribute"/> is used to mark a test assembly as needing a
-    /// special assembly resolution hook that will explicitly search the test assembly's
-    /// directory for dependent assemblies. This works around a conflict between mixed-mode
-    /// assembly initialization and tests running in their own AppDomain in some cases.
+    /// Marks a test assembly as needing a special assembly resolution hook that will 
+    /// explicitly search the test assembly's directory for dependent assemblies. 
+    /// This works around a conflict between mixed-mode assembly initialization and 
+    /// tests running in their own AppDomain in some cases.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public class TestAssemblyDirectoryResolveAttribute : NUnitAttribute

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework
     using NUnit.Framework.Internal.Builders;
 
     /// <summary>
-    /// Adding this attribute to a method makes the method callable from the NUnit test runner.
+    /// <see cref="TestAttribute"/> makes the method callable from the NUnit test runner.
     /// </summary>
     /// 
     /// <example>

--- a/src/NUnitFramework/framework/Attributes/TestAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAttribute.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework
     using NUnit.Framework.Internal.Builders;
 
     /// <summary>
-    /// <see cref="TestAttribute"/> makes the method callable from the NUnit test runner.
+    /// Marks the method as callable from the NUnit test runner.
     /// </summary>
     /// 
     /// <example>

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -32,7 +32,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// TestCaseAttribute is used to mark parameterized test cases
+    /// <see cref="TestCaseAttribute"/> marks parameterized test cases
     /// and provide them with their arguments.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -32,7 +32,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks the method as a parameterized test cases and provide them with their arguments.
+    /// Marks a method as a parameterized test case and provides them with their arguments.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited=false)]
     public class TestCaseAttribute : NUnitAttribute, ITestBuilder, ITestCaseData, IImplyFixture

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -32,8 +32,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestCaseAttribute"/> marks parameterized test cases
-    /// and provide them with their arguments.
+    /// Marks the method as a parameterized test cases and provide them with their arguments.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited=false)]
     public class TestCaseAttribute : NUnitAttribute, ITestBuilder, ITestCaseData, IImplyFixture

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// TestCaseSourceAttribute indicates the source to be used to
+    /// <see cref="TestCaseSourceAttribute"/> indicates the source to be used to
     /// provide test cases for a test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -33,8 +33,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestCaseSourceAttribute"/> indicates the source to be used to
-    /// provide test cases for a test method.
+    /// Identifies the source to be used as the test cases for a test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class TestCaseSourceAttribute : NUnitAttribute, ITestBuilder, IImplyFixture

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Identifies the source to be used as the test cases for a test method.
+    /// Indicates the source to be used to provide test fixture instances for a test class.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class TestCaseSourceAttribute : NUnitAttribute, ITestBuilder, IImplyFixture

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestFixtureAttribute"/> marks a class that represents a TestFixture.
+    /// Marks the class as a TestFixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
     public class TestFixtureAttribute : NUnitAttribute, IFixtureBuilder2, ITestFixtureData

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// TestFixtureAttribute is used to mark a class that represents a TestFixture.
+    /// <see cref="TestFixtureAttribute"/> marks a class that represents a TestFixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
     public class TestFixtureAttribute : NUnitAttribute, IFixtureBuilder2, ITestFixtureData

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestFixtureSourceAttribute"/> indicates the source to be used to
+    /// <see cref="TestFixtureSourceAttribute"/> indicates the source used to
     /// provide test fixture instances for a test class.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -33,8 +33,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestFixtureSourceAttribute"/> indicates the source used to
-    /// provide test fixture instances for a test class.
+    /// Identifies the source used to provide test fixture instances for a test class.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public class TestFixtureSourceAttribute : NUnitAttribute, IFixtureBuilder2

--- a/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TestOfAttribute"/> indicates which class the test or test fixture is testing
+    /// Indicates the method or class the test or test fixture is testing
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     public class TestOfAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Indicates the method or class the test or test fixture is testing
+    /// Indicates the method or class the assembly, test fixture or test method is testing.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     public class TestOfAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestOfAttribute.cs
@@ -33,7 +33,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Indicates which class the test or test fixture is testing
+    /// <see cref="TestOfAttribute"/> indicates which class the test or test fixture is testing
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     public class TestOfAttribute : PropertyAttribute

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -30,11 +30,10 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="TimeoutAttribute"/> applies a timeout to a test.
-    /// When used on a method it marks the test with a timeout value in milliseconds. 
-    /// The test is cancelled if the timeout is exceeded. 
-    /// When used on a class or assembly it sets the default timeout for all contained 
-    /// test methods.
+    /// Applies a timeout to a test. When used on a method it marks the test 
+    /// with a timeout value in milliseconds. The test is cancelled if the 
+    /// timeout is exceeded. When used on a class or assembly it sets the 
+    /// default timeout for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class TimeoutAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -32,9 +32,9 @@ namespace NUnit.Framework
     /// <summary>
     /// <see cref="TimeoutAttribute"/> applies a timeout to a test.
     /// When used on a method it marks the test with a timeout value in milliseconds. 
-    /// The test will be run in a separate thread and is cancelled if the timeout 
-    /// is exceeded. When used on a class or assembly it sets the default timeout 
-    /// for all contained test methods.
+    /// The test is cancelled if the timeout is exceeded. 
+    /// When used on a class or assembly it sets the default timeout for all contained 
+    /// test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class TimeoutAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -30,9 +30,10 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Used on a method, marks the test with a timeout value in milliseconds. 
+    /// <see cref="TimeoutAttribute"/> applies a timeout to a test.
+    /// When used on a method it marks the test with a timeout value in milliseconds. 
     /// The test will be run in a separate thread and is cancelled if the timeout 
-    /// is exceeded. Used on a class or assembly, sets the default timeout 
+    /// is exceeded. When used on a class or assembly it sets the default timeout 
     /// for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -30,10 +30,9 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Applies a timeout to a test. When used on a method it marks the test 
-    /// with a timeout value in milliseconds. The test is cancelled if the 
-    /// timeout is exceeded. When used on a class or assembly it sets the 
-    /// default timeout for all contained test methods.
+    /// Applies a timeout in milliseconds to a test. 
+    /// When applied to a method the test is cancelled if the timeout is exceeded. 
+    /// When applied to a class or assembly it sets the default timeout for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class TimeoutAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -31,8 +31,8 @@ namespace NUnit.Framework
 {
     /// <summary>
     /// Applies a timeout in milliseconds to a test. 
-    /// When applied to a method the test is cancelled if the timeout is exceeded. 
-    /// When applied to a class or assembly it sets the default timeout for all contained test methods.
+    /// When applied to a method, the test is cancelled if the timeout is exceeded. 
+    /// When applied to a class or assembly, the default timeout is set for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class TimeoutAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -32,8 +32,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ValueSourceAttribute"/> indicates the source used to
-    /// provide data for one parameter of a test method.
+    /// Indicates the source used to provide data for one parameter of a test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
     public class ValueSourceAttribute : NUnitAttribute, IParameterDataSource

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -32,7 +32,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// ValueSourceAttribute indicates the source to be used to
+    /// <see cref="ValueSourceAttribute"/> indicates the source used to
     /// provide data for one parameter of a test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -31,7 +31,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// ValuesAttribute is used to provide literal arguments for
+    /// <see cref="ValuesAttribute"/> provides literal arguments for
     /// an individual parameter of a test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -31,8 +31,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// <see cref="ValuesAttribute"/> provides literal arguments for
-    /// an individual parameter of a test.
+    /// Provides literal arguments for an individual parameter of a test.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public class ValuesAttribute : NUnitAttribute, IParameterDataSource


### PR DESCRIPTION
I have been through and modified all attributes to use consistent wording for their XML summaries.  There were a couple of grammatical changes in there so it is worth checking all files to see if you are happy with the wording.