### PR TITLE
Remove outdated comment

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
@@ -71,7 +71,6 @@ namespace NUnit
         /// <summary>
         /// A list of tests to be loaded. 
         /// </summary>
-        // TODO: Remove?
         public const string LOAD = "LOAD";
 
         /// <summary>


### PR DESCRIPTION
`FrameworkPackageSetting.LOAD` is now used by some runners, and shouldn't be removed.