### PR TITLE
Handle nested not filters correctly

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -46,17 +46,21 @@ namespace NUnit.Framework.Internal.Filters
         public TestFilter BaseFilter { get; }
 
         /// <summary>
-        /// Determine if a particular test passes the filter criteria. The default 
-        /// implementation checks the test itself, its parents and any descendants.
+        /// Determine if a particular test passes the filter criteria.
         /// 
-        /// Derived classes may override this method or any of the Match methods
-        /// to change the behavior of the filter.
+        /// Overriden in NotFilter so that
+        /// 1. Two nested NotFilters are simply ignored
+        /// 2. Otherwise, we only look at the test itself and parents, ignoring
+        /// any child test matches.
         /// </summary>
         /// <param name="test">The test to which the filter is applied</param>
         /// <returns>True if the test passes the filter, otherwise false</returns>
         public override bool Pass(ITest test)
         {
-            return !BaseFilter.Match (test) && !BaseFilter.MatchParent (test);
+            var secondNotFilter = BaseFilter as NotFilter;
+            return secondNotFilter != null
+                ? secondNotFilter.BaseFilter.Pass(test) 
+                : !BaseFilter.Match (test) && !BaseFilter.MatchParent (test);
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
@@ -1,0 +1,73 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    [TestFixture("TestFilterTests+DummyFixture", false)]
+    [TestFixture("Dummy", true)]
+    public class DoubleNegativeFilterTests : TestFilterTests
+    {
+        private readonly TestFilter _filter;
+
+        public DoubleNegativeFilterTests(string value, bool isRegex)
+        {
+            _filter = new NotFilter(new NotFilter(new TestNameFilter(value) { IsRegex = isRegex }));
+        }
+
+        [Test]
+        public void IsNotEmpty()
+        {
+            Assert.False(_filter.IsEmpty);
+        }
+
+        [Test]
+        public void MatchTest()
+        {
+            Assert.That(_filter.Match(_dummyFixture));
+            Assert.False(_filter.Match(_anotherFixture));
+        }
+
+        [Test]
+        public void PassTest()
+        {
+            Assert.That(_filter.Pass(_topLevelSuite));
+            Assert.That(_filter.Pass(_dummyFixture));
+            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+
+            Assert.False(_filter.Pass(_anotherFixture));
+        }
+
+        public void ExplicitMatchTest()
+        {
+            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
+            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+
+            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3231 

After a few false starts, I decided to just skip over two nested NotFilters when encountered and just evaluate the BaseFilter wrapped by both of them.