### PR TITLE
Compare elements within ValueTuples with NUnitEqualityComparer

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -81,9 +81,9 @@ namespace NUnit.Framework.Constraints
                 new NumericsComparer(),
                 new DateTimeOffsetsComparer(this),
                 new TimeSpanToleranceComparer(),
-                new EquatablesComparer(this),
                 new TupleComparer(this),
                 new ValueTupleComparer(this),
+                new EquatablesComparer(this),
                 enumerablesComparer
             };
         }

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -778,6 +778,22 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AreEqual(set1, set2, new TestComparer()));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
+
+        [Test]
+        public void ElementsWithinTuplesAreComparedUsingNUnitEqualityComparer()
+        {
+            var a = new Dictionary<string, ValueTuple<string, Dictionary<string, string>>>()
+            {
+                { "key", ValueTuple.Create("name", new Dictionary<string, string>())}
+            };
+
+            var b = new Dictionary<string, ValueTuple<string, Dictionary<string, string>>>()
+            {
+                { "key", ValueTuple.Create("name", new Dictionary<string, string>())}
+            };
+
+            CollectionAssert.AreEquivalent(a, b);
+        }
 #endregion
 #endif
     }

--- a/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
@@ -23,6 +23,7 @@
 
 #if !NET20 && !NET35
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
@@ -87,6 +88,14 @@ namespace NUnit.Framework.Constraints
             var tuple1 = Tuple.Create(1, 2, 3, 4, 5, 6, 7, 8);
             var tuple2 = Tuple.Create(1, 2, 3, 4, 5, 6, 7, 9);
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
+        }
+
+        [Test]
+        public void TupleElementsAreComparedUsingNUnitEqualityComparer()
+        {
+            var a = Tuple.Create(new Dictionary<string, string>());
+            var b = Tuple.Create(new Dictionary<string, string>());
+            Assert.That(a, Is.EqualTo(b));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
@@ -23,6 +23,7 @@
 
 #if !NET20 && !NET35
 using System;
+using System.Collections.Generic;
 
 namespace NUnit.Framework.Constraints
 {
@@ -87,6 +88,14 @@ namespace NUnit.Framework.Constraints
             var tuple1 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8);
             var tuple2 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 9);
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
+        }
+
+        [Test]
+        public void ValueTupleElementsAreComparedUsingNUnitEqualityComparer()
+        {
+            var a = ValueTuple.Create(new Dictionary<string, string>());
+            var b = ValueTuple.Create(new Dictionary<string, string>());
+            Assert.That(a, Is.EqualTo(b));
         }
     }
 }


### PR DESCRIPTION
ValueTuples implement IEquatable and we tried to compare using
EquatablesComparer before ValueTupleComparer, so ValueTuples
was compared using the standard semantics and not using
NUnitEqualityComparer, so e.g. Dictionaries was compared using
reference equality and not using DictionariesComparer.

Note that the test for Tuples passed before this change
as Tuples does not implement IEquatable.

Fixes #3073