### PR TITLE
Workaround for lost MethodInfo.Invoke stack trace beginning in Mono 5.20

### DIFF
--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -23,8 +23,6 @@
 
 #if PLATFORM_DETECTION
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -36,26 +34,6 @@ using Microsoft.Win32;
 
 namespace NUnit.Framework.Internal
 {
-    /// <summary>
-    /// Enumeration identifying a common language
-    /// runtime implementation.
-    /// </summary>
-    public enum RuntimeType
-    {
-        /// <summary>Any supported runtime framework</summary>
-        Any,
-        /// <summary>Microsoft .NET Framework</summary>
-        Net,
-        /// <summary>Microsoft Shared Source CLI</summary>
-        SSCLI,
-        /// <summary>Mono</summary>
-        Mono,
-        /// <summary>MonoTouch</summary>
-        MonoTouch,
-        /// <summary>Microsoft .NET Core</summary>
-        NetCore
-    }
-
     /// <summary>
     /// RuntimeFramework represents a particular version
     /// of a common language runtime implementation.
@@ -387,7 +365,7 @@ namespace NUnit.Framework.Internal
         private static bool IsNetCore()
         {
 #if NETSTANDARD2_0
-            // Mono versions will throw a TypeLoadException when attempting to run the internal method, so we wrap it in a try/catch 
+            // Mono versions will throw a TypeLoadException when attempting to run the internal method, so we wrap it in a try/catch
             // block to stop any inlining in release builds and check whether the type exists
             Type runtimeInfoType = Type.GetType("System.Runtime.InteropServices.RuntimeInformation,System.Runtime.InteropServices.RuntimeInformation", false);
             if (runtimeInfoType != null)

--- a/src/NUnitFramework/framework/Internal/RuntimeType.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeType.cs
@@ -1,0 +1,45 @@
+// ***********************************************************************
+// Copyright (c) 2007-2016 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// Enumeration identifying a common language
+    /// runtime implementation.
+    /// </summary>
+    public enum RuntimeType
+    {
+        /// <summary>Any supported runtime framework</summary>
+        Any,
+        /// <summary>Microsoft .NET Framework</summary>
+        Net,
+        /// <summary>Microsoft Shared Source CLI</summary>
+        SSCLI,
+        /// <summary>Mono</summary>
+        Mono,
+        /// <summary>MonoTouch</summary>
+        MonoTouch,
+        /// <summary>Microsoft .NET Core</summary>
+        NetCore
+    }
+}

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -106,8 +106,12 @@ namespace NUnit.Framework.Assertions
             Assert.That(result.ResultState, Is.EqualTo(expectedResultState), "ResultState");
             Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "AssertCount");
             Assert.That(result.AssertionResults.Count, Is.EqualTo(assertionMessageRegex.Length), "Number of AssertionResults");
-            if (result.ResultState.Status == TestStatus.Failed)
-                Assert.That(result.StackTrace, Is.Not.Null.And.Contains(methodName), "StackTrace");
+
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+            {
+                if (result.ResultState.Status == TestStatus.Failed)
+                    Assert.That(result.StackTrace, Is.Not.Null.And.Contains(methodName), "StackTrace");
+            });
 
             if (result.AssertionResults.Count > 0)
             {
@@ -130,7 +134,11 @@ namespace NUnit.Framework.Assertions
                     // NOTE: This test expects the stack trace to contain the name of the method 
                     // that actually caused the failure. To ensure it is not optimized away, we
                     // compile the testdata assembly with optimizations disabled.
-                    Assert.That(assertion.StackTrace, Is.Not.Null.And.Contains(methodName), errmsg);
+
+                    PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+                    {
+                        Assert.That(assertion.StackTrace, Is.Not.Null.And.Contains(methodName), errmsg);
+                    });
                 }
             }
 

--- a/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
@@ -127,7 +127,11 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(ResultState.Error, result.ResultState, "Test should be in error state");
             string expected = string.Format("{0} : {1}", e.GetType().FullName, e.Message);
             Assert.AreEqual(expected, result.Message);
-            Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+            {
+                Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+            });
         }
 
         [Test]
@@ -143,7 +147,11 @@ namespace NUnit.Framework.Internal
             string expected = string.Format("TearDown : {0} : {1}", e.GetType().FullName, e.Message);
             Assert.AreEqual(expected, result.Message);
             Assert.That(result.StackTrace, Does.StartWith("--TearDown"));
-            Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+            {
+                Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+            });
         }
 
         [Test]
@@ -162,7 +170,11 @@ namespace NUnit.Framework.Internal
                 + string.Format("TearDown : {0} : {1}", e2.GetType().FullName, e2.Message);
             Assert.AreEqual(expected, result.Message);
             Assert.That(result.StackTrace, Does.Contain("--TearDown"));
-            Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+            {
+                Assert.That(result.StackTrace, Does.Contain(fixture.GetType().FullName)); // Sanity check
+            });
         }
 
         public class SetupCallBase

--- a/src/NUnitFramework/tests/PlatformInconsistency.cs
+++ b/src/NUnitFramework/tests/PlatformInconsistency.cs
@@ -39,6 +39,7 @@ namespace NUnit.Framework
             _maxVersion = maxVersion;
         }
 
+#if PLATFORM_DETECTION
         private static Version GetCurrentVersion()
         {
             if (RuntimeFramework.CurrentFramework.Runtime == RuntimeType.Mono)
@@ -50,11 +51,13 @@ namespace NUnit.Framework
 
             return RuntimeFramework.CurrentFramework.FrameworkVersion;
         }
+#endif
 
         private bool CurrentPlatformIsInconsistent
         {
             get
             {
+#if PLATFORM_DETECTION
                 if (RuntimeFramework.CurrentFramework.Runtime != _runtimeType) return false;
 
                 var version = GetCurrentVersion();
@@ -62,6 +65,9 @@ namespace NUnit.Framework
                 if (_maxVersion != null && version > _maxVersion) return false;
 
                 return true;
+#else
+                return false;
+#endif
             }
         }
 

--- a/src/NUnitFramework/tests/PlatformInconsistency.cs
+++ b/src/NUnitFramework/tests/PlatformInconsistency.cs
@@ -1,0 +1,83 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework
+{
+    internal sealed class PlatformInconsistency
+    {
+        private readonly RuntimeType _runtimeType;
+        private readonly Version _minVersion;
+        private readonly Version _maxVersion;
+
+        private PlatformInconsistency(RuntimeType runtimeType, Version minVersion, Version maxVersion)
+        {
+            _runtimeType = runtimeType;
+            _minVersion = minVersion;
+            _maxVersion = maxVersion;
+        }
+
+        private static Version GetCurrentVersion()
+        {
+            if (RuntimeFramework.CurrentFramework.Runtime == RuntimeType.Mono)
+            {
+                var displayName = RuntimeFramework.CurrentFramework.DisplayName;
+
+                return new Version(displayName.Substring(0, displayName.IndexOf(' ')));
+            }
+
+            return RuntimeFramework.CurrentFramework.FrameworkVersion;
+        }
+
+        private bool CurrentPlatformIsInconsistent
+        {
+            get
+            {
+                if (RuntimeFramework.CurrentFramework.Runtime != _runtimeType) return false;
+
+                var version = GetCurrentVersion();
+                if (_minVersion != null && version < _minVersion) return false;
+                if (_maxVersion != null && version > _maxVersion) return false;
+
+                return true;
+            }
+        }
+
+        public void SkipOnAffectedPlatform(Action action)
+        {
+            Guard.ArgumentNotNull(action, nameof(action));
+
+            if (!CurrentPlatformIsInconsistent) action.Invoke();
+        }
+
+        /// <summary>
+        /// Mono's MethodInfo.Invoke loses the stack trace beginning in 5.20.
+        /// </summary>
+        public static PlatformInconsistency MonoMethodInfoInvokeLosesStackTrace { get; } = new PlatformInconsistency(
+            RuntimeType.Mono,
+            minVersion: new Version(5, 20),
+            maxVersion: null);
+    }
+}

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -319,7 +319,11 @@ namespace NUnit.Framework
             TestBuilder.RunTestFixture(fixture);
             Assert.That(fixture.FailCount, Is.EqualTo(1));
             Assert.That(fixture.Message, Is.EqualTo("Deliberate failure"));
-            Assert.That(fixture.StackTrace, Does.Contain("NUnit.TestData.TestContextData.TestTestContextInTearDown.FailingTest"));
+
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
+            {
+                Assert.That(fixture.StackTrace, Does.Contain("NUnit.TestData.TestContextData.TestTestContextInTearDown.FailingTest"));
+            });
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3257. This is a regression in Mono 5.20 which is interfering with @oznetmaster's work and which will be on Azure Pipelines any minute as far as I know, affecting all our builds. (5.20 has been out for a month and a half and AzDO is still on 5.18.)

I stepped through the code on MonoDevelop on Ubuntu. The stack trace is present when the exception is initially thrown:

![image](https://user-images.githubusercontent.com/8040367/58386509-a03f3c00-7fce-11e9-9ca9-c5c7e6737904.png)

On the very next step when you press F10, the step out of MethodInfo.Invoke, the stack trace has been overwritten with useless info:

![image](https://user-images.githubusercontent.com/8040367/58386536-29567300-7fcf-11e9-99ad-80ebe7f7697a.png)

Full text of the thrown exception's StackTrace after stepping out of MethodInfo.Invoke:

![image](https://user-images.githubusercontent.com/8040367/58386539-34110800-7fcf-11e9-882e-24722fab8947.png)
