### PR TITLE
Add tests for use of ApartmentState.Unknown in RequiresThreadAttribute

### DIFF
--- a/src/NUnitFramework/testdata/ApartmentData.cs
+++ b/src/NUnitFramework/testdata/ApartmentData.cs
@@ -1,0 +1,40 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Threading;
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+#if APARTMENT_STATE
+    [RequiresThread(ApartmentState.Unknown)]
+    public class ApartmentDataRequiresThreadAttribute
+    {
+    }
+
+    [Apartment(ApartmentState.Unknown)]
+    public class ApartmentDataApartmentAttribute
+    {
+    }
+#endif
+}

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -24,17 +24,24 @@
 #if APARTMENT_STATE
 using System;
 using System.Threading;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.TestData;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
     [TestFixture]
     public class ApartmentAttributeTests : ThreadingTests
     {
+#if APARTMENT_STATE
         [Test]
-        public void ApartmentStateUnknownThrowsException()
+        public void ApartmentStateUnknownIsNotRunnable()
         {
-            Assert.That(() => new ApartmentAttribute(ApartmentState.Unknown), Throws.ArgumentException);
+            var testSuite = TestBuilder.MakeFixture(typeof(ApartmentDataRequiresThreadAttribute));
+            Assert.That(testSuite, Has.Property(nameof(TestSuite.RunState)).EqualTo(RunState.NotRunnable));
         }
+#endif
 
         [Test, Apartment(ApartmentState.STA)]
         public void TestWithRequiresSTARunsInSTA()

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ApartmentStateUnknownIsNotRunnable()
         {
-            var testSuite = TestBuilder.MakeFixture(typeof(ApartmentDataRequiresThreadAttribute));
+            var testSuite = TestBuilder.MakeFixture(typeof(ApartmentDataApartmentAttribute));
             Assert.That(testSuite, Has.Property(nameof(TestSuite.RunState)).EqualTo(RunState.NotRunnable));
         }
 #endif

--- a/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
@@ -24,6 +24,10 @@
 #if !NETCOREAPP1_1
 using System;
 using System.Threading;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.TestData;
+using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
 {
@@ -44,22 +48,24 @@ namespace NUnit.Framework.Attributes
 
 #if APARTMENT_STATE
         [Test]
-        public void ApartmentStateUnknownThrowsException() {
-            Assert.That(() => new RequiresThreadAttribute(ApartmentState.Unknown), Throws.ArgumentException);
+        public void ApartmentStateUnknownIsNotRunnable()
+        {
+            var testSuite = TestBuilder.MakeFixture(typeof(ApartmentDataRequiresThreadAttribute));
+            Assert.That(testSuite, Has.Property(nameof(TestSuite.RunState)).EqualTo(RunState.NotRunnable));
         }
 
-        [Test, RequiresThread( ApartmentState.STA )]
+        [Test, RequiresThread(ApartmentState.STA)]
         public void TestWithRequiresThreadWithSTAArgRunsOnSeparateThreadInSTA()
         {
-            Assert.That( GetApartmentState( Thread.CurrentThread ), Is.EqualTo( ApartmentState.STA ) );
-            Assert.That( Thread.CurrentThread, Is.Not.EqualTo( ParentThread ) );
+            Assert.That(GetApartmentState(Thread.CurrentThread), Is.EqualTo(ApartmentState.STA));
+            Assert.That(Thread.CurrentThread, Is.Not.EqualTo(ParentThread));
         }
 
-        [Test, RequiresThread( ApartmentState.MTA )]
+        [Test, RequiresThread(ApartmentState.MTA)]
         public void TestWithRequiresThreadWithMTAArgRunsOnSeparateThreadInMTA()
         {
-            Assert.That( GetApartmentState( Thread.CurrentThread ), Is.EqualTo( ApartmentState.MTA ) );
-            Assert.That( Thread.CurrentThread, Is.Not.EqualTo( ParentThread ) );
+            Assert.That(GetApartmentState(Thread.CurrentThread), Is.EqualTo(ApartmentState.MTA));
+            Assert.That(Thread.CurrentThread, Is.Not.EqualTo(ParentThread));
         }
 #endif
 


### PR DESCRIPTION
Tests for #3058. I wasn't sure of behaviour of myself, so wrote a test to check that, and it made sense to keep it!

Given that ApartmentAttribute has the same behaviour, I also added a test in the same format, and remove the previous test which tested at a lower level, for consistencies sake.