### PR TITLE
More consistency fixes for attribute doc comments

### DIFF
--- a/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
@@ -29,7 +29,8 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Sets the tolerance used by default when checking the equality of floating point values.
+    /// Sets the tolerance used by default when checking the equality of floating point values
+    /// within the test assembly, fixture or method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class DefaultFloatingPointToleranceAttribute : NUnitAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelizableAttribute.cs
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal.Execution;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks tests that may be run in parallel.
+    /// Marks a test assembly, fixture or method that may be run in parallel.
     /// </summary>
     [AttributeUsage( AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple=false, Inherited=true )]
     public class ParallelizableAttribute : PropertyAttribute, IApplyToContext

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -28,7 +28,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Attaches information to a test as a name/value pair.
+    /// Attaches information to a test assembly, fixture or method as a name/value pair.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class PropertyAttribute : NUnitAttribute, IApplyToTest

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -32,7 +32,7 @@ using NUnit.Framework.Internal.Builders;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Marks a method as a parameterized test case and provides them with their arguments.
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited=false)]
     public class TestCaseAttribute : NUnitAttribute, ITestBuilder, ITestCaseData, IImplyFixture


### PR DESCRIPTION
Following up @oznetmaster’s comments on merge of https://github.com/nunit/nunit/pull/2954 (https://github.com/nunit/nunit/commit/5163de63d94174f2857ac197248b1306164ee5d8).