### PR TITLE
[RFC] Add extensibility to the async pipeline to allow custom implementation of waiting strategy

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/IAsyncCompletionStrategy.cs
+++ b/src/NUnitFramework/framework/Interfaces/IAsyncCompletionStrategy.cs
@@ -1,0 +1,46 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework.Internal.Commands;
+
+namespace NUnit.Framework.Interfaces
+{
+    /// <summary>
+    /// Implement this interface to customize the waiting behavior
+    /// of the test adapter for <c>async</c> test methods
+    /// </summary>
+    public interface IAsyncCompletionStrategy
+    {
+        /// <summary>
+        /// This method will be called by the adapter to wait for the completion
+        /// of an asynchronous test
+        /// </summary>
+        /// <remarks>
+        /// Implementers must ensure that the awaitable object provided has
+        /// completed before returning from this method
+        /// </remarks>
+        void WaitForCompletion(IAwaiterObject awaitable);
+    }
+}

--- a/src/NUnitFramework/framework/Interfaces/IAwaiterObject.cs
+++ b/src/NUnitFramework/framework/Interfaces/IAwaiterObject.cs
@@ -1,0 +1,42 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework.Internal.Commands;
+
+namespace NUnit.Framework.Interfaces
+{
+    /// <summary>
+    /// Represent an abstracted awaiter object (Task based or not)
+    /// </summary>
+    public interface IAwaiterObject
+    {
+        /// <summary><c>true</c> if the underlying operation has been completed, <c>false</c> otherwise</summary>
+        bool IsCompleted { get; }
+        /// <summary>Queue a continuation to run when the underlying operation has been completed</summary>
+        void OnCompleted(Action action);
+        /// <summary>Block the caller until the underlying operation has been completed</summary>
+        void BlockUntilCompleted();
+    }
+}

--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -27,6 +27,7 @@ using System.Reflection;
 using System.Security;
 using System.Threading;
 using NUnit.Compatibility;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
@@ -43,7 +44,7 @@ namespace NUnit.Framework.Internal
             return IsAsyncOperation(@delegate.GetMethodInfo());
         }
 
-        public static object Await(Func<object> invoke)
+        public static object Await(Func<object> invoke, IAsyncCompletionStrategy waitStrategy = null)
         {
             Guard.ArgumentNotNull(invoke, nameof(invoke));
 
@@ -53,7 +54,8 @@ namespace NUnit.Framework.Internal
 
                 if (!awaitAdapter.IsCompleted)
                 {
-                    var waitStrategy = MessagePumpStrategy.FromCurrentSynchronizationContext();
+                    if (waitStrategy == null)
+                        waitStrategy = MessagePumpStrategy.FromCurrentSynchronizationContext();
                     waitStrategy.WaitForCompletion(awaitAdapter);
                 }
 

--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -22,10 +22,11 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
-    internal abstract class AwaitAdapter
+    internal abstract class AwaitAdapter : IAwaiterObject
     {
         public abstract bool IsCompleted { get; }
         public abstract void OnCompleted(Action action);

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -105,7 +105,7 @@ namespace NUnit.Framework.Internal.Commands
             Guard.ArgumentNotAsyncVoid(method, nameof(method));
 
             if (AsyncToSyncAdapter.IsAsyncOperation(method))
-                AsyncToSyncAdapter.Await(() => InvokeMethod(method, context));
+                AsyncToSyncAdapter.Await(() => InvokeMethod(method, context), context.CurrentTest.GetWaitStrategy ());
             else
                 InvokeMethod(method, context);
         }

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal.Commands
         {
             if (AsyncToSyncAdapter.IsAsyncOperation(testMethod.Method.MethodInfo))
             {
-                return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context));
+                return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context), testMethod.GetWaitStrategy ());
             }
 
             return InvokeTestMethod(context);

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal.Execution
                 var method = _testMethod.Method;
 
                 // Add any wrappers to the TestMethodCommand
-                foreach (IWrapTestMethod wrapper in method.GetCustomAttributes<IWrapTestMethod>(true))
+                foreach (IWrapTestMethod wrapper in _testMethod.GetCombinedCustomAttributes<IWrapTestMethod>(true))
                     command = wrapper.Wrap(command);
 
                 // Create TestActionCommands using attributes of the method
@@ -133,7 +133,7 @@ namespace NUnit.Framework.Internal.Execution
                 }
 
                 // Add wrappers that apply before setup and after teardown
-                foreach (ICommandWrapper decorator in method.GetCustomAttributes<IWrapSetUpTearDown>(true))
+                foreach (ICommandWrapper decorator in _testMethod.GetCombinedCustomAttributes<IWrapSetUpTearDown>(true))
                     command = decorator.Wrap(command);
 
                 // Add command to set up context using attributes that implement IApplyToContext

--- a/src/NUnitFramework/framework/Internal/Extensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions.cs
@@ -1,0 +1,35 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal
+{
+    internal static class Extensions
+    {
+        public static IAsyncCompletionStrategy GetWaitStrategy (this Test test)
+            => test?.GetCombinedCustomAttributes<IAsyncCompletionStrategy> (true)?.FirstOrDefault ();
+    }
+}

--- a/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
@@ -30,10 +30,14 @@ using System.Windows.Forms;
 using System.Windows.Threading;
 #endif
 
+using NUnit.Framework.Interfaces;
+
 namespace NUnit.Framework.Internal
 {
-    internal abstract class MessagePumpStrategy
+    internal abstract class MessagePumpStrategy : IAsyncCompletionStrategy
     {
+        void IAsyncCompletionStrategy.WaitForCompletion(IAwaiterObject obj) => WaitForCompletion ((AwaitAdapter)obj);
+
         public abstract void WaitForCompletion(AwaitAdapter awaitable);
 
         public static MessagePumpStrategy FromCurrentSynchronizationContext()

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -412,6 +412,33 @@ namespace NUnit.Framework.Internal
             return new TAttr[0];
         }
 
+        /// <summary>
+        /// Get custom attributes applied to a test by combining the set
+        /// applied to both test method and fixture
+        /// </summary>
+        public virtual TAttr[] GetCombinedCustomAttributes<TAttr>(bool inherit) where TAttr : class
+        {
+            TAttr[] result = null;
+
+            if (Method != null)
+                result = Method.GetCustomAttributes<TAttr>(inherit);
+
+            if (TypeInfo != null) {
+                var typeAttrs = TypeInfo.GetCustomAttributes<TAttr>(inherit);
+                if (typeAttrs != null && typeAttrs.Length > 0) {
+                    if (result == null)
+                        result = typeAttrs;
+                    else {
+                        var oldLength = result.Length;
+                        Array.Resize (ref result, oldLength + typeAttrs.Length);
+                        Array.Copy (typeAttrs, 0, result, oldLength, typeAttrs.Length);
+                    }
+                }
+            }
+
+            return result ?? new TAttr[0];
+        }
+
         #endregion
 
         #region Protected Methods


### PR DESCRIPTION
/cc @jnm2 

Related to:
 - https://github.com/nunit/nunit/issues/2220
 - https://github.com/nunit/nunit/issues/3013
 - https://github.com/nunit/nunit/issues/2917

This PR is an example of extensibility mechanism for the async machinery allowing external people to customize its behavior via attributes.

By leveraging the existing `IWrapSetUpTearDown` interface, one can now fully execute unit-test inside any sort of mainloop (GUI-based or not).

For instance here is the set of custom attribute created to support running tests with [XWT](https://github.com/mono/xwt):

```csharp
// Run wrapper
[System.AttributeUsage (AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
public class XwtCommandWrapperAttribute : Attribute, IWrapSetUpTearDown
{
	public TestCommand Wrap (TestCommand command) => new RunOnUICommand (command);
	class RunOnUICommand : DelegatingTestCommand
	{
		public RunOnUICommand (TestCommand innerCommand)
			: base (innerCommand)
		{
		}

		public override TestResult Execute (TestExecutionContext context)
		{
			TestResult result = null;
			var evt = new ManualResetEventSlim ();
			Xwt.Application.Invoke (() => {
				try {
					result = innerCommand.Execute (context);
				} catch (Exception e) {
					Console.WriteLine ("Catastrophic fail", e);
				}
				evt.Set ();
			});
			evt.Wait ();
			return result;
		}
	}
}

// Custom wait strategy
[System.AttributeUsage (AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
public class XwtAsyncWaitStrategyAttribute : Attribute, IAsyncCompletionStrategy
{
	public void WaitForCompletion (IAwaiterObject awaitable)
	{
		while (!awaitable.IsCompleted)
			Xwt.Application.MainLoop.DispatchPendingEvents ();
	}
}
```

Additionally, this PR adds a `GetCombinedCustomAttributes` method to support looking up attribute definitions on both the test method and the containing fixture so that those two attributes above can be applied at the fixture level thus ensuring all the tests automatically inherit the behavior.

(Note that this way of doing things work for our own test suite with minimal changes to the nunit codebase but I don't have any strong feeling about going in that specific direction)