### PR TITLE
Add Platform detection to .NET Standard 2.0 build

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -28,7 +28,10 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.4'
                             and '$(TargetFramework)' != 'netcoreapp1.1'
                             and '$(TargetFramework)' != 'netstandard2.0'
-                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);PLATFORM_DETECTION;THREAD_ABORT;APARTMENT_STATE</DefineConstants>
+                            and '$(TargetFramework)' != 'netcoreapp2.0'">$(DefineConstants);THREAD_ABORT;APARTMENT_STATE</DefineConstants>
+
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.4'
+                            and '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);PLATFORM_DETECTION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -372,7 +372,7 @@ namespace NUnit.Framework.Api
 #else
             env.AddAttribute("clr-version", Environment.Version.ToString());
 #endif
-#if !PLATFORM_DETECTION
+#if NETSTANDARD1_4 || NETSTANDARD2_0
             env.AddAttribute("os-version", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
             env.AddAttribute("os-version", OSPlatform.CurrentPlatform.ToString());

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -248,7 +248,7 @@ namespace NUnit.Framework.Internal
                     isSupported = IntPtr.Size == 4;
                     break;
 
-#if NET40 || NET45
+#if NET40 || NET45 || NETSTANDARD2_0
                 // We only support bitness tests of the OS in .NET 4.0 and up
                 case "64-BIT-OS":
                     isSupported = Environment.Is64BitOperatingSystem;

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -327,7 +327,7 @@ namespace NUnit.Framework.Internal
         {
             if (versionSpecification != null)
             {
-                throw new PlatformNotSupportedException("Detection versions of .NET Core is not supported - " + runtime.ToString() + "-" + versionSpecification);
+                throw new PlatformNotSupportedException($"Detecting versions of .NET Core is not supported - {runtime.ToString()}-{versionSpecification}");
             }
 
             RuntimeFramework target = new RuntimeFramework(runtime, RuntimeFramework.DefaultVersion);

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -295,7 +295,7 @@ namespace NUnit.Framework.Internal
                     return IsRuntimeSupported(RuntimeType.Net, versionSpecification);
 
                 case "NETCORE":
-                    return IsRuntimeSupported(RuntimeType.NetCore, versionSpecification);
+                    return IsNetCoreRuntimeSupported(RuntimeType.NetCore, versionSpecification);
 
                 case "SSCLI":
                 case "ROTOR":
@@ -319,6 +319,18 @@ namespace NUnit.Framework.Internal
                 : new Version(versionSpecification);
 
             RuntimeFramework target = new RuntimeFramework(runtime, version);
+
+            return _rt.Supports(target);
+        }
+
+        private bool IsNetCoreRuntimeSupported(RuntimeType runtime, string versionSpecification)
+        {
+            if (versionSpecification != null)
+            {
+                throw new PlatformNotSupportedException("Detection versions of .NET Core is not supported - " + runtime.ToString() + "-" + versionSpecification);
+            }
+
+            RuntimeFramework target = new RuntimeFramework(runtime, RuntimeFramework.DefaultVersion);
 
             return _rt.Supports(target);
         }

--- a/src/NUnitFramework/framework/Internal/PlatformHelper.cs
+++ b/src/NUnitFramework/framework/Internal/PlatformHelper.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Internal
         /// Comma-delimited list of all supported Runtime platform constants
         /// </summary>
         public static readonly string RuntimePlatforms =
-            "Net,SSCLI,Rotor,Mono,MonoTouch";
+            "Net,NetCore,SSCLI,Rotor,Mono,MonoTouch";
 
         /// <summary>
         /// Default constructor uses the operating system and
@@ -293,6 +293,9 @@ namespace NUnit.Framework.Internal
             {
                 case "NET":
                     return IsRuntimeSupported(RuntimeType.Net, versionSpecification);
+
+                case "NETCORE":
+                    return IsRuntimeSupported(RuntimeType.NetCore, versionSpecification);
 
                 case "SSCLI":
                 case "ROTOR":

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -110,21 +110,8 @@ namespace NUnit.Framework.Internal
             }
             else if (isNetCore)
             {
-#if NETSTANDARD2_0
-                var assembly = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly;
-                var assemblyPath = assembly.CodeBase.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
-                int netCoreAppIndex = Array.IndexOf(assemblyPath, "Microsoft.NETCore.App");
-                if (netCoreAppIndex > 0 && netCoreAppIndex < assemblyPath.Length - 2)
-                {
-                    string version = assemblyPath[netCoreAppIndex + 1];
-                    Version frameworkVersion;
-                    if (Version.TryParse(version, out frameworkVersion))
-                    {
-                        major = frameworkVersion.Major;
-                        minor = frameworkVersion.Minor;
-                    }
-                }
-#endif
+                major = 0;
+                minor = 0;
             }
             else /* It's windows */
 #if NETSTANDARD2_0
@@ -406,7 +393,7 @@ namespace NUnit.Framework.Internal
         private static bool IsNetCore()
         {
 #if NETSTANDARD2_0
-            //Mono versions will throw a TypeLoadException when attempting to run the internal method, so we wrap it in a try/catch 
+            // Mono versions will throw a TypeLoadException when attempting to run the internal method, so we wrap it in a try/catch 
             // block to stop any inlining in release builds and check whether the type exists
             Type runtimeInfoType = Type.GetType("System.Runtime.InteropServices.RuntimeInformation,System.Runtime.InteropServices.RuntimeInformation", false);
             if (runtimeInfoType != null)

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 #if NETSTANDARD2_0
 using System.Runtime.Versioning;
 #endif
@@ -413,10 +414,11 @@ namespace NUnit.Framework.Internal
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool IsNetCore_Internal()
         {
 #if NETSTANDARD2_0
-            //Mono versions will throw a TypeLoadException when attempting to run any method that uses RuntimeInformation
+            // Mono versions will throw a TypeLoadException when attempting to run any method that uses RuntimeInformation
             // so we wrap it in a try/catch block in IsNetCore to catch it in case it ever gets this far
             if (System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -27,6 +27,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NETSTANDARD2_0
+using System.Runtime.Versioning;
+#endif
 using Microsoft.Win32;
 
 namespace NUnit.Framework.Internal
@@ -46,7 +49,9 @@ namespace NUnit.Framework.Internal
         /// <summary>Mono</summary>
         Mono,
         /// <summary>MonoTouch</summary>
-        MonoTouch
+        MonoTouch,
+        /// <summary>Microsoft .NET Core</summary>
+        NetCore
     }
 
     /// <summary>
@@ -75,12 +80,15 @@ namespace NUnit.Framework.Internal
             Type monoTouchType = Type.GetType("MonoTouch.UIKit.UIApplicationDelegate,monotouch");
             bool isMonoTouch = monoTouchType != null;
             bool isMono = monoRuntimeType != null;
+            bool isNetCore = !isMono && !isMonoTouch && IsNetCore();
 
             RuntimeType runtime = isMonoTouch
                 ? RuntimeType.MonoTouch
                 : isMono
                     ? RuntimeType.Mono
-                    : RuntimeType.Net;
+                    : isNetCore
+                        ? RuntimeType.NetCore
+                        : RuntimeType.Net;
 
             int major = Environment.Version.Major;
             int minor = Environment.Version.Minor;
@@ -97,6 +105,23 @@ namespace NUnit.Framework.Internal
                         minor = 5;
                         break;
                 }
+            }
+            else if (isNetCore)
+            {
+#if NETSTANDARD2_0
+                string frameworkName = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+                if (frameworkName != null)
+                {
+                    string[] versionSplit = frameworkName.Split(new string[1] { "=v" }, StringSplitOptions.RemoveEmptyEntries);
+                    Version frameworkVersion;
+                    if (versionSplit.Length == 2 &&
+                        Version.TryParse(versionSplit[1], out frameworkVersion))
+                    {
+                        major = frameworkVersion.Major;
+                        minor = frameworkVersion.Minor;
+                    }
+                }
+#endif
             }
             else /* It's windows */
             if (major == 2)
@@ -173,6 +198,10 @@ namespace NUnit.Framework.Internal
             if (version.Major > 0) // 0 means any version
                 switch (Runtime)
                 {
+                    case RuntimeType.NetCore:
+                        ClrVersion = new Version(4, 0, 30319);
+                        break;
+
                     case RuntimeType.Net:
                     case RuntimeType.Mono:
                     case RuntimeType.Any:
@@ -222,6 +251,10 @@ namespace NUnit.Framework.Internal
             ClrVersion = version;
             if (Runtime == RuntimeType.Mono && version.Major == 1)
                 FrameworkVersion = new Version(1, 0);
+            if (Runtime == RuntimeType.Net && version.Major == 4 && version.Minor == 5)
+                ClrVersion = new Version(4, 0, 30319);
+            if (Runtime == RuntimeType.NetCore)
+                ClrVersion = new Version(4, 0, 30319);
         }
 
         #endregion
@@ -352,12 +385,46 @@ namespace NUnit.Framework.Internal
             if (!VersionsMatch(ClrVersion, target.ClrVersion))
                 return false;
 
-            return FrameworkVersion.Major >= target.FrameworkVersion.Major && FrameworkVersion.Minor >= target.FrameworkVersion.Minor;
+            if (FrameworkVersion.Major > target.FrameworkVersion.Major)
+                return true;
+            return FrameworkVersion.Major == target.FrameworkVersion.Major && FrameworkVersion.Minor >= target.FrameworkVersion.Minor;
         }
 
         #endregion
 
         #region Helper Methods
+
+        private static bool IsNetCore()
+        {
+#if NETSTANDARD2_0
+            //Mono versions will throw a TypeLoadException when attempting to run the internal method, so we wrap it in a try/catch 
+            // block to stop any inlining in release builds and check whether the type exists
+            Type runtimeInfoType = Type.GetType("System.Runtime.InteropServices.RuntimeInformation,System.Runtime.InteropServices.RuntimeInformation", false);
+            if (runtimeInfoType != null)
+            {
+                try
+                {
+                    return IsNetCore_Internal();
+                }
+                catch { }
+            }
+#endif
+
+            return false;
+        }
+
+        private static bool IsNetCore_Internal()
+        {
+#if NETSTANDARD2_0
+            //Mono versions will throw a TypeLoadException when attempting to run any method that uses RuntimeInformation
+            // so we wrap it in a try/catch block in IsNetCore to catch it in case it ever gets this far
+            if (System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+#endif
+            return false;
+        }
 
         private static bool IsRuntimeTypeName(string name)
         {

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Internal
                 string frameworkName = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
                 if (frameworkName != null)
                 {
-                    string[] versionSplit = frameworkName.Split(new string[1] { "=v" }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] versionSplit = frameworkName.Split(new [] { "=v" }, StringSplitOptions.RemoveEmptyEntries);
                     Version frameworkVersion;
                     if (versionSplit.Length == 2 &&
                         Version.TryParse(versionSplit[1], out frameworkVersion))

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -415,7 +415,7 @@ namespace NUnit.Framework.Internal
                 {
                     return IsNetCore_Internal();
                 }
-                catch(TypeLoadException) { }
+                catch (TypeLoadException) { }
             }
 #endif
 

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net20;net35;net40;net45;netstandard1.4;netstandard2.0</TargetFrameworks>
@@ -13,6 +13,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
     <PackageReference Include="NUnit.System.Linq" Version="0.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -125,7 +125,7 @@ namespace NUnitLite
             xmlWriter.WriteAttributeString("clr-version",
                 Environment.Version.ToString());
 #endif
-#if !PLATFORM_DETECTION
+#if NETSTANDARD1_4 || NETSTANDARD2_0
             xmlWriter.WriteAttributeString("os-version",
                                            System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -166,7 +166,7 @@ namespace NUnitLite
         public void DisplayRuntimeEnvironment()
         {
             WriteSectionHeader("Runtime Environment");
-#if !PLATFORM_DETECTION
+#if NETSTANDARD1_4 || NETSTANDARD2_0
             Writer.WriteLabelLine("   OS Version: ", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
             Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -99,6 +99,19 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         public void MethodWithExcludePlatform(int num)
         {
         }
+        [TestCase(1, IncludePlatform = "Net")]
+        [TestCase(2, IncludePlatform = "NetCore")]
+        [TestCase(3, IncludePlatform = "Mono")]
+        public void MethodWithIncludeRuntime(int num)
+        {
+        }
+
+        [TestCase(1, ExcludePlatform = "Net")]
+        [TestCase(2, ExcludePlatform = "NetCore")]
+        [TestCase(3, ExcludePlatform = "Mono")]
+        public void MethodWithExcludeRuntime(int num)
+        {
+        }
 #endif
 
         [TestCase((object)new object[] { })]

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -328,14 +328,15 @@ namespace NUnit.Framework.Attributes
         {
             bool isLinux = OSPlatform.CurrentPlatform.IsUnix;
             bool isMacOSX = OSPlatform.CurrentPlatform.IsMacOSX;
-            
-            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), "MethodWithIncludePlatform");
 
-            Test testCase1 = TestFinder.Find("MethodWithIncludePlatform(1)", suite, false);
-            Test testCase2 = TestFinder.Find("MethodWithIncludePlatform(2)", suite, false);
-            Test testCase3 = TestFinder.Find("MethodWithIncludePlatform(3)", suite, false);
-            Test testCase4 = TestFinder.Find("MethodWithIncludePlatform(4)", suite, false);
+            const string methodName = nameof(TestCaseAttributeFixture.MethodWithIncludePlatform);
+            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture), methodName);
+
+            Test testCase1 = TestFinder.Find($"{methodName}(1)", suite, false);
+            Test testCase2 = TestFinder.Find($"{methodName}(2)", suite, false);
+            Test testCase3 = TestFinder.Find($"{methodName}(3)", suite, false);
+            Test testCase4 = TestFinder.Find($"{methodName}(4)", suite, false);
             if (isLinux)
             {
                 Assert.That(testCase1.RunState, Is.EqualTo(RunState.Skipped));
@@ -393,6 +394,84 @@ namespace NUnit.Framework.Attributes
                 Assert.That(testCase2.RunState, Is.EqualTo(RunState.Runnable));
                 Assert.That(testCase3.RunState, Is.EqualTo(RunState.Runnable));
                 Assert.That(testCase4.RunState, Is.EqualTo(RunState.Runnable));
+            }
+        }
+
+        [Test]
+        public void CanIncludeRuntime()
+        {
+            bool isNetCore;
+            Type monoRuntimeType = Type.GetType("Mono.Runtime", false);
+            bool isMono = monoRuntimeType != null;
+#if NETCOREAPP2_0
+            isNetCore = true;
+#else
+            isNetCore = false;
+#endif
+
+            const string methodName = nameof(TestCaseAttributeFixture.MethodWithIncludeRuntime);
+            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture), methodName);
+
+            Test testCase1 = TestFinder.Find($"{methodName}(1)", suite, false);
+            Test testCase2 = TestFinder.Find($"{methodName}(2)", suite, false);
+            Test testCase3 = TestFinder.Find($"{methodName}(3)", suite, false);
+            if (isNetCore)
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Skipped));
+            }
+            else if (isMono)
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Runnable));
+            }
+            else
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Skipped));
+            }
+        }
+
+        [Test]
+        public void CanExcludeRuntime()
+        {
+            bool isNetCore;
+            Type monoRuntimeType = Type.GetType("Mono.Runtime", false);
+            bool isMono = monoRuntimeType != null;
+#if NETCOREAPP2_0
+            isNetCore = true;
+#else
+            isNetCore = false;
+#endif
+
+            const string methodName = nameof(TestCaseAttributeFixture.MethodWithExcludeRuntime);
+            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture), methodName);
+
+            Test testCase1 = TestFinder.Find($"{methodName}(1)", suite, false);
+            Test testCase2 = TestFinder.Find($"{methodName}(2)", suite, false);
+            Test testCase3 = TestFinder.Find($"{methodName}(3)", suite, false);
+            if (isNetCore)
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Runnable));
+            }
+            else if (isMono)
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Skipped));
+            }
+            else
+            {
+                Assert.That(testCase1.RunState, Is.EqualTo(RunState.Skipped));
+                Assert.That(testCase2.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(testCase3.RunState, Is.EqualTo(RunState.Runnable));
             }
         }
 #endif

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM_DETECTION
+#if PLATFORM_DETECTION && THREAD_ABORT
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Internal
             CheckPlatforms(
                 new PlatformHelper( OSPlatform.CurrentPlatform, runtimeFramework ),
                 expectedPlatforms,
-                PlatformHelper.RuntimePlatforms + ",NET-1.0,NET-1.1,NET-2.0,NET-3.0,NET-3.5,NET-4.0,NET-4.5,MONO-1.0,MONO-2.0,MONO-3.0,MONO-3.5,MONO-4.0,MONOTOUCH" );
+                PlatformHelper.RuntimePlatforms + ",NET-1.0,NET-1.1,NET-2.0,NET-3.0,NET-3.5,NET-4.0,NET-4.5,MONO-1.0,MONO-2.0,MONO-3.0,MONO-3.5,MONO-4.0,MONOTOUCH,NETCORE-2.0,NETCORE-2.1,NETCORE-2.2,NETCORE-3.0");
         }
 
         private void CheckPlatforms( PlatformHelper helper, 
@@ -319,6 +319,14 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        public void DetectNet45()
+        {
+            CheckRuntimePlatforms(
+                new RuntimeFramework(RuntimeType.Net, new Version(4, 5, 0, 0)),
+                "Net,Net-4.0,Net-4.5");
+        }
+
+        [Test]
         public void DetectSSCLI()
         {
             CheckRuntimePlatforms(
@@ -372,6 +380,38 @@ namespace NUnit.Framework.Internal
             CheckRuntimePlatforms(
                 new RuntimeFramework(RuntimeType.MonoTouch, new Version(4, 0, 30319)),
                 "MonoTouch");
+        }
+
+        [Test]
+        public void DetectNetCore20()
+        {
+            CheckRuntimePlatforms(
+                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 0, 0)),
+                "NetCore,NetCore-2.0");
+        }
+
+        [Test]
+        public void DetectNetCore21()
+        {
+            CheckRuntimePlatforms(
+                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 1, 0)),
+                "NetCore,NetCore-2.0,NetCore-2.1");
+        }
+
+        [Test]
+        public void DetectNetCore22()
+        {
+            CheckRuntimePlatforms(
+                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 2, 0)),
+                "NetCore,NetCore-2.0,NetCore-2.1,NetCore-2.2");
+        }
+
+        [Test]
+        public void DetectNetCore30()
+        {
+            CheckRuntimePlatforms(
+                new RuntimeFramework(RuntimeType.NetCore, new Version(3, 0, 0)),
+                "NetCore,NetCore-2.0,NetCore-2.1,NetCore-2.2,NetCore-3.0");
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Internal
             CheckPlatforms(
                 new PlatformHelper( OSPlatform.CurrentPlatform, runtimeFramework ),
                 expectedPlatforms,
-                PlatformHelper.RuntimePlatforms + ",NET-1.0,NET-1.1,NET-2.0,NET-3.0,NET-3.5,NET-4.0,NET-4.5,MONO-1.0,MONO-2.0,MONO-3.0,MONO-3.5,MONO-4.0,MONOTOUCH,NETCORE-2.0,NETCORE-2.1,NETCORE-2.2,NETCORE-3.0");
+                PlatformHelper.RuntimePlatforms + ",NET-1.0,NET-1.1,NET-2.0,NET-3.0,NET-3.5,NET-4.0,NET-4.5,MONO-1.0,MONO-2.0,MONO-3.0,MONO-3.5,MONO-4.0,MONOTOUCH");
         }
 
         private void CheckPlatforms( PlatformHelper helper, 
@@ -383,37 +383,13 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
-        public void DetectNetCore20()
+        public void DetectNetCore()
         {
             CheckRuntimePlatforms(
-                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 0, 0)),
-                "NetCore,NetCore-2.0");
+                new RuntimeFramework(RuntimeType.NetCore, new Version(0, 0, 0)),
+                "NetCore");
         }
-
-        [Test]
-        public void DetectNetCore21()
-        {
-            CheckRuntimePlatforms(
-                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 1, 0)),
-                "NetCore,NetCore-2.0,NetCore-2.1");
-        }
-
-        [Test]
-        public void DetectNetCore22()
-        {
-            CheckRuntimePlatforms(
-                new RuntimeFramework(RuntimeType.NetCore, new Version(2, 2, 0)),
-                "NetCore,NetCore-2.0,NetCore-2.1,NetCore-2.2");
-        }
-
-        [Test]
-        public void DetectNetCore30()
-        {
-            CheckRuntimePlatforms(
-                new RuntimeFramework(RuntimeType.NetCore, new Version(3, 0, 0)),
-                "NetCore,NetCore-2.0,NetCore-2.1,NetCore-2.2,NetCore-3.0");
-        }
-
+        
         [Test]
         public void DetectExactVersion()
         {

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -85,6 +85,27 @@ namespace NUnit.Framework.Internal
             Assert.That(RuntimeFramework.CurrentFramework.ClrVersion.Build, Is.GreaterThan(0));
         }
 
+        [Test]
+        [TestCaseSource(nameof(netcoreRuntimes))]
+        public void SpecifyingNetCoreVersioningThrowsPlatformException(string netcoreRuntime)
+        {
+            PlatformHelper platformHelper = new PlatformHelper();
+            Assert.Throws<PlatformNotSupportedException>(() => platformHelper.IsPlatformSupported(netcoreRuntime));
+        }
+
+        [Test]
+        public void SpecifyingNetCoreWithoutVersioningSucceeds()
+        {
+            PlatformHelper platformHelper = new PlatformHelper();
+            bool isNetCore;
+#if NETCOREAPP2_0
+            isNetCore = true;
+#else
+            isNetCore = false;
+#endif
+            Assert.AreEqual(isNetCore, platformHelper.IsPlatformSupported("netcore"));
+        }
+
         [TestCaseSource(nameof(frameworkData))]
         public void CanCreateUsingFrameworkVersion(FrameworkData data)
         {
@@ -338,6 +359,14 @@ namespace NUnit.Framework.Internal
             new FrameworkData(RuntimeType.Any, new Version(3,5), new Version(2,0,50727), "v3.5", "v3.5"),
             new FrameworkData(RuntimeType.Any, new Version(4,0), new Version(4,0,30319), "v4.0", "v4.0"),
             new FrameworkData(RuntimeType.Any, RuntimeFramework.DefaultVersion, RuntimeFramework.DefaultVersion, "any", "Any")
+        };
+
+        internal static string[] netcoreRuntimes = new string[] {
+            "netcore-1.0",
+            "netcore-1.1",
+            "netcore-2.0",
+            "netcore-2.1",
+            "netcore-2.2"
         };
     }
 }

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PARALLEL && PLATFORM_DETECTION
+#if PARALLEL && PLATFORM_DETECTIONN && THREAD_ABORT
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.TestUtilities;

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -396,20 +396,11 @@ namespace NUnit.Framework
 
         [TestCase(null)]
 #if PLATFORM_DETECTION
-        [TestCase("bad<>path.png", IncludePlatform = "Win")]
+        [TestCase("bad|path.png", IncludePlatform = "Win")]
 #endif
         public void InvalidFilePathsThrowsArgumentException(string filePath)
         {
-#if NETCOREAPP2_0
-            // Due to changes in .NET Core 2.0 around file path verification, this test does not match
-            // behavior on .NET Core vs .NET Framework - https://github.com/dotnet/corefx/pull/8669
-            if (filePath == null)
-                Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());
-            else
-                Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<FileNotFoundException>());
-#else
             Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());
-#endif
         }
 
         [Test]

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -401,7 +401,7 @@ namespace NUnit.Framework
         public void InvalidFilePathsThrowsArgumentException(string filePath)
         {
 #if NETCOREAPP2_0
-            //Due to changes in .NET Core 2.0 around file path verification, this test does not match
+            // Due to changes in .NET Core 2.0 around file path verification, this test does not match
             // behavior on .NET Core vs .NET Framework - https://github.com/dotnet/corefx/pull/8669
             if (filePath == null)
                 Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -400,7 +400,16 @@ namespace NUnit.Framework
 #endif
         public void InvalidFilePathsThrowsArgumentException(string filePath)
         {
+#if NETCOREAPP2_0
+            //Due to changes in .NET Core 2.0 around file path verification, this test does not match
+            // behavior on .NET Core vs .NET Framework - https://github.com/dotnet/corefx/pull/8669
+            if (filePath == null)
+                Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());
+            else
+                Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<FileNotFoundException>());
+#else
             Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());
+#endif
         }
 
         [Test]


### PR DESCRIPTION
Closes #2432.

Implements platform detection for .NET Standard 2.0. .NET Standard 1.4 did not have the APIs available to implement this feature, so .NET Core 1.1 and 1.0 apps will not be able to be detected. Adds NETCORE as a new identifier for runtime detection and adds .NET Core version detection. 

Adds unit tests for .NET Core detection, enables the existing platform detection unit tests for .NET Core 2.0 testing, and fixes a hidden failing unit test now that .NET Core support was enabled (InvalidFilePathsThrowsArgumentException has a change in behavior vs .NET Framework). 

Fixes a couple of existing issues with platform detection that I ran into while creating the unit tests with runtime support. First issue was that .NET Framework 4.5 was not able to be used as a exclude/include option as the CLRVersion was not set to a detected version when using InitFromClrVersion. This change allows for "net-4.5" to be used as a runtime identifier. Secondly, checking whether a runtime supported a different runtime checked that the major and minor versions were greater than each other. However, this failed in cases such as checking that .Net Core 3.0 would support .Net Core 2.2. I'm unsure if this was intentional, but it previously worked with .NET Framework due to the differences in CLR versions up until 4.0+. If this is intentional, I'll add a comment around that section of the code and change the unit tests.