### PR TITLE
ConstraintExpression.AnyOf returns AnyOfConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -984,14 +984,14 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests if an item is equal to any of parameters
         /// </summary>
         /// <param name="expected">Expected values</param>
-        public Constraint AnyOf(params object[] expected)
+        public AnyOfConstraint AnyOf(params object[] expected)
         {
             if (expected == null)
             {
                 expected = new object[] { null };
             }
 
-            return Append(new AnyOfConstraint(expected));
+            return (AnyOfConstraint)this.Append(new AnyOfConstraint(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -98,6 +98,14 @@ namespace NUnit.Framework.Constraints
             var collection1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
             var result = containsConstraint.ApplyTo(collection1);
             Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public void ConstraintExpressionAnyOfType()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.AnyOf(new string[] { "RED", "GREEN" }).IgnoreCase;
+            Assert.That("red", constraint);
         }
     }
 }


### PR DESCRIPTION
Other methods of ConstraintExpression (e.g. SubPathOf, SamePath, Contains)
have a return signature of their specific constraint (SubPathConstraint,
SamePathConstraint, ContainsConstraint or SomeItemsConstraint). For AnyOf
the signature was just Constraint. Changed the signature to returning
AnyOfConstraint and in the return casted the response from Append like
it was done in other constraint.
    
Addresses Issue  #3024 

No tests failed due to this pull request (before request: 33 fail, 3 skip; after request: 33 fail, 3 skip).
No unit tests were added to address this case. I was not sure where they should go. Examples of
code that previously failed to compile are in the original issue.