### PR TITLE
Try to fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ matrix:
       osx_image: xcode9.1
 
 script:
-  - ./build.sh --target=Travis --configuration=Release
+  - travis_wait ./build.sh --target=Travis --configuration=Release


### PR DESCRIPTION
Sometimes travis build is timed out. Following [this](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) I added `travis_wait` for build command.