### PR TITLE
Error in .NET Standard 1.4 DictionaryContainsKeyConstraint MetadataToken compatibility methods

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -253,7 +253,7 @@ namespace NUnit.Framework.Constraints
                     {
 #if NETSTANDARD1_4
                         var signature = CreateGenericContainsSignature(method, tKeyGenericArg);
-                        method = methods.Single(m => CreateGenericContainsSignature(m, tKeyGenericArg) == signature);
+                        method = methods.Where(x => x.Name == "Contains").Single(m => CreateGenericContainsSignature(m, tKeyGenericArg) == signature);
 #else
                         method = methods.Single(m => m.MetadataToken == method.MetadataToken);
 #endif

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -272,21 +272,6 @@ namespace NUnit.Framework.Constraints
                    methodInfo.GetParameters()[0].Name == compareToMethodInfo.GetParameters()[0].Name;
         }
 
-        private static string CreateGenericContainsSignature(MethodInfo methodInfo, Type keyGenericArg)
-        {
-            var signature = new StringBuilder(methodInfo.Name);
-            signature.Append("(");
-
-            if (keyGenericArg != null)
-                signature.Append($"{keyGenericArg.Name} ");
-
-            if (methodInfo.GetParameters().Length == 1)
-                signature.Append($"{methodInfo.GetParameters()[0].Name}");
-
-            signature.Append(")");
-            return signature.ToString();
-        }
-
 #endif
 
         private static IEnumerable<Type> GetBaseTypes(Type type)

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -226,8 +226,6 @@ namespace NUnit.Framework.Constraints
 
         private static MethodInfo FindContainsKeyMethod(Type type)
         {
-            if (type == null) return null;
-
             var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
             var method = methods.FirstOrDefault(m =>
                 m.ReturnType == typeof(bool)
@@ -253,8 +251,7 @@ namespace NUnit.Framework.Constraints
                     if (method != null)
                     {
 #if NETSTANDARD1_4
-                        var signature = CreateGenericContainsSignature(method, tKeyGenericArg);
-                        method = methods.Where(x => x.Name == ContainsMethodName).Single(m => CreateGenericContainsSignature(m, tKeyGenericArg) == signature);
+                        method = methods.Where(x => x.Name == ContainsMethodName).Single(m => MatchedContainsMethod(m, method));
 #else
                         method = methods.Single(m => m.MetadataToken == method.MetadataToken);
 #endif
@@ -266,6 +263,14 @@ namespace NUnit.Framework.Constraints
         }
 
 #if NETSTANDARD1_4
+
+        private static bool MatchedContainsMethod(MethodInfo methodInfo, MethodInfo compareToMethodInfo)
+        {
+            return methodInfo.Name == compareToMethodInfo.Name &&
+                   methodInfo.GetParameters().Length == 1 &&
+                   compareToMethodInfo.GetParameters().Length == 1 &&
+                   methodInfo.GetParameters()[0].Name == compareToMethodInfo.GetParameters()[0].Name;
+        }
 
         private static string CreateGenericContainsSignature(MethodInfo methodInfo, Type keyGenericArg)
         {

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -39,6 +39,7 @@ namespace NUnit.Framework.Constraints
     public class DictionaryContainsKeyConstraint : CollectionItemsEqualConstraint
     {
         private const string ObsoleteMessage = "DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.";
+        private const string ContainsMethodName = "Contains";
         private bool _isDeprecatedMode = false;
 
         /// <summary>
@@ -244,7 +245,7 @@ namespace NUnit.Framework.Constraints
                     method = definition
                              .GetMethods(BindingFlags.Instance | BindingFlags.Public)
                              .FirstOrDefault(m => m.ReturnType == typeof(bool) &&
-                                                  m.Name == "Contains" &&
+                                                  m.Name == ContainsMethodName &&
                                                   !m.IsGenericMethod &&
                                                   m.GetParameters().Length == 1 &&
                                                   m.GetParameters()[0].ParameterType == tKeyGenericArg);
@@ -253,7 +254,7 @@ namespace NUnit.Framework.Constraints
                     {
 #if NETSTANDARD1_4
                         var signature = CreateGenericContainsSignature(method, tKeyGenericArg);
-                        method = methods.Where(x => x.Name == "Contains").Single(m => CreateGenericContainsSignature(m, tKeyGenericArg) == signature);
+                        method = methods.Where(x => x.Name == ContainsMethodName).Single(m => CreateGenericContainsSignature(m, tKeyGenericArg) == signature);
 #else
                         method = methods.Single(m => m.MetadataToken == method.MetadataToken);
 #endif

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -251,7 +251,10 @@ namespace NUnit.Framework.Constraints
                     if (method != null)
                     {
 #if NETSTANDARD1_4
-                        method = methods.Where(x => x.Name == ContainsMethodName).Single(m => MatchedContainsMethod(m, method));
+                        method = methods.Single(m => m.Name == method.Name &&
+                                                     m.GetParameters().Length == 1 &&
+                                                     method.GetParameters().Length == 1 &&
+                                                     m.GetParameters()[0].Name == method.GetParameters()[0].Name);
 #else
                         method = methods.Single(m => m.MetadataToken == method.MetadataToken);
 #endif
@@ -261,18 +264,6 @@ namespace NUnit.Framework.Constraints
 
             return method;
         }
-
-#if NETSTANDARD1_4
-
-        private static bool MatchedContainsMethod(MethodInfo methodInfo, MethodInfo compareToMethodInfo)
-        {
-            return methodInfo.Name == compareToMethodInfo.Name &&
-                   methodInfo.GetParameters().Length == 1 &&
-                   compareToMethodInfo.GetParameters().Length == 1 &&
-                   methodInfo.GetParameters()[0].Name == compareToMethodInfo.GetParameters()[0].Name;
-        }
-
-#endif
 
         private static IEnumerable<Type> GetBaseTypes(Type type)
         {

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -143,7 +143,7 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
-        public void SucceedsWhenKeyIsNotPresentUsingContainsKeyUsingKeyedCollectionDefaultComparer()
+        public void KeyIsNotPresentUsingContainsKeyUsingKeyedCollectionDefaultComparer()
         {
             var list = new TestKeyedCollection { "ALICE", "BOB", "CALUM" };
 


### PR DESCRIPTION
@ChrisMaddock @oznetmaster 
As per the #2994 comments.

I've gone with a signature matching routine. Remember this is for `.NET Standard 1.4` only, I'm hoping the use case is low, I'm expecting the users in the "wild" is low and most people would be using > 1.6, I can but hope.

As per C# specification... I've been looking... basically a signature to be unique needs to be method name and parameter combination. Doesn't even need to worry about return type as you can't overload. 

In this instance we know we are trying to match 
- `Contains` method.
- Return type will always be `bool`, or same for all instances of the method.
- Generic type with name `TKey`.

So the signature matches against all the methods of the main type with the filtered list. We know the above points. So I basically try to construct the signature matching the method with those types. 

`TKey` is hard coded as per all code paths.
Parameter Name (usually `key`) is matched as per the method, this will allow us to match if the user changes the parameter name when overriding.

Am I loving it... hmm... I'll go with it works and it is probably better than the last code. We could just support `1.6 ` upwards and this would go away 😃 

Debuging against `.NetCore` is hard work..... 

Fixes #2994