### PR TITLE
[WIP] Remove TypeHelper.ConvertArgumentList

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -228,9 +228,6 @@ namespace NUnit.Framework.Internal.Builders
                 parameters = testMethod.Method.GetParameters();
             }
 
-            if (arglist != null && parameters != null)
-                TypeHelper.ConvertArgumentList(arglist, parameters);
-
             return true;
         }
 

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -222,45 +222,6 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Convert an argument list to the required parameter types.
-        /// Currently, only widening numeric conversions are performed.
-        /// </summary>
-        /// <param name="arglist">An array of args to be converted</param>
-        /// <param name="parameters">A ParameterInfo[] whose types will be used as targets</param>
-        public static void ConvertArgumentList(object[] arglist, IParameterInfo[] parameters)
-        {
-            System.Diagnostics.Debug.Assert(arglist.Length <= parameters.Length);
-
-            for (int i = 0; i < arglist.Length; i++)
-            {
-                object arg = arglist[i];
-
-                if (arg is IConvertible)
-                {
-                    Type argType = arg.GetType();
-                    Type targetType = parameters[i].ParameterType;
-                    bool convert = false;
-
-                    if (argType != targetType && IsNumeric(argType) && IsNumeric(targetType))
-                    {
-                        if (targetType == typeof(double) || targetType == typeof(float))
-                            convert = arg is int || arg is long || arg is short || arg is byte || arg is sbyte;
-                        else
-                            if (targetType == typeof(long))
-                                convert = arg is int || arg is short || arg is byte || arg is sbyte;
-                            else
-                                if (targetType == typeof(short))
-                                    convert = arg is byte || arg is sbyte;
-                    }
-
-                    if (convert)
-                        arglist[i] = Convert.ChangeType(arg, targetType,
-                            System.Globalization.CultureInfo.InvariantCulture);
-                }
-            }
-        }
-
-        /// <summary>
         /// Determines whether this instance can deduce type args for a generic type from the supplied arguments.
         /// </summary>
         /// <param name="type">The type to be examined.</param>

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -385,6 +385,16 @@ namespace NUnit.Framework.Attributes
             });
         }
 
+        [TestCaseSource(nameof(CasesWithInteger))]
+        public void TestIntegerConvertedToFloat(string a, float b)
+        {
+        }
+
+        [TestCaseSource(nameof(CasesWithInteger))]
+        public void TestIntegerKeptAsItIs(string a, int b)
+        {
+        }
+
         #region Sources used by the tests
         static object[] MyData = new object[] {
             new object[] { 12, 3, 4 },
@@ -422,6 +432,12 @@ namespace NUnit.Framework.Attributes
         static object[] Params = new object[] {
             new TestCaseData(24, 3).Returns(8),
             new TestCaseData(24, 2).Returns(12) };
+
+        static readonly TestCaseData[] CasesWithInteger =
+        {
+            new TestCaseData("Empty", 0),
+            new TestCaseData("Empty", 1)
+        };
 
         private class DivideDataProvider
         {


### PR DESCRIPTION
The added tests failed with the message "Object of type 'System.Single'
cannot be converted to type 'System.Int32'. The removal of
`TypeHelper.ConvertArgumentList` solves the problem.

Fixes #3125