### PR TITLE
Don't truncate individual arguments unless specified

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Internal
                     case "{8}":
                     case "{9}":
                         int index = token[1] - '0';
-                        fragments.Add(new ArgumentFragment(index, 40));
+                        fragments.Add(new ArgumentFragment(index, 0));
                         break;
                     default:
                         char c = token[1];

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -79,6 +79,8 @@ namespace NUnit.Framework.Internal
         [TestCase("{m}({3})", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethod()")]
         [TestCase("{m}({1:20})", new object[] { 42, "Now is the time for all good men to come to the aid of their country.", 5.2 },
             ExpectedResult = "TestMethod(\"Now is the time f...\")")]
+        [TestCase("{m}({0})", new object[] { "Now is the time for all good men to come to the aid of their country." },
+            ExpectedResult = "TestMethod(\"Now is the time for all good men to come to the aid of their country.\")")]
         public string ParameterizedTests(string pattern, object[] args)
         {
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, args);


### PR DESCRIPTION
The new test, that was missed before, is in the same format as the others. It is probably better to just have {0} instead of {m}({0}).  I have not updated the copyright as the change seems trivial. 

Closes #3181