### PR TITLE
3059 - Fix assert throws for async Task<>

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -98,7 +98,12 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
 #if ASYNC
-            if (typeof(TActual) == typeof(Task)) return ApplyTo(new AsyncTestDelegate(() => (Task)(object)del.Invoke()));
+            if (typeof(TActual) == typeof(Task))
+                return ApplyTo(new AsyncTestDelegate(() => (Task)(object)del.Invoke()));
+            
+            var typeWrapper = new TypeWrapper(typeof(TActual));
+            if (typeWrapper.IsGenericType && typeWrapper.GetGenericTypeDefinition() == typeof(Task<>))
+                return ApplyTo(new AsyncTestDelegate(() => (Task)(object)del.Invoke()));
 #endif
             return ApplyTo(new TestDelegate(() => del.Invoke()));
         }

--- a/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
@@ -26,6 +26,7 @@ using NUnit.TestUtilities;
 
 #if ASYNC
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 #endif
 
@@ -65,19 +66,39 @@ namespace NUnit.Framework.Constraints
         };
 
 #if ASYNC
+        private static async Task YieldAsync()
+        {
+#if NET40
+            await TaskEx.Yield();
+#else
+            await Task.Yield();
+#endif
+        }
+
+
         [Test]
         public static void CatchesAsyncException()
         {
             Assert.That(async () =>
             {
-#if NET40
-                await TaskEx.Yield();
-#else
-                await Task.Yield();
-#endif
+                await YieldAsync();
                 throw new Exception();
             }, Throws.Exception);
         }
+        
+        [Test]
+        public static void CatchesAsyncOfTException()
+        {
+            Assert.That(async () =>
+            {
+#pragma warning disable CS0162
+                await YieldAsync();
+                throw new Exception();
+                return 2;
+#pragma warning restore CS0162
+            }, Throws.Exception);
+        }
+
 #endif
     }
 }

--- a/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
+++ b/src/NUnitFramework/tests/TestUtilities/AsyncTestDelegates.cs
@@ -1,4 +1,4 @@
-﻿#if ASYNC
+#if ASYNC
 
 using System;
 using System.Threading.Tasks;


### PR DESCRIPTION
Update `ThrowsExceptionConstraint` to detect if anonymous `async Task<>` is passed.

Fixes https://github.com/nunit/nunit/issues/3059