### PR TITLE
Add more event tests

### DIFF
--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -58,6 +58,7 @@ namespace NUnit.Framework.Api
 
         private ITestAssemblyRunner _runner;
 
+        private int _suiteStartedCount;
         private int _testStartedCount;
         private int _testFinishedCount;
         private int _testOutputCount;
@@ -71,6 +72,7 @@ namespace NUnit.Framework.Api
         {
             _runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
 
+            _suiteStartedCount = 0;
             _testStartedCount = 0;
             _testFinishedCount = 0;
             _testOutputCount = 0;
@@ -264,6 +266,7 @@ namespace NUnit.Framework.Api
             LoadMockAssembly();
             _runner.Run(this, TestFilter.Empty);
 
+            Assert.That(_suiteStartedCount, Is.EqualTo(MockAssembly.Suites));
             Assert.That(_testStartedCount, Is.EqualTo(MockAssembly.TestStartedEvents));
             Assert.That(_testFinishedCount, Is.EqualTo(MockAssembly.TestFinishedEvents));
             Assert.That(_testOutputCount, Is.EqualTo(MockAssembly.TestOutputEvents));
@@ -495,7 +498,9 @@ namespace NUnit.Framework.Api
 
         void ITestListener.TestStarted(ITest test)
         {
-            if (!test.IsSuite)
+            if (test.IsSuite)
+                _suiteStartedCount++;
+            else
                 _testStartedCount++;
         }
 

--- a/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -47,7 +47,39 @@ namespace NUnit.Framework.Internal
 			_listener.Reports.Clear();
 		}
 
-		[Test]
+        [Test]
+        public void TestStarted_AssemblyEmitsSingleStartSuiteElement()
+        {
+            var work = TestBuilder.CreateWorkItem(new TestAssembly("mytest.dll"));
+            work.Context.Listener = _reporter;
+
+            TestBuilder.ExecuteWorkItem(work);
+
+            var startReport = _listener.Reports.FirstOrDefault();
+            Assert.NotNull(startReport);
+            Assert.That(startReport, Does.StartWith("<start-suite"));
+            Assert.That(startReport, Contains.Substring("type=\"Assembly\""));
+
+            Assert.That(_listener.Reports.Count(x => x.StartsWith("<start-suite") && x.Contains("type=\"Assembly\"")), Is.EqualTo(1), "More than one Assembly event");
+        }
+
+        [Test]
+        public void TestFinished_AssemblyEmitsSingleTestSuiteElement()
+        {
+            var work = TestBuilder.CreateWorkItem(new TestAssembly("mytest.dll"));
+            work.Context.Listener = _reporter;
+
+            TestBuilder.ExecuteWorkItem(work);
+
+            var endReport = _listener.Reports.LastOrDefault();
+            Assert.NotNull(endReport);
+            Assert.That(endReport, Does.StartWith("<test-suite"));
+            Assert.That(endReport, Contains.Substring("type=\"Assembly\""));
+
+            Assert.That(_listener.Reports.Count(x => x.StartsWith("<test-suite") && x.Contains("type=\"Assembly\"")), Is.EqualTo(1), "More than one Assembly event");
+        }
+
+        [Test]
 		public void TestStarted_FixtureEmitsStartSuiteElement()
 		{
 			var work = TestBuilder.CreateWorkItem(typeof(FixtureWithTestFixtureAttribute));
@@ -58,6 +90,7 @@ namespace NUnit.Framework.Internal
 			var startReport = _listener.Reports.FirstOrDefault();
 			Assert.NotNull(startReport);
 			StringAssert.StartsWith("<start-suite", startReport);
+            Assert.That(startReport, Contains.Substring("type=\"TestFixture\""));
 		}
 
 		[Test]


### PR DESCRIPTION
Investigating the duplicate assembly finished event reported in nunit/nunit-console#603, I wanted to check that the framework was not the source of the problem. These additional tests seem to demonstrate that it is not.