### PR TITLE
Fix forced StopRun

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -382,8 +382,10 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         private void OnAllChildItemsCompleted()
         {
-            var teardown = new OneTimeTearDownWorkItem(this);
-            Context.Dispatcher.Dispatch(teardown);
+            if (Context.ExecutionStatus == TestExecutionStatus.AbortRequested)
+                WorkItemComplete();
+            else
+                Context.Dispatcher.Dispatch(new OneTimeTearDownWorkItem(this));
         }
 
         private readonly object cancelLock = new object();

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -28,6 +28,7 @@ using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Interfaces;
+using System.Diagnostics;
 
 namespace NUnit.Framework.Internal.Execution
 {
@@ -459,9 +460,6 @@ namespace NUnit.Framework.Internal.Execution
             {
                 lock (_teardownLock)
                 {
-                    //if (Test.Parent != null && Test.Parent.Name.EndsWith("nunit.framework.tests.dll"))
-                    //    System.Diagnostics.Debugger.Launch();
-
                     if (Test.TestType == "Theory" && Result.ResultState == ResultState.Success && Result.PassCount == 0)
                         Result.SetResult(ResultState.Failure, "No test cases were provided");
 
@@ -483,6 +481,20 @@ namespace NUnit.Framework.Internal.Execution
             /// PerformWork is not used in CompositeWorkItem
             /// </summary>
             protected override void PerformWork() { }
+
+#if PARALLEL
+            /// <summary>
+            /// WorkItemCancelled is called directly by the parallel dispatcher
+            /// when a test suite is left hanging after a forced StopRun. We
+            /// simulate WorkItemComplete() but without the ripple effect to
+            /// higher level suites, since we are controlling it all directly.
+            /// </summary>
+            internal void WorkItemCancelled()
+            {
+                Result.SetResult(ResultState.Cancelled, TestResult.USER_CANCELLED_MESSAGE);
+                _originalWorkItem.WorkItemComplete();
+            }
+#endif
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
@@ -170,6 +170,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         private void PumpThreadProc()
         {
+            log.Debug("Starting EventPump");
+
             //ITestListener hostListeners = CoreExtensions.Host.Listeners;
             try
             {
@@ -188,6 +190,8 @@ namespace NUnit.Framework.Internal.Execution
                         log.Error("Exception in event handler {0}", ExceptionHelper.BuildStackTrace(ex));
                     }
                 }
+
+                log.Debug("EventPump Terminating");
             }
             catch (Exception ex)
             {

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Gets the current state of the WorkItem
         /// </summary>
-        public WorkItemState State { get; private set; }
+        public WorkItemState State { get; protected set; }
 
         /// <summary>
         /// The test being executed by the work item
@@ -303,6 +303,7 @@ namespace NUnit.Framework.Internal.Execution
 
                 lock (threadLock)
                 {
+                    // Exit if not running on a separate thread
                     if (thread == null)
                         return;
 

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -58,6 +58,11 @@ namespace NUnit.Framework.Internal
         internal static readonly string CHILD_IGNORE_MESSAGE = "One or more child tests were ignored";
 
         /// <summary>
+        /// Error message for when user has cancelled the test run
+        /// </summary>
+        internal const string USER_CANCELLED_MESSAGE = "Test run cancelled by user";
+
+        /// <summary>
         /// The minimum duration for tests
         /// </summary>
         internal const double MIN_DURATION = 0.000001d;

--- a/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
@@ -257,7 +257,9 @@ namespace NUnit.Framework.Internal
                     break;
 
                 case TestStatus.Failed:
-                    if (ResultState.Status != TestStatus.Failed)
+                    if (childResultState.Label == "Cancelled")
+                        SetResult(ResultState.Cancelled, USER_CANCELLED_MESSAGE);
+                    else if (ResultState.Status != TestStatus.Failed)
                         SetResult(ResultState.ChildFailure, CHILD_ERRORS_MESSAGE);
                     break;
 

--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Tests
 {
     public class SlowTests
     {
-        const int DELAY = 1000;
+        public const int SINGLE_TEST_DELAY = 1000;
 
         public class AAA
         {
@@ -61,7 +61,7 @@ namespace NUnit.Tests
 
         private static void Delay()
         {
-            System.Threading.Thread.Sleep(DELAY);
+            System.Threading.Thread.Sleep(SINGLE_TEST_DELAY);
         }
     }
 }

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -249,9 +249,9 @@ namespace NUnit.Framework.Api
             var explorer = _runner.ExploreTests(filter);
             Assert.That(explorer.TestCaseCount, Is.EqualTo(_runner.CountTestCases(filter)));
         }
-#endregion
+        #endregion
 
-#region Run
+        #region Run
 
         [Test]
         public void Run_AfterLoad_ReturnsRunnableSuite()
@@ -364,9 +364,9 @@ namespace NUnit.Framework.Api
                 Does.StartWith("Could not load"));
         }
 
-#endregion
+        #endregion
 
-#region RunAsync
+        #region RunAsync
 
         [Test]
         public void RunAsync_AfterLoad_ReturnsRunnableSuite()
@@ -447,7 +447,7 @@ namespace NUnit.Framework.Api
 
         #endregion
 
-#region StopRun
+        #region StopRun
 
 #if THREAD_ABORT // Can't stop run on platforms without ability to abort thread
         [Test]
@@ -507,9 +507,9 @@ namespace NUnit.Framework.Api
         }
 #endif
 
-#endregion
+        #endregion
 
-#region ITestListener Implementation
+        #region ITestListener Implementation
 
         void ITestListener.TestStarted(ITest test)
         {
@@ -569,9 +569,9 @@ namespace NUnit.Framework.Api
 
         }
 
-#endregion
+        #endregion
 
-#region Helper Methods
+        #region Helper Methods
 
         private ITest LoadMockAssembly()
         {
@@ -603,6 +603,6 @@ namespace NUnit.Framework.Api
                 "Parameter Y = 7" + Environment.NewLine));
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -39,6 +39,7 @@ using NUnit.Framework.Internal.Filters;
 namespace NUnit.Framework.Api
 {
     // Functional tests of the TestAssemblyRunner and all subordinate classes
+    [NonParallelizable]
     public class TestAssemblyRunnerTests : ITestListener
     {
         private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";
@@ -85,11 +86,6 @@ namespace NUnit.Framework.Api
             _failCount = 0;
             _skipCount = 0;
             _inconclusiveCount = 0;
-        }
-
-        public void DestroyRunner()
-        {
-            
         }
 
         #region Load
@@ -458,9 +454,11 @@ namespace NUnit.Framework.Api
         {
             new TestCaseData(0, false).SetName("{m}(Simple dispatcher, cooperative stop)"),
             new TestCaseData(0, true).SetName("{m}(Simple dispatcher, forced stop)"),
+#if PARALLEL
             new TestCaseData(2, false).SetName("{m}(Parallel dispatcher, cooperative stop)"),
 #if !NETCOREAPP2_0 // Hangs the CI build
             new TestCaseData(2, true).SetName("{m}(Parallel dispatcher, forced stop)")
+#endif
 #endif
         };
 


### PR DESCRIPTION
A start on issue #3276.

I made this a WIP PR with failing tests so we could all see where the problem is and what might be involved in fixing it. Also, to get some ideas for moving further. Here's what I know.

1. When a runner uses `StopRun(true)` to force cancelling the run, the system hangs.

2. We never knew this for two reasons:
  * We don't use this call in the console runner
  * Our tests of this feature were never actually testing anything because the `StopRun` call occured before the run even got started. I used a `SpinWait.SpinUntil` to fix that and get the tests to fail.

3. All running test cases were properly terminated. That code seems solid.

4. The containing fixtures for such test cases, however, are never terminated. That's because we enqueue a special `WorkItem` for one time teardown after the test workers have stopped processing the queue. I fixed this in `CompositeWorkItem`.

5. However, any such special one time teardown work items that were enqueued __before__ we stopped the run will never be executed. I believe this is true whether the stop is forced or cooperative but I don't have a test for it because it involves a very narrow window and a race condition.

6. Higher level suites, such as namespaces and the assembly itself are never terminated. That's why we get the hang. I've taken the code to the point where the terminating fixture __tries__ to notify the higher level suite but an exception gets thrown because of the pending Thread abort.

Here's what I believe...

1. We may be able to craft some special-purpose code to ensure that all in-flight suites terminate. Such code is likely IMO to lead to more technical debt in the dispatcher.

2. We probably need a full re-design of the parallel dispatcher that takes into account all the various addons that have happened since the first version. That version managed test cases very explicitly but allowed suites and fixtures to manage themselves WRT dependencies on completing children. I've always had a sense that we would eventually go to a more explicit model in the dispatcher, where every work item was tracked, along with it's dependencies, from the time of creation until it completed. Maybe that time is now.

I'm setting the issue to the side for now while I work on a workaround on the GUI side but if anyone has ideas about this I can come back to it and give them a try.