### PR TITLE
Enable and begin using C# 7.0 syntax (requires capable compiler)

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -283,7 +283,7 @@ namespace System.Threading
     /// </summary>
     internal static class PlatformHelper
     {
-        private const int PROCESSOR_COUNT_REFRESH_INTERVAL_MS = 30000; // How often to refresh the count, in milliseconds.
+        private const int PROCESSOR_COUNT_REFRESH_INTERVAL_MS = 30_000; // How often to refresh the count, in milliseconds.
         private static volatile int s_processorCount; // The last count seen.
         private static volatile int s_lastProcessorCountRefreshTicks; // The last time we refreshed.
 

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -127,16 +127,14 @@ namespace NUnitLite.Tests
         public void TestResults_HasValidDateAttribute()
         {
             string dateString = RequiredAttribute(topNode, "date");
-            DateTime date;
-            Assert.That(DateTime.TryParse(dateString, out date), "Invalid date attribute: {0}", dateString);
+            Assert.That(DateTime.TryParse(dateString, out _), "Invalid date attribute: {0}", dateString);
         }
 
         [Test]
         public void TestResults_HasValidTimeAttribute()
         {
             string timeString = RequiredAttribute(topNode, "time");
-            DateTime time;
-            Assert.That(DateTime.TryParse(timeString, out time), "Invalid time attribute: {0}", timeString);
+            Assert.That(DateTime.TryParse(timeString, out _), "Invalid time attribute: {0}", timeString);
         }
 
         [Test]
@@ -204,10 +202,9 @@ namespace NUnitLite.Tests
         [Test]
         public void TestSuite_HasValidTimeAttribute()
         {
-            double time;
             var timeString = RequiredAttribute(suiteNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
-            var success = double.TryParse(timeString,System.Globalization.NumberStyles.Float,System.Globalization.NumberFormatInfo.InvariantInfo, out time);
+            var success = double.TryParse(timeString, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out _);
             Assert.That(success, "{0} is an invalid value for time", timeString);
         }
 

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -48,12 +48,12 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         [TestCase(2, 3, 4, Category = "XYZ")]
         public void MethodHasSingleCategory(int x, int y, int z)
         { }
- 
+
         [TestCase(2, 3, 4, Category = "X,Y,Z")]
         public void MethodHasMultipleCategories(int x, int y, int z)
         { }
- 
-        [TestCase(2, 2000000, ExpectedResult=4)]
+
+        [TestCase(2, 2_000_000, ExpectedResult=4)]
         public int MethodCausesConversionOverflow(short x, short y)
         {
             return x + y;

--- a/src/NUnitFramework/testdata/WarningFixture.cs
+++ b/src/NUnitFramework/testdata/WarningFixture.cs
@@ -661,7 +661,7 @@ namespace NUnit.TestData
                     }
                 }).BeginInvoke(ar => { }, null);
 
-                if (!finished.WaitOne(10000)) Assert.Fail("Timeout while waiting for BeginInvoke to execute.");
+                if (!finished.WaitOne(10_000)) Assert.Fail("Timeout while waiting for BeginInvoke to execute.");
             }
         }
 
@@ -682,7 +682,7 @@ namespace NUnit.TestData
                     }
                 }).Start();
 
-                if (!finished.WaitOne(10000))
+                if (!finished.WaitOne(10_000))
                     Assert.Fail("Timeout while waiting for threadstart to execute.");
             }
         }
@@ -704,7 +704,7 @@ namespace NUnit.TestData
                     }
                 });
 
-                if (!finished.WaitOne(10000))
+                if (!finished.WaitOne(10_000))
                     Assert.Fail("Timeout while waiting for Threadpool.QueueUserWorkItem to execute.");
             }
         }
@@ -713,7 +713,7 @@ namespace NUnit.TestData
         [Test]
         public static void WarningInTaskRun()
         {
-            if (!Task.Run(() => Assert.Warn("(Warning message)")).Wait(10000))
+            if (!Task.Run(() => Assert.Warn("(Warning message)")).Wait(10_000))
                 Assert.Fail("Timeout while waiting for Task.Run to execute.");
         }
 

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -752,8 +752,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ValueTupleAreEqual()
         {
-            var set1 = new SimpleEnumerable(ValueTuple.Create(1,2,3), ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 3));
-            var set2 = new SimpleEnumerable(ValueTuple.Create(1,2,3), ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 3));
+            var set1 = new SimpleEnumerable((1, 2, 3), (1, 2, 3), (1, 2, 3));
+            var set2 = new SimpleEnumerable((1, 2, 3), (1, 2, 3), (1, 2, 3));
 
             CollectionAssert.AreEqual(set1, set2);
             CollectionAssert.AreEqual(set1, set2, new TestComparer());
@@ -764,8 +764,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ValueTupleAreEqualFail()
         {
-            var set1 = new SimpleEnumerable(ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 3));
-            var set2 = new SimpleEnumerable(ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 3), ValueTuple.Create(1, 2, 4));
+            var set1 = new SimpleEnumerable((1, 2, 3), (1, 2, 3), (1, 2, 3));
+            var set2 = new SimpleEnumerable((1, 2, 3), (1, 2, 3), (1, 2, 4));
 
             var expectedMessage =
                 "  Expected and actual are both <NUnit.TestUtilities.Collections.SimpleEnumerable>" + Environment.NewLine +
@@ -780,14 +780,14 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ElementsWithinTuplesAreComparedUsingNUnitEqualityComparer()
         {
-            var a = new Dictionary<string, ValueTuple<string, Dictionary<string, string>>>()
+            var a = new Dictionary<string, (string, Dictionary<string, string>)>()
             {
-                { "key", ValueTuple.Create("name", new Dictionary<string, string>())}
+                { "key", ("name", new Dictionary<string, string>())}
             };
 
-            var b = new Dictionary<string, ValueTuple<string, Dictionary<string, string>>>()
+            var b = new Dictionary<string, (string, Dictionary<string, string>)>()
             {
-                { "key", ValueTuple.Create("name", new Dictionary<string, string>())}
+                { "key", ("name", new Dictionary<string, string>())}
             };
 
             CollectionAssert.AreEquivalent(a, b);

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Assertions
             Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
         }
 
-        static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
+        static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10_000);
 
         static readonly IEnumerable[] PerformanceData =
         {

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Attributes
 
         [Test]
 #if THREAD_ABORT
-        [Timeout(10000)]
+        [Timeout(10_000)]
 #endif
 #if NETCOREAPP2_0
         [Platform(Include = "Win, Mono")]
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Attributes
 
         [TestFixture]
 #if THREAD_ABORT
-        [Timeout(10000)]
+        [Timeout(10_000)]
 #endif
 #if NETCOREAPP2_0
         [Platform(Include = "Win, Mono")]

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Constraints
             {
                 DateTime expected = new DateTime(2007, 4, 1, 13, 0, 0);
                 DateTime actual = new DateTime(2007, 4, 1, 13, 1, 0);
-                Assert.That(actual, new EqualConstraint(expected).Within(300000).Milliseconds);
+                Assert.That(actual, new EqualConstraint(expected).Within(300_000).Milliseconds);
             }
 
             [Test]
@@ -308,7 +308,7 @@ namespace NUnit.Framework.Constraints
             {
                 var expected = new DateTimeOffset(new DateTime(2007, 4, 1, 13, 0, 0));
                 var actual =  new DateTimeOffset(new DateTime(2007, 4, 1, 13, 1, 0));
-                Assert.That(actual, new EqualConstraint(expected).Within(300000).Milliseconds);
+                Assert.That(actual, new EqualConstraint(expected).Within(300_000).Milliseconds);
             }
 
             [Test]

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -170,21 +170,22 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_TwoElementsValueTupleTest()
         {
-            string s = MsgUtils.FormatValue(ValueTuple.Create("Hello", 123));
+            string s = MsgUtils.FormatValue(("Hello", 123));
             Assert.That(s, Is.EqualTo("(\"Hello\", 123)"));
         }
 
         [Test]
         public static void FormatValue_ThreeElementsValueTupleTest()
         {
-            string s = MsgUtils.FormatValue(ValueTuple.Create("Hello", 123, 'a'));
+            string s = MsgUtils.FormatValue(("Hello", 123, 'a'));
             Assert.That(s, Is.EqualTo("(\"Hello\", 123, 'a')"));
         }
 
         [Test]
         public static void FormatValue_EightElementsValueTupleTest()
         {
-            var tuple = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8);
+            var tuple = (1, 2, 3, 4, 5, 6, 7, 8);
+
             string s = MsgUtils.FormatValue(tuple);
             Assert.That(s, Is.EqualTo("(1, 2, 3, 4, 5, 6, 7, 8)"));
         }
@@ -192,7 +193,8 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_EightElementsValueTupleNestedTest()
         {
-            var tuple = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, "9"));
+            var tuple = (1, 2, 3, 4, 5, 6, 7, (8, "9"));
+
             string s = MsgUtils.FormatValue(tuple);
             Assert.That(s, Is.EqualTo("(1, 2, 3, 4, 5, 6, 7, (8, \"9\"))"));
         }
@@ -200,9 +202,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void FormatValue_FifteenElementsValueTupleTest()
         {
-            var tupleLastElements = ValueTuple.Create(8, 9, 10, 11, "12", 13, 14, "15");
-            var tuple = new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, string, int, int, ValueTuple<string>>>
-                (1, 2, 3, 4, 5, 6, 7, tupleLastElements);
+            var tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, "12", 13, 14, "15");
 
             string s = MsgUtils.FormatValue(tuple);
             Assert.That(s, Is.EqualTo("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, \"12\", 13, 14, \"15\")"));

--- a/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
@@ -33,35 +33,33 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void SucceedsWhenTuplesAreTheSame()
         {
-            ValueTuple<string, int> tuple1 = new ValueTuple<string, int>("Hello", 3);
-            ValueTuple<string, int> tuple2 = new ValueTuple<string, int>("Hello", 3);
+            ValueTuple<string, int> tuple1 = ("Hello", 3);
+            ValueTuple<string, int> tuple2 = ("Hello", 3);
             Assert.That(tuple1, Is.EqualTo(tuple2));
         }
 
         [Test]
         public void SucceedsWhenContentOfTuplesAreEquivalent()
         {
-            ValueTuple<string, int> tuple1 = new ValueTuple<string, int>("Hello", 3);
-            ValueTuple<string, int?> tuple2 = new ValueTuple<string, int?>("Hello", 3);
+            ValueTuple<string, int> tuple1 = ("Hello", 3);
+            ValueTuple<string, int?> tuple2 = ("Hello", 3);
             Assert.That(tuple1, Is.EqualTo(tuple2));
         }
 
         [Test]
         public void SucceedsWhenContentOfTuplesAreEquivalentWith8Elements()
         {
-            var tuple1 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8);
-            var tuple2 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8.0f);
+            var tuple1 = (1, 2, 3, 4, 5, 6, 7, 8);
+            var tuple2 = (1, 2, 3, 4, 5, 6, 7, 8.0f);
+
             Assert.That(tuple1, Is.EqualTo(tuple2));
         }
 
         [Test]
         public void SucceedsWhenContentOfTuplesAreEquivalentWith15Elements()
         {
-            var tuple1LastElements = ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, 15);
-            var tuple1 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, tuple1LastElements);
-
-            var tuple2LastElements = ValueTuple.Create(8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f);
-            var tuple2 = ValueTuple.Create(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, tuple2LastElements);
+            var tuple1 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+            var tuple2 = (1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f);
 
             Assert.That(tuple1, Is.EqualTo(tuple2));
         }
@@ -69,24 +67,24 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void FailsWhenTuplesAreOfDifferentLengths()
         {
-            ValueTuple<string, int> tuple1 = new ValueTuple<string, int>("Hello", 3);
-            ValueTuple<string, int, int> tuple2 = new ValueTuple<string, int, int>("Hello", 3, 1);
+            ValueTuple<string, int> tuple1 = ("Hello", 3);
+            ValueTuple<string, int, int> tuple2 = ("Hello", 3, 1);
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
         }
 
         [Test]
         public void FailsWhenContentOfTuplesAreDifferent()
         {
-            ValueTuple<string, int> tuple1 = new ValueTuple<string, int>("Hello", 3);
-            ValueTuple<string, int> tuple2 = new ValueTuple<string, int>("Hello", 4);
+            ValueTuple<string, int> tuple1 = ("Hello", 3);
+            ValueTuple<string, int> tuple2 = ("Hello", 4);
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
         }
 
         [Test]
         public void FailsWhenContentOfTuplesAreDifferentWith8Elements()
         {
-            var tuple1 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8);
-            var tuple2 = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 9);
+            var tuple1 = (1, 2, 3, 4, 5, 6, 7, 8);
+            var tuple2 = (1, 2, 3, 4, 5, 6, 7, 9);
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
         }
 

--- a/src/NUnitFramework/tests/Internal/RandomizerBiasTests.cs
+++ b/src/NUnitFramework/tests/Internal/RandomizerBiasTests.cs
@@ -25,7 +25,7 @@ namespace NUnit.Framework.Internal
 {
     public static class RandomizerBiasTests
     {
-        private const int TrialCount = 100000;
+        private const int TrialCount = 100_000;
         private const double ConfidenceInterval = 0.00965802342765787;
 
         /* Random generators wouldn’t be truly random if it was impossible to hit a highly biased sequence.
@@ -51,14 +51,14 @@ namespace NUnit.Framework.Internal
         negatives would then only occur on average only one month out of every 286 years.
 
         One in a billion, or 99.9999999% confidence, seems desirable. To obtain this confidence level, we need a
-        sufficiently high trial count or a sufficiently high tolerance. I chose a trial count of 100000 because
+        sufficiently high trial count or a sufficiently high tolerance. I chose a trial count of 100,000 because
         that takes only about 10ms on my machine. That results in a confidence interval (see Wikipedia link above)
         of ~±0.0097 around 0.5. 0.5 of the trials are expected to succeed, where success means something
         like "the third bit is set"—something which we expect to happen half the time if the generator is not
         biased. If we check whether the actual tested fraction of the time is within ~±0.0097 of 0.5, we will
         have the desired 99.9999999% confidence level per trial.
 
-        I used this tool to calculate the confidence interval for trial count 100000, success count 50000,
+        I used this tool to calculate the confidence interval for trial count 100,000, success count 50,000,
         confidence 99.9999999%, and method Agresti-Coull:
         http://epitools.ausvet.com.au/content.php?page=CIProportion&SampleSize=100000&Positive=50000&Conf=0.999999999&method=5&Digits=17
         The result is placed in the ConfidenceInterval constant above.

--- a/src/NUnitFramework/tests/Internal/TestWorkerTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestWorkerTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Internal.Execution
             _queue.Start();
 
             Assert.That(() => sb.ToString(), Is.EqualTo("BusyExecIdle").After(
-                delayInMilliseconds: 10000, pollingInterval: 200));
+                delayInMilliseconds: 10_000, pollingInterval: 200));
         }
 
         private void FakeMethod()

--- a/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
+++ b/src/NUnitFramework/tests/Internal/ThreadUtilityTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal
                 // I measured timer callbacks to be firing around ten times later than the 100 ms requested.
                 // All this number does is manage how long we can tolerate waiting for a build if a bug
                 // is introduced and the thread never aborts.
-                const int waitTime = 15000;
+                const int waitTime = 15_000;
 
                 Assert.That(thread.Join(waitTime), "Native message pump was not able to be interrupted to enable a managed thread abort.");
             }

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -136,7 +136,7 @@ namespace NUnit.Framework
             return (SynchronizationContext)Activator.CreateInstance(knownSynchronizationContextType);
         }
 
-        [Test, Timeout(10000)]
+        [Test, Timeout(10_000)]
         public static void ContinuationDoesNotDeadlockOnKnownSynchronizationContext(
             [ValueSource(nameof(KnownSynchronizationContextTypes))] Type knownSynchronizationContextType,
             [ValueSource(nameof(ApiAdapters))] AsyncExecutionApiAdapter apiAdapter)
@@ -166,7 +166,7 @@ namespace NUnit.Framework
             }
         }
 
-        [Test, Timeout(10000)]
+        [Test, Timeout(10_000)]
         public static void AwaitingContinuationDoesNotAlterSynchronizationContext(
             [ValueSource(nameof(KnownSynchronizationContextTypes))] Type knownSynchronizationContextType,
             [ValueSource(nameof(ApiAdapters))] AsyncExecutionApiAdapter apiAdapter)


### PR DESCRIPTION
There is one commit to enable C# 7 and then four small cleanup commits.

@rprouse at https://github.com/nunit/nunit/pull/3258#discussion_r286954570:

> I think we should keep the `<LangVersion>` to make sure language features that aren't supported in VS 2017 don't creep in, but I'm fine with updating it to 7 from 6. I'm not sure, but I think we may require 15.3+ which would allow 7.1, but our `BUILDING.md` just says VS 2017, so 7 is safest.

