### PR TITLE
TimeoutAttribute not available when targeting netcoreapp framework

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -51,20 +51,10 @@ namespace NUnit.Framework
 
         #region IApplyToContext Members
 
-#if PLATFORM_DETECTION
-
         void IApplyToContext.ApplyToContext(TestExecutionContext context)
         {
             context.TestCaseTimeout = _timeout;
         }
-#else
-
-        void IApplyToContext.ApplyToContext(TestExecutionContext context)
-        {
-            
-        }
-
-#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2018 Charlie Poole, Rob Prouse
+// Copyright (c) 2008-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -20,7 +20,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if THREAD_ABORT
 
 using System;
 using NUnit.Framework.Internal;
@@ -36,7 +35,7 @@ namespace NUnit.Framework
     /// for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
-    public class TimeoutAttribute : PropertyAttribute, IApplyToContext
+    public class TimeoutAttribute : PropertyAttribute, IApplyToContext, IWrapTestMethod
     {
         private readonly int _timeout;
 
@@ -50,48 +49,14 @@ namespace NUnit.Framework
             _timeout = timeout;
         }
 
-#region IApplyToContext Members
+        #region IApplyToContext
 
         void IApplyToContext.ApplyToContext(TestExecutionContext context)
         {
             context.TestCaseTimeout = _timeout;
         }
 
-#endregion
-    }
-}
-
-#endif
-
-#if !THREAD_ABORT && !NET20 && !NET35
-
-using System;
-using System.Threading.Tasks;
-using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.Commands;
-using NUnit.Framework.Interfaces;
-
-namespace NUnit.Framework
-{
-    /// <summary>
-    /// Used on a method, marks the test with a timeout value in milliseconds. 
-    /// The test will be run in a separate thread and is cancelled if the timeout 
-    /// is exceeded. Used on a class or assembly, sets the default timeout 
-    /// for all contained test methods.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)]
-    public class TimeoutAttribute : PropertyAttribute, IWrapTestMethod
-    {
-        private readonly int _timeout;
-
-        /// <summary>
-        /// Construct a TimeoutAttribute given a time in milliseconds
-        /// </summary>
-        /// <param name="timeout">The timeout value in milliseconds</param>
-        public TimeoutAttribute(int timeout) : base(timeout)
-        {
-            _timeout = timeout;
-        }
+        #endregion
 
         /// <summary>
         /// Wrap a command and return the result.
@@ -100,10 +65,11 @@ namespace NUnit.Framework
         /// <returns>The wrapped command</returns>
         public TestCommand Wrap(TestCommand command)
         {
+#if !THREAD_ABORT && !(NET20 || NET35)
             return new TimeoutCommand(command, _timeout);
+#else
+            return command;
+#endif
         }
     }
 }
-
-#endif
-

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2008 Charlie Poole, Rob Prouse
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if THREAD_ABORT
 using System;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
@@ -52,12 +51,22 @@ namespace NUnit.Framework
 
         #region IApplyToContext Members
 
+#if PLATFORM_DETECTION
+
         void IApplyToContext.ApplyToContext(TestExecutionContext context)
         {
             context.TestCaseTimeout = _timeout;
         }
+#else
+
+        void IApplyToContext.ApplyToContext(TestExecutionContext context)
+        {
+            
+        }
+
+#endif
 
         #endregion
     }
 }
-#endif
+

--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework
     /// for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
-    public class TimeoutAttribute : PropertyAttribute, IApplyToContext, IWrapTestMethod
+    public class TimeoutAttribute : PropertyAttribute, IApplyToContext
     {
         private readonly int _timeout;
 
@@ -57,19 +57,5 @@ namespace NUnit.Framework
         }
 
         #endregion
-
-        /// <summary>
-        /// Wrap a command and return the result.
-        /// </summary>
-        /// <param name="command">The command to be wrapped</param>
-        /// <returns>The wrapped command</returns>
-        public TestCommand Wrap(TestCommand command)
-        {
-#if !THREAD_ABORT && !(NET20 || NET35)
-            return new TimeoutCommand(command, _timeout);
-#else
-            return command;
-#endif
-        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -99,11 +99,7 @@ namespace NUnit.Framework.Internal.Commands
         {
             try
             {
-                if (!Task.Run(() =>
-                {
-                    context.CurrentResult = innerCommand.Execute(context);
-
-                }).Wait(_timeout))
+                if (!Task.Run(() => context.CurrentResult = innerCommand.Execute(context)).Wait(_timeout))
                 {
                     context.CurrentResult.SetResult(new ResultState(
                         TestStatus.Failed,
@@ -113,7 +109,7 @@ namespace NUnit.Framework.Internal.Commands
             }
             catch (Exception exception)
             {
-                context.CurrentResult.RecordException(exception);
+                context.CurrentResult.RecordException(exception, FailureSite.Test);
             }
 
             return context.CurrentResult;

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2012-2017 Charlie Poole, Rob Prouse
+// Copyright (c) 2012-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -141,7 +141,6 @@ namespace NUnit.Framework.Internal.Execution
                     command = new ApplyChangesToContextCommand(command, attr);
 
                 // If a timeout is specified, create a TimeoutCommand
-#if THREAD_ABORT
                 // Timeout set at a higher level
                 int timeout = Context.TestCaseTimeout;
 
@@ -151,7 +150,6 @@ namespace NUnit.Framework.Internal.Execution
 
                 if (timeout > 0)
                     command = new TimeoutCommand(command, timeout);
-#endif
 
                 return command;
             }

--- a/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ThreadingTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2009 Charlie Poole, Rob Prouse
+// Copyright (c) 2009-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,13 +21,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1
+
 using System.Threading;
 
 namespace NUnit.Framework.Attributes
 {
     public class ThreadingTests
     {
+#if !NETCOREAPP1_1
         protected Thread ParentThread { get; private set; }
         protected Thread SetupThread { get; private set; }
         protected ApartmentState ParentThreadApartment { get; private set; }
@@ -65,6 +66,6 @@ namespace NUnit.Framework.Attributes
         {
             return thread.GetApartmentState();
         }
+#endif
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -190,7 +190,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test, Timeout(100)]
-        public void TestTimesoutDoesNotStopCompletion()
+        public void TestTimeoutDoesNotStopCompletion()
         {
             Thread.Sleep(20);
             Assert.True(true);

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -192,9 +192,8 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestTimesOut()
         {
-            var testCase = TestBuilder.MakeTestCase(GetType(), nameof(TestTimeoutAndReportsTimeoutFailure));
-            var workItem = TestBuilder.CreateWorkItem(testCase, this);
-            var testResult = TestBuilder.ExecuteWorkItem(workItem);
+            var testMethod = TestBuilder.MakeTestCase(GetType(), nameof(TestTimeoutAndReportsTimeoutFailure));
+            var testResult = TestBuilder.RunTest(testMethod, this);
 
             Assert.That(testResult?.ResultState.Status, Is.EqualTo(TestStatus.Failed));
             Assert.That(testResult?.ResultState.Site, Is.EqualTo(FailureSite.Test));
@@ -204,13 +203,12 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestTimeoutWithExceptionThrown()
         {
-            var testCase = TestBuilder.MakeTestCase(GetType(), nameof(TestTimeoutWhichThrowsTestException));
-            var workItem = TestBuilder.CreateWorkItem(testCase, this);
-            var testResult = TestBuilder.ExecuteWorkItem(workItem);
+            var testMethod = TestBuilder.MakeTestCase(GetType(), nameof(TestTimeoutWhichThrowsTestException));
+            var testResult = TestBuilder.RunTest(testMethod, this);
 
             Assert.That(testResult?.ResultState.Status, Is.EqualTo(TestStatus.Failed));
             Assert.That(testResult?.ResultState.Site, Is.EqualTo(FailureSite.Test));
-            Assert.That(testResult?.ResultState.Label, Is.EqualTo("Test exceeded Timeout value 50ms."));
+            Assert.That(testResult?.ResultState.Label, Is.EqualTo("Error"));
         }
 #endif
     }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2018 Charlie Poole, Rob Prouse
+// Copyright (c) 2012-2018 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if PLATFORM_DETECTION
 using System;
 using System.Linq;
 using System.Threading;
@@ -36,6 +35,7 @@ namespace NUnit.Framework.Attributes
     [NonParallelizable]
     public class TimeoutTests : ThreadingTests
     {
+#if PLATFORM_DETECTION
         [Test, Timeout(500)]
         public void TestWithTimeoutRunsOnSameThread()
         {
@@ -167,22 +167,9 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Is.EqualTo("Test exceeded Timeout value of 500ms"));
         }
-    }
-}
 #endif
 
-#if !THREAD_ABORT
-
-using System;
-using System.Threading;
-using NUnit.Framework.Interfaces;
-using NUnit.TestUtilities;
-
-namespace NUnit.Framework.Attributes
-{
-    [TestFixture, NonParallelizable]
-    public class TimeoutTests
-    {
+#if !THREAD_ABORT && !(NET20 || NET35)
         [Timeout(50)]
         public void TestTimeoutAndReportsTimeoutFailure()
         {
@@ -196,7 +183,7 @@ namespace NUnit.Framework.Attributes
             Assert.True(true);
         }
 
-        [Timeout(50)]
+        [Timeout(100)]
         public void TestTimeoutWhichThrowsTestException()
         {
             throw new ArgumentException($"{nameof(ArgumentException)} was thrown.");
@@ -223,9 +210,8 @@ namespace NUnit.Framework.Attributes
 
             Assert.That(testResult?.ResultState.Status, Is.EqualTo(TestStatus.Failed));
             Assert.That(testResult?.ResultState.Site, Is.EqualTo(FailureSite.Test));
-            Assert.That(testResult?.ResultState.Label, Is.EqualTo($"{nameof(ArgumentException)} was thrown."));
+            Assert.That(testResult?.ResultState.Label, Is.EqualTo("Test exceeded Timeout value 50ms."));
         }
+#endif
     }
 }
-
-#endif

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <DebugType>Full</DebugType>
 

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <DebugType>Full</DebugType>
 
@@ -18,7 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net20' and '$(TargetFramework)' != 'net35' and '$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">


### PR DESCRIPTION
Fixes #1638 

As mentioned in the issue #1638, I had to delete the inital branch I created using abbotwares code, this was due to the branch being corrupt and not to do with the discussion around contribution. I then worked on a number of other PR's. When I started again on this issue, I decided enough time had gone by to be able to implement my own version as my memory was hazy to details, even if based on his concept. This means the thorny issue of contribution is side stepped, hopefully.

Happy to address any short comings but wanted to get PR out to get feedback. The original issue seems to have been lost in the very long thread, so no real definition to the solution. I've done the basics, i.e. allowed `TimeoutAttribute` to be applied to `.NetStandard1.4` and '.NetStandard1.6' or more specifically, `.NetCoreApp1.1` and `.NetCoreApp2.0`.

Tests added and no broken tests in other targets.