### PR TITLE
Run work posted to test synchronization context for up to ten seconds after the test method completes

### DIFF
--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -118,7 +118,9 @@ namespace NUnit.Framework.Internal
                 var context = SynchronizationContext.Current;
                 if (context == null || context.GetType() == typeof(SynchronizationContext))
                 {
-                    var singleThreadedContext = new SingleThreadedTestSynchronizationContext();
+                    var singleThreadedContext = new SingleThreadedTestSynchronizationContext(
+                        shutdownTimeout: TimeSpan.FromSeconds(10));
+
                     SetSynchronizationContext(singleThreadedContext);
 
                     return On.Dispose(() =>

--- a/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
+++ b/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2018 Charlie Poole, Rob Prouse
+// Copyright (c) 2018–2019 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,14 +23,26 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
 {
     internal sealed partial class SingleThreadedTestSynchronizationContext : SynchronizationContext, IDisposable
     {
+        private const string ShutdownTimeoutMessage =
+            "Work posted to the synchronization context did not complete within ten seconds. Consider explicitly waiting for the work to complete.";
+
+        private readonly TimeSpan _shutdownTimeout;
         private readonly Queue<ScheduledWork> _queue = new Queue<ScheduledWork>();
-        private Status status;
+        private Status _status;
+        private Stopwatch _timeSinceShutdown;
+
+        public SingleThreadedTestSynchronizationContext(TimeSpan shutdownTimeout)
+        {
+            _shutdownTimeout = shutdownTimeout;
+        }
 
         private enum Status
         {
@@ -74,7 +86,11 @@ namespace NUnit.Framework.Internal
         {
             lock (_queue)
             {
-                if (status == Status.ShutDown) throw CreateInvalidWhenShutDownException();
+                if (_status == Status.ShutDown)
+                {
+                    throw CreateInvalidWhenShutDownException();
+                }
+
                 _queue.Enqueue(work);
                 Monitor.Pulse(_queue);
             }
@@ -87,11 +103,9 @@ namespace NUnit.Framework.Internal
         {
             lock (_queue)
             {
-                status = Status.ShutDown;
+                _timeSinceShutdown = Stopwatch.StartNew();
+                _status = Status.ShutDown;
                 Monitor.Pulse(_queue);
-
-                if (_queue.Count != 0)
-                    throw new InvalidOperationException("Shutting down SingleThreadedTestSynchronizationContext with work still in the queue.");
             }
         }
 
@@ -107,7 +121,7 @@ namespace NUnit.Framework.Internal
         {
             lock (_queue)
             {
-                switch (status)
+                switch (_status)
                 {
                     case Status.Running:
                         throw new InvalidOperationException("SingleThreadedTestSynchronizationContext.Run may not be reentered.");
@@ -115,7 +129,7 @@ namespace NUnit.Framework.Internal
                         throw CreateInvalidWhenShutDownException();
                 }
 
-                status = Status.Running;
+                _status = Status.Running;
             }
 
             ScheduledWork scheduledWork;
@@ -127,16 +141,24 @@ namespace NUnit.Framework.Internal
         {
             lock (_queue)
             {
-                for (;;)
+                while (_queue.Count == 0)
                 {
-                    if (status == Status.ShutDown)
+                    if (_status == Status.ShutDown)
                     {
                         scheduledWork = default(ScheduledWork);
                         return false;
                     }
 
-                    if (_queue.Count != 0) break;
                     Monitor.Wait(_queue);
+                }
+
+                if (_status == Status.ShutDown && _timeSinceShutdown.Elapsed > _shutdownTimeout)
+                {
+                    var testExecutionContext = TestExecutionContext.CurrentContext;
+
+                    testExecutionContext?.CurrentResult.RecordAssertion(AssertionStatus.Error, ShutdownTimeoutMessage);
+
+                    throw new InvalidOperationException(ShutdownTimeoutMessage);
                 }
 
                 scheduledWork = _queue.Dequeue();

--- a/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
+++ b/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Internal
                 {
                     case Status.ShuttingDown:
                     case Status.ShutDown:
-                        break;
+                        return;
                 }
 
                 _timeSinceShutdown = Stopwatch.StartNew();

--- a/src/NUnitFramework/tests/Internal/SingleThreadedTestSynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/SingleThreadedTestSynchronizationContextTests.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public static void RecursivelyPostedWorkIsStillExecutedIfStartedWithinTimeout()
         {
-            using (var context = new SingleThreadedTestSynchronizationContext())
+            using (var context = new SingleThreadedTestSynchronizationContext(shutdownTimeout: TimeSpan.FromSeconds(1)))
             using (TestUtils.TemporarySynchronizationContext(context))
             {
                 var wasExecuted = false;
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public static void RecursivelyPostedWorkIsStillExecutedWithinTimeout()
         {
-            using (var context = new SingleThreadedTestSynchronizationContext())
+            using (var context = new SingleThreadedTestSynchronizationContext(shutdownTimeout: TimeSpan.FromSeconds(1)))
             using (TestUtils.TemporarySynchronizationContext(context))
             {
                 context.Post(_ =>

--- a/src/NUnitFramework/tests/Internal/SingleThreadedTestSynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/SingleThreadedTestSynchronizationContextTests.cs
@@ -1,0 +1,77 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace NUnit.Framework.Internal
+{
+    public static class SingleThreadedTestSynchronizationContextTests
+    {
+        [Test]
+        public static void RecursivelyPostedWorkIsStillExecutedIfStartedWithinTimeout()
+        {
+            using (var context = new SingleThreadedTestSynchronizationContext())
+            using (TestUtils.TemporarySynchronizationContext(context))
+            {
+                var wasExecuted = false;
+
+                context.Post(state =>
+                {
+                    context.Post(_ => Thread.Sleep(TimeSpan.FromSeconds(0.5)), null);
+                    context.Post(_ => wasExecuted = true, null);
+
+                    context.ShutDown();
+                }, null);
+
+                context.Run();
+                Assert.That(wasExecuted);
+            }
+        }
+
+        [Test]
+        public static void RecursivelyPostedWorkIsStillExecutedWithinTimeout()
+        {
+            using (var context = new SingleThreadedTestSynchronizationContext())
+            using (TestUtils.TemporarySynchronizationContext(context))
+            {
+                context.Post(_ =>
+                {
+                    ScheduleWorkRecursively(Stopwatch.StartNew(), until: TimeSpan.FromSeconds(0.5));
+
+                    context.ShutDown();
+                }, null);
+
+                context.Run();
+            }
+        }
+
+        private static void ScheduleWorkRecursively(Stopwatch stopwatch, TimeSpan until)
+        {
+            if (stopwatch.Elapsed >= until) return;
+
+            SynchronizationContext.Current.Post(_ => ScheduleWorkRecursively(stopwatch, until), null);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         [Test]
         public static void SynchronizationContextIsRestoredBetweenTestCases()
         {
-            using (RestoreSynchronizationContext()) // Restore the synchronization context so as not to affect other tests if this test fails
+            using (TestUtils.RestoreSynchronizationContext()) // Restore the synchronization context so as not to affect other tests if this test fails
             {
                 var result = TestBuilder.RunParameterizedMethodSuite(
                     typeof(SynchronizationContextFixture),
@@ -54,7 +54,7 @@ namespace NUnit.Framework
         [Test]
         public static void SynchronizationContextIsRestoredBetweenTestCaseSources()
         {
-            using (RestoreSynchronizationContext()) // Restore the synchronization context so as not to affect other tests if this test fails
+            using (TestUtils.RestoreSynchronizationContext()) // Restore the synchronization context so as not to affect other tests if this test fails
             {
                 var fixture = TestBuilder.MakeFixture(typeof(SynchronizationContextFixture));
 
@@ -143,7 +143,7 @@ namespace NUnit.Framework
         {
             var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
-            using (TemporarySynchronizationContext(createdOnThisThread))
+            using (TestUtils.TemporarySynchronizationContext(createdOnThisThread))
             {
                 apiAdapter.Execute(async () => await TaskEx.Yield());
             }
@@ -156,7 +156,7 @@ namespace NUnit.Framework
         {
             var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
-            using (TemporarySynchronizationContext(createdOnThisThread))
+            using (TestUtils.TemporarySynchronizationContext(createdOnThisThread))
             {
                 apiAdapter.Execute(() =>
                 {
@@ -173,7 +173,7 @@ namespace NUnit.Framework
         {
             var createdOnThisThread = CreateSynchronizationContext(knownSynchronizationContextType);
 
-            using (TemporarySynchronizationContext(createdOnThisThread))
+            using (TestUtils.TemporarySynchronizationContext(createdOnThisThread))
             {
                 apiAdapter.Execute(async () => await TaskEx.Yield());
 
@@ -181,19 +181,6 @@ namespace NUnit.Framework
             }
         }
 #endif
-
-        private static IDisposable TemporarySynchronizationContext(SynchronizationContext synchronizationContext)
-        {
-            var restore = RestoreSynchronizationContext();
-            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
-            return restore;
-        }
-
-        private static IDisposable RestoreSynchronizationContext()
-        {
-            var originalContext = SynchronizationContext.Current;
-            return On.Dispose(() => SynchronizationContext.SetSynchronizationContext(originalContext));
-        }
     }
 }
 #endif

--- a/src/NUnitFramework/tests/TestUtilities/CallbackWatcher.cs
+++ b/src/NUnitFramework/tests/TestUtilities/CallbackWatcher.cs
@@ -1,0 +1,107 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace NUnit.TestUtilities
+{
+    /// <summary>
+    /// Provides idiomatic callback-based assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var watcher = new CallbackWatcher();
+    ///
+    /// systemUnderTest.PropertyChanged += (sender, e) => watcher.OnCallback();
+    ///
+    /// using (watcher.ExpectCallback())
+    /// {
+    ///     systemUnderTest.SomeProperty = 42;
+    /// } // Fails if PropertyChanged did not fire
+    ///
+    /// systemUnderTest.SomeProperty = 42; // Fails if PropertyChanged fires
+    /// </code>
+    /// </example>
+    public sealed class CallbackWatcher
+    {
+        private int _expectedCount;
+        private int _actualCount;
+
+        /// <summary>
+        /// Begins expecting callbacks. When the returned scope is disposed, stops expecting callbacks and throws <see cref="AssertionException"/>
+        /// if <see cref="OnCallback"/> was not called the expected number of times between beginning and ending.
+        /// </summary>
+        /// <param name="count">
+        /// The number of times that <see cref="OnCallback"/> is expected to be called before the returned scope is disposed.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count"/> is less than 1.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the returned scope from the previous call has not been disposed.</exception>
+        /// <exception cref="AssertionException">Thrown when <see cref="OnCallback"/> was not called the expected number of times between beginning and ending.</exception>
+        public IDisposable ExpectCallback(int count = 1)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), _expectedCount, "Expected callback count must be greater than or equal to zero.");
+
+            if (_expectedCount != 0)
+                throw new InvalidOperationException($"The previous {nameof(ExpectCallback)} scope must be disposed before calling again.");
+
+            _expectedCount = count;
+            _actualCount = 0;
+
+            return On.Dispose(() =>
+            {
+                try
+                {
+                    if (_actualCount < _expectedCount)
+                        Assert.Fail($"Expected {(_expectedCount == 1 ? "a single call" : _expectedCount + " calls")}, but there {(_actualCount == 1 ? "was" : "were")} {_actualCount}.");
+                }
+                finally
+                {
+                    _expectedCount = 0;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Call this from the callback being tested.
+        /// Throws <see cref="AssertionException"/> if this watcher is not currently expecting a callback
+        /// (see <see cref="ExpectCallback"/>) or if the expected number of callbacks has been exceeded.
+        /// </summary>
+        /// <exception cref="AssertionException">
+        /// Thrown when this watcher is not currently expecting a callback (see <see cref="ExpectCallback"/>)
+        /// or if the expected number of callbacks has been exceeded.
+        /// </exception>
+        public void OnCallback()
+        {
+            _actualCount++;
+            if (_actualCount > _expectedCount)
+            {
+                Assert.Fail(_expectedCount == 0
+                    ? "Expected no callback."
+                    : $"Expected {(_expectedCount == 1 ? "a single call" : _expectedCount + " calls")}, but there were more.");
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/TestUtilities/TestUtils.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestUtils.cs
@@ -1,0 +1,45 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Threading;
+using NUnit.Framework.Internal;
+
+namespace NUnit.TestUtilities
+{
+    internal static class TestUtils
+    {
+        public static IDisposable TemporarySynchronizationContext(SynchronizationContext synchronizationContext)
+        {
+            var restore = RestoreSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            return restore;
+        }
+
+        public static IDisposable RestoreSynchronizationContext()
+        {
+            var originalContext = SynchronizationContext.Current;
+            return On.Dispose(() => SynchronizationContext.SetSynchronizationContext(originalContext));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3209.