### PR TITLE
Fixes #2837 DictionaryContainsKeyConstraint behaviour ignores the dictionary key comparer.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2007 Charlie Poole, Rob Prouse
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -88,7 +88,6 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using(IComparer comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
@@ -99,7 +98,6 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using<T>(IComparer<T> comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
@@ -109,11 +107,10 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag the constraint to use the supplied Comparison object.
         /// </summary>
-        /// <param name="comparer">The IComparer object to use.</param>
-        /// <returns>Self.</returns>
-        public CollectionItemsEqualConstraint Using<T>(Comparison<T> comparer)
+        /// <param name="comparison">The Comparison object to use.</param>
+        public CollectionItemsEqualConstraint Using<T>(Comparison<T> comparison)
         {
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
+            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparison));
             return this;
         }
 
@@ -121,7 +118,6 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using(IEqualityComparer comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
@@ -132,7 +128,6 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        /// <returns>Self.</returns>
         public CollectionItemsEqualConstraint Using<T>(IEqualityComparer<T> comparer)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -263,9 +263,8 @@ namespace NUnit.Framework.Constraints
 
 #if NETSTANDARD1_4
         
-        //
         // This is for missing MetadataToken in NetStandard 1.4, matched by method signature
-        //
+
         private static bool Matched(MethodInfo methodInfo, MethodInfo matchedMethodInfo)
         {
             return methodInfo.Name == matchedMethodInfo.Name &&
@@ -273,7 +272,7 @@ namespace NUnit.Framework.Constraints
                    methodInfo.IsHideBySig == matchedMethodInfo.IsHideBySig &&
                    methodInfo.IsGenericMethod == matchedMethodInfo.IsGenericMethod &&
                    methodInfo.ReturnParameter.ParameterType == matchedMethodInfo.ReturnParameter.ParameterType &&
-                   Matched(methodInfo.GetParameters(), matchedMethodInfo.GetParameters())&&
+                   Matched(methodInfo.GetParameters(), matchedMethodInfo.GetParameters()) &&
                    Matched(methodInfo.GetGenericArguments(), matchedMethodInfo.GetGenericArguments());
         }
 

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,6 +23,10 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -33,6 +37,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class DictionaryContainsKeyConstraint : CollectionItemsEqualConstraint
     {
+        private bool _isDeprecatedMode = false;
+
         /// <summary>
         /// Construct a DictionaryContainsKeyConstraint
         /// </summary>
@@ -66,31 +72,242 @@ namespace NUnit.Framework.Constraints
         protected object Expected { get; }
 
         /// <summary>
+        /// Flag the constraint to ignore case and return self.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.ContainKey")]
+        public new CollectionItemsEqualConstraint IgnoreCase
+        {
+            get
+            {
+                _isDeprecatedMode = true;
+                return base.IgnoreCase;
+            }
+        }
+
+        private bool Matches(object actual)
+        {
+            if (_isDeprecatedMode)
+            {
+                var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
+                foreach (object obj in dictionary.Keys)
+                    if (ItemsEqual(obj, Expected))
+                        return true;
+
+                return false;
+            }
+
+            var method = GetContainsKeyMethod(actual);
+            if (method != null)
+                return (bool)method.Invoke(actual, new[] { Expected });
+
+            throw new ArgumentException("The actual value must have a ContainsKey or Contains(TKey) method.");
+        }
+
+        #region Shadowing CollectionItemsEqualConstraint Methods
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            return new ConstraintResult(this, actual, Matches(actual));
+        }
+
+        /// <summary>
         /// Test whether the expected key is contained in the dictionary
         /// </summary>
-        protected override bool Matches(IEnumerable actual)
+        protected override bool Matches(IEnumerable collection)
         {
-            var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
-
-            foreach (object obj in dictionary.Keys)
-                if (ItemsEqual(obj, Expected))
-                    return true;
-
-            return false;
+            return Matches(collection);
         }
 
         /// <summary>
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
-        /// <returns>Self.</returns>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
         public DictionaryContainsKeyConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
         {
             // reverse the order of the arguments to match expectations of PredicateEqualityComparer
             Func<TMemberType, TCollectionType, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
 
+            _isDeprecatedMode = true;
             base.Using(EqualityAdapter.For(invertedComparison));
             return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied Comparison object.
+        /// </summary>
+        /// <param name="comparison">The Comparison object to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using<T>(Comparison<T> comparison)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparison);
+        }
+
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using(IComparer comparer)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparer);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using<T>(IComparer<T> comparer)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparer);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using(IEqualityComparer comparer)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparer);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using<T>(IEqualityComparer<T> comparer)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparer);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied boolean-returning delegate.
+        /// </summary>
+        /// <param name="comparer">The supplied boolean-returning delegate to use.</param>
+        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public new CollectionItemsEqualConstraint Using<T>(Func<T, T, bool> comparer)
+        {
+            _isDeprecatedMode = true;
+            return base.Using(comparer);
+        }
+
+        #endregion
+
+        private MethodInfo GetContainsKeyMethod(object keyedItemContainer)
+        {
+            if (keyedItemContainer == null) throw new ArgumentNullException(nameof(keyedItemContainer));
+            var instanceType = keyedItemContainer.GetType();
+
+            var method = FindContainsKeyMethod(instanceType)
+                         ?? instanceType
+                            .GetInterfaces()
+                            .Concat(GetBaseTypes(instanceType))
+                            .Select(FindContainsKeyMethod)
+                            .FirstOrDefault(m => m != null);
+
+            return method;
+        }
+
+        private MethodInfo FindContainsKeyMethod(Type type)
+        {
+            var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            var method = methods.FirstOrDefault(m =>
+                m.ReturnType == typeof(bool)
+                && m.Name == "ContainsKey"
+                && m.GetParameters().Length == 1);
+
+            if (method == null && type.GetTypeInfo().IsGenericType)
+            {
+                var definition = type.GetGenericTypeDefinition();
+                var tKeyGenericArg = definition.GetGenericArguments().FirstOrDefault(typeArg => typeArg.Name == "TKey");
+
+                if (tKeyGenericArg != null)
+                {
+                    method = definition
+                             .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                             .FirstOrDefault(m =>
+                                 m.ReturnType == typeof(bool)
+                                 && m.Name == "Contains"
+                                 && m.GetParameters().FirstOrDefault()?.ParameterType == tKeyGenericArg);
+
+                    if (method != null)
+                    {
+#if NETSTANDARD1_4
+                        method = methods.Single(m => Matched(method, m));                    
+#else
+                        method = methods.Single(m => m.MetadataToken == method.MetadataToken);
+#endif
+                    }
+                }
+            }
+
+            return method;
+        }
+
+#if NETSTANDARD1_4
+        
+        //
+        // This is for missing MetadataToken in NetStandard 1.4, matched by method signature
+        //
+        private bool Matched(MethodInfo methodInfo, MethodInfo matchedMethodInfo)
+        {
+            return methodInfo.Name == matchedMethodInfo.Name &&
+                   methodInfo.Attributes == matchedMethodInfo.Attributes &&
+                   methodInfo.IsHideBySig == matchedMethodInfo.IsHideBySig &&
+                   methodInfo.IsGenericMethod == matchedMethodInfo.IsGenericMethod &&
+                   methodInfo.ReturnParameter.ParameterType == matchedMethodInfo.ReturnParameter.ParameterType &&
+                   Matched(methodInfo.GetParameters(), matchedMethodInfo.GetParameters())&&
+                   Matched(methodInfo.GetGenericArguments(), matchedMethodInfo.GetGenericArguments());
+        }
+
+        private bool Matched(ParameterInfo[] parameterInfos, ParameterInfo[] matchedParameterInfos)
+        {
+            if (parameterInfos.Length != matchedParameterInfos.Length) return false;
+
+            for (var index = 0; index < parameterInfos.Length; index++)
+            {
+                if (parameterInfos[index].ParameterType == matchedParameterInfos[index].ParameterType)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool Matched(Type[] types, Type[] matchedTypes)
+        {
+            if (types.Length != matchedTypes.Length) return false;
+
+            for (var index = 0; index < types.Length; index++)
+            {
+                if (types[index] == matchedTypes[index])
+                    return false;
+            }
+
+            return true;
+        }
+#endif
+
+        private IEnumerable<Type> GetBaseTypes(Type type)
+        {
+            for (; ; )
+            {
+                type = type.GetTypeInfo().BaseType;
+                if (type == null) break;
+                yield return type;
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -254,12 +254,11 @@ namespace NUnit.Framework.Constraints
                     }
                 }
 #else
-                    method = methods.FirstOrDefault(m => 
-                        m.ReturnType == typeof(bool)
-                        && m.Name == "Contains"
-                        && !m.IsGenericMethod
-                        && m.GetParameters().Length == 1
-                        && m.GetParameters()[0].ParameterType == type.GetGenericTypeDefinition());
+                method = methods.FirstOrDefault(m => 
+                    m.ReturnType == typeof(bool)
+                    && m.Name == "Contains"
+                    && !m.IsGenericMethod
+                    && m.GetParameters().Length == 1);
 #endif
             }
 

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -257,6 +257,7 @@ namespace NUnit.Framework.Constraints
                     method = methods.FirstOrDefault(m => 
                         m.ReturnType == typeof(bool)
                         && m.Name == "Contains"
+                        && m.IsGenericMethod
                         && m.GetParameters().Length == 1
                         && m.GetParameters()[0].ParameterType == type.GetGenericTypeDefinition());
 #endif

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Constraints
             if (method != null)
                 return (bool)method.Invoke(actual, new[] { Expected });
 
-            throw new ArgumentException("The actual value must have a ContainsKey or Contains(TKey) method.");
+            throw new ArgumentException($"The {actual.GetType().Name} value must have a ContainsKey or Contains(TKey) method.");
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -37,6 +37,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class DictionaryContainsKeyConstraint : CollectionItemsEqualConstraint
     {
+        private const string ObsoleteMessage = "DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.";
         private bool _isDeprecatedMode = false;
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag the constraint to ignore case and return self.
         /// </summary>
-        [Obsolete("Deprecated, use Does.ContainKey")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint IgnoreCase
         {
             get
@@ -103,8 +104,6 @@ namespace NUnit.Framework.Constraints
             throw new ArgumentException("The actual value must have a ContainsKey or Contains(TKey) method.");
         }
 
-        #region Shadowing CollectionItemsEqualConstraint Methods
-
         /// <summary>
         /// Test whether the constraint is satisfied by a given value
         /// </summary>
@@ -122,11 +121,13 @@ namespace NUnit.Framework.Constraints
             return Matches(collection);
         }
 
+        #region Shadowing CollectionItemsEqualConstraint Methods
+
         /// <summary>
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public DictionaryContainsKeyConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
         {
             // reverse the order of the arguments to match expectations of PredicateEqualityComparer
@@ -141,7 +142,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied Comparison object.
         /// </summary>
         /// <param name="comparison">The Comparison object to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using<T>(Comparison<T> comparison)
         {
             _isDeprecatedMode = true;
@@ -153,7 +154,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using(IComparer comparer)
         {
             _isDeprecatedMode = true;
@@ -164,7 +165,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using<T>(IComparer<T> comparer)
         {
             _isDeprecatedMode = true;
@@ -175,7 +176,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using(IEqualityComparer comparer)
         {
             _isDeprecatedMode = true;
@@ -186,7 +187,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using<T>(IEqualityComparer<T> comparer)
         {
             _isDeprecatedMode = true;
@@ -197,7 +198,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied boolean-returning delegate.
         /// </summary>
         /// <param name="comparer">The supplied boolean-returning delegate to use.</param>
-        [Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Obsolete(ObsoleteMessage)]
         public new CollectionItemsEqualConstraint Using<T>(Func<T, T, bool> comparer)
         {
             _isDeprecatedMode = true;
@@ -206,7 +207,7 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
-        private MethodInfo GetContainsKeyMethod(object keyedItemContainer)
+        private static MethodInfo GetContainsKeyMethod(object keyedItemContainer)
         {
             if (keyedItemContainer == null) throw new ArgumentNullException(nameof(keyedItemContainer));
             var instanceType = keyedItemContainer.GetType();
@@ -221,7 +222,7 @@ namespace NUnit.Framework.Constraints
             return method;
         }
 
-        private MethodInfo FindContainsKeyMethod(Type type)
+        private static MethodInfo FindContainsKeyMethod(Type type)
         {
             var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
             var method = methods.FirstOrDefault(m =>
@@ -262,7 +263,7 @@ namespace NUnit.Framework.Constraints
         //
         // This is for missing MetadataToken in NetStandard 1.4, matched by method signature
         //
-        private bool Matched(MethodInfo methodInfo, MethodInfo matchedMethodInfo)
+        private static bool Matched(MethodInfo methodInfo, MethodInfo matchedMethodInfo)
         {
             return methodInfo.Name == matchedMethodInfo.Name &&
                    methodInfo.Attributes == matchedMethodInfo.Attributes &&
@@ -273,7 +274,7 @@ namespace NUnit.Framework.Constraints
                    Matched(methodInfo.GetGenericArguments(), matchedMethodInfo.GetGenericArguments());
         }
 
-        private bool Matched(ParameterInfo[] parameterInfos, ParameterInfo[] matchedParameterInfos)
+        private static bool Matched(ParameterInfo[] parameterInfos, ParameterInfo[] matchedParameterInfos)
         {
             if (parameterInfos.Length != matchedParameterInfos.Length) return false;
 
@@ -286,7 +287,7 @@ namespace NUnit.Framework.Constraints
             return true;
         }
 
-        private bool Matched(Type[] types, Type[] matchedTypes)
+        private static bool Matched(Type[] types, Type[] matchedTypes)
         {
             if (types.Length != matchedTypes.Length) return false;
 
@@ -300,7 +301,7 @@ namespace NUnit.Framework.Constraints
         }
 #endif
 
-        private IEnumerable<Type> GetBaseTypes(Type type)
+        private static IEnumerable<Type> GetBaseTypes(Type type)
         {
             for (; ; )
             {

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Constraints
             if (method != null)
                 return (bool)method.Invoke(actual, new[] { Expected });
 
-            throw new ArgumentException($"The {actual.GetType().Name} value must have a ContainsKey or Contains(TKey) method.");
+            throw new ArgumentException($"The {TypeHelper.GetDisplayName(actual.GetType())} value must have a ContainsKey or Contains(TKey) method.");
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -233,7 +233,6 @@ namespace NUnit.Framework.Constraints
 
             if (method == null && type.GetTypeInfo().IsGenericType)
             {
-#if !NETSTANDARD1_4
                 var definition = type.GetGenericTypeDefinition();
                 var tKeyGenericArg = definition.GetGenericArguments().FirstOrDefault(typeArg => typeArg.Name == "TKey");
 
@@ -245,21 +244,18 @@ namespace NUnit.Framework.Constraints
                                  m.ReturnType == typeof(bool)
                                  && m.Name == "Contains"
                                  && !m.IsGenericMethod
-                                 && m.GetParameters().Length == 1 
+                                 && m.GetParameters().Length == 1
                                  && m.GetParameters()[0].ParameterType == tKeyGenericArg);
 
                     if (method != null)
                     {
+#if NETSTANDARD1_4
+                        method = methods.Single(m => Matched(method, m));
+#else
                         method = methods.Single(m => m.MetadataToken == method.MetadataToken);
+#endif
                     }
                 }
-#else
-                method = methods.FirstOrDefault(m => 
-                    m.ReturnType == typeof(bool)
-                    && m.Name == "Contains"
-                    && !m.IsGenericMethod
-                    && m.GetParameters().Length == 1);
-#endif
             }
 
             return method;

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -257,7 +257,7 @@ namespace NUnit.Framework.Constraints
                     method = methods.FirstOrDefault(m => 
                         m.ReturnType == typeof(bool)
                         && m.Name == "Contains"
-                        && m.IsGenericMethod
+                        && !m.IsGenericMethod
                         && m.GetParameters().Length == 1
                         && m.GetParameters()[0].ParameterType == type.GetGenericTypeDefinition());
 #endif

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,7 +24,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
+using System.Collections.ObjectModel;
+using System.Linq;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
@@ -36,7 +37,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void SucceedsWhenKeyIsPresent()
         {
-            var dictionary = new Dictionary<string, string> {{"Hello", "World"}, {"Hola", "Mundo"}};
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
 
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("Hello"));
         }
@@ -56,7 +57,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void FailsWhenKeyIsMissing()
         {
-            var dictionary = new Dictionary<string, string> {{"Hello", "World"}, {"Hola", "Mundo"}};
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
 
             TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyConstraint("Hallo"));
 
@@ -67,11 +68,11 @@ namespace NUnit.Framework.Constraints
         public void FailsWhenNotUsedAgainstADictionary()
         {
             List<KeyValuePair<string, string>> keyValuePairs = new List<KeyValuePair<string, string>>(
-                new Dictionary<string, string> {{"Hello", "World"}, {"Hola", "Mundo"}});
+                new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } });
 
             TestDelegate act = () => Assert.That(keyValuePairs, new DictionaryContainsKeyConstraint("Hallo"));
 
-            Assert.That(act, Throws.ArgumentException.With.Message.Contains("IDictionary"));
+            Assert.That(act, Throws.ArgumentException.With.Message.Contains("ContainsKey"));
         }
 
 #if !NETCOREAPP1_1
@@ -84,7 +85,7 @@ namespace NUnit.Framework.Constraints
         }
 #endif
 
-        [Test]
+        [Test, Obsolete]
         public void IgnoreCaseIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -92,27 +93,584 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").IgnoreCase);
         }
 
-        [Test]
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
         public void UsingIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
 
-            Assert.That(dictionary,
-                new DictionaryContainsKeyConstraint("HELLO").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
         }
 
-        [Test, Explicit("Demonstrates issue #2837")]
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
         public void SucceedsWhenKeyIsPresentWhenDictionaryUsingCustomComparer()
         {
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Hello", "World" }, { "Hola", "Mundo" } };
 
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello"));
         }
-        [Test, Explicit("Demonstrates issue #2837")]
-        public void SucceedsWhenKeyIsPresentUsingContainKeyWhenDictionaryUsingCustomComparer()
+
+        [Test]
+        public void SucceedsWhenKeyIsPresentUsingContainsKeyWhenDictionaryUsingCustomComparer()
         {
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Hello", "World" }, { "Hola", "Mundo" } };
             Assert.That(dictionary, Does.ContainKey("hola"));
         }
+
+        [Test]
+        public void SucceedsWhenKeyIsPresentUsingContainsKeyWhenUsingLookupCustomComparer()
+        {
+            var list = new List<string> { "ALICE", "BOB", "CATHERINE" };
+            ILookup<string, string> lookup = list.ToLookup(x => x, StringComparer.OrdinalIgnoreCase);
+
+            Assert.That(lookup, Does.ContainKey("catherine"));
+        }
+
+        [Test]
+        public void SucceedsWhenKeyIsNotPresentUsingContainsKeyUsingLookupDefaultComparer()
+        {
+            var list = new List<string> { "ALICE", "BOB", "CATHERINE" };
+            ILookup<string, string> lookup = list.ToLookup(x => x);
+
+            Assert.That(lookup, !Does.ContainKey("alice"));
+        }
+
+        [Test]
+        public void SucceedsWhenKeyIsPresentUsingContainsKeyWhenUsingKeyedCollectionCustomComparer()
+        {
+            var list = new TestKeyedCollection(StringComparer.OrdinalIgnoreCase) { "ALICE", "BOB", "CALUM" };
+
+            Assert.That(list, Does.ContainKey("calum"));
+        }
+
+        [Test]
+        public void SucceedsWhenKeyIsNotPresentUsingContainsKeyUsingKeyedCollectionDefaultComparer()
+        {
+            var list = new TestKeyedCollection { "ALICE", "BOB", "CALUM" };
+
+            Assert.That(list, !Does.ContainKey("alice"));
+        }
+
+        [Test]
+        public void SucceedsWhenKeyIsPresentUsingContainsKeyUsingHashtableCustomComparer()
+        {
+            var table = new Hashtable(StringComparer.OrdinalIgnoreCase) { { "ALICE", "BOB" }, { "CALUM", "DENNIS" } };
+
+            Assert.That(table, Does.ContainKey("alice"));
+        }
+
+        [Test]
+        public void SucceedsWhenKeyIsPresentUsingContainsKeyUsingHashtableDefaultComparer()
+        {
+            var table = new Hashtable { { "ALICE", "BOB" }, { "CALUM", "DENNIS" } };
+
+            Assert.That(table, !Does.ContainKey("calum"));
+        }
+
+        [Test]
+        public void ShouldCallContainsKeysMethodWithTKeyParameterOnNewMethod()
+        {
+            var dictionary = new TestDictionaryGeneric<string, string> { { "ALICE", "BOB" }, { "CALUM", "DENNIS" } };
+
+            Assert.That(dictionary, Does.ContainKey("BOB"));
+        }
+
+        [Test]
+        public void ShouldCallContainsKeysMethodOnDictionary()
+        {
+            var dictionary = new TestDictionary(20);
+
+            Assert.That(dictionary, Does.ContainKey(20));
+            Assert.That(dictionary, !Does.ContainKey(10));
+        }
+
+        [Test]
+        public void ShouldCallContainsKeysMethodOnPlainDictionary()
+        {
+            var dictionary = new TestNonGenericDictionary(99);
+
+            Assert.Catch<ArgumentException>(() => Assert.That(dictionary, Does.ContainKey(99)));
+        }
+
+        [Test]
+        public void ShouldCallContainsKeysMethodOnObject()
+        {
+            var poco = new TestPlainContainsKey("David");
+
+            Assert.DoesNotThrow(() => Assert.That(poco, Does.ContainKey("David")));
+        }
+
+        [Test]
+        public void ShouldThrowWhenUsedOnObjectWithNonGenericContains()
+        {
+            var poco = new TestPlainObjectContainsNonGeneric("Peter");
+
+            Assert.Catch<ArgumentException>(() => Assert.That(poco, Does.ContainKey("Peter")));
+        }
+
+        [Test]
+        public void ShouldCallContainsWhenUsedOnObjectWithGenericContains()
+        {
+            var poco = new TestPlainObjectContainsGeneric<string>("Peter");
+
+            Assert.DoesNotThrow(() => Assert.That(poco, Does.ContainKey("Peter")));
+        }
+
+#if NET45
+
+        [Test]
+        public void ShouldCallContainsKeysMethodOnReadOnlyInterface()
+        {
+            var dictionary = new TestReadOnlyDictionary("BOB");
+
+            Assert.That(dictionary, Does.ContainKey("BOB"));
+            Assert.That(dictionary, !Does.ContainKey("ALICE"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenUsedWithISet()
+        {
+            var set = new TestSet();
+
+            Assert.Catch<ArgumentException>(() => Assert.That(set, Does.ContainKey("NotHappening")));
+        }
+
+#endif
+
+#if !NET20
+
+        [Test]
+        public void ShouldCallContainsKeysMethodOnLookupInterface()
+        {
+            var dictionary = new TestLookup(20);
+
+            Assert.That(dictionary, Does.ContainKey(20));
+            Assert.That(dictionary, !Does.ContainKey(43));
+        }
+
+#endif
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingDictionaryContainsKeyConstraintComparisonFunc()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").Using<string, string>((x, y) => x.ToUpper().Equals(y.ToUpper())));
+        }
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingBaseCollectionItemsEqualConstraintNonGenericComparer()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("hola").Using((IComparer)StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingBaseCollectionItemsEqualConstraintGenericComparer()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("hola").Using((IComparer<string>)StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingBaseCollectionItemsEqualConstraintNonGenericEqualityComparer()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using((IEqualityComparer)StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingBaseCollectionItemsEqualConstraintGenericEqualityComparer()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using((IEqualityComparer<string>)StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        public void UsingBaseCollectionItemsEqualConstraintComparerFunc()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using<string>((x, y) => x.ToLower().Equals(y.ToLower())));
+        }
+
+        #region Test Assets
+
+        public class TestPlainContainsKey
+        {
+            private readonly string _key;
+
+            public TestPlainContainsKey(string key)
+            {
+                _key = key;
+            }
+
+            public bool ContainsKey(string key)
+            {
+                return _key.Equals(key);
+            }
+        }
+
+        public class TestPlainObjectContainsNonGeneric
+        {
+            private readonly string _key;
+
+            public TestPlainObjectContainsNonGeneric(string key)
+            {
+                _key = key;
+            }
+
+            public bool Contains(string key)
+            {
+                return _key.Equals(key);
+            }
+        }
+
+        public class TestPlainObjectContainsGeneric<TKey>
+        {
+            private readonly TKey _key;
+
+            public TestPlainObjectContainsGeneric(TKey key)
+            {
+                _key = key;
+            }
+
+            public bool Contains(TKey key)
+            {
+                return _key.Equals(key);
+            }
+        }
+
+        public class TestKeyedCollection : KeyedCollection<string, string>
+        {
+            public TestKeyedCollection() { }
+
+            public TestKeyedCollection(IEqualityComparer<string> comparer) : base(comparer) { }
+
+            protected override string GetKeyForItem(string item)
+            {
+                return item;
+            }
+        }
+
+        public class TestDictionaryGeneric<TKey, TItem> : Dictionary<TKey, TItem>
+        {
+            public new bool ContainsKey(TKey key)
+            {
+                return base.Values.Any(x => x.Equals(key));
+            }
+        }
+
+        public class TestDictionary : IDictionary<int, string>
+        {
+            private readonly int _key;
+
+            public TestDictionary(int key)
+            {
+                _key = key;
+            }
+
+            public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void Add(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<int, string>[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int Count { get; }
+            public bool IsReadOnly { get; }
+            public bool ContainsKey(int key)
+            {
+                return key == _key;
+            }
+
+            public void Add(int key, string value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(int key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(int key, out string value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string this[int key]
+            {
+                get { throw new NotImplementedException(); }
+                set { throw new NotImplementedException(); }
+            }
+
+            public ICollection<int> Keys { get; }
+            public ICollection<string> Values { get; }
+        }
+
+        public class TestNonGenericDictionary : IDictionary
+        {
+            private readonly int _key;
+
+            public TestNonGenericDictionary(int key)
+            {
+                _key = key;
+            }
+
+            public bool Contains(object key)
+            {
+                return _key == (int)key;
+            }
+
+            public void Add(object key, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionaryEnumerator GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(object key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object this[object key]
+            {
+                get { throw new NotImplementedException(); }
+                set { throw new NotImplementedException(); }
+            }
+
+            public ICollection Keys { get; }
+            public ICollection Values { get; }
+            public bool IsReadOnly { get; }
+            public bool IsFixedSize { get; }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void CopyTo(Array array, int index)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int Count { get; }
+            public object SyncRoot { get; }
+            public bool IsSynchronized { get; }
+        }
+
+#if !NET20
+        public class TestLookup : ILookup<int, string>
+        {
+            private readonly int _key;
+
+            public TestLookup(int key)
+            {
+                _key = key;
+            }
+
+            public IEnumerator<IGrouping<int, string>> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public bool Contains(int key)
+            {
+                return key == _key;
+            }
+
+            public int Count { get; }
+
+            public IEnumerable<string> this[int key]
+            {
+                get { throw new NotImplementedException(); }
+            }
+        }
+#endif
+
+#if !NET20 && !NET35 && !NET40
+        public class TestReadOnlyDictionary : IReadOnlyDictionary<string, string>
+        {
+            private readonly string _key;
+
+            public TestReadOnlyDictionary(string key)
+            {
+                _key = key;
+            }
+
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public int Count { get; }
+            public bool ContainsKey(string key)
+            {
+                return _key == key;
+            }
+
+            public bool TryGetValue(string key, out string value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string this[string key]
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public IEnumerable<string> Keys { get; }
+            public IEnumerable<string> Values { get; }
+        }
+
+        public class TestSet : ISet<int>
+        {
+            public IEnumerator<int> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            void ICollection<int>.Add(int item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UnionWith(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void IntersectWith(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ExceptWith(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SymmetricExceptWith(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsSubsetOf(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsSupersetOf(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsProperSupersetOf(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsProperSubsetOf(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Overlaps(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool SetEquals(IEnumerable<int> other)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ISet<int>.Add(int item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(int item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(int[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(int item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int Count { get; }
+            public bool IsReadOnly { get; }
+        }
+#endif
+
+        #endregion
     }
 }


### PR DESCRIPTION
@ChrisMaddock @jnm2 

I've had to create a new branch, there were only 3 files that were changed in the original PR. My branch was too messed up which was my fault 100% and it was just me being unfarmiliar with git when I started. I might need to do the same for #2786 (it might be ok) but I will check this myself.

I've made the change so that is fixed for NetStandard1.4, it was a bit of a trial and confusion rained heavily as I needed `System.Reflection.TypeExtensions` which was refereneced but... missing what I thought was there. After a lot of head scratching and drinking neat vodka 😉, I ended up ILSpying and finding out 1.4 uses a degraded version... Anyway I have a fix and it passes all unit tests.

I don't get any other breaks and I ran the tests a number of times to see if they were threading/sync issue but nothing.