### PR TITLE
Fix for IRepeatTest attributes bypass always the IMethodInfo interface

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <returns>True if the method signature is valid, false if not</returns>
         private static bool CheckTestMethodAttributes(TestMethod testMethod)
         {
-            if (testMethod.Method.MethodInfo.GetAttributes<IRepeatTest>(true).Length > 1)
+            if (testMethod.Method.GetCustomAttributes<IRepeatTest>(true).Length > 1)
                 return MarkAsNotRunnable(testMethod, "Multiple attributes that repeat a test may cause issues.");
 
             return true;

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Internal.Execution
                     command = new TimeoutCommand(command, timeout);
 
                 // Add wrappers for repeatable tests after timeout so the timeout is reset on each repeat
-                foreach (var repeatableAttribute in method.MethodInfo.GetAttributes<IRepeatTest>(true))
+                foreach (var repeatableAttribute in method.GetCustomAttributes<IRepeatTest>(true))
                     command = repeatableAttribute.Wrap(command);
 
                 return command;


### PR DESCRIPTION
When looking for IRepeatTest instead of doing it through the IMethodInfo (and by inheritage IReflectionInfo) interface it, it was done directly through the MethodInfo.

This was not allowing a full customization of the MethodWrapper class to add custom attributes.

The default implemementation of the GetCustomAttributes directly calls MethodInfo.GetAttributes and should not effect current usage.