### PR TITLE
Issue #2772: Ensure _isolationLevel is checked while in lock

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -278,18 +278,16 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         /// <summary>
-        /// Remove isolated queues and restore old ones
+        /// Try to remove isolated queues and restore old ones
         /// </summary>
-        private void RestoreQueues()
+        private void TryRestoreQueues()
         {
-            Guard.OperationValid(_isolationLevel > 0, $"Called {nameof(RestoreQueues)} with no saved queues.");
-            
             // Keep lock until we can remove for both methods
             lock (_queueLock)
             {
                 if (_isolationLevel <= 0)
                 {
-                    log.Debug("ParallelWorkItemDispatcher.RestoreQueues(): Isolation level <= 0");
+                    log.Debug("Ignoring call to restore Queue State");
                     return;
                 }
 
@@ -331,7 +329,7 @@ namespace NUnit.Framework.Internal.Execution
                 // If the shift has ended for an isolated queue, restore
                 // the queues and keep trying. Otherwise, we are done.
                 if (_isolationLevel > 0)
-                    RestoreQueues();
+                    TryRestoreQueues();
                 else
                     break;
             }

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -287,6 +287,12 @@ namespace NUnit.Framework.Internal.Execution
             // Keep lock until we can remove for both methods
             lock (_queueLock)
             {
+                if (_isolationLevel <= 0)
+                {
+                    log.Debug("ParallelWorkItemDispatcher.RestoreQueues(): Isolation level <= 0");
+                    return;
+                }
+
                 log.Info("Restoring Queue State");
 
                 foreach (WorkItemQueue queue in Queues)


### PR DESCRIPTION
This PR resolves issue https://github.com/nunit/nunit/issues/2772. In some instances, with a large number of parallel test runs, there is a concurrency issue that results in `RestoreQueues` being invoked twice.

Resulting Log:

```
14:00:48.202 Info  [19] Dispatcher: Restoring Queue State
14:00:48.203 Info  [13] WorkShift: NonParallel shift ending
14:00:48.203 Debug [13] WorkItemQueue: NonParallelQueue.1 pausing
14:00:48.204 Info  [13] Dispatcher: Restoring Queue State
14:00:48.204 Info  [13] TestWorker: NonParallelWorker stopping - 2 WorkItems processed.
14:00:48.206 Info  [19] WorkItemQueue: ParallelQueue.0 stopping - 141 WorkItems processed
14:00:48.206 Info  [21] TestWorker: ParallelWorker#8 stopping - 21 WorkItems processed.
14:00:48.206 Info  [19] WorkItemQueue: NonParallelQueue.0 stopping - 3 WorkItems processed
14:00:48.206 Info  [18] TestWorker: ParallelWorker#5 stopping - 19 WorkItems processed.
14:00:48.206 Info  [19] TestWorker: ParallelWorker#6 stopping - 21 WorkItems processed.
14:00:48.206 Info  [20] TestWorker: ParallelWorker#7 stopping - 20 WorkItems processed.
14:00:48.206 Info  [17] TestWorker: ParallelWorker#4 stopping - 14 WorkItems processed.
14:00:48.206 Info  [14] TestWorker: ParallelWorker#1 stopping - 19 WorkItems processed.
14:00:48.206 Info  [15] TestWorker: ParallelWorker#2 stopping - 13 WorkItems processed.
14:00:48.206 Info  [16] TestWorker: ParallelWorker#3 stopping - 14 WorkItems processed.

```

With this change, we ensure that the queues are not restored if _isolationLevel is <= 0 while we are in the lock, which would result in the Stack empty exception.

```
16:30:31.286 Info  [17] Dispatcher: Restoring Queue State
16:30:31.286 Info  [13] WorkShift: NonParallel shift ending
16:30:31.287 Debug [13] WorkItemQueue: NonParallelQueue.1 pausing
16:30:31.287 Debug [13] Dispatcher: ParallelWorkItemDispatcher.RestoreQueues(): Isolation level <= 0
16:30:31.288 Info  [17] WorkItemQueue: ParallelQueue.0 stopping - 165 WorkItems processed
16:30:31.288 Info  [13] WorkItemQueue: ParallelQueue.0 stopping - 165 WorkItems processed
16:30:31.288 Info  [13] WorkItemQueue: NonParallelQueue.0 stopping - 3 WorkItems processed
16:30:31.288 Info  [18] TestWorker: ParallelWorker#5 stopping - 24 WorkItems processed.
16:30:31.288 Info  [15] TestWorker: ParallelWorker#2 stopping - 26 WorkItems processed.
16:30:31.288 Info  [21] TestWorker: ParallelWorker#8 stopping - 31 WorkItems processed.
16:30:31.288 Info  [19] TestWorker: ParallelWorker#6 stopping - 5 WorkItems processed.
16:30:31.288 Info  [14] TestWorker: ParallelWorker#1 stopping - 27 WorkItems processed.
16:30:31.288 Info  [16] TestWorker: ParallelWorker#3 stopping - 24 WorkItems processed.
16:30:31.288 Info  [17] WorkItemQueue: NonParallelQueue.0 stopping - 3 WorkItems processed
16:30:31.288 Info  [13] TestWorker: NonParallelWorker stopping - 3 WorkItems processed.
16:30:31.288 Info  [20] TestWorker: ParallelWorker#7 stopping - 6 WorkItems processed.
16:30:31.288 Info  [17] TestWorker: ParallelWorker#4 stopping - 22 WorkItems processed.
```