### PR TITLE
Only create PlatformHelper when required/Don't throw for MonoTouch

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -454,7 +454,6 @@ namespace NUnit.Framework
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
 
 #if PLATFORM_DETECTION
-
             if (IncludePlatform != null || ExcludePlatform != null)
             {
                 if (test.RunState == RunState.NotRunnable || test.RunState == RunState.Ignored)

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -454,10 +454,16 @@ namespace NUnit.Framework
             TestMethod test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForTestCase(method));
 
 #if PLATFORM_DETECTION
-            if (test.RunState != RunState.NotRunnable &&
-                test.RunState != RunState.Ignored)
+
+            if (IncludePlatform != null || ExcludePlatform != null)
             {
-                PlatformHelper platformHelper = new PlatformHelper();
+                if (test.RunState == RunState.NotRunnable || test.RunState == RunState.Ignored)
+                {
+                    yield return test;
+                    yield break;
+                }
+
+                var platformHelper = new PlatformHelper();
 
                 if (!platformHelper.IsPlatformSupported(this))
                 {

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -78,8 +78,19 @@ namespace NUnit.Framework.Internal
 
         private static readonly Lazy<RuntimeFramework> currentFramework = new Lazy<RuntimeFramework>(() =>
         {
-            Type monoRuntimeType = Type.GetType("Mono.Runtime", false);
-            Type monoTouchType = Type.GetType("MonoTouch.UIKit.UIApplicationDelegate,monotouch");
+            Type monoRuntimeType = null;
+            Type monoTouchType = null;
+
+            try
+            {
+                monoRuntimeType = Type.GetType("Mono.Runtime", false);
+                monoTouchType = Type.GetType("MonoTouch.UIKit.UIApplicationDelegate,monotouch", false);
+            }
+            catch
+            {
+                //If exception throw, assume no valid installation
+            }
+
             bool isMonoTouch = monoTouchType != null;
             bool isMono = monoRuntimeType != null;
             bool isNetCore = !isMono && !isMonoTouch && IsNetCore();

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Internal
             }
             catch
             {
-                //If exception throw, assume no valid installation
+                //If exception thrown, assume no valid installation
             }
 
             bool isMonoTouch = monoTouchType != null;


### PR DESCRIPTION
Fixes #3068. Two changes:

1. I was hitting a first-chance exception when evaluating the current framework. I couldn't actually replicate this when I came back to it, I imagine the issue may have been a dodgy MonoTouch installation on my work machine. Either was that shouldn't cause an exception here, so I've err'd on the side of caution with these low-popularity platform `GetType()` calls.

2. More importantly, the first TestCase attribute in an assembly was previously required to work out the current runtime framework and OS platform, regardless of whether the information was required or not. This isn't a cheap operation - so it now only happens if the IncludePlatform/ExcludePlatform properties are in use.