### PR TITLE
Ignores Mono stack trace inconsistency (missed these two in the first PR)

### DIFF
--- a/src/NUnitFramework/tests/Internal/ReflectTests.cs
+++ b/src/NUnitFramework/tests/Internal/ReflectTests.cs
@@ -241,23 +241,29 @@ namespace NUnit.Framework.Internal
         [Test]
         public static void InvokeWithTransparentExceptionsPreservesStackTrace()
         {
-            Assert.That(
-                () => typeof(ReflectTests)
-                    .GetMethod(nameof(MethodThrowingTargetInvocationException), BindingFlags.Static | BindingFlags.NonPublic)
-                    .InvokeWithTransparentExceptions(instance: null),
-                Throws.Exception
-                    .With.Property(nameof(Exception.StackTrace))
-                        .Contains(nameof(MethodThrowingTargetInvocationException)));
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.IgnoreOnAffectedPlatform(() =>
+            {
+                Assert.That(
+                    () => typeof(ReflectTests)
+                        .GetMethod(nameof(MethodThrowingTargetInvocationException), BindingFlags.Static | BindingFlags.NonPublic)
+                        .InvokeWithTransparentExceptions(instance: null),
+                    Throws.Exception
+                        .With.Property(nameof(Exception.StackTrace))
+                            .Contains(nameof(MethodThrowingTargetInvocationException)));
+            });
         }
 
         [Test]
         public static void DynamicInvokeWithTransparentExceptionsPreservesStackTrace()
         {
-            Assert.That(
-                () => new Func<int>(MethodThrowingTargetInvocationException).DynamicInvokeWithTransparentExceptions(),
-                Throws.Exception
-                    .With.Property(nameof(Exception.StackTrace))
-                        .Contains(nameof(MethodThrowingTargetInvocationException)));
+            PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.IgnoreOnAffectedPlatform(() =>
+            {
+                Assert.That(
+                    () => new Func<int>(MethodThrowingTargetInvocationException).DynamicInvokeWithTransparentExceptions(),
+                    Throws.Exception
+                        .With.Property(nameof(Exception.StackTrace))
+                            .Contains(nameof(MethodThrowingTargetInvocationException)));
+            });
         }
 
         private static int MethodReturning42() => 42;


### PR DESCRIPTION
Closes #3257 since I missed two tests in #3261. Now that AzDo uses Mono 5.20, the CI is actually validating this effort.

EDIT: Corrected link to PR.