### PR TITLE
Make tests more tolerant

### DIFF
--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -65,12 +65,8 @@ namespace NUnit.Framework.Internal
         [Test]
         public void FailRecordsInnerExceptionsAsPartOfAggregateException()
         {
-            string expectedMessage =
-#if NETCOREAPP1_1 || NETCOREAPP2_0
-                "System.AggregateException : Outer Aggregate Exception (Inner Exception 1 of 2) (Inner Exception 2 of 2)" + Environment.NewLine +
-#else
-                "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +
-#endif
+            string expectedStartOfMessage = "System.AggregateException : Outer Aggregate Exception";
+            string expectedEndOfMessage =
                 "  ----> System.Exception : Inner Exception 1 of 2" + Environment.NewLine +
                 "  ----> System.Exception : Inner Exception 2 of 2";
 
@@ -79,18 +75,15 @@ namespace NUnit.Framework.Internal
                 "ThrowsWithAggregateException");
 
             Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual(expectedMessage, result.Message);
+            Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
+            Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
         }
 
         [Test]
         public void FailRecordsNestedInnerExceptionAsPartOfAggregateException()
         {
-            string expectedMessage =
-#if NETCOREAPP1_1 || NETCOREAPP2_0
-                "System.AggregateException : Outer Aggregate Exception (Inner Exception)" + Environment.NewLine +
-#else
-                "System.AggregateException : Outer Aggregate Exception" + Environment.NewLine +
-#endif
+            string expectedStartOfMessage = "System.AggregateException : Outer Aggregate Exception";
+            string expectedEndOfMessage =
                 "  ----> System.Exception : Inner Exception" + Environment.NewLine +
                 "  ----> System.Exception : Inner Inner Exception";
 
@@ -99,7 +92,8 @@ namespace NUnit.Framework.Internal
                 "ThrowsWithAggregateExceptionContainingNestedInnerException");
 
             Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual(expectedMessage, result.Message);
+            Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
+            Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
         }
 #endif
 


### PR DESCRIPTION
We no longer expect an exact match, only a matching beginning and end.

Fixes #3156