### PR TITLE
RawInt32() can't use Next since the maximum is always exclusive and it would never return int.MaxValue

### DIFF
--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -699,7 +699,7 @@ namespace NUnit.Framework.Internal
 
         private int RawInt32()
         {
-            return Next(int.MinValue, int.MaxValue);
+            return unchecked((int)RawUInt32());
         }
 
         private uint RawUInt32()


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/pull/3241#issuecomment-494193816

/cc @oznetmaster, @CharliePoole 