### PR TITLE
If you can’t beat ’em, join ’em

### DIFF
--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -50,6 +50,9 @@ namespace NUnit.Framework.Attributes
         }
 
 #if PLATFORM_DETECTION && THREAD_ABORT
+        // Most recent version of Mono tested: 5.20.1
+        private const string MonoFailsToAbortThreadReason = "ThreadAbortException is never thrown on Mono";
+
         [Test, Timeout(500)]
         public void TestWithTimeoutRunsOnSameThread()
         {
@@ -63,7 +66,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        [Platform(Exclude = "Mono", Reason = "Runner hangs at end when this is run")]
+        [Platform(Exclude = "Mono", Reason = MonoFailsToAbortThreadReason)]
         public void TestTimesOutAndTearDownIsRun()
         {
             TimeoutFixture fixture = new TimeoutFixture();
@@ -88,7 +91,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        [Platform(Exclude = "Mono", Reason = "Test never aborts on Mono (tested 5.4–5.12)")]
+        [Platform(Exclude = "Mono", Reason = MonoFailsToAbortThreadReason)]
         public void TearDownTimesOutAndNoFurtherTearDownIsRun()
         {
             TimeoutFixture fixture = new TimeoutFixtureWithTimeoutInTearDown();
@@ -101,7 +104,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        [Platform(Exclude = "Mono", Reason = "Runner hangs at end when this is run")]
+        [Platform(Exclude = "Mono", Reason = MonoFailsToAbortThreadReason)]
         public void TimeoutCanBeSetOnTestFixture()
         {
             ITestResult suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutFixtureWithTimeoutOnFixture));
@@ -172,6 +175,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test, Platform("Win")]
+        [Platform(Exclude = "Mono", Reason = MonoFailsToAbortThreadReason)]
         public void TimeoutWithMessagePumpShouldAbort()
         {
             ITestResult result = TestBuilder.RunTest(


### PR DESCRIPTION
Fixes #3222. It would be nice to figure out why thread aborting hasn't worked for us on Mono [in the last ten years](https://github.com/nunit/nunit/commit/fc042531ab73cfebc0c1b71e1bb26ff2bc2483dc), but I should have excluded Mono in #2023 for my test as well, since it's just a fancier version of:

https://github.com/nunit/nunit/blob/9f2d8ea7c35518ee28f1255bc21aeca6d84057b3/src/NUnitFramework/tests/Attributes/TimeoutTests.cs#L65-L76

https://github.com/nunit/nunit/blob/9f2d8ea7c35518ee28f1255bc21aeca6d84057b3/src/NUnitFramework/testdata/TimeoutFixture.cs#L49-L67