### PR TITLE
Bump Ubuntu version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ mono: 5.10.0 # Need 5.2+ for the included MSBuild.
 
 matrix:
   include:
-    - os: linux
+    - dist: xenial
       install:
         - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.6
 


### PR DESCRIPTION
The Linux build has started to fail in a similar manner to nunit/nunit-console#611, so we bump the Ubuntu version.