### PR TITLE
Allow static SetUpFixture classes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework
     /// <see cref="OneTimeTearDownAttribute" /> methods for all the test fixtures
     /// under a given namespace.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class SetUpFixtureAttribute : NUnitAttribute, IFixtureBuilder
     {
         #region ISuiteBuilder Members
@@ -67,16 +67,19 @@ namespace NUnit.Framework
 
         private static bool IsValidFixtureType(ITypeInfo typeInfo, ref string reason)
         {
-            if (typeInfo.IsAbstract)
+            if (!typeInfo.IsStaticClass)
             {
-                reason = string.Format("{0} is an abstract class", typeInfo.FullName);
-                return false;
-            }
+                if (typeInfo.IsAbstract)
+                {
+                    reason = string.Format("{0} is an abstract class", typeInfo.FullName);
+                    return false;
+                }
 
-            if (!typeInfo.HasConstructor(new Type[0]))
-            {
-                reason = string.Format("{0} does not have a default constructor", typeInfo.FullName);
-                return false;
+                if (!typeInfo.HasConstructor(new Type[0]))
+                {
+                    reason = string.Format("{0} does not have a default constructor", typeInfo.FullName);
+                    return false;
+                }
             }
 
             var invalidAttributes = new Type[] {

--- a/src/NUnitFramework/testdata/SetUpFixtureData.cs
+++ b/src/NUnitFramework/testdata/SetUpFixtureData.cs
@@ -167,6 +167,62 @@ namespace NUnit.TestUtilities
 
 namespace NUnit.TestData.SetupFixture
 {
+    namespace StaticFixture
+    {
+        #region SomeFixture
+        [TestFixture]
+        public class TestSetupFixtureStuff
+        {
+            [OneTimeSetUp]
+            public void FixtureSetup()
+            {
+                TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.Fixture.SetUp");
+            }
+
+            [SetUp]
+            public void Setup()
+            {
+                TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.Test.SetUp");
+            }
+
+            [Test]
+            public void Test()
+            {
+                TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.Test");
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.Test.TearDown");
+            }
+
+            [OneTimeTearDown]
+            public void FixtureTearDown()
+            {
+                TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.Fixture.TearDown");
+            }
+        }
+        #endregion SomeFixture
+
+
+        [SetUpFixture]
+        public static class StaticSetupTeardown
+        {
+            [OneTimeSetUp]
+            public static void DoNamespaceSetUp()
+            {
+                NUnit.TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.OneTimeSetUp");
+            }
+
+            [OneTimeTearDown]
+            public static void DoNamespaceTearDown()
+            {
+                NUnit.TestUtilities.SimpleEventRecorder.RegisterEvent("StaticFixture.OneTimeTearDown");
+            }
+        }
+    }
+
     namespace Namespace1
     {
         #region SomeFixture

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -64,6 +64,39 @@ namespace NUnit.Framework.Attributes
                 Assert.That(fixture.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
+        [Test]
+        public void AbstractClassNotAllowed()
+        {
+            var abstractType = typeof(AbstractSetupClass);
+            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeWrapper(abstractType));
+            foreach (var fixture in fixtures)
+                Assert.That(fixture.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public void StaticClassIsAllowed()
+        {
+            var abstractType = typeof(StaticSetupClass);
+            var fixtures = new SetUpFixtureAttribute().BuildFrom(new TypeWrapper(abstractType));
+            foreach (var fixture in fixtures)
+                Assert.That(fixture.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
+        private static class StaticSetupClass
+        {
+            [OneTimeSetUp]
+            public static void SomeSetUpMethod() { }
+
+            [OneTimeTearDown]
+            public static void SomeTearDownMethod() { }
+        }
+
+        private abstract class AbstractSetupClass
+        {
+            [OneTimeSetUp]
+            public void SomeSetUpMethod() { }
+        }
+
         private class TestSetupClass
         {
             [SetUp]

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -184,6 +184,19 @@ namespace NUnit.Framework.Internal
                                                      "NS5.Fixture.TearDown",
                                                      "NS5.OneTimeTearDown");
         }
+
+        [Test]
+        public void NamespaceSetUpFixtureMayBeStatic()
+        {
+            Assert.That(RunTests("NUnit.TestData.SetupFixture.StaticFixture").ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            TestUtilities.SimpleEventRecorder.Verify("StaticFixture.OneTimeSetUp",
+                                                     "StaticFixture.Fixture.SetUp",
+                                                     "StaticFixture.Test.SetUp",
+                                                     "StaticFixture.Test",
+                                                     "StaticFixture.Test.TearDown",
+                                                     "StaticFixture.Fixture.TearDown",
+                                                     "StaticFixture.OneTimeTearDown");
+        }
         #endregion
 
         #region TwoTestFixtures


### PR DESCRIPTION
This PR adds support for `SetupFixtureAttribute` on static classes + some tests.

Fixes #3166 