### PR TITLE
Fix failing CI Builds by upgrading to NUnit Console 3.10.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#tool nuget:https://www.myget.org/F/nunit/api/v3/index.json?package=NUnit.ConsoleRunner&version=3.9.0-dev-03938
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.9.0
 #tool GitLink
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
All framework CI builds are currently failing, as the framework tests currently use `NUnit.ConsoleRunner 3.9.0-dev-03938`, and this version can't be found. 

As far as I can see (publicly), it looks like only the last 20 builds are available on MyGet. I'm not sure if that's intentional or not - but probably means we shouldn't be using myget in this case! @rprouse - I think you're the only person with myget access, could you check this? Looks like there are [package retention settings](https://docs.myget.org/docs/reference/package-retention) that may be set 'wrong'.

To fix the CI, this upgrades us to 3.9.0, from NuGet.