### PR TITLE
Find the correct location for MSBUILD in Visual Studio 2019

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -159,17 +159,29 @@ Task("Build")
 
 MSBuildSettings CreateSettings()
 {
-    var settings = new MSBuildSettings { Verbosity = Verbosity.Minimal, Configuration = configuration };
+    // Find MSBuild for Visual Studio 2017
+    DirectoryPath vsLatest  = VSWhereLatest();
+    FilePath msBuildPathX64 = (vsLatest==null) ? null
+                                : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
-    // Only needed when packaging
-    settings.WithProperty("DebugType", "pdbonly");
+    // Find MSBuild for Visual Studio 2019
+    if ( msBuildPathX64 != null && !FileExists(msBuildPathX64))
+        msBuildPathX64 = vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
-    if (IsRunningOnWindows())
-        settings.ToolVersion = MSBuildToolVersion.VS2017;
-    else
-        settings.ToolPath = Context.Tools.Resolve("msbuild");
+    // Have we found MSBuild yet?
+    if ( !FileExists(msBuildPathX64) )
+    {
+        throw new Exception($"Failed to find MSBuild: {msBuildPathX64}");
+    }
 
-    return settings;
+    Information("Building using MSBuild at " + msBuildPathX64);
+
+    return new MSBuildSettings { ToolPath = msBuildPathX64 }
+        .SetConfiguration(configuration)
+        .WithProperty("DebugType", "pdbonly")
+        .SetVerbosity(Verbosity.Minimal)
+        // Workaround for https://github.com/Microsoft/msbuild/issues/3626
+        .WithProperty("AddSyntheticProjectReferencesForSolutionDependencies", "false");
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -166,23 +166,22 @@ MSBuildSettings CreateSettings()
 
     if (IsRunningOnWindows())
     {
-        // Find MSBuild for Visual Studio 2017
+        // Find MSBuild for Visual Studio 2019 and newer
         DirectoryPath vsLatest  = VSWhereLatest();
-        FilePath msBuildPathX64 = (vsLatest==null) ? null
-                                    : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
-        // Find MSBuild for Visual Studio 2019
-        if ( msBuildPathX64 != null && !FileExists(msBuildPathX64))
-            msBuildPathX64 = vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
+        // Find MSBuild for Visual Studio 2017
+        if (msBuildPath != null && !FileExists(msBuildPath))
+            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
         // Have we found MSBuild yet?
-        if ( !FileExists(msBuildPathX64) )
+        if (!FileExists(msBuildPath))
         {
-            throw new Exception($"Failed to find MSBuild: {msBuildPathX64}");
+            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
         }
 
-        Information("Building using MSBuild at " + msBuildPathX64);
-        settings.ToolPath = msBuildPathX64;
+        Information("Building using MSBuild at " + msBuildPath);
+        settings.ToolPath = msBuildPath;
     }
     else
         settings.ToolPath = Context.Tools.Resolve("msbuild");

--- a/build.cake
+++ b/build.cake
@@ -167,7 +167,7 @@ MSBuildSettings CreateSettings()
     if (IsRunningOnWindows())
     {
         // Find MSBuild for Visual Studio 2019 and newer
-        DirectoryPath vsLatest  = VSWhereLatest();
+        DirectoryPath vsLatest = VSWhereLatest();
         FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
         // Find MSBuild for Visual Studio 2017


### PR DESCRIPTION
Fixes #3193 

Visual Studio 2019 changed the location of MSBuild. If you attempt to build using Cake with VS2019 installed without 2017 installed, the build fails.