### PR TITLE
Allow Warn.If and Warn.Unless to run in a Multiple assert block

### DIFF
--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -93,8 +93,6 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
@@ -125,8 +123,6 @@ namespace NUnit.Framework
             IResolveConstraint expr,
             Func<string> getExceptionMessage)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
@@ -254,8 +250,6 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void Unless<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
@@ -279,8 +273,6 @@ namespace NUnit.Framework
             IResolveConstraint expression,
             Func<string> getExceptionMessage)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
@@ -322,8 +314,6 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = new NotConstraint(expr.Resolve());
 
             IncrementAssertCount();
@@ -354,8 +344,6 @@ namespace NUnit.Framework
             IResolveConstraint expr,
             Func<string> getExceptionMessage)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = new NotConstraint(expr.Resolve());
 
             IncrementAssertCount();
@@ -465,8 +453,6 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static void If<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = new NotConstraint(expression.Resolve());
 
             IncrementAssertCount();
@@ -490,8 +476,6 @@ namespace NUnit.Framework
             IResolveConstraint expression,
             Func<string> getExceptionMessage)
         {
-            CheckMultipleAssertLevel();
-
             var constraint = new NotConstraint(expression.Resolve());
 
             IncrementAssertCount();
@@ -507,12 +491,6 @@ namespace NUnit.Framework
         #endregion
 
         #region Helper Methods
-
-        private static void CheckMultipleAssertLevel()
-        {
-            if (TestExecutionContext.CurrentContext.MultipleAssertLevel > 0)
-                throw new Exception("Warn.If may not be used in a multiple assertion block.");
-        }
 
         private static void IncrementAssertCount()
         {

--- a/src/NUnitFramework/testdata/AssertMultipleData.cs
+++ b/src/NUnitFramework/testdata/AssertMultipleData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 
 #if ASYNC
@@ -95,6 +95,61 @@ namespace NUnit.TestData.AssertMultipleData
         }
 
         [Test]
+        public void ThreeAssertWarns()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Warn("WARNING1");
+                Assert.Warn("WARNING2");
+                Assert.Warn("WARNING3");
+            });
+        }
+
+        [Test]
+        public void ThreeWarnIf_AllPass()
+        {
+            Assert.Multiple(() =>
+            {
+                Warn.If(false, "WARNING1");
+                Warn.If(false, "WARNING2");
+                Warn.If(false, "WARNING3");
+            });
+        }
+
+        [Test]
+        public void ThreeWarnIf_TwoFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Warn.If(true, "WARNING1");
+                Warn.If(false, "WARNING2");
+                Warn.If(true, "WARNING3");
+            });
+        }
+
+        [Test]
+        public void ThreeWarnUnless_AllPass()
+        {
+            Assert.Multiple(() =>
+            {
+                Warn.Unless(true, "WARNING1");
+                Warn.Unless(true, "WARNING2");
+                Warn.Unless(true, "WARNING3");
+            });
+        }
+
+        [Test]
+        public void ThreeWarnUnless_TwoFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Warn.Unless(false, "WARNING1");
+                Warn.Unless(true, "WARNING2");
+                Warn.Unless(false, "WARNING3");
+            });
+        }
+
+        [Test]
         public void MethodCallsFail()
         {
             Assert.Multiple(() =>
@@ -111,6 +166,28 @@ namespace NUnit.TestData.AssertMultipleData
                 Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
                 Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 Assert.Fail("Message from Assert.Fail");
+            });
+        }
+
+        [Test]
+        public void WarningAfterTwoAssertsFail()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.Warn("WARNING");
+            });
+        }
+
+        [Test]
+        public void TwoAssertsFailAfterWarning()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Warn("WARNING");
+                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
             });
         }
 
@@ -226,6 +303,16 @@ namespace NUnit.TestData.AssertMultipleData
             {
                 Assert.AreEqual(5, 2 + 2, "Failure 1");
                 Assert.True(1 == 0, "Failure 2");
+                throw new Exception("Simulated Error");
+            });
+        }
+
+        [Test]
+        public void ExceptionThrownAfterWarning()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Warn("WARNING");
                 throw new Exception("Simulated Error");
             });
         }

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -25,6 +25,7 @@ using System;
 using NUnit.Framework.Interfaces;
 using NUnit.TestData.AssertMultipleData;
 using NUnit.TestUtilities;
+using AM = NUnit.TestData.AssertMultipleData.AssertMultipleFixture;
 
 namespace NUnit.Framework.Assertions
 {
@@ -32,94 +33,81 @@ namespace NUnit.Framework.Assertions
     {
         private static readonly ComplexNumber _complex = new ComplexNumber(5.2, 3.9);
 
-        [OneTimeSetUp]
-        public void CreateSampleFile()
-        {
-
-        }
-
-        [TestCase("EmptyBlock", 0)]
-        [TestCase("SingleAssertSucceeds", 1)]
-        [TestCase("TwoAssertsSucceed", 2)]
-        [TestCase("ThreeAssertsSucceed", 3)]
-        [TestCase("NestedBlock_ThreeAssertsSucceed", 3)]
-        [TestCase("TwoNestedBlocks_ThreeAssertsSucceed", 3)]
-        [TestCase("NestedBlocksInMethodCalls", 3)]
+        [TestCase(nameof(AM.EmptyBlock), 0)]
+        [TestCase(nameof(AM.SingleAssertSucceeds), 1)]
+        [TestCase(nameof(AM.TwoAssertsSucceed), 2)]
+        [TestCase(nameof(AM.ThreeAssertsSucceed), 3)]
+        [TestCase(nameof(AM.NestedBlock_ThreeAssertsSucceed), 3)]
+        [TestCase(nameof(AM.TwoNestedBlocks_ThreeAssertsSucceed), 3)]
+        [TestCase(nameof(AM.NestedBlocksInMethodCalls), 3)]
+        [TestCase(nameof(AM.ThreeWarnIf_AllPass), 3)]
+        [TestCase(nameof(AM.ThreeWarnUnless_AllPass), 3)]
 #if ASYNC
-        [TestCase("ThreeAssertsSucceed_Async", 3)]
-        [TestCase("NestedBlock_ThreeAssertsSucceed_Async", 3)]
-        [TestCase("TwoNestedBlocks_ThreeAssertsSucceed_Async", 3)]
+        [TestCase(nameof(AM.ThreeAssertsSucceed_Async), 3)]
+        [TestCase(nameof(AM.NestedBlock_ThreeAssertsSucceed_Async), 3)]
+        [TestCase(nameof(AM.TwoNestedBlocks_ThreeAssertsSucceed_Async), 3)]
 #endif
         public void AssertMultipleSucceeds(string methodName, int asserts)
         {
-            var result = TestBuilder.RunTestCase(typeof(AssertMultipleFixture), methodName);
-
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
-            Assert.That(result.AssertCount, Is.EqualTo(asserts));
-            Assert.IsEmpty(result.AssertionResults);
+            CheckResult(methodName, ResultState.Success, asserts);
         }
 
-        [TestCase("TwoAsserts_FirstAssertFails", "RealPart")]
-        [TestCase("TwoAsserts_SecondAssertFails", "ImaginaryPart")]
-        [TestCase("TwoAsserts_BothAssertsFail", "RealPart", "ImaginaryPart")]
-        [TestCase("NestedBlock_FirstAssertFails", "Expected: 5")]
-        [TestCase("NestedBlock_TwoAssertsFail", "Expected: 5", "ImaginaryPart")]
-        [TestCase("TwoNestedBlocks_FirstAssertFails", "Expected: 5")]
-        [TestCase("TwoNestedBlocks_TwoAssertsFail", "Expected: 5", "ImaginaryPart")]
-        [TestCase("MethodCallsFail", "Message from Assert.Fail")]
-        [TestCase("MethodCallsFailAfterTwoAssertsFail", "Expected: 5", "ImaginaryPart", "Message from Assert.Fail")]
+        [TestCase(nameof(AM.TwoAsserts_FirstAssertFails), 2, "RealPart")]
+        [TestCase(nameof(AM.TwoAsserts_SecondAssertFails), 2, "ImaginaryPart")]
+        [TestCase(nameof(AM.TwoAsserts_BothAssertsFail), 2, "RealPart", "ImaginaryPart")]
+        [TestCase(nameof(AM.NestedBlock_FirstAssertFails), 3, "Expected: 5")]
+        [TestCase(nameof(AM.NestedBlock_TwoAssertsFail), 3, "Expected: 5", "ImaginaryPart")]
+        [TestCase(nameof(AM.TwoNestedBlocks_FirstAssertFails), 3, "Expected: 5")]
+        [TestCase(nameof(AM.TwoNestedBlocks_TwoAssertsFail), 3, "Expected: 5", "ImaginaryPart")]
+        [TestCase(nameof(AM.MethodCallsFail), 0, "Message from Assert.Fail")]
+        [TestCase(nameof(AM.MethodCallsFailAfterTwoAssertsFail), 2, "Expected: 5", "ImaginaryPart", "Message from Assert.Fail")]
+        [TestCase(nameof(AM.TwoAssertsFailAfterWarning), 2, "WARNING", "Expected: 5", "ImaginaryPart")]
+        [TestCase(nameof(AM.WarningAfterTwoAssertsFail), 2, "Expected: 5", "ImaginaryPart", "WARNING")]
 #if ASYNC
-        [TestCase("TwoAsserts_BothAssertsFail_Async", "RealPart", "ImaginaryPart")]
-        [TestCase("TwoNestedBlocks_TwoAssertsFail_Async", "Expected: 5", "ImaginaryPart")]
+        [TestCase(nameof(AM.TwoAsserts_BothAssertsFail_Async), 2, "RealPart", "ImaginaryPart")]
+        [TestCase(nameof(AM.TwoNestedBlocks_TwoAssertsFail_Async), 3, "Expected: 5", "ImaginaryPart")]
 #endif
-        public void AssertMultipleFails(string methodName, params string[] assertionMessageRegex)
+        public void AssertMultipleFails(string methodName, int asserts, params string[] assertionMessages)
         {
-            CheckResult(methodName, ResultState.Failure, assertionMessageRegex);
+            CheckResult(methodName, ResultState.Failure, asserts, assertionMessages);
         }
 
-        [TestCase("ExceptionThrown")]
-        [TestCase("ExceptionThrownAfterTwoFailures", "Failure 1", "Failure 2", "Simulated Error")]
-        public void AssertMultipleErrorTests(string methodName, params string[] assertionMessageRegex)
+        [TestCase(nameof(AM.ThreeAssertWarns), 0, "WARNING1", "WARNING2", "WARNING3")]
+        [TestCase(nameof(AM.ThreeWarnIf_TwoFail), 3, "WARNING1", "WARNING3")]
+        [TestCase(nameof(AM.ThreeWarnUnless_TwoFail), 3, "WARNING1", "WARNING3")]
+        public void AssertMultipleWarns(string methodName, int asserts, params string[] assertionMessages)
         {
-            ITestResult result = CheckResult(methodName, ResultState.Error, assertionMessageRegex);
+            CheckResult(methodName, ResultState.Warning, asserts, assertionMessages);
+        }
+
+        [TestCase(nameof(AM.ExceptionThrown), 0)]
+        [TestCase(nameof(AM.ExceptionThrownAfterTwoFailures), 2, "Failure 1", "Failure 2", "Simulated Error")]
+        [TestCase(nameof(AM.ExceptionThrownAfterWarning), 0, "WARNING", "Simulated Error")]
+        public void AssertMultipleErrorTests(string methodName, int asserts, params string[] assertionMessages)
+        {
+            ITestResult result = CheckResult(methodName, ResultState.Error, asserts, assertionMessages);
             Assert.That(result.Message, Does.StartWith("System.Exception : Simulated Error"));//
         }
 
-        [Test]
-        public void AssertPassInBlockThrowsException()
+        [TestCase(nameof(AM.AssertPassInBlock), "Assert.Pass")]
+        [TestCase(nameof(AM.AssertIgnoreInBlock), "Assert.Ignore")]
+        [TestCase(nameof(AM.AssertInconclusiveInBlock), "Assert.Inconclusive")]
+        [TestCase(nameof(AM.AssumptionInBlock), "Assume.That")]
+        public void AssertMultiple_InvalidAssertThrowsException(string methodName, string invalidAssert)
         {
-            ITestResult result = CheckResult("AssertPassInBlock", ResultState.Error);
-            Assert.That(result.Message, Contains.Substring("Assert.Pass may not be used in a multiple assertion block."));
+            ITestResult result = CheckResult(methodName, ResultState.Error, 0);
+            Assert.That(result.Message, Contains.Substring($"{invalidAssert} may not be used in a multiple assertion block."));
         }
 
-        [Test]
-        public void AssertIgnoreInBlockThrowsException()
-        {
-            ITestResult result = CheckResult("AssertIgnoreInBlock", ResultState.Error);
-            Assert.That(result.Message, Contains.Substring("Assert.Ignore may not be used in a multiple assertion block."));
-        }
-
-        [Test]
-        public void AssertInconclusiveInBlockThrowsException()
-        {
-            ITestResult result = CheckResult("AssertInconclusiveInBlock", ResultState.Error);
-            Assert.That(result.Message, Contains.Substring("Assert.Inconclusive may not be used in a multiple assertion block."));
-        }
-
-        [Test]
-        public void AssumptionInBlockThrowsException()
-        {
-            ITestResult result = CheckResult("AssumptionInBlock", ResultState.Error);
-            Assert.That(result.Message, Contains.Substring("Assume.That may not be used in a multiple assertion block."));
-        }
-
-        private ITestResult CheckResult(string methodName, ResultState expectedResultState, params string[] assertionMessageRegex)
+        private ITestResult CheckResult(string methodName, ResultState expectedResultState, int expectedAsserts, params string[] assertionMessageRegex)
         {
             ITestResult result = TestBuilder.RunTestCase(typeof(AssertMultipleFixture), methodName);
 
             Assert.That(result.ResultState, Is.EqualTo(expectedResultState), "ResultState");
+            Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "AssertCount");
             Assert.That(result.AssertionResults.Count, Is.EqualTo(assertionMessageRegex.Length), "Number of AssertionResults");
-            Assert.That(result.StackTrace, Is.Not.Null.And.Contains(methodName), "StackTrace");
+            if (result.ResultState.Status == TestStatus.Failed)
+                Assert.That(result.StackTrace, Is.Not.Null.And.Contains(methodName), "StackTrace");
 
             if (result.AssertionResults.Count > 0)
             {


### PR DESCRIPTION
Fixes #2979 

`Warn.If` and `Warn.Unless` were modified to run in multiple assert block.

New tests were added

Existing tests were improved and refactored.