### PR TITLE
Attempt to fix hangs by using Sleep(1) instead of Sleep(0) for the polyfill's replacement of Thread.Yield

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -142,14 +142,19 @@ namespace System.Threading
                 {
                     Thread.Sleep(1);
                 }
-                else // if ((yieldsSoFar % SLEEP_0_EVERY_HOW_MANY_TIMES) == (SLEEP_0_EVERY_HOW_MANY_TIMES - 1))
+                else if ((yieldsSoFar % SLEEP_0_EVERY_HOW_MANY_TIMES) == (SLEEP_0_EVERY_HOW_MANY_TIMES - 1))
                 {
                     Thread.Sleep(0);
                 }
-                //else
-                //{
-                //    Thread.Yield();
-                //}
+                else
+                {
+                    // Polyfill note:
+                    // Thread.Yield() is not available in the 2.0 CLR, and the native implementation
+                    // is much more nuanced than p/invoking SwitchToThread.
+                    // Replace with Thread.Sleep(1) since Thread.Sleep(0) kills performance by often not actually yielding.
+                    // http://joeduffyblog.com/2006/08/22/priorityinduced-starvation-why-sleep1-is-better-than-sleep0-and-the-windows-balance-set-manager/
+                    Thread.Sleep(1);
+                }
             }
             else
             {


### PR DESCRIPTION
tl;dr `Thread.Sleep(0)` hogs the CPU and is a terrible replacement for `Thread.Yield()`. `Thread.Sleep(1)` is probably the best we can do on .NET CLR 2.0.

See the comment in the (small) diff. I'm no expert here, so I could be missing something.
Sources:

- http://joeduffyblog.com/2006/08/22/priorityinduced-starvation-why-sleep1-is-better-than-sleep0-and-the-windows-balance-set-manager/

  > In our example above when Sleep(0) is used, we hope this will unstick the machine and let the producer produce and finally the consumer to consume. Indeed with some testing, we see it unstick after a little more than 3 seconds. This is still long enough, however, to kill performance on a server application, cause a noticeable perf degradation on the client, and destroy responsiveness in a GUI app.

- https://blogs.msdn.microsoft.com/khen1234/2006/02/02/sleeping-vs-yielding/

/cc @rprouse @oznetmaster @CharliePoole 