### PR TITLE
3053 - Conversion from TestCase string parameter to DateTimeOffset

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -30,6 +30,7 @@ Supported platforms:
       <group targetFramework="net45" />
       <group targetFramework="netstandard1.4">
         <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
         <dependency id="System.Reflection.TypeExtensions" version="4.4.0" exclude="compile" />
       </group>
       <group targetFramework="netstandard2.0">

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -288,9 +288,7 @@ namespace NUnit.Framework
                             if (!lastParameterType.IsInstanceOfType(parms.Arguments[argsProvided - 1]))
                             {
                                 Array array = Array.CreateInstance(elementType, 1);
-                                var argValue = ParamAttributeTypeConversions.Convert(parms.Arguments[argsProvided - 1], elementType);
-
-                                array.SetValue(argValue, 0);
+                                array.SetValue(parms.Arguments[argsProvided - 1], 0);
                                 parms.Arguments[argsProvided - 1] = array;
                             }
                         }
@@ -303,10 +301,7 @@ namespace NUnit.Framework
                             int length = argsProvided - argsNeeded + 1;
                             Array array = Array.CreateInstance(elementType, length);
                             for (int i = 0; i < length; i++)
-                            {
-                                var argValue = ParamAttributeTypeConversions.Convert(parms.Arguments[argsNeeded + i - 1], elementType);
-                                array.SetValue(argValue, i);
-                            }
+                                array.SetValue(parms.Arguments[argsNeeded + i - 1], i);
 
                             newArglist[argsNeeded - 1] = array;
                             parms.Arguments = newArglist;

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -431,10 +431,10 @@ namespace NUnit.Framework
                 return true;
             }
 
-            // Convert.ChangeType doesn't work for TimeSpan from string
-            if ((targetType == typeof(TimeSpan) || targetType == typeof(TimeSpan?)) && arg is string)
+            var converter = System.ComponentModel.TypeDescriptor.GetConverter(targetType);
+            if (converter.CanConvertFrom(arg.GetType()))
             {
-                argAsTargetType = TimeSpan.Parse((string)arg);
+                argAsTargetType = converter.ConvertFrom(null, System.Globalization.CultureInfo.InvariantCulture, arg);
                 return true;
             }
 

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -263,7 +263,7 @@ namespace NUnit.Framework
                 IParameterInfo[] parameters = method.GetParameters();
                 int argsNeeded = parameters.Length;
                 int argsProvided = Arguments.Length;
-                
+
                 parms = new TestCaseParameters(this);
 
                 // Special handling for ExpectedResult (see if it needs to be converted into method return type)

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Internal
             var underlyingTargetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
 
             if (underlyingTargetType == typeof(short) || underlyingTargetType == typeof(byte) || underlyingTargetType == typeof(sbyte)
-                || targetType == typeof(long?) || targetType == typeof(double?))
+                || underlyingTargetType == typeof(long) || underlyingTargetType == typeof(double))
             {
                 convert = value is int;
             }

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -133,14 +134,14 @@ namespace NUnit.Framework.Internal
                 Type convertTo = targetType.GetTypeInfo().IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Nullable<>) ?
                     targetType.GetGenericArguments()[0] : targetType;
 
-                convertedValue = System.Convert.ChangeType(value, convertTo, System.Globalization.CultureInfo.InvariantCulture);
+                convertedValue = System.Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
                 return true;
             }
 
             var converter = TypeDescriptor.GetConverter(targetType);
             if (converter.CanConvertFrom(value.GetType()))
             {
-                convertedValue = converter.ConvertFrom(null, System.Globalization.CultureInfo.InvariantCulture, value);
+                convertedValue = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
                 return true;
             }
 

--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -123,6 +123,13 @@ namespace NUnit.Framework.Internal
                 return true;
             }
 
+            var converter = System.ComponentModel.TypeDescriptor.GetConverter(targetType);
+            if (converter.CanConvertFrom(value.GetType()))
+            {
+                convertedValue = converter.ConvertFrom(null, System.Globalization.CultureInfo.InvariantCulture, value);
+                return true;
+            }
+
             convertedValue = null;
             return false;
         }

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;netstandard1.4;netstandard2.0</TargetFrameworks>
@@ -12,6 +12,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" PrivateAssets="compile" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Attributes
         };
 
         // See XML docs for the ParamAttributeTypeConversions class.
-        private static readonly Type[] Int32RangeConvertibleToParameterTypes = { typeof(int), typeof(sbyte), typeof(byte), typeof(short), typeof(decimal) };
+        private static readonly Type[] Int32RangeConvertibleToParameterTypes = { typeof(int), typeof(sbyte), typeof(byte), typeof(short), typeof(decimal), typeof(long), typeof(double) };
         private static readonly Type[] UInt32RangeConvertibleToParameterTypes = { typeof(uint) };
         private static readonly Type[] Int64RangeConvertibleToParameterTypes = { typeof(long) };
         private static readonly Type[] UInt64RangeConvertibleToParameterTypes = { typeof(ulong) };

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -604,6 +604,12 @@ namespace NUnit.Framework.Attributes
             Assert.That(x.Value, Is.EqualTo(1));
         }
 
+        [TestCase(1)]
+        public void CanConvertIntToLong(long x)
+        {
+            Assert.That(x, Is.EqualTo(1));
+        }
+
         [TestCase("2.2", "3.3", ExpectedResult = 5.5)]
         public decimal? CanConvertStringToNullableDecimal(decimal? x, decimal? y)
         {

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -128,13 +128,6 @@ namespace NUnit.Framework.Attributes
             return dt;
         }
 
-        [TestCase("1942-10-12")]
-        [TestCase("1942-10-12", "1942-10-12")]
-        public void CanConvertStringToDateTimeAsParamArray(params DateTime[] dt)
-        {
-            CanConvertSpecialCaseToParams(dt);
-        }
-
         [TestCase("4:44:15")]
         public void CanConvertStringToTimeSpan(TimeSpan ts)
         {
@@ -147,13 +140,6 @@ namespace NUnit.Framework.Attributes
         public TimeSpan CanConvertExpectedResultStringToTimeSpan(TimeSpan ts)
         {
             return ts;
-        }
-        
-        [TestCase("4:44:15")]
-        [TestCase("4:44:15", "4:44:15")]
-        public void CanConvertStringToTimeSpanAsParamArray(params TimeSpan[] ts)
-        {
-            CanConvertSpecialCaseToParams(ts);
         }
 
         [TestCase("2018-10-09 15:15:00+02:30")]
@@ -176,30 +162,7 @@ namespace NUnit.Framework.Attributes
         {
             return offset;
         }
-
-        [TestCase("2018-10-09 15:15:00+02:30")]
-        [TestCase("2018-10-09 15:15:00+02:30", "2018-10-09 15:15:00+02:30")]
-        public void CanConvertStringToDateTimeOffsetAsParamArray(params DateTimeOffset[] offsets)
-        {
-            CanConvertSpecialCaseToParams(offsets);
-        }
-
-        [TestCase("2018-10-09 15:15:00+02:30")]
-        [TestCase("2018-10-09 15:15:00+02:30", "2018-10-09 15:15:00+02:30")]
-        public void CanConvertStringToNullableDateTimeOffsetAsParamArray(params DateTimeOffset?[] offsets)
-        {
-            CanConvertSpecialCaseToParams(offsets);
-        }
-
-        private static void CanConvertSpecialCaseToParams<T>(T[] args)
-        {
-            Assert.IsNotNull(args);
-            CollectionAssert.IsNotEmpty(args);
-
-            foreach (var arg in args)
-                Assert.AreNotEqual(default(T), arg);
-        }
-
+        
         [TestCase(null)]
         public void CanPassNullAsFirstArgument(object a)
         {

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -142,6 +142,27 @@ namespace NUnit.Framework.Attributes
             return ts;
         }
 
+        [TestCase("2018-10-09 15:15:00+02:30")]
+        public void CanConvertStringToDateTimeOffset(DateTimeOffset offset)
+        {
+            Assert.AreEqual(2018, offset.Year);
+            Assert.AreEqual(10, offset.Month);
+            Assert.AreEqual(9, offset.Day);
+
+            Assert.AreEqual(15, offset.Hour);
+            Assert.AreEqual(15, offset.Minute);
+            Assert.AreEqual(0, offset.Second);
+
+            Assert.AreEqual(2, offset.Offset.Hours);
+            Assert.AreEqual(30, offset.Offset.Minutes);
+        }
+
+        [TestCase("2018-10-09 15:15:00+02:30", ExpectedResult = "2018-10-09 15:15:00+02:30")]
+        public DateTimeOffset CanConvertExpectedResultStringToDateTimeOffset(DateTimeOffset offset)
+        {
+            return offset;
+        }
+
         [TestCase(null)]
         public void CanPassNullAsFirstArgument(object a)
         {

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -184,6 +184,13 @@ namespace NUnit.Framework.Attributes
             CanConvertSpecialCaseToParams(offsets);
         }
 
+        [TestCase("2018-10-09 15:15:00+02:30")]
+        [TestCase("2018-10-09 15:15:00+02:30", "2018-10-09 15:15:00+02:30")]
+        public void CanConvertStringToNullableDateTimeOffsetAsParamArray(params DateTimeOffset?[] offsets)
+        {
+            CanConvertSpecialCaseToParams(offsets);
+        }
+
         private static void CanConvertSpecialCaseToParams<T>(T[] args)
         {
             Assert.IsNotNull(args);

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -128,6 +128,13 @@ namespace NUnit.Framework.Attributes
             return dt;
         }
 
+        [TestCase("1942-10-12")]
+        [TestCase("1942-10-12", "1942-10-12")]
+        public void CanConvertStringToDateTimeAsParamArray(params DateTime[] dt)
+        {
+            CanConvertSpecialCaseToParams(dt);
+        }
+
         [TestCase("4:44:15")]
         public void CanConvertStringToTimeSpan(TimeSpan ts)
         {
@@ -140,6 +147,13 @@ namespace NUnit.Framework.Attributes
         public TimeSpan CanConvertExpectedResultStringToTimeSpan(TimeSpan ts)
         {
             return ts;
+        }
+        
+        [TestCase("4:44:15")]
+        [TestCase("4:44:15", "4:44:15")]
+        public void CanConvertStringToTimeSpanAsParamArray(params TimeSpan[] ts)
+        {
+            CanConvertSpecialCaseToParams(ts);
         }
 
         [TestCase("2018-10-09 15:15:00+02:30")]
@@ -161,6 +175,22 @@ namespace NUnit.Framework.Attributes
         public DateTimeOffset CanConvertExpectedResultStringToDateTimeOffset(DateTimeOffset offset)
         {
             return offset;
+        }
+
+        [TestCase("2018-10-09 15:15:00+02:30")]
+        [TestCase("2018-10-09 15:15:00+02:30", "2018-10-09 15:15:00+02:30")]
+        public void CanConvertStringToDateTimeOffsetAsParamArray(params DateTimeOffset[] offsets)
+        {
+            CanConvertSpecialCaseToParams(offsets);
+        }
+
+        private static void CanConvertSpecialCaseToParams<T>(T[] args)
+        {
+            Assert.IsNotNull(args);
+            CollectionAssert.IsNotEmpty(args);
+
+            foreach (var arg in args)
+                Assert.AreNotEqual(default(T), arg);
         }
 
         [TestCase(null)]

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -47,8 +47,25 @@ namespace NUnit.Framework.Attributes
         #region Conversion Tests
 
         [Test]
+        public void CanConvertIntsToLong([Values(5, int.MaxValue)]long x)
+        {
+        }
+
+        [Test]
+        public void CanConvertIntsToNullableLong([Values(5, int.MaxValue)]long? x)
+        {
+            Assert.That(x.HasValue, Is.True);
+        }
+
+        [Test]
         public void CanConvertSmallIntsToShort([Values(5)]short x)
         {
+        }
+
+        [Test]
+        public void CanConvertSmallIntsToNullableShort([Values(5)]short? x)
+        {
+            Assert.That(x.HasValue, Is.True);
         }
 
         [Test]
@@ -57,8 +74,20 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void CanConvertSmallIntsToNullableByte([Values(5)]byte? x)
+        {
+            Assert.That(x.HasValue, Is.True);
+        }
+
+        [Test]
         public void CanConvertSmallIntsToSByte([Values(5)]sbyte x)
         {
+        }
+
+        [Test]
+        public void CanConvertSmallIntsToNullableSByte([Values(5)]sbyte? x)
+        {
+            Assert.That(x.HasValue, Is.True);
         }
 
         [Test]
@@ -69,18 +98,18 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertValuesToNullableDecimal([Values(12, 12.5, "12.5")]decimal? x)
         {
-            Assert.IsNotNull(x);
-        }
-
-        [Test]
-        public void CanConvertStringToNullableDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset? x)
-        {
-            Assert.IsNotNull(x);
+            Assert.That(x.HasValue, Is.True);
         }
 
         [Test]
         public void CanConvertStringToDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset x)
         {
+        }
+
+        [Test]
+        public void CanConvertStringToNullableDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset? x)
+        {
+            Assert.That(x.HasValue, Is.True);
         }
 
         [Test]
@@ -91,18 +120,18 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertStringToNullableTimeSpan([Values("4:44:15")]TimeSpan? x)
         {
-            Assert.IsNotNull(x);
-        }
-
-        [Test]
-        public void CanConvertStringToNullableDateTime([Values("2018-10-10")]DateTime? x)
-        {
-            Assert.IsNotNull(x);
+            Assert.That(x.HasValue, Is.True);
         }
 
         [Test]
         public void CanConvertStringToDateTime([Values("2018-10-10")]DateTime x)
         {
+        }
+
+        [Test]
+        public void CanConvertStringToNullableDateTime([Values("2018-10-10")]DateTime? x)
+        {
+            Assert.That(x.HasValue, Is.True);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -62,23 +62,20 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void CanConvertIntToDecimal([Values(12)]decimal x)
+        public void CanConvertValuesToDecimal([Values(12, 12.5, "12.5")]decimal x)
         {
         }
 
         [Test]
-        public void CanConvertDoubleToDecimal([Values(12.5)]decimal x)
+        public void CanConvertValuesToNullableDecimal([Values(12, 12.5, "12.5")]decimal? x)
         {
-        }
-
-        [Test]
-        public void CanConvertStringToDecimal([Values("12.5")]decimal x)
-        {
+            Assert.IsNotNull(x);
         }
 
         [Test]
         public void CanConvertStringToNullableDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset? x)
         {
+            Assert.IsNotNull(x);
         }
 
         [Test]
@@ -88,6 +85,23 @@ namespace NUnit.Framework.Attributes
 
         [Test]
         public void CanConvertStringToTimeSpan([Values("4:44:15")]TimeSpan x)
+        {
+        }
+
+        [Test]
+        public void CanConvertStringToNullableTimeSpan([Values("4:44:15")]TimeSpan? x)
+        {
+            Assert.IsNotNull(x);
+        }
+
+        [Test]
+        public void CanConvertStringToNullableDateTime([Values("2018-10-10")]DateTime? x)
+        {
+            Assert.IsNotNull(x);
+        }
+
+        [Test]
+        public void CanConvertStringToDateTime([Values("2018-10-10")]DateTime x)
         {
         }
 

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -49,6 +49,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertIntsToLong([Values(5, int.MaxValue)]long x)
         {
+            Assert.That(x, Is.Not.EqualTo(default(long)));
         }
 
         [Test]
@@ -93,6 +94,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertValuesToDecimal([Values(12, 12.5, "12.5")]decimal x)
         {
+            Assert.That(x, Is.Not.EqualTo(default(decimal)));
         }
 
         [Test]
@@ -104,6 +106,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertStringToDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset x)
         {
+            Assert.That(x, Is.Not.EqualTo(default(DateTimeOffset)));
         }
 
         [Test]
@@ -115,6 +118,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertStringToTimeSpan([Values("4:44:15")]TimeSpan x)
         {
+            Assert.That(x, Is.Not.EqualTo(default(TimeSpan)));
         }
 
         [Test]
@@ -126,6 +130,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanConvertStringToDateTime([Values("2018-10-10")]DateTime x)
         {
+            Assert.That(x, Is.Not.EqualTo(default(DateTime)));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -76,6 +76,21 @@ namespace NUnit.Framework.Attributes
         {
         }
 
+        [Test]
+        public void CanConvertStringToNullableDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset? x)
+        {
+        }
+
+        [Test]
+        public void CanConvertStringToDateTimeOffset([Values("2018-10-09 15:15:00+02:30")]DateTimeOffset x)
+        {
+        }
+
+        [Test]
+        public void CanConvertStringToTimeSpan([Values("4:44:15")]TimeSpan x)
+        {
+        }
+
         #endregion
 
         #region Helper Methods


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/3053

Updates `TestCaseAttribute` to convert `String` parameter to `DateTimeOffset`
I noticed the existing type conversion logic wasn't applied to params arrays, so I expanded it to work there too (I added a test for the existing TimeSpan logic for that too).

### Added Dependencies
#### NET Standard 1.4
- `System.ComponentModel.TypeConverter`

### Scope Creep
I also noticed that the `ValuesAttribute` handles most type conversions the `TestCaseAttribute` does, so I added this `string -> DateTimeOffset` conversion for it too. I also consolidated some of the type conversion logic between them (`TestCaseAttribute` now uses `ParamAttributeTypeConversions` too). In the process, I had to update `ParamAttributeTypeConversions` to map values to nullable primitives, it looks like previously we only mapped null to nullable primitives.

One potential change to existing behaviour is that `TestCaseAttribute` previously called `TimeSpan.Parse()` without providing a culture, whereas it looked like most other conversions used `CultureInfo.InvariantCulture` (including when `ValuesAttribute` converts a string to a `TimeSpan`. So in the process of centralizing the type conversion logic, `TestCaseAttribute` now also uses `CultureInfo.InvariantCulture` when converting a string to a `TimeSpan`.

In keeping with comment https://github.com/nunit/nunit/issues/3053#issuecomment-428203802, `TimeSpan` now also gets converted using `TypeConverter` instead of `Convert`, as it does not implemement `IConvertible`.

Since this is a bit more than just "Conversion from TestCase string parameter to DateTimeOffset" covered in this PR, let me know if a second GH issue and/or PR should be required for the broader changes.