### PR TITLE
Require non-whitespace string as test name

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -228,6 +228,9 @@ namespace NUnit.Framework.Internal.Builders
                 parameters = testMethod.Method.GetParameters();
             }
 
+            if (parms != null && parms.TestName != null && parms.TestName.Trim() == "")
+                return MarkAsNotRunnable(testMethod, "Test has no name");
+
             if (arglist != null && parameters != null)
                 TypeHelper.ConvertArgumentList(arglist, parameters);
 

--- a/src/NUnitFramework/testdata/TestNameFixture.cs
+++ b/src/NUnitFramework/testdata/TestNameFixture.cs
@@ -1,0 +1,55 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+    public class TestNameFixture
+    {
+        [TestCase("ImplicitNull")]
+        public void ImplicitNull(string name)
+        {
+        }
+
+        [TestCase("ExplicitNull", TestName = null)]
+        public void ExplicitNull(string name)
+        {
+        }
+
+        [TestCase("Empty", TestName = "")]
+        public void EmptyTest(string name)
+        {
+        }
+
+        [TestCase("WhiteSpace", TestName = "    ")]
+        public void WhiteSpaceTest(string name)
+        {
+        }
+
+        [TestCase("ProperName", TestName = "ProperName")]
+        public void ProperNameTest(string name)
+        {
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
@@ -83,5 +83,19 @@ namespace NUnit.Framework.Internal
             var testCase = (Test)suite.Tests[0];
             Assert.That(testCase.RunState, Is.EqualTo(expectedState));
         }
+
+        private readonly Type testNameFixtureType = typeof(TestNameFixture);
+
+        [TestCase(nameof(TestNameFixture.ImplicitNull), RunState.Runnable)]
+        [TestCase(nameof(TestNameFixture.ExplicitNull), RunState.Runnable)]
+        [TestCase(nameof(TestNameFixture.EmptyTest), RunState.NotRunnable)]
+        [TestCase(nameof(TestNameFixture.WhiteSpaceTest), RunState.NotRunnable)]
+        [TestCase(nameof(TestNameFixture.ProperNameTest), RunState.Runnable)]
+        public void TestNameTests(string methodName, RunState expectedState)
+        {
+            var suite = TestBuilder.MakeParameterizedMethodSuite(testNameFixtureType, methodName);
+            var testCase = (Test)suite.Tests[0];
+            Assert.That(testCase.RunState, Is.EqualTo(expectedState));
+        }
     }
 }


### PR DESCRIPTION
If the test name is specified - and different from null - then it must
be a non-whitespace string.

Fixes #3038