### PR TITLE
Added TestCaseData.Combinatorial() method

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/CombinatorialStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/CombinatorialStrategy.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -40,7 +40,16 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns>The test cases.</returns>
         public IEnumerable<ITestCaseData> GetTestCases(IEnumerable[] sources)
         {
-            List<ITestCaseData> testCases = new List<ITestCaseData>();
+            return GetCombinations<ITestCaseData>(sources, (o) => new TestCaseParameters(o));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IEnumerable{T}"/> representing every single possible combination of the given parameters
+        /// </summary>
+        /// <returns>Every combination of parameters</returns>
+        public static IEnumerable<T> GetCombinations<T>(IEnumerable[] sources, Func<object[], T> handle)
+        {
+            List<T> testCases = new List<T>();
             IEnumerator[] enumerators = new IEnumerator[sources.Length];
             int index = -1;
 
@@ -58,7 +67,7 @@ namespace NUnit.Framework.Internal.Builders
                 for (int i = 0; i < sources.Length; i++)
                     testdata[i] = enumerators[i].Current;
 
-                TestCaseParameters parms = new TestCaseParameters(testdata);
+                T parms = handle(testdata);
                 testCases.Add(parms);
 
                 index = sources.Length;

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -22,10 +22,12 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
 
 namespace NUnit.Framework
 {
@@ -239,8 +241,8 @@ namespace NUnit.Framework
         ///     private static IEnumerable ExampleTest_TestCases
         ///     {
         ///         return TestCaseData.Combinatorial(
-        ///             new[] { true, false }.Cast&lt;object&gt;(),
-        ///             new[] { 0, 1, 10 }.Cast&lt;object&gt;());
+        ///             new[] { true, false }(),
+        ///             new[] { 0, 1, 10 }());
         ///     }
         /// 
         ///     #endregion
@@ -252,40 +254,9 @@ namespace NUnit.Framework
         /// }
         /// </code>
         /// </example>
-        public static IEnumerable<TestCaseData> Combinatorial(params IEnumerable<object>[] values)
+        public static IEnumerable<TestCaseData> Combinatorial(params IEnumerable[] values)
         {
-            // Let's first figure out how many combinations we're going to be creating (the count of each list multiplied together)
-            int combinations = values.Aggregate(1, (x, y) => x * y.Count());
-
-            // If there are no combinations to be made, just return an empty list
-            if (combinations == 0)
-            {
-                return Enumerable.Empty<TestCaseData>();
-            }
-
-            // Iterate through every list of objects and do the magic
-            List<List<object>> result = Enumerable.Range(0, combinations).Select(i => new List<object>()).ToList();
-            int repetition = combinations;
-            foreach (IEnumerable<object> value in values)
-            {
-                int index = 0;
-
-                repetition = repetition / value.Count();
-
-                while (index < combinations)
-                {
-                    foreach (object o in value)
-                    {
-                        for (int i = 0; i < repetition; i++)
-                        {
-                            result[index].Add(o);
-                            index++;
-                        }
-                    }
-                }
-            }
-
-            return result.Select(i => new TestCaseData(i.ToArray()));
+            return CombinatorialStrategy.GetCombinations<TestCaseData>(values, (o) => new TestCaseData(o));
         }
 
         #endregion


### PR DESCRIPTION
When generating test cases, it is extremely convenient to be able to use the Combinatorial strategy for parameterized tests.

Unfortunately, this concept was not available when using TestCaseSource / TestCaseData.  This change is meant to make this functionality available in that situation.

I originally rolled out my own Combinatorial method, not thinking about how the logic already exists elsewhere.  I eventually modified that logic to be re-usable, and just re-implemented it for TestCaseSource / TestCaseData.