### PR TITLE
Copy test fixtures with filters

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
@@ -43,10 +43,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given parameterized fixture suite
+        /// Creates a copy of the given suite with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="suite">Parameterized Fixture Suite to copy</param>
-        /// <param name="filter">Filter to be applied</param>
+        /// <param name="suite">The <see cref="ParameterizedFixtureSuite"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public ParameterizedFixtureSuite(ParameterizedFixtureSuite suite, ITestFilter filter)
             : base(suite, filter)
         {
@@ -66,9 +66,9 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Overriden to return a Parameterized Fixture Suite
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public override TestSuite Copy(ITestFilter filter)
         {
             return new ParameterizedFixtureSuite(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedFixtureSuite.cs
@@ -43,6 +43,16 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Copy constructor style to create a filtered copy of the given parameterized fixture suite
+        /// </summary>
+        /// <param name="suite">Parameterized Fixture Suite to copy</param>
+        /// <param name="filter">Filter to be applied</param>
+        public ParameterizedFixtureSuite(ParameterizedFixtureSuite suite, ITestFilter filter)
+            : base(suite, filter)
+        {
+        }
+
+        /// <summary>
         /// Gets a string representing the type of test
         /// </summary>
         public override string TestType
@@ -53,6 +63,15 @@ namespace NUnit.Framework.Internal
                     ? "GenericFixture"
                     : "ParameterizedFixture";
             }
+        }
+
+        /// <summary>
+        /// Overriden to return a Parameterized Fixture Suite
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        public override TestSuite Copy(ITestFilter filter)
+        {
+            return new ParameterizedFixtureSuite(this, filter);
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
@@ -45,6 +45,16 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Copy constructor style to create a filtered copy of the given parameterized method suite
+        /// </summary>
+        /// <param name="suite">Parameterized Method Suite to copy</param>
+        /// <param name="filter">Filter to be applied</param>
+        public ParameterizedMethodSuite(ParameterizedMethodSuite suite, ITestFilter filter)
+            : base(suite, filter)
+        {
+        }
+
+        /// <summary>
         /// Gets a string representing the type of test
         /// </summary>
         public override string TestType
@@ -59,6 +69,15 @@ namespace NUnit.Framework.Internal
 
                 return "ParameterizedMethod";
             }
+        }
+
+        /// <summary>
+        /// Overriden to return a Parameterized Method Suite
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        public override TestSuite Copy(ITestFilter filter)
+        {
+            return new ParameterizedMethodSuite(this, filter);
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
@@ -45,10 +45,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given parameterized method suite
+        /// Creates a copy of the given suite with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="suite">Parameterized Method Suite to copy</param>
-        /// <param name="filter">Filter to be applied</param>
+        /// <param name="suite">The <see cref="ParameterizedMethodSuite"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public ParameterizedMethodSuite(ParameterizedMethodSuite suite, ITestFilter filter)
             : base(suite, filter)
         {
@@ -72,9 +72,9 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Overriden to return a Parameterized Method Suite
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public override TestSuite Copy(ITestFilter filter)
         {
             return new ParameterizedMethodSuite(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -53,10 +53,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given setup fixture
+        /// Creates a copy of the given suite with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="setUpFixture">SetUp Fixture to copy</param>
-        /// <param name="filter">Filter to be applied</param>
+        /// <param name="setUpFixture">The <see cref="SetUpFixture"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public SetUpFixture(SetUpFixture setUpFixture, ITestFilter filter)
             : base(setUpFixture, filter)
         {
@@ -67,9 +67,9 @@ namespace NUnit.Framework.Internal
         #region Test Suite Overrides
 
         /// <summary>
-        /// Overriden to return a SetUp Fixture
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public override TestSuite Copy(ITestFilter filter)
         {
             return new SetUpFixture(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -52,6 +52,29 @@ namespace NUnit.Framework.Internal
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);
         }
 
+        /// <summary>
+        /// Copy constructor style to create a filtered copy of the given setup fixture
+        /// </summary>
+        /// <param name="setUpFixture">SetUp Fixture to copy</param>
+        /// <param name="filter">Filter to be applied</param>
+        public SetUpFixture(SetUpFixture setUpFixture, ITestFilter filter)
+            : base(setUpFixture, filter)
+        {
+        }
+
+        #endregion
+
+        #region Test Suite Overrides
+
+        /// <summary>
+        /// Overriden to return a SetUp Fixture
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        public override TestSuite Copy(ITestFilter filter)
+        {
+            return new SetUpFixture(this, filter);
+        }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -95,6 +95,15 @@ namespace NUnit.Framework.Internal
                 ? Assembly.GetAttributes<TAttr>()
                 : new TAttr[0];
         }
+
+        /// <summary>
+        /// Overriden to return a Test Assembly
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        public override TestSuite Copy(ITestFilter filter)
+        {
+            return new TestAssembly(this, filter);
+        }
     }
 }
 

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -57,11 +57,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy-constructor style to create a filtered copy of the test assemblies
-        /// test cases
+        /// Creates a copy of the given assembly with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="assembly"></param>
-        /// <param name="filter"></param>
+        /// <param name="assembly">The <see cref="TestAssembly"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public TestAssembly(TestAssembly assembly, ITestFilter filter)
             : base(assembly as TestSuite, filter)
         {
@@ -97,9 +96,9 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Overriden to return a Test Assembly
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public override TestSuite Copy(ITestFilter filter)
         {
             return new TestAssembly(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -52,10 +52,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given test fixture
+        /// Creates a copy of the given suite with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="fixture">Test Fixture to copy</param>
-        /// <param name="filter">Filter to be applied</param>
+        /// <param name="fixture">The <see cref="TestFixture"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         private TestFixture(TestFixture fixture, ITestFilter filter) 
             : base(fixture, filter)
         {
@@ -66,9 +66,9 @@ namespace NUnit.Framework.Internal
         #region Test Suite Overrides
 
         /// <summary>
-        /// Overriden to return a Test Fixture
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public override TestSuite Copy(ITestFilter filter)
         {
             return new TestFixture(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -52,13 +52,26 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given test suite
+        /// Copy constructor style to create a filtered copy of the given test fixture
         /// </summary>
-        /// <param name="suite">Test Suite to copy</param>
+        /// <param name="fixture">Test Fixture to copy</param>
         /// <param name="filter">Filter to be applied</param>
-        public TestFixture(TestSuite suite, ITestFilter filter) 
-            : base(suite, filter)
+        private TestFixture(TestFixture fixture, ITestFilter filter) 
+            : base(fixture, filter)
         {
+        }
+
+        #endregion
+
+        #region Test Suite Overrides
+
+        /// <summary>
+        /// Overriden to return a Test Fixture
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        public override TestSuite Copy(ITestFilter filter)
+        {
+            return new TestFixture(this, filter);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -51,6 +51,16 @@ namespace NUnit.Framework.Internal
             CheckSetUpTearDownMethods(TearDownMethods);
         }
 
+        /// <summary>
+        /// Copy constructor style to create a filtered copy of the given test suite
+        /// </summary>
+        /// <param name="suite">Test Suite to copy</param>
+        /// <param name="filter">Filter to be applied</param>
+        public TestFixture(TestSuite suite, ITestFilter filter) 
+            : base(suite, filter)
+        {
+        }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -117,7 +117,9 @@ namespace NUnit.Framework.Internal
                 {
                     if(child.IsSuite)
                     {
-                        TestSuite childSuite = new TestSuite(child as TestSuite, filter);
+                        TestSuite childSuite = child.GetType() == typeof(TestFixture)
+                            ? new TestFixture(child as TestSuite, filter)
+                            : new TestSuite(child as TestSuite, filter);
                         childSuite.Parent    = this;
                         this.tests.Add(childSuite);
                     }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -99,10 +99,10 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Copy constructor style to create a filtered copy of the given test suite
+        /// Creates a copy of the given suite with only the descendants that pass the specified filter.
         /// </summary>
-        /// <param name="suite">Test Suite to copy</param>
-        /// <param name="filter">Filter to be applied</param>
+        /// <param name="suite">The <see cref="TestSuite"/> to copy.</param>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public TestSuite(TestSuite suite, ITestFilter filter)
             : base(suite.Name)
         {
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Internal
                 {
                     if(child.IsSuite)
                     {
-                        TestSuite childSuite = ((TestSuite) child).Copy(filter);
+                        TestSuite childSuite = ((TestSuite)child).Copy(filter);
                         childSuite.Parent    = this;
                         this.tests.Add(childSuite);
                     }
@@ -180,10 +180,9 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Creates a filtered copy of the test suite
+        /// Creates a filtered copy of the test suite.
         /// </summary>
-        /// <param name="filter">Filter to apply</param>
-        /// <returns></returns>
+        /// <param name="filter">Determines which descendants are copied.</param>
         public virtual TestSuite Copy(ITestFilter filter)
         {
             return new TestSuite(this, filter);

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -117,9 +117,7 @@ namespace NUnit.Framework.Internal
                 {
                     if(child.IsSuite)
                     {
-                        TestSuite childSuite = child.GetType() == typeof(TestFixture)
-                            ? new TestFixture(child as TestSuite, filter)
-                            : new TestSuite(child as TestSuite, filter);
+                        TestSuite childSuite = ((TestSuite) child).Copy(filter);
                         childSuite.Parent    = this;
                         this.tests.Add(childSuite);
                     }
@@ -179,6 +177,16 @@ namespace NUnit.Framework.Internal
         {
             test.Parent = this;
             tests.Add(test);
+        }
+
+        /// <summary>
+        /// Creates a filtered copy of the test suite
+        /// </summary>
+        /// <param name="filter">Filter to apply</param>
+        /// <returns></returns>
+        public virtual TestSuite Copy(ITestFilter filter)
+        {
+            return new TestSuite(this, filter);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework.Api;
+using NUnit.TestData.OneTimeSetUpTearDownData;
+using NUnit.TestData.TestFixtureSourceData;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Internal
+{
+    // Tests that Copy is properly overridden for all types extending TestSuite - #3171
+    public class TestSuiteCopyTests
+    {
+        [Test]
+        public void CopyTestSuiteReturnsCorrectType()
+        {
+            TestSuite testSuite =
+                new TestSuite(new TypeWrapper(typeof(NUnit.TestData.ParameterizedTestFixture)));
+            var copiedTestSuite = testSuite.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedTestSuite.GetType(), typeof(TestSuite));
+        }
+        
+        [Test]
+        public void CopyParameterizedTestFixtureReturnsCorrectType()
+        {
+            TestSuite parameterizedTestFixture =
+                new ParameterizedFixtureSuite(new TypeWrapper(typeof(NUnit.TestData.ParameterizedTestFixture)));
+            var copiedParameterizedTestFixture = parameterizedTestFixture.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedParameterizedTestFixture.GetType(), typeof(ParameterizedFixtureSuite));
+        }
+
+        [Test]
+        public void CopyParameterizedMethodSuiteReturnsCorrectType()
+        {
+            TestSuite parameterizedMethodSuite = new ParameterizedMethodSuite(new MethodWrapper(
+                typeof(NUnit.TestData.ParameterizedTestFixture),
+                nameof(NUnit.TestData.ParameterizedTestFixture.MethodWithParams)));
+            var copiedparameterizedMethodSuite = parameterizedMethodSuite.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedparameterizedMethodSuite.GetType(), typeof(ParameterizedMethodSuite));
+        }
+
+        [Test]
+        public void CopyTestFixtureReturnsCorrectType()
+        {
+            TestSuite testFixture = TestBuilder.MakeFixture(typeof(FixtureWithNoTests));
+            var copiedTestFixture = testFixture.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedTestFixture.GetType(), typeof(TestFixture));
+        }
+
+        [Test]
+        public void CopySetUpFixtureReturnsCorrectType()
+        {
+            TestSuite setUpFixture =
+                new SetUpFixture(
+                    new TypeWrapper(typeof(NUnit.TestData.SetupFixture.Namespace1.NUnitNamespaceSetUpFixture1)));
+            var copiedSetupFixture = setUpFixture.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedSetupFixture.GetType(), typeof(SetUpFixture));
+        }
+
+        [Test]
+        public void CopyTestAssemblyReturnsCorrectType()
+        {
+            var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
+            TestSuite assembly = new TestAssembly(AssemblyHelper.Load("mock-assembly.dll"), "mock-assembly");
+            var copiedAssembly = assembly.Copy(TestFilter.Empty);
+            Assert.AreEqual(copiedAssembly.GetType(), typeof(TestAssembly));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework.Internal
             TestSuite testSuite =
                 new TestSuite(new TypeWrapper(typeof(NUnit.TestData.ParameterizedTestFixture)));
             var copiedTestSuite = testSuite.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedTestSuite.GetType(), typeof(TestSuite));
+            Assert.That(copiedTestSuite, Is.TypeOf<TestSuite>());
         }
         
         [Test]
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Internal
             TestSuite parameterizedTestFixture =
                 new ParameterizedFixtureSuite(new TypeWrapper(typeof(NUnit.TestData.ParameterizedTestFixture)));
             var copiedParameterizedTestFixture = parameterizedTestFixture.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedParameterizedTestFixture.GetType(), typeof(ParameterizedFixtureSuite));
+            Assert.That(copiedParameterizedTestFixture, Is.TypeOf<ParameterizedFixtureSuite>());
         }
 
         [Test]
@@ -33,7 +33,8 @@ namespace NUnit.Framework.Internal
                 typeof(NUnit.TestData.ParameterizedTestFixture),
                 nameof(NUnit.TestData.ParameterizedTestFixture.MethodWithParams)));
             var copiedparameterizedMethodSuite = parameterizedMethodSuite.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedparameterizedMethodSuite.GetType(), typeof(ParameterizedMethodSuite));
+            Assert.That(copiedparameterizedMethodSuite, Is.TypeOf<ParameterizedMethodSuite>());
+
         }
 
         [Test]
@@ -41,7 +42,7 @@ namespace NUnit.Framework.Internal
         {
             TestSuite testFixture = TestBuilder.MakeFixture(typeof(FixtureWithNoTests));
             var copiedTestFixture = testFixture.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedTestFixture.GetType(), typeof(TestFixture));
+            Assert.That(copiedTestFixture, Is.TypeOf<TestFixture>());
         }
 
         [Test]
@@ -51,7 +52,7 @@ namespace NUnit.Framework.Internal
                 new SetUpFixture(
                     new TypeWrapper(typeof(NUnit.TestData.SetupFixture.Namespace1.NUnitNamespaceSetUpFixture1)));
             var copiedSetupFixture = setUpFixture.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedSetupFixture.GetType(), typeof(SetUpFixture));
+            Assert.That(copiedSetupFixture, Is.TypeOf<SetUpFixture>());
         }
 
         [Test]
@@ -63,7 +64,7 @@ namespace NUnit.Framework.Internal
                     AssemblyHelper.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll")),
                     "mock-assembly");
             var copiedAssembly = assembly.Copy(TestFilter.Empty);
-            Assert.AreEqual(copiedAssembly.GetType(), typeof(TestAssembly));
+            Assert.That(copiedAssembly, Is.TypeOf<TestAssembly>());
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestSuiteCopyTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework.Api;
 using NUnit.TestData.OneTimeSetUpTearDownData;
-using NUnit.TestData.TestFixtureSourceData;
 using NUnit.TestUtilities;
+using System.IO;
 
 namespace NUnit.Framework.Internal
 {
@@ -58,7 +58,10 @@ namespace NUnit.Framework.Internal
         public void CopyTestAssemblyReturnsCorrectType()
         {
             var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
-            TestSuite assembly = new TestAssembly(AssemblyHelper.Load("mock-assembly.dll"), "mock-assembly");
+            TestSuite assembly =
+                new TestAssembly(
+                    AssemblyHelper.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll")),
+                    "mock-assembly");
             var copiedAssembly = assembly.Copy(TestFilter.Empty);
             Assert.AreEqual(copiedAssembly.GetType(), typeof(TestAssembly));
         }


### PR DESCRIPTION
Fixes #3171 

When reconstructing test suites with filters, check if the given suite is test fixture and construct that instead. 