### PR TITLE
Fix EqualConstraint failure message for enumerables of different size

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -271,13 +271,11 @@ namespace NUnit.Framework.Constraints
                         ++depth);
                 else if (failurePoint.ActualHasData)
                 {
-                    writer.Write("  Extra:    ");
-                    writer.WriteValue(failurePoint.ActualValue);
+                    writer.Write($"  Extra:    < {MsgUtils.FormatValue(failurePoint.ActualValue)}, ... >");
                 }
                 else
                 {
-                    writer.Write("  Missing:  ");
-                    writer.WriteValue(failurePoint.ExpectedValue);
+                    writer.Write($"  Missing:  < {MsgUtils.FormatValue(failurePoint.ExpectedValue)}, ... >");
                 }
             }
         }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -269,16 +269,16 @@ namespace NUnit.Framework.Constraints
                         failurePoint.ExpectedValue,
                         failurePoint.ActualValue,
                         ++depth);
-                //else if (failurePoint.ActualHasData)
-                //{
-                //    writer.Write("  Extra:    ");
-                //    writer.WriteCollectionElements(actual, failurePoint.Position, 3);
-                //}
-                //else
-                //{
-                //    writer.Write("  Missing:  ");
-                //    writer.WriteCollectionElements(expected, failurePoint.Position, 3);
-                //}
+                else if (failurePoint.ActualHasData)
+                {
+                    writer.Write("  Extra:    ");
+                    writer.WriteValue(failurePoint.ActualValue);
+                }
+                else
+                {
+                    writer.Write("  Missing:  ");
+                    writer.WriteValue(failurePoint.ExpectedValue);
+                }
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using NUnit.Framework;
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -45,6 +45,19 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void FailureForEnumerablesWithDifferentSizes()
+        {
+            IEnumerable<int> expected = new int[] { 1, 2, 3 }.Select(i => i);
+            IEnumerable<int> actual = expected.Take(2);
+
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
+            Assert.That(ex.Message, Is.EqualTo(
+                $"  Expected is {MsgUtils.GetTypeRepresentation(expected)}, actual is {MsgUtils.GetTypeRepresentation(actual)}" + Environment.NewLine +
+                "  Values differ at index [2]" + Environment.NewLine +
+                "  Missing:  3"));
+        }
+
+        [Test]
         public void FailureMatchingArrayAndCollection()
         {
             int[] expected = new int[] { 1, 2, 3 };
@@ -58,10 +71,10 @@ namespace NUnit.Framework.Constraints
                 TextMessageWriter.Pfx_Actual + "5" + Environment.NewLine));
         }
 
-        [TestCaseSource( nameof(IgnoreCaseData) )]
-        public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
+        [TestCaseSource(nameof(IgnoreCaseData))]
+        public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
         {
-            Assert.That( expected, Is.EqualTo( actual ).IgnoreCase );
+            Assert.That(expected, Is.EqualTo(actual).IgnoreCase);
         }
 
         private static readonly object[] IgnoreCaseData =

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(ex.Message, Is.EqualTo(
                 $"  Expected is {MsgUtils.GetTypeRepresentation(expected)}, actual is {MsgUtils.GetTypeRepresentation(actual)}" + Environment.NewLine +
                 "  Values differ at index [2]" + Environment.NewLine +
-                "  Missing:  3"));
+                "  Missing:  < 3, ... >"));
         }
 
         [Test]


### PR DESCRIPTION
(fixes #3094 )

Uninformative message occurs when there are non-collection arguments, and quantity differs:
```
        [Test]
        public void DifferentCollectionType()
        {
            var expected = new int[] { 1, 2, 3 };
            var actual = expected.Take(2);

            Assert.That(actual, Is.EqualTo(expected));
        }
```

Before fix message:
```
Expected is <System.Int32[3]>, actual is <System.Linq.Enumerable+ListPartition`1[System.Int32]>
  Values differ at index [2]
```

After fix:
```
Expected is <System.Int32[3]>, actual is <System.Linq.Enumerable+ListPartition`1[System.Int32]>
Values differ at index [2]
Missing: 3
```


In PR were added overloads for messages methods, accepting parameter `hasValue`, which in case of `false` means that no value present at all (not even null).