### PR TITLE
Improve user-facing messages

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -254,7 +254,7 @@ namespace NUnit.Framework.Api
 
             if (fixtures.Count == 0)
             {
-                testAssembly.MakeInvalid("Has no TestFixtures");
+                testAssembly.MakeInvalid("No test fixtures were found.");
             }
             else
             {

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -213,9 +213,6 @@ namespace NUnit.Framework.Api
         /// <returns>The XML result of exploring the tests</returns>
         public string ExploreTests(string filter)
         {
-            if (Runner.LoadedTest == null)
-                throw new InvalidOperationException("The Explore method was called but no test has been loaded");
-
             return Runner.ExploreTests(TestFilter.FromXml(filter)).ToXml(true).OuterXml;
         }
 
@@ -320,10 +317,7 @@ namespace NUnit.Framework.Api
 
         private void ExploreTests(ICallbackEventHandler handler, string filter)
         {
-            if (Runner.LoadedTest == null)
-                throw new InvalidOperationException("The Explore method was called but no test has been loaded");
-
-            handler.RaiseCallbackEvent(Runner.ExploreTests(TestFilter.FromXml(filter)).ToXml(true).OuterXml);
+            handler.RaiseCallbackEvent(ExploreTests(filter));
         }
 
         private void RunTests(ICallbackEventHandler handler, string filter)

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -181,7 +181,7 @@ namespace NUnit.Framework.Api
         public int CountTestCases(ITestFilter filter)
         {
             if (LoadedTest == null)
-                throw new InvalidOperationException("The CountTestCases method was called but no test has been loaded");
+                throw new InvalidOperationException("Tests must be loaded before counting test cases.");
 
             return CountTestCases(LoadedTest, filter);
         }
@@ -194,7 +194,7 @@ namespace NUnit.Framework.Api
         public ITest ExploreTests(ITestFilter filter)
         {
             if (LoadedTest == null)
-                throw new InvalidOperationException("The ExploreTests method was called but no test has been loaded");
+                throw new InvalidOperationException("Tests must be loaded before exploring them.");
 
             if (filter == TestFilter.Empty)
                 return LoadedTest;
@@ -229,7 +229,7 @@ namespace NUnit.Framework.Api
         {
             log.Info("Running tests");
             if (LoadedTest == null)
-                throw new InvalidOperationException("The Run method was called but no test has been loaded");
+                throw new InvalidOperationException("Tests must be loaded before running them.");
 
             _runComplete.Reset();
 
@@ -306,13 +306,13 @@ namespace NUnit.Framework.Api
                 }
                 catch (SecurityException)
                 {
-                    TopLevelWorkItem.MarkNotRunnable("System.Security.Permissions.UIPermission is not set to start the debugger.");
+                    TopLevelWorkItem.MarkNotRunnable("System.Security.Permissions.UIPermission must be granted in order to launch the debugger.");
                     return;
                 }
                 //System.Diagnostics.Debugger.Launch() not implemented on mono
                 catch (NotImplementedException)
                 {
-                    TopLevelWorkItem.MarkNotRunnable("Debugger unavailable on this platform.");
+                    TopLevelWorkItem.MarkNotRunnable("This platform does not support launching the debugger.");
                     return;
                 }
             }
@@ -353,7 +353,7 @@ namespace NUnit.Framework.Api
                 (bool)Settings[FrameworkPackageSettings.RunOnMainThread])
                 Context.Dispatcher = new MainThreadWorkItemDispatcher();
             else if (levelOfParallelism > 0)
-                Context.Dispatcher = new ParallelWorkItemDispatcher(levelOfParallelism); 
+                Context.Dispatcher = new ParallelWorkItemDispatcher(levelOfParallelism);
             else
                 Context.Dispatcher = new SimpleWorkItemDispatcher();
 #endif
@@ -408,8 +408,14 @@ namespace NUnit.Framework.Api
         private static void PauseBeforeRun()
         {
             var process = Process.GetCurrentProcess();
-            string attachMessage = string.Format("Attach debugger to Process {0}.exe with Id {1} if desired.", process.ProcessName, process.Id);
-            MessageBox.Show(attachMessage, process.ProcessName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            MessageBox.Show(
+                $"Pausing as requested. If you would like to attach a debugger, the process name and ID are {process.ProcessName}.exe and {process.Id}." + Environment.NewLine
+                + Environment.NewLine
+                + "Click OK when you are ready to continue.",
+                $"{process.ProcessName} – paused",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
         }
 #endif
 

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Assert.Equals should not be used for Assertions, use Assert.AreEqual(...) instead.");
+            throw new InvalidOperationException("Assert.Equals should not be used. Use Assert.AreEqual instead.");
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Assert.ReferenceEquals should not be used for Assertions, use Assert.AreSame(...) instead.");
+            throw new InvalidOperationException("Assert.ReferenceEquals should not be used. Use Assert.AreSame instead.");
         }
 
         #endregion
@@ -314,7 +314,7 @@ namespace NUnit.Framework
         public static void Multiple(TestDelegate testDelegate)
         {
             TestExecutionContext context = TestExecutionContext.CurrentContext;
-            Guard.OperationValid(context != null, "Assert.Multiple called outside of a valid TestExecutionContext");
+            Guard.OperationValid(context != null, "There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 
@@ -344,7 +344,7 @@ namespace NUnit.Framework
         public static void Multiple(AsyncTestDelegate testDelegate)
         {
             TestExecutionContext context = TestExecutionContext.CurrentContext;
-            Guard.OperationValid(context != null, "Assert.Multiple called outside of a valid TestExecutionContext");
+            Guard.OperationValid(context != null, "There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 
@@ -365,9 +365,9 @@ namespace NUnit.Framework
         }
 #endif
 
-#endregion
+        #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
         private static void ReportFailure(ConstraintResult result, string message)
         {

--- a/src/NUnitFramework/framework/AssertionHelper.cs
+++ b/src/NUnitFramework/framework/AssertionHelper.cs
@@ -31,8 +31,8 @@ namespace NUnit.Framework
     /// AssertionHelper is an optional base class for user tests,
     /// allowing the use of shorter names in making asserts.
     /// </summary>
-    [Obsolete("The AssertionHelper class will be removed in a coming release. " +
-              "Consider using the NUnit.StaticExpect NuGet package as a replacement.")]
+    [Obsolete("The AssertionHelper class has been deprecated and will be removed in a future release. "
+        + "Please consider using the NUnit.StaticExpect NuGet package instead.")]
     public class AssertionHelper
     {
         #region Expect
@@ -730,7 +730,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Contains")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Contains instead.")]
         public SubstringConstraint StringContaining(string expected)
         {
             return new SubstringConstraint(expected);
@@ -740,7 +740,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Contains")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Contains instead.")]
         public SubstringConstraint ContainsSubstring(string expected)
         {
             return new SubstringConstraint(expected);
@@ -754,7 +754,7 @@ namespace NUnit.Framework
         /// Returns a constraint that fails if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Not.Contain")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Not.Contain instead.")]
         public SubstringConstraint DoesNotContain(string expected)
         {
             return new ConstraintExpression().Not.ContainsSubstring(expected);
@@ -786,7 +786,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value starts with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.StartWith or StartsWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.StartWith or StartsWith instead.")]
         public StartsWithConstraint StringStarting(string expected)
         {
             return new StartsWithConstraint(expected);
@@ -800,7 +800,7 @@ namespace NUnit.Framework
         /// Returns a constraint that fails if the actual
         /// value starts with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Not.StartWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Not.StartWith instead.")]
         public StartsWithConstraint DoesNotStartWith(string expected)
         {
             return new ConstraintExpression().Not.StartsWith(expected);
@@ -832,7 +832,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value ends with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.EndWith or EndsWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.EndWith or EndsWith instead.")]
         public EndsWithConstraint StringEnding(string expected)
         {
             return new EndsWithConstraint(expected);
@@ -846,7 +846,7 @@ namespace NUnit.Framework
         /// Returns a constraint that fails if the actual
         /// value ends with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Not.EndWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Not.EndWith instead.")]
         public EndsWithConstraint DoesNotEndWith(string expected)
         {
             return new ConstraintExpression().Not.EndsWith(expected);
@@ -878,7 +878,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Match or Matches")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Match or Matches instead.")]
         public RegexConstraint StringMatching(string pattern)
         {
             return new RegexConstraint(pattern);
@@ -892,7 +892,7 @@ namespace NUnit.Framework
         /// Returns a constraint that fails if the actual
         /// value matches the pattern supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Not.Match")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Not.Match instead.")]
         public RegexConstraint DoesNotMatch(string pattern)
         {
             return new ConstraintExpression().Not.Matches(pattern);

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2009 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -40,7 +40,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE!
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
@@ -49,19 +49,19 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Assume.Equals should not be used for Assertions.");
+            throw new InvalidOperationException("Assume.Equals should not be used. Use Assume.That instead.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
         /// <param name="b">The right object.</param>
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Assume.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("Assume.ReferenceEquals should not be used. Use Assume.That instead.");
         }
 
         #endregion
@@ -140,7 +140,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -150,7 +150,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the 
+        /// Asserts that a condition is true. If the condition is false the
         /// method throws an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
@@ -162,7 +162,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(bool condition, Func<string> getExceptionMessage)
@@ -177,7 +177,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -199,7 +199,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(Func<bool> condition, Func<string> getExceptionMessage)

--- a/src/NUnitFramework/framework/Attributes/DataAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DataAttribute.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2010 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -27,11 +27,11 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Abstract base class for all data-providing attributes defined by NUnit. 
+    /// Abstract base class for all data-providing attributes defined by NUnit.
     /// Used to select all data sources for a method, class or parameter.
     /// </summary>
-    [Obsolete("Holdover from NUnit v2. Please implement " + nameof(IParameterDataSource) +
-              " for your attribute instead.")]
+    [Obsolete("The DataAttribute class has been deprecated and will be removed in a future release. "
+        + "Please use " + nameof(IParameterDataSource) + " instead.")]
     public abstract class DataAttribute : NUnitAttribute
     {
         /// <summary>

--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -38,7 +38,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE! Use CollectionAssert.AreEqual(...) instead.
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -46,23 +46,23 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("CollectionAssert.Equals should not be used for Assertions, use CollectionAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("CollectionAssert.Equals should not be used. Use CollectionAssert.AreEqual instead.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("CollectionAssert.ReferenceEquals should not be used.");
         }
 
         #endregion
-                
+
         #region AllItemsAreInstancesOfType
         /// <summary>
         /// Asserts that all items contained in collection are of the type specified by expectedType.
@@ -93,7 +93,7 @@ namespace NUnit.Framework
         /// Asserts that all items contained in collection are not equal to null.
         /// </summary>
         /// <param name="collection">IEnumerable containing objects to be considered</param>
-        public static void AllItemsAreNotNull (IEnumerable collection) 
+        public static void AllItemsAreNotNull (IEnumerable collection)
         {
             AllItemsAreNotNull(collection, string.Empty, null);
         }
@@ -104,7 +104,7 @@ namespace NUnit.Framework
         /// <param name="collection">IEnumerable of objects to be considered</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AllItemsAreNotNull (IEnumerable collection, string message, params object[] args) 
+        public static void AllItemsAreNotNull (IEnumerable collection, string message, params object[] args)
         {
             Assert.That(collection, Is.All.Not.Null, message, args);
         }
@@ -117,11 +117,11 @@ namespace NUnit.Framework
         /// once and only once.
         /// </summary>
         /// <param name="collection">IEnumerable of objects to be considered</param>
-        public static void AllItemsAreUnique (IEnumerable collection) 
+        public static void AllItemsAreUnique (IEnumerable collection)
         {
             AllItemsAreUnique(collection, string.Empty, null);
         }
-        
+
         /// <summary>
         /// Ensures that every object contained in collection exists within the collection
         /// once and only once.
@@ -129,7 +129,7 @@ namespace NUnit.Framework
         /// <param name="collection">IEnumerable of objects to be considered</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AllItemsAreUnique (IEnumerable collection, string message, params object[] args) 
+        public static void AllItemsAreUnique (IEnumerable collection, string message, params object[] args)
         {
             Assert.That(collection, Is.Unique, message, args);
         }
@@ -138,44 +138,44 @@ namespace NUnit.Framework
         #region AreEqual
 
         /// <summary>
-        /// Asserts that expected and actual are exactly equal.  The collections must have the same count, 
+        /// Asserts that expected and actual are exactly equal.  The collections must have the same count,
         /// and contain the exact same objects in the same order.
         /// </summary>
         /// <param name="expected">The first IEnumerable of objects to be considered</param>
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
-        public static void AreEqual (IEnumerable expected, IEnumerable actual) 
+        public static void AreEqual (IEnumerable expected, IEnumerable actual)
         {
             AreEqual(expected, actual, string.Empty, null);
         }
 
         /// <summary>
-        /// Asserts that expected and actual are exactly equal.  The collections must have the same count, 
+        /// Asserts that expected and actual are exactly equal.  The collections must have the same count,
         /// and contain the exact same objects in the same order.
         /// If comparer is not null then it will be used to compare the objects.
         /// </summary>
         /// <param name="expected">The first IEnumerable of objects to be considered</param>
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
         /// <param name="comparer">The IComparer to use in comparing objects from each IEnumerable</param>
-        public static void AreEqual (IEnumerable expected, IEnumerable actual, IComparer comparer) 
+        public static void AreEqual (IEnumerable expected, IEnumerable actual, IComparer comparer)
         {
             AreEqual(expected, actual, comparer, string.Empty, null);
         }
 
         /// <summary>
-        /// Asserts that expected and actual are exactly equal.  The collections must have the same count, 
+        /// Asserts that expected and actual are exactly equal.  The collections must have the same count,
         /// and contain the exact same objects in the same order.
         /// </summary>
         /// <param name="expected">The first IEnumerable of objects to be considered</param>
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args) 
+        public static void AreEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args)
         {
             Assert.That(actual, Is.EqualTo(expected).AsCollection, message, args);
         }
 
         /// <summary>
-        /// Asserts that expected and actual are exactly equal.  The collections must have the same count, 
+        /// Asserts that expected and actual are exactly equal.  The collections must have the same count,
         /// and contain the exact same objects in the same order.
         /// If comparer is not null then it will be used to compare the objects.
         /// </summary>
@@ -184,7 +184,7 @@ namespace NUnit.Framework
         /// <param name="comparer">The IComparer to use in comparing objects from each IEnumerable</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreEqual (IEnumerable expected, IEnumerable actual, IComparer comparer, string message, params object[] args) 
+        public static void AreEqual (IEnumerable expected, IEnumerable actual, IComparer comparer, string message, params object[] args)
         {
             Assert.That(actual, Is.EqualTo(expected).Using(comparer), message, args);
         }
@@ -197,7 +197,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expected">The first IEnumerable of objects to be considered</param>
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
-        public static void AreEquivalent (IEnumerable expected, IEnumerable actual) 
+        public static void AreEquivalent (IEnumerable expected, IEnumerable actual)
         {
             AreEquivalent(expected, actual, string.Empty, null);
         }
@@ -209,7 +209,7 @@ namespace NUnit.Framework
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreEquivalent (IEnumerable expected, IEnumerable actual, string message, params object[] args) 
+        public static void AreEquivalent (IEnumerable expected, IEnumerable actual, string message, params object[] args)
         {
             Assert.That(actual, Is.EquivalentTo(expected), message, args);
         }
@@ -246,7 +246,7 @@ namespace NUnit.Framework
         /// <param name="actual">The second IEnumerable of objects to be considered</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreNotEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args) 
+        public static void AreNotEqual (IEnumerable expected, IEnumerable actual, string message, params object[] args)
         {
             Assert.That(actual, Is.Not.EqualTo(expected).AsCollection, message, args);
         }
@@ -485,7 +485,7 @@ namespace NUnit.Framework
             IsNotEmpty(collection, string.Empty, null);
         }
         #endregion
- 
+
         #region IsOrdered
         /// <summary>
         /// Assert that an array, list or other collection is ordered

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsConstraint.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -36,14 +36,15 @@ namespace NUnit.Framework.Constraints
         /// Construct a CollectionContainsConstraint
         /// </summary>
         /// <param name="expected"></param>
-        [Obsolete("Deprecated, use 'new SomeItemsConstraint(new EqualConstraint(expected))' or 'Has.Some.EqualTo(expected)' instead.")]
+        [Obsolete("This constructor has been deprecated and will be removed in a future release. "
+            + "Please use 'new SomeItemsConstraint(new EqualConstraint(expected))' or 'Has.Some.EqualTo(expected)' instead.")]
         public CollectionContainsConstraint(object expected)
             : base(expected)
         {
             Expected = expected;
         }
 
-        /// <summary> 
+        /// <summary>
         /// The display name of this Constraint for use by ToString().
         /// The default value is the name of the constraint with
         /// trailing "Constraint" removed. Derived classes may set

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -811,7 +811,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Contains")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Contains instead.")]
         public SubstringConstraint StringContaining(string expected)
         {
             return (SubstringConstraint)this.Append(new SubstringConstraint(expected));
@@ -821,7 +821,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Contains")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Contains instead.")]
         public SubstringConstraint ContainsSubstring(string expected)
         {
             return (SubstringConstraint)this.Append(new SubstringConstraint(expected));
@@ -853,7 +853,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value starts with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.StartWith or StartsWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.StartWith or StartsWith instead.")]
         public StartsWithConstraint StringStarting(string expected)
         {
             return (StartsWithConstraint)this.Append(new StartsWithConstraint(expected));
@@ -885,7 +885,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value ends with the substring supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.EndWith or EndsWith")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.EndWith or EndsWith instead.")]
         public EndsWithConstraint StringEnding(string expected)
         {
             return (EndsWithConstraint)this.Append(new EndsWithConstraint(expected));
@@ -917,7 +917,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        [Obsolete("Deprecated, use Does.Match or Matches")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use Does.Match or Matches instead.")]
         public RegexConstraint StringMatching(string pattern)
         {
             return (RegexConstraint)this.Append(new RegexConstraint(pattern));

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -38,7 +38,9 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class DictionaryContainsKeyConstraint : CollectionItemsEqualConstraint
     {
-        private const string ObsoleteMessage = "DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.";
+        private const string ComparerMemberObsoletionMessage = "This member has been deprecated and will be removed in a future release. "
+            + "To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.";
+
         private const string ContainsMethodName = "Contains";
         private bool _isDeprecatedMode = false;
 
@@ -52,7 +54,7 @@ namespace NUnit.Framework.Constraints
             Expected = expected;
         }
 
-        /// <summary> 
+        /// <summary>
         /// The display name of this Constraint for use by ToString().
         /// The default value is the name of the constraint with
         /// trailing "Constraint" removed. Derived classes may set
@@ -77,7 +79,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag the constraint to ignore case and return self.
         /// </summary>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint IgnoreCase
         {
             get
@@ -129,7 +131,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public DictionaryContainsKeyConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
         {
             // reverse the order of the arguments to match expectations of PredicateEqualityComparer
@@ -144,7 +146,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied Comparison object.
         /// </summary>
         /// <param name="comparison">The Comparison object to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using<T>(Comparison<T> comparison)
         {
             _isDeprecatedMode = true;
@@ -156,7 +158,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using(IComparer comparer)
         {
             _isDeprecatedMode = true;
@@ -167,7 +169,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using<T>(IComparer<T> comparer)
         {
             _isDeprecatedMode = true;
@@ -178,7 +180,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using(IEqualityComparer comparer)
         {
             _isDeprecatedMode = true;
@@ -189,7 +191,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied IEqualityComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using<T>(IEqualityComparer<T> comparer)
         {
             _isDeprecatedMode = true;
@@ -200,7 +202,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied boolean-returning delegate.
         /// </summary>
         /// <param name="comparer">The supplied boolean-returning delegate to use.</param>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(ComparerMemberObsoletionMessage)]
         public new CollectionItemsEqualConstraint Using<T>(Func<T, T, bool> comparer)
         {
             _isDeprecatedMode = true;

--- a/src/NUnitFramework/framework/Constraints/FileExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/FileExistsConstraint.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -28,7 +28,8 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// FileExistsConstraint is used to determine if a file exists
     /// </summary>
-    [Obsolete("FileExistsConstraint is deprecated, please use FileOrDirectoryExistsConstraint instead.")]
+    [Obsolete("The FileExistsConstraint class has been deprecated and will be removed in a future release. "
+        + "Please use " + nameof(FileOrDirectoryExistsConstraint) + " instead.")]
     public class FileExistsConstraint : FileOrDirectoryExistsConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns the default NUnitEqualityComparer
         /// </summary>
-        [Obsolete("Deprecated. Use the default constructor instead.")]
+        [Obsolete("This property has been deprecated and will be removed in a future release. Please use 'new NUnitEqualityComparer()' instead.")]
         public static NUnitEqualityComparer Default
         {
             get { return new NUnitEqualityComparer(); }

--- a/src/NUnitFramework/framework/DirectoryAssert.cs
+++ b/src/NUnitFramework/framework/DirectoryAssert.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2006 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,7 +37,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE! Use DirectoryAssert.AreEqual(...) instead.
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -45,12 +45,12 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("DirectoryAssert.Equals should not be used for Assertions, use DirectoryAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("DirectoryAssert.Equals should not be used. Use DirectoryAssert.AreEqual instead.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -58,7 +58,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("DirectoryAssert.ReferenceEquals should not be used.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/FileAssert.cs
+++ b/src/NUnitFramework/framework/FileAssert.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,7 +37,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE! Use FileAssert.AreEqual(...) instead.
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -45,12 +45,12 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("FileAssert.Equals should not be used for Assertions, use FileAssert.AreEqual(...) instead.");
+            throw new InvalidOperationException("FileAssert.Equals should not be used. Use FileAssert.AreEqual instead.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -58,7 +58,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("FileAssert.ReferenceEquals should not be used.");
         }
 
         #endregion

--- a/src/NUnitFramework/framework/StringAssert.cs
+++ b/src/NUnitFramework/framework/StringAssert.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,7 +37,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE! Use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -45,12 +45,12 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("StringAssert.Equals should not be used for Assertions, use StringAssert.AreEqualIgnoringCase(...) or Assert.AreEqual(...) instead.");
+            throw new InvalidOperationException("StringAssert.Equals should not be used. Use StringAssert.AreEqualIgnoringCase or Assert.AreEqual instead.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a"></param>
@@ -58,7 +58,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("StringAssert.ReferenceEquals should not be used.");
         }
 
         #endregion
@@ -302,7 +302,7 @@ namespace NUnit.Framework
         static public void DoesNotMatch(string pattern, string actual, string message, params object[] args)
         {
             Assert.That(actual, Does.Not.Match(pattern), message, args);
-        } 
+        }
 
         /// <summary>
         /// Asserts that a string does not match an expected regular expression pattern.

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -29,7 +29,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework
 {
     /// <summary>
-    /// Provides static methods to express conditions 
+    /// Provides static methods to express conditions
     /// that must be met for the test to succeed. If
     /// any test fails, a warning is issued.
     /// </summary>
@@ -39,7 +39,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// DO NOT USE!
-        /// The Equals method throws an InvalidOperationException. This is done 
+        /// The Equals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
@@ -48,12 +48,12 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new bool Equals(object a, object b)
         {
-            throw new InvalidOperationException("Warn.Equals should not be used for Assertions.");
+            throw new InvalidOperationException("Warn.Equals should not be used.");
         }
 
         /// <summary>
         /// DO NOT USE!
-        /// The ReferenceEquals method throws an InvalidOperationException. This is done 
+        /// The ReferenceEquals method throws an InvalidOperationException. This is done
         /// to make sure there is no mistake by calling this function.
         /// </summary>
         /// <param name="a">The left object.</param>
@@ -61,7 +61,7 @@ namespace NUnit.Framework
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static new void ReferenceEquals(object a, object b)
         {
-            throw new InvalidOperationException("Warn.ReferenceEquals should not be used for Assertions.");
+            throw new InvalidOperationException("Warn.ReferenceEquals should not be used.");
         }
 
         #endregion
@@ -137,7 +137,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -147,7 +147,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false a warning is issued. 
+        /// Asserts that a condition is true. If the condition is false a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void Unless(bool condition)
@@ -157,7 +157,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(bool condition, Func<string> getExceptionMessage)
@@ -172,7 +172,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -194,7 +194,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Asserts that a condition is true. If the condition is false the method throws
         /// an <see cref="InconclusiveException"/>.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(Func<bool> condition, Func<string> getExceptionMessage)
@@ -350,7 +350,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -360,7 +360,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false a warning is issued. 
+        /// Asserts that a condition is true. If the condition is false a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void If(bool condition)
@@ -370,7 +370,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(bool condition, Func<string> getExceptionMessage)
@@ -384,7 +384,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is false. If the condition is true a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
@@ -404,7 +404,7 @@ namespace NUnit.Framework
 
         /// <summary>
         /// Asserts that a condition is false. If the condition is true a warning is issued.
-        /// </summary> 
+        /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(Func<bool> condition, Func<string> getExceptionMessage)

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -536,7 +536,7 @@ namespace NUnit.Options
             throw new InvalidOperationException ("Option has no names!");
         }
 
-        [Obsolete ("Use KeyedCollection.this[string]")]
+        [Obsolete("This method has been deprecated and will be removed in a future release. Please use the default indexer instead.")]
         protected Option GetOptionForName (string option)
         {
             if (option == null)

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -364,7 +364,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new FrameworkController.ExploreTestsAction(_controller, EMPTY_FILTER, _handler));
-            Assert.That(ex.Message, Is.EqualTo("The Explore method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before exploring them."));
         }
 
         [Test]
@@ -421,7 +421,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new FrameworkController.CountTestsAction(_controller, EMPTY_FILTER, _handler));
-            Assert.That(ex.Message, Is.EqualTo("The CountTestCases method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before counting test cases."));
         }
 
         [Test]
@@ -475,7 +475,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new FrameworkController.RunTestsAction(_controller, EMPTY_FILTER, _handler));
-            Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before running them."));
         }
 
         [Test]
@@ -545,7 +545,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new FrameworkController.RunAsyncAction(_controller, EMPTY_FILTER, _handler));
-            Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before running them."));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -138,7 +138,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                     () => _runner.CountTestCases(TestFilter.Empty));
-            Assert.That(ex.Message, Is.EqualTo("The CountTestCases method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before counting test cases."));
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                     () => _runner.ExploreTests(TestFilter.Empty));
-            Assert.That(ex.Message, Is.EqualTo("The ExploreTests method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before exploring them."));
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                     () => _runner.Run(TestListener.NULL, TestFilter.Empty));
-            Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before running them."));
         }
 
         [Test, SetUICulture("en-US")]
@@ -393,7 +393,7 @@ namespace NUnit.Framework.Api
         {
             var ex = Assert.Throws<InvalidOperationException>(
                     () => _runner.RunAsync(TestListener.NULL, TestFilter.Empty));
-            Assert.That(ex.Message, Is.EqualTo("The Run method was called but no test has been loaded"));
+            Assert.That(ex.Message, Is.EqualTo("Tests must be loaded before running them."));
         }
 
         [Test, SetUICulture("en-US")]
@@ -538,7 +538,7 @@ namespace NUnit.Framework.Api
         /// <param name="message">A TestMessage object containing the text to send</param>
         public void SendMessage(TestMessage message)
         {
-            
+
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -42,11 +42,11 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void EqualsNull() 
+        public void EqualsNull()
         {
             Assert.AreEqual(null, null);
         }
-        
+
         [Test]
         public void Bug575936Int32Int64Comparison()
         {
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual(val, 42);
         }
 
-        
+
         [Test]
         public void EqualsFail()
         {
@@ -106,21 +106,21 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(expected, junitString));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
-        
+
         [Test]
-        public void EqualsNaNFails() 
+        public void EqualsNaNFails()
         {
             var expectedMessage =
                 "  Expected: 1.234d +/- 0.0d" + Environment.NewLine +
                 "  But was:  " + Double.NaN + Environment.NewLine;
-            
+
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(1.234, Double.NaN, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
-        }    
+        }
 
 
         [Test]
-        public void NanEqualsFails() 
+        public void NanEqualsFails()
         {
             var expectedMessage =
                 "  Expected: " + Double.NaN + Environment.NewLine +
@@ -128,55 +128,55 @@ namespace NUnit.Framework.Assertions
 
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.NaN, 1.234, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
-        }     
-        
-        [Test]
-        public void NanEqualsNaNSucceeds() 
-        {
-            Assert.AreEqual(Double.NaN, Double.NaN, 0.0);
-        }     
+        }
 
         [Test]
-        public void NegInfinityEqualsInfinity() 
+        public void NanEqualsNaNSucceeds()
+        {
+            Assert.AreEqual(Double.NaN, Double.NaN, 0.0);
+        }
+
+        [Test]
+        public void NegInfinityEqualsInfinity()
         {
             Assert.AreEqual(Double.NegativeInfinity, Double.NegativeInfinity, 0.0);
         }
 
         [Test]
-        public void PosInfinityEqualsInfinity() 
+        public void PosInfinityEqualsInfinity()
         {
             Assert.AreEqual(Double.PositiveInfinity, Double.PositiveInfinity, 0.0);
         }
-        
+
         [Test]
-        public void PosInfinityNotEquals() 
+        public void PosInfinityNotEquals()
         {
             var expectedMessage =
                 "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
                 "  But was:  1.23d" + Environment.NewLine;
-            
+
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.PositiveInfinity, 1.23, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
-        public void PosInfinityNotEqualsNegInfinity() 
+        public void PosInfinityNotEqualsNegInfinity()
         {
             var expectedMessage =
                 "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
                 "  But was:  " + Double.NegativeInfinity + Environment.NewLine;
-            
+
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.PositiveInfinity, Double.NegativeInfinity, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
-        [Test]	
-        public void SinglePosInfinityNotEqualsNegInfinity() 
+        [Test]
+        public void SinglePosInfinityNotEqualsNegInfinity()
         {
             var expectedMessage =
                 "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
                 "  But was:  " + Double.NegativeInfinity + Environment.NewLine;
-            
+
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(float.PositiveInfinity, float.NegativeInfinity, (float)0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
@@ -194,9 +194,9 @@ namespace NUnit.Framework.Assertions
             object o = new object();
             Assert.Throws<InvalidOperationException>(() => Assert.ReferenceEquals(o, o));
         }
-        
+
         [Test]
-        public void Float() 
+        public void Float()
         {
             float val = (float)1.0;
             float expected = val;
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void Byte() 
+        public void Byte()
         {
             byte val = 1;
             byte expected = val;
@@ -218,7 +218,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void String() 
+        public void String()
         {
             string s1 = "test";
             string s2 = new System.Text.StringBuilder(s1).ToString();
@@ -228,7 +228,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void Short() 
+        public void Short()
         {
             short val = 1;
             short expected = val;
@@ -239,7 +239,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void Int() 
+        public void Int()
         {
             int val = 1;
             int expected = val;
@@ -250,7 +250,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void UInt() 
+        public void UInt()
         {
             uint val = 1;
             uint expected = val;
@@ -261,7 +261,7 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void Decimal() 
+        public void Decimal()
         {
             decimal expected = 100m;
             decimal actual = 100.0m;
@@ -276,13 +276,13 @@ namespace NUnit.Framework.Assertions
         }
 
 
-        
+
         /// <summary>
         /// Checks to see that a value comparison works with all types.
         /// Current version has problems when value is the same but the
         /// types are different...C# is not like Java, and doesn't automatically
         /// perform value type conversion to simplify this type of comparison.
-        /// 
+        ///
         /// Related to Bug575936Int32Int64Comparison, but covers all numeric
         /// types.
         /// </summary>
@@ -301,17 +301,17 @@ namespace NUnit.Framework.Assertions
             ushort  us11 = 35;
             char      c1 = '3';
             char      c2 = 'a';
-        
-            System.Byte    b12  = 35;  
-            System.SByte   sb13 = 35; 
-            System.Decimal d14  = 35; 
-            System.Double  d15  = 35; 
-            System.Single  s16  = 35; 
-            System.Int32   i17  = 35; 
-            System.UInt32  ui18 = 35; 
-            System.Int64   i19  = 35; 
-            System.UInt64  ui20 = 35; 
-            System.Int16   i21  = 35; 
+
+            System.Byte    b12  = 35;
+            System.SByte   sb13 = 35;
+            System.Decimal d14  = 35;
+            System.Double  d15  = 35;
+            System.Single  s16  = 35;
+            System.Int32   i17  = 35;
+            System.UInt32  ui18 = 35;
+            System.Int64   i19  = 35;
+            System.UInt64  ui20 = 35;
+            System.Int16   i21  = 35;
             System.UInt16  i22  = 35;
             System.Char    c12 = '3';
             System.Char    c22 = 'a';
@@ -328,7 +328,7 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual(35, us11);
             Assert.AreEqual('3', c1);
             Assert.AreEqual('a', c2);
-        
+
             Assert.AreEqual( 35, b12  );
             Assert.AreEqual( 35, sb13 );
             Assert.AreEqual( 35, d14  );
@@ -552,14 +552,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => Assert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assert.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("Assert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => Assert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assert.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("Assert.ReferenceEquals should not be used."));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
@@ -3,9 +3,10 @@ using System.IO;
 using NUnit.Framework.Constraints;
 using NUnit.TestUtilities.Comparers;
 
+#pragma warning disable CS0618 // AssertionHelper is obsolete
+
 namespace NUnit.Framework.Syntax
 {
-    [Obsolete("Test of Obsolete AssertionHelper class")]
     class AssertionHelperTests : AssertionHelper
     {
         private static readonly string DEFAULT_PATH_CASE = Path.DirectorySeparatorChar == '\\' ? "ignorecase" : "respectcase";
@@ -309,7 +310,7 @@ namespace NUnit.Framework.Syntax
         #endregion
 
         #region After
-        
+
         [Test]
         public void After()
         {

--- a/src/NUnitFramework/tests/Assertions/AssumeEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssumeEqualsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NUnit.Framework.Assertions
 {
@@ -9,14 +9,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => Assume.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assume.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("Assume.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => Assume.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assume.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("Assume.ReferenceEquals should not be used."));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -736,14 +736,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => CollectionAssert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("CollectionAssert.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("CollectionAssert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => CollectionAssert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("CollectionAssert.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("CollectionAssert.ReferenceEquals should not be used."));
         }
 #endregion
 

--- a/src/NUnitFramework/tests/Assertions/DirectoryAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/DirectoryAssertTests.cs
@@ -235,14 +235,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => DirectoryAssert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("DirectoryAssert.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("DirectoryAssert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => DirectoryAssert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("DirectoryAssert.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("DirectoryAssert.ReferenceEquals should not be used."));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/FileAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/FileAssertTests.cs
@@ -465,14 +465,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => FileAssert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("FileAssert.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("FileAssert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => FileAssert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("FileAssert.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("FileAssert.ReferenceEquals should not be used."));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/StringAssertTests.cs
+++ b/src/NUnitFramework/tests/Assertions/StringAssertTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Assertions
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
-        [Test]		
+        [Test]
         public void IsMatch()
         {
             StringAssert.IsMatch( "a?bc", "12a3bc45" );
@@ -166,14 +166,14 @@ namespace NUnit.Framework.Assertions
         public void EqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => StringAssert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("StringAssert.Equals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("StringAssert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => StringAssert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("StringAssert.ReferenceEquals should not be used for Assertions"));
+            Assert.That(ex.Message, Does.StartWith("StringAssert.ReferenceEquals should not be used."));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -85,7 +85,8 @@ namespace NUnit.Framework.Constraints
         }
 #endif
 
-        [Test, Obsolete]
+#pragma warning disable CS0618 // DictionaryContainsKeyConstraint.IgnoreCase and .Using are deprecated
+
         public void IgnoreCaseIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -93,7 +94,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").IgnoreCase);
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -101,13 +102,15 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void SucceedsWhenKeyIsPresentWhenDictionaryUsingCustomComparer()
         {
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Hello", "World" }, { "Hola", "Mundo" } };
 
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello"));
         }
+
+#pragma warning restore CS0618
 
         [Test]
         public void SucceedsWhenKeyIsPresentUsingContainsKeyWhenDictionaryUsingCustomComparer()
@@ -245,7 +248,9 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, !Does.ContainKey(43));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+#pragma warning disable CS0618 // DictionaryContainsKeyConstraint.Using is obsolete
+
+        [Test]
         public void UsingDictionaryContainsKeyConstraintComparisonFunc()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -253,7 +258,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").Using<string, string>((x, y) => x.ToUpper().Equals(y.ToUpper())));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingBaseCollectionItemsEqualConstraintNonGenericComparer()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -261,7 +266,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hola").Using((IComparer)StringComparer.OrdinalIgnoreCase));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingBaseCollectionItemsEqualConstraintGenericComparer()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -269,7 +274,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hola").Using((IComparer<string>)StringComparer.OrdinalIgnoreCase));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingBaseCollectionItemsEqualConstraintNonGenericEqualityComparer()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -277,7 +282,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using((IEqualityComparer)StringComparer.OrdinalIgnoreCase));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingBaseCollectionItemsEqualConstraintGenericEqualityComparer()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -285,13 +290,15 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using((IEqualityComparer<string>)StringComparer.OrdinalIgnoreCase));
         }
 
-        [Test, Obsolete("DictionaryContainsKeyConstraint now uses the comparer which the dictionary is based on. To test using a comparer which the dictionary is not based on, use a collection constraint on the set of keys.")]
+        [Test]
         public void UsingBaseCollectionItemsEqualConstraintComparerFunc()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
 
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("hello").Using<string>((x, y) => x.ToLower().Equals(y.ToLower())));
         }
+
+#pragma warning restore CS0618
 
         #region Test Assets
 


### PR DESCRIPTION
Ran out of time, but small PRs are fun PRs. I didn't get to the motivating example I ran into today, so I'll be back with more soon.

We should try to use full sentences in all messages to the user, including obsoletion and exception messages, message boxes, console messages, and XML documentation.