### PR TITLE
Fix NRE

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -121,7 +121,7 @@ namespace NUnit.Framework
         /// </summary>
         public string WorkerId
         {
-            get { return _testExecutionContext.TestWorker.Name; }
+            get { return _testExecutionContext.TestWorker?.Name; }
         }
 #endif
 


### PR DESCRIPTION
Fixes #2696 

I merely added the obvious `?.` so that null is returned when there is no WorkerId in the context. The issue seems to have degenerated into a broad discussion of who should want to use the WorkerId and why but the NRE is still there.

If somebody wants more done on this issue, then I suggest removing "fixes" above so it doesn't close but merging this trivial change so there's no more NRE.