### PR TITLE
Improve performance of discovery/execution #2488

### DIFF
--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -113,6 +113,14 @@ namespace NUnit.Framework.Internal
             Assert.That(testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"\\u0001HappyFace\""));
         }
 
+        [Test]
+        public void TestNameWithInvalidCharacter_NonFirstPosition()
+        {
+            testMethod.Name = "Happy\u0001Face";
+            // This throws if the name is not properly escaped
+            Assert.That(testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"Happy\\u0001Face\""));
+        }
+
         #region Helper Methods For Checking XML
 
         private void CheckXmlForTest(Test test, bool recursive)


### PR DESCRIPTION
Related to #2488 

Changes the regex that stripped out invalid XML characters to an equivalent method that will not allocate more strings unless there is an invalid character in the string. This was a performance issue for me when attempting to run a single test in a project with 20,000 tests with the VS test runner as this method took nearly 8s before (now down to < 1s with my changes).