### PR TITLE
Fixes #2970 InvalidCastException @ NUnit.Framework.TestFixtureSourceAttribute.BuildFrom

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
@@ -109,7 +108,7 @@ namespace NUnit.Framework
         {
             Type sourceType = SourceType ?? type;
 
-            foreach (TestFixtureParameters parms in GetParametersFor(sourceType))
+            foreach (ITestFixtureData parms in GetParametersFor(sourceType))
                 yield return _builder.BuildFrom(type, PreFilter.Empty, parms);
         }
 

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -106,10 +106,7 @@ namespace NUnit.Framework
         /// <param name="type">The type to be used as a fixture.</param>
         public IEnumerable<TestSuite> BuildFrom(Type type)
         {
-            Type sourceType = SourceType ?? type;
-
-            foreach (ITestFixtureData parms in GetParametersFor(sourceType))
-                yield return _builder.BuildFrom(type, PreFilter.Empty, parms);
+            return BuildFrom(type, PreFilter.Empty);
         }
 
         #endregion
@@ -125,7 +122,7 @@ namespace NUnit.Framework
         {
             Type sourceType = SourceType ?? type;
 
-            foreach (TestFixtureParameters parms in GetParametersFor(sourceType))
+            foreach (ITestFixtureData parms in GetParametersFor(sourceType))
                 yield return _builder.BuildFrom(type, filter, parms);
         }
 

--- a/src/NUnitFramework/framework/Internal/TestFixtureParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestFixtureParameters.cs
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Type arguments used to create a generic fixture instance
         /// </summary>
-        public Type[] TypeArgs { get; internal set; }
+        public Type[] TypeArgs { get; }
 
         #endregion
     }

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -375,11 +375,11 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 
     [TestFixtureSource(typeof(GenericFixtureWithTypeAndConstructorArgsSource), "Source")]
-    public class GenerixFixtureSourceWithTypeAndConstructorArgs<T>
+    public class GenericFixtureSourceWithTypeAndConstructorArgs<T>
     {
         private readonly T _arg;
 
-        public GenerixFixtureSourceWithTypeAndConstructorArgs(T arg)
+        public GenericFixtureSourceWithTypeAndConstructorArgs(T arg)
         {
             _arg = arg;
         }

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -23,6 +23,7 @@
 
 using System.Collections;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
@@ -92,9 +93,9 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 
     [TestFixtureSource("StaticProperty")]
-    public class StaticProperty_InheritedClass : StaticProperty_SameClass 
+    public class StaticProperty_InheritedClass : StaticProperty_SameClass
     {
-        public StaticProperty_InheritedClass (string arg) : base(arg, "StaticPropertyInClass") { }
+        public StaticProperty_InheritedClass(string arg) : base(arg, "StaticPropertyInClass") { }
     }
 
     [TestFixtureSource("StaticMethod")]
@@ -267,12 +268,12 @@ namespace NUnit.TestData.TestFixtureSourceData
         public static IEnumerable<TestFixtureData> IndividualInstanceNameTestDataSource() =>
             from spec in TestDataSpec.Specs
             select new TestFixtureData(spec.Arguments)
-                {
-                    Properties = // SetProperty does not exist
+            {
+                Properties = // SetProperty does not exist
                     {
                         ["ExpectedTestName"] = { spec.GetFixtureName(nameof(IndividualInstanceNameTestDataFixture)) }
                     }
-                }
+            }
                 .SetArgDisplayNames(spec.ArgDisplayNames);
     }
 
@@ -350,6 +351,42 @@ namespace NUnit.TestData.TestFixtureSourceData
         [Test]
         public void SomeTest()
         {
+        }
+    }
+
+    public class GenericFixtureWithConstructorArgumentsSource
+    {
+        public static readonly ITestFixtureData[] Source = {
+            new TypedTestFixture<int>(5),
+            new TypedTestFixture<object>(new object())
+        };
+
+        public class TypedTestFixture<T> : Framework.Internal.TestParameters, ITestFixtureData
+        {
+            public TypedTestFixture(params object[] arguments)
+                : base(arguments)
+            {
+                TypeArgs = new[] { typeof(T) };
+            }
+
+            public Type[] TypeArgs { get; }
+        }
+    }
+
+    [TestFixtureSource(typeof(GenericFixtureWithConstructorArgumentsSource), "Source")]
+    public class GenerixFixtureSourceWithTypeAndConstructorArgs<T>
+    {
+        private readonly T _arg;
+
+        public GenerixFixtureSourceWithTypeAndConstructorArgs(T arg)
+        {
+            _arg = arg;
+        }
+
+        [Test]
+        public void SomeTest()
+        {
+            Assert.That(!EqualityComparer<T>.Default.Equals(_arg, default(T)), "constructor argument was not injected");
         }
     }
 

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -354,9 +354,10 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    public class GenericFixtureWithConstructorArgumentsSource
+    public class GenericFixtureWithTypeAndConstructorArgsSource
     {
-        public static readonly ITestFixtureData[] Source = {
+        public static readonly ITestFixtureData[] Source =
+        {
             new TypedTestFixture<int>(5),
             new TypedTestFixture<object>(new object())
         };
@@ -373,12 +374,38 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource(typeof(GenericFixtureWithConstructorArgumentsSource), "Source")]
+    [TestFixtureSource(typeof(GenericFixtureWithTypeAndConstructorArgsSource), "Source")]
     public class GenerixFixtureSourceWithTypeAndConstructorArgs<T>
     {
         private readonly T _arg;
 
         public GenerixFixtureSourceWithTypeAndConstructorArgs(T arg)
+        {
+            _arg = arg;
+        }
+
+        [Test]
+        public void SomeTest()
+        {
+            Assert.That(!EqualityComparer<T>.Default.Equals(_arg, default(T)), "constructor argument was not injected");
+        }
+    }
+
+    public class GenericFixtureWithConstructorArgsSource
+    {
+        public static readonly TestFixtureData[] Source =
+        {
+            new TestFixtureData(5),
+            new TestFixtureData(new object())
+        };
+    }
+
+    [TestFixtureSource(typeof(GenericFixtureWithConstructorArgsSource), "Source")]
+    public class GenericFixtureSourceWithConstructorArgs<T>
+    {
+        private readonly T _arg;
+
+        public GenericFixtureSourceWithConstructorArgs(T arg)
         {
             _arg = arg;
         }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -23,10 +23,8 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.Filters;
 using NUnit.TestData.TestFixtureSourceData;
 using NUnit.TestUtilities;
 
@@ -164,7 +162,7 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenerixFixtureSourceWithTypeAndConstructorArgs<>));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureWithTypeAndConstructorArgsSource.Source.Length));
         }
 
         [Test]
@@ -173,7 +171,7 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithConstructorArgs<>));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureWithConstructorArgsSource.Source.Length));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -166,5 +166,14 @@ namespace NUnit.Framework.Attributes
             Assert.That(suite is ParameterizedFixtureSuite);
             Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
         }
+
+        [Test]
+        public void CanRunGenericFixtureSourceWithConstructorArgsProvidedAndTypeArgsDeduced()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithConstructorArgs<>));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            Assert.That(suite is ParameterizedFixtureSuite);
+            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanRunGenericFixtureSourceWithProperTypeAndConstructorArgsProvided()
         {
-            TestSuite suite = TestBuilder.MakeFixture(typeof(GenerixFixtureSourceWithTypeAndConstructorArgs<>));
+            TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithTypeAndConstructorArgs<>));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
             Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureWithTypeAndConstructorArgsSource.Source.Length));

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -150,9 +150,18 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void CanRunGenericFixtureSourceWithProperArgsProvided()
+        public void CanRunGenericFixtureSourceWithProperTypeArgsProvided()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithProperArgsProvided<>));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            Assert.That(suite is ParameterizedFixtureSuite);
+            Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+        }
+
+        [Test]
+        public void CanRunGenericFixtureSourceWithProperTypeAndConstructorArgsProvided()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(GenerixFixtureSourceWithTypeAndConstructorArgs<>));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
             Assert.That(suite.Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));


### PR DESCRIPTION
Fixes #2970

I've done three things:

- removed the unnecessary cast from NUnit.Framework.TestFixtureSourceAttribute.BuildFrom
- removed internal setter from NUnit.Framework.Internal.TestFixtureParameters.TypeArgs - as there's no usages of the setter (apart from being set by ctor)
- added test cases, including one for type parameter deduction from ctor arguments (=> goal: unit tests show what's supported and what not).

Question: how can / should I run the tests included in the nunit solution locally? I've not found any documentation on this.