### PR TITLE
Byte ranges no longer fail when they end on a boundary

### DIFF
--- a/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal
             {
                 if (value is byte)
                 {
-                    step = new ComparableStep<byte>((byte)value, (prev, stepValue) => unchecked((byte)(prev + stepValue)));
+                    step = new ComparableStep<byte>((byte)value, (prev, stepValue) => checked((byte)(prev + stepValue)));
                     return true;
                 }
 
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Internal
                 // -1 can be converted natively to Int16, SByte and Decimal, so we can fall back on the automatic conversion for them.
                 if (value is int)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => unchecked((byte)(prev + stepValue)));
+                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((byte)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -350,6 +350,14 @@ namespace NUnit.Framework.Attributes
         #region MaxValue
 
         [Test]
+        public static void MaxValueRange_Byte()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(byte.MaxValue - 2, byte.MaxValue), typeof(byte)),
+                Is.EqualTo(new[] { byte.MaxValue - 2, byte.MaxValue - 1, byte.MaxValue }));
+        }
+
+        [Test]
         public static void MaxValueRange_Int32()
         {
             Assert.That(
@@ -438,6 +446,14 @@ namespace NUnit.Framework.Attributes
         #endregion
 
         #region MinValue
+
+        [Test]
+        public static void MinValueRange_Byte()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(byte.MinValue + 2, byte.MinValue), typeof(byte)),
+                Is.EqualTo(new[] { byte.MinValue + 2, byte.MinValue + 1, byte.MinValue }));
+        }
 
         [Test]
         public static void MinValueRange_Int32()

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -358,6 +358,22 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public static void MaxValueRange_SByte()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(sbyte.MaxValue - 2, sbyte.MaxValue), typeof(sbyte)),
+                Is.EqualTo(new[] { sbyte.MaxValue - 2, sbyte.MaxValue - 1, sbyte.MaxValue }));
+        }
+
+        [Test]
+        public static void MaxValueRange_Int16()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(short.MaxValue - 2, short.MaxValue), typeof(short)),
+                Is.EqualTo(new[] { short.MaxValue - 2, short.MaxValue - 1, short.MaxValue }));
+        }
+
+        [Test]
         public static void MaxValueRange_Int32()
         {
             Assert.That(
@@ -453,6 +469,22 @@ namespace NUnit.Framework.Attributes
             Assert.That(
                 GetData(new RangeAttribute(byte.MinValue + 2, byte.MinValue), typeof(byte)),
                 Is.EqualTo(new[] { byte.MinValue + 2, byte.MinValue + 1, byte.MinValue }));
+        }
+
+        [Test]
+        public static void MinValueRange_SByte()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(sbyte.MinValue + 2, sbyte.MinValue), typeof(sbyte)),
+                Is.EqualTo(new[] { sbyte.MinValue + 2, sbyte.MinValue + 1, sbyte.MinValue }));
+        }
+
+        [Test]
+        public static void MinValueRange_Int16()
+        {
+            Assert.That(
+                GetData(new RangeAttribute(short.MinValue + 2, short.MinValue), typeof(short)),
+                Is.EqualTo(new[] { short.MinValue + 2, short.MinValue + 1, short.MinValue }));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3079.