### PR TITLE
Addresses issue 3063.

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -144,7 +144,7 @@ namespace NUnit.Framework.Interfaces
             return FromXml(XElement.Parse(xmlText));
 #else
             var doc = new XmlDocument();
-            doc.LoadXml(xmlText);
+            doc.LoadXml(TNode.EscapeInvalidXmlCharacters(xmlText));
             return FromXml(doc.FirstChild);
 #endif
         }
@@ -319,7 +319,12 @@ namespace NUnit.Framework.Interfaces
         }
 
         private static readonly Regex InvalidXmlCharactersRegex = new Regex("[^\u0009\u000a\u000d\u0020-\ufffd]|([\ud800-\udbff](?![\udc00-\udfff]))|((?<![\ud800-\udbff])[\udc00-\udfff])", RegexOptions.Compiled);
-        private static string EscapeInvalidXmlCharacters(string str)
+        /// <summary>
+        /// Escapes a string into an XML compatible string
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static string EscapeInvalidXmlCharacters(string str)
         {
             if (str == null) return null;
 

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -141,10 +141,10 @@ namespace NUnit.Framework.Interfaces
         public static TNode FromXml(string xmlText)
         {
 #if NETSTANDARD1_4
-            return FromXml(XElement.Parse(xmlText));
+            return FromXml(XElement.Parse(EscapeInvalidXmlCharacters(xmlText)));
 #else
             var doc = new XmlDocument();
-            doc.LoadXml(TNode.EscapeInvalidXmlCharacters(xmlText));
+            doc.LoadXml(EscapeInvalidXmlCharacters(xmlText));
             return FromXml(doc.FirstChild);
 #endif
         }

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal.Filters
         /// </summary>
         public override bool Match(ITest test)
         {
-            return Match(test.FullName);
+            return Match(TNode.EscapeInvalidXmlCharacters(test.FullName));
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Internal.Filters
 {
@@ -61,6 +62,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.False(_filter.Pass(_anotherFixture));
         }
 
+        [Test]
         public void ExplicitMatchTest()
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
@@ -68,6 +70,41 @@ namespace NUnit.Framework.Internal.Filters
             Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
 
             Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+        }
+
+        [Test]
+        public void UTF8CharacterMatchFromXML()
+        {
+            TestFilter filter = TestFilter.FromXml("<filter><test>NUnit.Framework.Internal.Filters.FullNameFilterTests.UTF8CharacterMatchFromXMLTestMethod(&quot;ABC\u0001&quot;)</test></filter>");
+            var test = TestBuilder.MakeTestFromMethod(GetType(), nameof(UTF8CharacterMatchFromXMLTestMethod));
+
+            Assert.IsTrue(test.HasChildren);
+            Assert.IsTrue(test.Tests[0].Arguments[0] is string);
+            Assert.IsTrue((string)test.Tests[0].Arguments[0] == "ABC\x01");
+            Assert.IsTrue(filter.Match(test.Tests[0]));
+        }
+
+        [Test]
+        public void ArgumentsMatch()
+        {
+            TestFilter filter = TestFilter.FromXml("<filter><test>NUnit.Framework.Internal.Filters.FullNameFilterTests.ArgumentsMatchTestMethod(1)</test></filter>");
+            var test = TestBuilder.MakeTestFromMethod(GetType(), nameof(ArgumentsMatchTestMethod));
+
+            Assert.IsTrue(test.HasChildren);
+            Assert.IsTrue(test.Tests[0].Arguments[0] is int);
+            Assert.IsTrue((int)test.Tests[0].Arguments[0] == 1);
+            Assert.IsTrue(filter.Match(test.Tests[0]));
+        }
+
+        [TestCase("ABC\x01", ExpectedResult = "ABC%01")]
+        public string UTF8CharacterMatchFromXMLTestMethod(string s)
+        {
+            return string.Empty;
+        }
+
+        [Test]
+        public void ArgumentsMatchTestMethod([Values(1, 2)] int s)
+        {
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
@@ -67,7 +67,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            if (((FullNameFilter)_filter).IsRegex)
+                Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            else
+                Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
 
             Assert.False(_filter.IsExplicitMatch(_anotherFixture));
         }
@@ -96,10 +99,9 @@ namespace NUnit.Framework.Internal.Filters
             Assert.IsTrue(filter.Match(test.Tests[0]));
         }
 
-        [TestCase("ABC\x01", ExpectedResult = "ABC%01")]
-        public string UTF8CharacterMatchFromXMLTestMethod(string s)
+        [TestCase("ABC\x01")]
+        public void UTF8CharacterMatchFromXMLTestMethod(string s)
         {
-            return string.Empty;
         }
 
         [Test]


### PR DESCRIPTION
Closes nunit/nunit3-vs-adapter#484 and #3063

When NUnit VS adapter passes a test filter generated by VS into NUnit, the filter contains an invalid XML character (but valid UTF16 character) - for example, '\x01'. When read into TestFilter.LoadXML, it throws an exception and the test can never be run. Even if the XML character is escaped in the VS test adapter, it would still fail in FullNameFilter, as that expects the unescaped UTF16 character at that time.

We will first need to either (enforce) escaping from any applications calling into NUnit programmatically, or do the escaping ourselves when we read in a string (in FrameworkController.RunTests) so that it always will be read in as valid XML. Secondly, we will need to address the FullNameFilter, and my two proposals are copied from the other issue below:

My proposals from the other issue are as follows:
1: Unescape the characters that we escaped in the XML to make it load, so that FullNameFilter would match correctly.
2. Escape all FullNameFilter options that come in to match what is able to be loaded from the XML.

I think 2 is more feasible, as unescaping is a more difficult task and we know that the test filters will be coming in as XML (which will be escaped if they load properly), so the escaping in the filter will make it so that they will match between the two in (I believe) all cases.


I implemented escaping all filter strings when they come in if they contain non XML compliant characters and proposal 2 for how to handle the full name filtering. The only concern I have at this time is that until the escaping is faster (from a separate pull request), this may take a hit on performance as the regex is not a fast operation.