### PR TITLE
Correct documentation on ParallelScope

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// The test may be run in parallel with others at the same level.
-        /// Valid on classes and methods but not assemblies.
+        /// Valid on classes and methods but has no effect on assemblies.
         /// </summary>
         Self = 1,
 
@@ -81,7 +81,9 @@ namespace NUnit.Framework
 
         /// <summary>
         /// The test and its descendants may be run in parallel with others at
-        /// the same level. Valid on classes, parameterized methods, and assemblies.
+        /// the same level. Valid on classes and parameterized methods.
+        /// For assemblies it is recommended to use <see cref="Children"/>
+        /// instead, as <see cref="Self"/> has no effect on assemblies.
         /// </summary>
         All = Self + Children
     }

--- a/src/NUnitFramework/framework/Attributes/ParallelScope.cs
+++ b/src/NUnitFramework/framework/Attributes/ParallelScope.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -44,12 +44,14 @@ namespace NUnit.Framework
         /// Valid on classes and methods but not assemblies.
         /// </summary>
         Self = 1,
+
         /// <summary>
         /// Test may not be run in parallel with any others. Valid on
         /// classes and methods but not assemblies.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         None = 2,
+
         /// <summary>
         /// Mask used to extract the flags that apply to the item on which a
         /// ParallelizableAttribute has been placed, as opposed to descendants.
@@ -59,26 +61,27 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Descendants of the test may be run in parallel with one another.
-        /// Valid on assemblies and classes but not on methods.
+        /// Valid on assemblies and classes but not on non-parameterized methods.
         /// </summary>
         Children = 256,
+
         /// <summary>
         /// Descendants of the test down to the level of TestFixtures may be 
         /// run in parallel with one another. Valid on assemblies and classes
         /// but not on methods.
         /// </summary>
         Fixtures = 512,
+
         /// <summary>
         /// Mask used to extract all the flags that impact descendants of a 
         /// test and place them in the TestExecutionContext.
         /// </summary>
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         ContextMask = Children + Fixtures,
 
         /// <summary>
         /// The test and its descendants may be run in parallel with others at
-        /// the same level. Valid on classes and methods but not assemblies.
+        /// the same level. Valid on classes, parameterized methods, and assemblies.
         /// </summary>
         All = Self + Children
     }


### PR DESCRIPTION
Now specifies that `ParallelScope.All` also can be used on assembly level.