### PR TITLE
Updated nUnit-VS-Adapter to 3.10.0

### DIFF
--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
@@ -18,7 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35' and '$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">


### PR DESCRIPTION
Fixes #3020, I had considered updating the ConsoleRunner to version 3.10.0-dev-4086 but as it was only added 9 days ago, I'll leave at the moment but happy to do so in this PR or in another issue. I know PR's are probably a bit of work for you but on the whole I prefer to commit work seperatly so roll backs are clean.

Anyway reference updated to 3.10.0

FYI - @jnm2 - Thanks for the help on getting to debug core, I had tried that and a miriade of other things. Turns out unistalling a whole bunch of old preview core sdk's, then I did a clean install and worked from there. Your help meant I knew it was environmental rather than me being a 🤡. This was the final fix 😄 