### PR TITLE
Catch exceptions preventing return of awaitable object

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -79,14 +79,7 @@ namespace NUnit.Framework.Internal.Commands
 #if ASYNC
             if (AsyncToSyncAdapter.IsAsyncOperation(testMethod.Method.MethodInfo))
             {
-                try
-                {
-                    return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context));
-                }
-                catch (Exception e)
-                {
-                    throw new NUnitException("Rethrown", e);
-                }
+                return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context));
             }
 #endif
             return InvokeTestMethod(context);

--- a/src/NUnitFramework/testdata/AsyncRealFixture.cs
+++ b/src/NUnitFramework/testdata/AsyncRealFixture.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -29,6 +29,9 @@ using NUnit.Framework;
 #if NET40
 using Task = System.Threading.Tasks.TaskEx;
 #endif
+
+// Don’t warn when async is used without await
+#pragma warning disable CS1998
 
 namespace NUnit.TestData
 {
@@ -68,9 +71,30 @@ namespace NUnit.TestData
             Assert.Fail("Should never get here");
         }
 
-#endregion
+        [Test]
+        public async System.Threading.Tasks.Task AsyncTaskPass()
+        {
+            Assert.Pass();
+            throw new Exception("This test expects Assert.Pass() to throw an exception.");
+        }
 
-#region non-async Task
+        [Test]
+        public async System.Threading.Tasks.Task AsyncTaskIgnore()
+        {
+            Assert.Ignore();
+            throw new Exception("This test expects Assert.Ignore() to throw an exception.");
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task AsyncTaskInconclusive()
+        {
+            Assert.Inconclusive();
+            throw new Exception("This test expects Assert.Inconclusive() to throw an exception.");
+        }
+
+        #endregion
+
+        #region non-async Task
 
         [Test]
         public System.Threading.Tasks.Task TaskSuccess()
@@ -90,7 +114,28 @@ namespace NUnit.TestData
             throw new InvalidOperationException();
         }
 
-#endregion
+        [Test]
+        public System.Threading.Tasks.Task TaskPass()
+        {
+            Assert.Pass();
+            throw new Exception("This test expects Assert.Pass() to throw an exception.");
+        }
+
+        [Test]
+        public System.Threading.Tasks.Task TaskIgnore()
+        {
+            Assert.Ignore();
+            throw new Exception("This test expects Assert.Ignore() to throw an exception.");
+        }
+
+        [Test]
+        public System.Threading.Tasks.Task TaskInconclusive()
+        {
+            Assert.Inconclusive();
+            throw new Exception("This test expects Assert.Inconclusive() to throw an exception.");
+        }
+
+        #endregion
 
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -59,10 +59,16 @@ namespace NUnit.Framework.Internal
                 yield return GetTestCase(Method("AsyncTaskSuccess"), ResultState.Success, 1, true);
                 yield return GetTestCase(Method("AsyncTaskFailure"), ResultState.Failure, 1, true);
                 yield return GetTestCase(Method("AsyncTaskError"), ResultState.Error, 0, false);
+                yield return GetTestCase(Method("AsyncTaskPass"), ResultState.Success, 0, false);
+                yield return GetTestCase(Method("AsyncTaskIgnore"), ResultState.Ignored, 0, false);
+                yield return GetTestCase(Method("AsyncTaskInconclusive"), ResultState.Inconclusive, 0, false);
 
                 yield return GetTestCase(Method("TaskSuccess"), ResultState.Success, 1, true);
                 yield return GetTestCase(Method("TaskFailure"), ResultState.Failure, 1, true);
                 yield return GetTestCase(Method("TaskError"), ResultState.Error, 0, false);
+                yield return GetTestCase(Method("TaskPass"), ResultState.Success, 0, false);
+                yield return GetTestCase(Method("TaskIgnore"), ResultState.Ignored, 0, false);
+                yield return GetTestCase(Method("TaskInconclusive"), ResultState.Inconclusive, 0, false);
 
                 yield return GetTestCase(Method("AsyncTaskResult"), ResultState.NotRunnable, 0, false);
                 yield return GetTestCase(Method("TaskResult"), ResultState.NotRunnable, 0, false);


### PR DESCRIPTION
Fixes #3138.

The problem was was an NUnitException with an InnerException of _another_ NUnitException with an InnerException of a Success/Ignore/InconclusiveException. `ValidateAndUnwrap` only unwraps one level, so `if (ex is ResultStateException)` never happens because the ResultStateException it's trying to find is actually `ex.InnerException` at that point.

https://github.com/nunit/nunit/blob/b5c1d549938476ff06f118557b29778b36593549/src/NUnitFramework/framework/Internal/Results/TestResult.cs#L578-L585

https://github.com/nunit/nunit/blob/b5c1d549938476ff06f118557b29778b36593549/src/NUnitFramework/framework/Internal/Results/TestResult.cs#L560-L568

The problem was caused in https://github.com/nunit/nunit/commit/b83f556cc41b3c12a6e1a7729d1e05e5e140f252#diff-6325ab2a4b2ce8d3a6fd52a0f58f75f5L98 by me keeping the `catch` block but failing to notice that it used to only apply to the `WaitForPendingOperationsToComplete` part and not the `Reflect.InvokeMethod` part which already wraps.