### PR TITLE
Use pattern matching and throw expressions

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -138,8 +138,7 @@ namespace NUnit.Framework.Api
 
                 if (options.ContainsKey(FrameworkPackageSettings.TestParametersDictionary))
                 {
-                    var testParametersDictionary = options[FrameworkPackageSettings.TestParametersDictionary] as IDictionary<string, string>;
-                    if (testParametersDictionary != null)
+                    if (options[FrameworkPackageSettings.TestParametersDictionary] is IDictionary<string, string> testParametersDictionary)
                     {
                         foreach (var parameter in testParametersDictionary)
                             TestContext.Parameters.Add(parameter.Key, parameter.Value);

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -421,8 +421,7 @@ namespace NUnit.Framework.Api
 
             if (value != null)
             {
-                var dict = value as IDictionary;
-                if (dict != null)
+                if (value is IDictionary dict)
                 {
                     AddDictionaryEntries(setting, dict);
                     AddBackwardsCompatibleDictionaryEntries(setting, dict);

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -196,8 +196,7 @@ namespace NUnit.Framework
                             // 3. An array was passed, it may be an object[]
                             //    or possibly some other kind of array, which
                             //    TestCaseSource can accept.
-                            var array = item as Array;
-                            if (array != null)
+                            if (item is Array array)
                             {
                                 // If array has the same number of elements as parameters
                                 // and it does not fit exactly into single existing parameter
@@ -258,22 +257,19 @@ namespace NUnit.Framework
             {
                 MemberInfo member = members[0];
 
-                var field = member as FieldInfo;
-                if (field != null)
+                if (member is FieldInfo field)
                     return field.IsStatic
                         ? (MethodParams == null ? (IEnumerable)field.GetValue(null)
                                                 : ReturnErrorAsParameter(ParamGivenToField))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
 
-                var property = member as PropertyInfo;
-                if (property != null)
+                if (member is PropertyInfo property)
                     return property.GetGetMethod(true).IsStatic
                         ? (MethodParams == null ? (IEnumerable)property.GetValue(null, null)
                                                 : ReturnErrorAsParameter(ParamGivenToProperty))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
 
-                var m = member as MethodInfo;
-                if (m != null)
+                if (member is MethodInfo m)
                     return m.IsStatic
                         ? (MethodParams == null || m.GetParameters().Length == MethodParams.Length
                             ? (IEnumerable)m.Invoke(null, MethodParams)

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -147,18 +147,8 @@ namespace NUnit.Framework
                 {
                     foreach (object item in source)
                     {
-                        var parms = item as ITestFixtureData;
-
-                        if (parms == null)
-                        {
-                            object[] args = item as object[];
-                            if (args == null)
-                            {
-                                args = new object[] { item };
-                            }
-
-                            parms = new TestFixtureParameters(args);
-                        }
+                        var parms = item as ITestFixtureData
+                            ?? new TestFixtureParameters(item as object[] ?? new object[] { item });
 
                         if (this.Category != null)
                             foreach (string cat in this.Category.Split(new char[] { ',' }))
@@ -190,20 +180,17 @@ namespace NUnit.Framework
             {
                 MemberInfo member = members[0];
 
-                var field = member as FieldInfo;
-                if (field != null)
+                if (member is FieldInfo field)
                     return field.IsStatic
                         ? (IEnumerable)field.GetValue(null)
                         : SourceMustBeStaticError();
 
-                var property = member as PropertyInfo;
-                if (property != null)
+                if (member is PropertyInfo property)
                     return property.GetGetMethod(true).IsStatic
                         ? (IEnumerable)property.GetValue(null, null)
                         : SourceMustBeStaticError();
 
-                var m = member as MethodInfo;
-                if (m != null)
+                if (member is MethodInfo m)
                     return m.IsStatic
                         ? (IEnumerable)m.Invoke(null, null)
                         : SourceMustBeStaticError();

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -118,8 +118,7 @@ namespace NUnit.Framework
 
             MemberInfo member = members[0];
 
-            var field = member as FieldInfo;
-            if (field != null)
+            if (member is FieldInfo field)
             {
                 if (field.IsStatic)
                     return (IEnumerable)field.GetValue(null);
@@ -127,8 +126,7 @@ namespace NUnit.Framework
                 ThrowInvalidDataSourceException();
             }
 
-            var property = member as PropertyInfo;
-            if (property != null)
+            if (member is PropertyInfo property)
             {
                 if (property.GetGetMethod(true).IsStatic)
                     return (IEnumerable)property.GetValue(null, null);
@@ -136,8 +134,7 @@ namespace NUnit.Framework
                 ThrowInvalidDataSourceException();
             }
 
-            var m = member as MethodInfo;
-            if (m != null)
+            if (member is MethodInfo m)
             {
                 if (m.IsStatic)
                     return (IEnumerable)m.Invoke(null, null);

--- a/src/NUnitFramework/framework/Compatibility/AttributeHelper.cs
+++ b/src/NUnitFramework/framework/Compatibility/AttributeHelper.cs
@@ -42,17 +42,17 @@ namespace NUnit.Compatibility
         public static Attribute[] GetCustomAttributes(object actual, Type attributeType, bool inherit)
         {
 #if NETSTANDARD1_4
-            var member = actual as MemberInfo;
-            if (member != null) return (Attribute[])member.GetCustomAttributes(attributeType, inherit);
+            if (actual is MemberInfo member)
+                return (Attribute[])member.GetCustomAttributes(attributeType, inherit);
 
-            var type = actual as Type;
-            if (type != null) return (Attribute[])type.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
+            if (actual is Type type)
+                return (Attribute[])type.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
 
-            var parameter = actual as ParameterInfo;
-            if (parameter != null) return (Attribute[])parameter.GetCustomAttributes(attributeType, inherit);
+            if (actual is ParameterInfo parameter)
+                return (Attribute[])parameter.GetCustomAttributes(attributeType, inherit);
 
-            var assembly = actual as Assembly;
-            if (assembly != null) return (Attribute[])assembly.GetCustomAttributes(attributeType);
+            if (actual is Assembly assembly)
+                return (Attribute[])assembly.GetCustomAttributes(attributeType);
 
             var interfaceType = actual?.GetType().GetInterfaces().SingleOrDefault(i => i.FullName == "System.Reflection.ICustomAttributeProvider");
             if (interfaceType != null)
@@ -61,8 +61,8 @@ namespace NUnit.Compatibility
                 return (Attribute[])method.Invoke(actual, new object[] { attributeType, inherit });
             }
 #else
-            var attrProvider = actual as ICustomAttributeProvider;
-            if (attrProvider != null) return (Attribute[])attrProvider.GetCustomAttributes(attributeType, inherit);
+            if (actual is ICustomAttributeProvider attrProvider)
+                return (Attribute[])attrProvider.GetCustomAttributes(attributeType, inherit);
 #endif
 
             throw new ArgumentException($"Actual value {actual} does not implement ICustomAttributeProvider.", nameof(actual));

--- a/src/NUnitFramework/framework/Constraints/CollectionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionConstraint.cs
@@ -53,8 +53,7 @@ namespace NUnit.Framework.Constraints
         /// </returns>
         protected static bool IsEmpty(IEnumerable enumerable)
         {
-            ICollection collection = enumerable as ICollection;
-            if (collection != null)
+            if (enumerable is ICollection collection)
                 return collection.Count == 0;
 
             foreach (object o in enumerable)

--- a/src/NUnitFramework/framework/Constraints/Comparers/EnumerablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EnumerablesComparer.cs
@@ -40,52 +40,40 @@ namespace NUnit.Framework.Constraints.Comparers
 
         public bool? Equal(object x, object y, ref Tolerance tolerance, bool topLevelComparison = true)
         {
-            if (!(x is IEnumerable) || !(y is IEnumerable))
+            if (!(x is IEnumerable xIEnumerable && y is IEnumerable yIEnumerable))
                 return null;
 
-            IEnumerable xIEnumerable = (IEnumerable)x;
-            IEnumerable yIEnumerable = (IEnumerable)y;
-
-            IEnumerator expectedEnum = null;
-            IEnumerator actualEnum = null;
-
-            try
+            var expectedEnum = xIEnumerable.GetEnumerator();
+            using (expectedEnum as IDisposable)
             {
-                expectedEnum = xIEnumerable.GetEnumerator();
-                actualEnum = yIEnumerable.GetEnumerator();
-
-                int count;
-                for (count = 0; ; count++)
+                var actualEnum = yIEnumerable.GetEnumerator();
+                using (actualEnum as IDisposable)
                 {
-                    bool expectedHasData = expectedEnum.MoveNext();
-                    bool actualHasData = actualEnum.MoveNext();
-
-                    if (!expectedHasData && !actualHasData)
-                        return true;
-                    
-                    if (expectedHasData != actualHasData ||
-                        !_equalityComparer.AreEqual(expectedEnum.Current, actualEnum.Current, ref tolerance, topLevelComparison: false))
+                    int count;
+                    for (count = 0; ; count++)
                     {
-                        NUnitEqualityComparer.FailurePoint fp = new NUnitEqualityComparer.FailurePoint();
-                        fp.Position = count;
-                        fp.ExpectedHasData = expectedHasData;
-                        if (expectedHasData)
-                            fp.ExpectedValue = expectedEnum.Current;
-                        fp.ActualHasData = actualHasData;
-                        if (actualHasData)
-                            fp.ActualValue = actualEnum.Current;
-                        _equalityComparer.FailurePoints.Insert(0, fp);
-                        return false;
+                        bool expectedHasData = expectedEnum.MoveNext();
+                        bool actualHasData = actualEnum.MoveNext();
+
+                        if (!expectedHasData && !actualHasData)
+                            return true;
+
+                        if (expectedHasData != actualHasData ||
+                            !_equalityComparer.AreEqual(expectedEnum.Current, actualEnum.Current, ref tolerance, topLevelComparison: false))
+                        {
+                            NUnitEqualityComparer.FailurePoint fp = new NUnitEqualityComparer.FailurePoint();
+                            fp.Position = count;
+                            fp.ExpectedHasData = expectedHasData;
+                            if (expectedHasData)
+                                fp.ExpectedValue = expectedEnum.Current;
+                            fp.ActualHasData = actualHasData;
+                            if (actualHasData)
+                                fp.ActualValue = actualEnum.Current;
+                            _equalityComparer.FailurePoints.Insert(0, fp);
+                            return false;
+                        }
                     }
                 }
-            }
-            finally
-            {
-                var expectedDisposable = expectedEnum as IDisposable;
-                if (expectedDisposable != null) expectedDisposable.Dispose();
-
-                var actualDisposable = actualEnum as IDisposable;
-                if (actualDisposable != null) actualDisposable.Dispose();
             }
         }
     }

--- a/src/NUnitFramework/framework/Constraints/EmptyDirectoryConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyDirectoryConstraint.cs
@@ -21,8 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.IO;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -50,9 +50,8 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            DirectoryInfo dirInfo = actual as DirectoryInfo;
-            if (dirInfo == null)
-                throw new ArgumentException("The actual value must be a DirectoryInfo", nameof(actual));
+            var dirInfo = ConstraintUtils.RequireActual<DirectoryInfo>(actual, nameof(actual));
+
             files = dirInfo.GetFiles().Length;
             subdirs = dirInfo.GetDirectories().Length;
             bool hasSucceeded = files == 0 && subdirs == 0;

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
 {
     /// <summary>
     /// The EqualConstraintResult class is tailored for formatting
-    /// and displaying the result of an EqualConstraint. 
+    /// and displaying the result of an EqualConstraint.
     /// </summary>
     public class EqualConstraintResult : ConstraintResult
     {
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Write a failure message. Overridden to provide custom 
+        /// Write a failure message. Overridden to provide custom
         /// failure messages for EqualConstraint.
         /// </summary>
         /// <param name="writer">The MessageWriter to write to</param>
@@ -164,7 +164,7 @@ namespace NUnit.Framework.Constraints
 
         /// <summary>
         /// Displays a single line showing the types and sizes of the expected
-        /// and actual collections or arrays. If both are identical, the value is 
+        /// and actual collections or arrays. If both are identical, the value is
         /// only shown once.
         /// </summary>
         /// <param name="writer">The MessageWriter on which to display</param>
@@ -223,23 +223,6 @@ namespace NUnit.Framework.Constraints
                 writer.WriteMessageLine(indent, ValuesDiffer_2,
                     MsgUtils.GetArrayIndicesAsString(expectedIndices), MsgUtils.GetArrayIndicesAsString(actualIndices));
             }
-        }
-
-        private static object GetValueFromCollection(ICollection collection, int index)
-        {
-            Array array = collection as Array;
-
-            if (array != null && array.Rank > 1)
-                return array.GetValue(MsgUtils.GetArrayIndicesFromCollectionIndex(array, index));
-
-            if (collection is IList)
-                return ((IList)collection)[index];
-
-            foreach (object obj in collection)
-                if (--index < 0)
-                    return obj;
-
-            return null;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -60,8 +60,8 @@ namespace NUnit.Framework.Constraints
             private readonly object caughtException;
 
             public ExceptionTypeConstraintResult(ExceptionTypeConstraint constraint, object caughtException, Type type, bool matches)
-                : base(constraint, type, matches) 
-            { 
+                : base(constraint, type, matches)
+            {
                 this.caughtException = caughtException;
             }
 
@@ -69,15 +69,13 @@ namespace NUnit.Framework.Constraints
             {
                 if (this.Status == ConstraintStatus.Failure)
                 {
-                    Exception ex = caughtException as Exception;
-
-                    if (ex == null)
+                    if (caughtException is Exception ex)
                     {
-                        base.WriteActualValueTo(writer);
+                        writer.WriteActualValue(ex);
                     }
                     else
                     {
-                        writer.WriteActualValue(ex);
+                        base.WriteActualValueTo(writer);
                     }
                 }
             }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -348,8 +348,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public static string GetTypeRepresentation(object obj)
         {
-            Array array = obj as Array;
-            if (array == null)
+            if (!(obj is Array array))
                 return string.Format("<{0}>", obj.GetType());
 
             StringBuilder sb = new StringBuilder();

--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -50,9 +50,10 @@ namespace NUnit.Framework.Interfaces
         /// <returns></returns>
         public override bool Equals(object obj)
         {
-            var other = obj as AssertionResult;
-
-            return other != null && Status == other.Status && Message == other.Message && StackTrace == other.StackTrace;
+            return obj is AssertionResult other
+                && Status == other.Status
+                && Message == other.Message
+                && StackTrace == other.StackTrace;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -52,8 +52,8 @@ namespace NUnit.Framework.Internal
             // special quality of blocking until complete in GetResult.
             // As long as the pattern-based adapters are reflection-based, this
             // is much more efficient as well.
-            var task = awaitable as System.Threading.Tasks.Task;
-            if (task != null) return TaskAwaitAdapter.Create(task);
+            if (awaitable is System.Threading.Tasks.Task task)
+                return TaskAwaitAdapter.Create(task);
 #endif
 
             // Await all the (C#) things
@@ -66,8 +66,8 @@ namespace NUnit.Framework.Internal
             // we still need to be able to await it to preserve NUnit behavior on machines
             // which have a max .NET Framework version of 4.0 installed, such as the default
             // for versions of Windows earlier than 8.
-            var task = awaitable as System.Threading.Tasks.Task;
-            if (task != null) return Net40BclTaskAwaitAdapter.Create(task);
+            if (awaitable is System.Threading.Tasks.Task task)
+                return Net40BclTaskAwaitAdapter.Create(task);
 #endif
 
             throw new NotSupportedException("NUnit can only await objects which follow the C# specification for awaitable expressions.");

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -80,8 +80,7 @@ namespace NUnit.Framework.Internal.Builders
             {
                 if (member.IsDefined(typeof(DatapointAttribute), true))
                 {
-                    var field = member as FieldInfo;
-                    if (GetTypeFromMemberInfo(member) == parameterType && field != null)
+                    if (GetTypeFromMemberInfo(member) == parameterType && member is FieldInfo field)
                     {
                         if (field.IsStatic)
                             datapoints.Add(field.GetValue(null));
@@ -94,24 +93,20 @@ namespace NUnit.Framework.Internal.Builders
                     if (GetElementTypeFromMemberInfo(member) == parameterType)
                     {
                         object instance;
-
-                        FieldInfo field = member as FieldInfo;
-                        PropertyInfo property = member as PropertyInfo;
-                        MethodInfo method = member as MethodInfo;
-                        if (field != null)
+                        if (member is FieldInfo field)
                         {
                             instance = field.IsStatic ? null : ProviderCache.GetInstanceOf(fixtureType);
                             foreach (object data in (IEnumerable)field.GetValue(instance))
                                 datapoints.Add(data);
                         }
-                        else if (property != null)
+                        else if (member is PropertyInfo property)
                         {
                             MethodInfo getMethod = property.GetGetMethod(true);
                             instance = getMethod.IsStatic ? null : ProviderCache.GetInstanceOf(fixtureType);
                             foreach (object data in (IEnumerable)property.GetValue(instance, null))
                                 datapoints.Add(data);
                         }
-                        else if (method != null)
+                        else if (member is MethodInfo method)
                         {
                             instance = method.IsStatic ? null : ProviderCache.GetInstanceOf(fixtureType);
                             foreach (object data in (IEnumerable)method.Invoke(instance, new Type[0]))
@@ -153,16 +148,13 @@ namespace NUnit.Framework.Internal.Builders
 
         private Type GetTypeFromMemberInfo(MemberInfo member)
         {
-            var field = member as FieldInfo;
-            if (field != null)
+            if (member is FieldInfo field)
                 return field.FieldType;
 
-            var property = member as PropertyInfo;
-            if (property != null)
+            if (member is PropertyInfo property)
                 return property.PropertyType;
 
-            var method = member as MethodInfo;
-            if (method != null)
+            if (member is MethodInfo method)
                 return method.ReturnType;
 
             return null;

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -188,12 +188,13 @@ namespace NUnit.Framework.Internal.Builders
             return attrs;
         }
 
-        private bool HasArguments(IFixtureBuilder attr)
+        private bool HasArguments(IFixtureBuilder builder)
         {
             // Only TestFixtureAttribute can be used without arguments
-            var temp = attr as TestFixtureAttribute;
 
-            return temp == null || temp.Arguments.Length > 0 || temp.TypeArgs.Length > 0;
+            return !(builder is TestFixtureAttribute attr)
+                || attr.Arguments.Length > 0
+                || attr.TypeArgs.Length > 0;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2008 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -55,9 +55,7 @@ namespace NUnit.Framework.Internal.Builders
         {
             foreach (CacheEntry key in instances.Keys)
             {
-                IDisposable provider = instances[key] as IDisposable;
-                if (provider != null)
-                    provider.Dispose();
+                (instances[key] as IDisposable)?.Dispose();
             }
 
             instances.Clear();
@@ -65,24 +63,21 @@ namespace NUnit.Framework.Internal.Builders
 
         class CacheEntry
         {
-            private readonly Type providerType;
+            private readonly Type _providerType;
 
             public CacheEntry(Type providerType, object[] providerArgs)
             {
-                this.providerType = providerType;
+                _providerType = providerType;
             }
 
             public override bool Equals(object obj)
             {
-                CacheEntry other = obj as CacheEntry;
-                if (other == null) return false;
-
-                return this.providerType == other.providerType;
+                return obj is CacheEntry other && other._providerType == _providerType;
             }
 
             public override int GetHashCode()
             {
-                return providerType.GetHashCode();
+                return _providerType.GetHashCode();
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -47,9 +47,7 @@ namespace NUnit.Framework.Internal.Commands
             {
                 try
                 {
-                    IDisposable disposable = context.TestObject as IDisposable;
-                    if (disposable != null)
-                        disposable.Dispose();
+                    (context.TestObject as IDisposable)?.Dispose();
                 }
                 catch (Exception ex)
                 {

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -147,8 +147,7 @@ namespace NUnit.Framework.Internal
             if (string.IsNullOrEmpty(ex.Message))
             {
                 // Special handling for Mono 5.0, which returns an empty message
-                var fnfEx = ex as System.IO.FileNotFoundException;
-                return fnfEx != null
+                return ex is System.IO.FileNotFoundException fnfEx
                     ? "Could not load assembly. File not found: " + fnfEx.FileName
                     : "No message provided";
             }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -360,8 +360,7 @@ namespace NUnit.Framework.Internal.Execution
             // only blocks its own children.
             lock (_childCompletionLock)
             {
-                WorkItem childTask = sender as WorkItem;
-                if (childTask != null)
+                if (sender is WorkItem childTask)
                 {
                     childTask.Completed -= new EventHandler(OnChildItemCompleted);
                     _suiteResult.AddResult(childTask.Result);

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -34,21 +34,21 @@ namespace NUnit.Framework.Internal.Execution
     /// listener is active in the context, or if there is no context,
     /// the output is forwarded to the supplied default writer.
     /// </summary>
-	public class EventListenerTextWriter : TextWriter
-	{
+    public class EventListenerTextWriter : TextWriter
+    {
         private readonly TextWriter _defaultWriter;
-		private readonly string _streamName;
+        private readonly string _streamName;
 
         /// <summary>
         /// Construct an EventListenerTextWriter
         /// </summary>
         /// <param name="streamName">The name of the stream to use for events</param>
         /// <param name="defaultWriter">The default writer to use if no listener is available</param>
-		public EventListenerTextWriter( string streamName, TextWriter defaultWriter )
-		{
-			_streamName = streamName;
+        public EventListenerTextWriter( string streamName, TextWriter defaultWriter )
+        {
+            _streamName = streamName;
             _defaultWriter = defaultWriter;
-		}
+        }
 
         /// <summary>
         /// Get the Encoding for this TextWriter
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal.Execution
             if (context == null || context.Listener == null)
                 return false;
 
-            context.Listener.TestOutput(new TestOutput(text, _streamName, 
+            context.Listener.TestOutput(new TestOutput(text, _streamName,
                 context.CurrentTest?.Id, context.CurrentTest?.FullName));
 
             return true;
@@ -111,24 +111,14 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public override void Write(object value)
         {
-            if (value != null)
+            if (value != null && TrySendToListener(value is IFormattable formattable
+                ? formattable.ToString(null, FormatProvider)
+                : value.ToString()))
             {
-                IFormattable f = value as IFormattable;
-                if (f != null)
-                {
-                    if (!TrySendToListener(f.ToString(null, FormatProvider)))
-                        _defaultWriter.Write(value);
-                }
-                else
-                {
-                    if (!TrySendToListener(value.ToString()))
-                        _defaultWriter.Write(value);
-                }
+                return;
             }
-            else
-            {
-                _defaultWriter.Write(value);
-            }
+
+            _defaultWriter.Write(value);
         }
 
         /// <summary>
@@ -271,8 +261,7 @@ namespace NUnit.Framework.Internal.Execution
             }
             else
             {
-                IFormattable f = value as IFormattable;
-                if (f != null)
+                if (value is IFormattable f)
                 {
                     if (!TrySendLineToListener(f.ToString(null, FormatProvider)))
                         _defaultWriter.WriteLine(value);

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -43,8 +43,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <returns></returns>
         static public WorkItem CreateWorkItem(ITest test, ITestFilter filter, bool recursive = false)
         {
-            TestSuite suite = test as TestSuite;
-            if (suite == null)
+            if (!(test is TestSuite suite))
                 return new SimpleWorkItem((TestMethod)test, filter);
 
             var work = new CompositeWorkItem(suite, filter);

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -57,10 +57,9 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if the test passes the filter, otherwise false</returns>
         public override bool Pass(ITest test)
         {
-            var secondNotFilter = BaseFilter as NotFilter;
-            return secondNotFilter != null
-                ? secondNotFilter.BaseFilter.Pass(test) 
-                : !BaseFilter.Match (test) && !BaseFilter.MatchParent (test);
+            return BaseFilter is NotFilter secondNotFilter
+                ? secondNotFilter.BaseFilter.Pass(test)
+                : !BaseFilter.Match(test) && !BaseFilter.MatchParent(test);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
@@ -134,10 +134,8 @@ namespace NUnit.Framework.Internal
 
             public override void WaitForCompletion(AwaitAdapter awaitable)
             {
-                var context = SynchronizationContext.Current as SingleThreadedTestSynchronizationContext;
-
-                if (context == null)
-                    throw new InvalidOperationException("This strategy must only be used from a SingleThreadedTestSynchronizationContext.");
+                var context = SynchronizationContext.Current as SingleThreadedTestSynchronizationContext
+                    ?? throw new InvalidOperationException("This strategy must only be used from a SingleThreadedTestSynchronizationContext.");
 
                 if (awaitable.IsCompleted) return;
 

--- a/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
+++ b/src/NUnitFramework/framework/Internal/SingleThreadedSynchronizationContext.cs
@@ -89,10 +89,7 @@ namespace NUnit.Framework.Internal
             {
                 switch (_status)
                 {
-                    case Status.ShuttingDown:
-                        if (_timeSinceShutdown.Elapsed < _shutdownTimeout) break;
-                        goto case Status.ShutDown;
-
+                    case Status.ShuttingDown when _timeSinceShutdown.Elapsed >= _shutdownTimeout:
                     case Status.ShutDown:
                         throw ErrorAndGetExceptionForShutdownTimeout();
                 }

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -173,9 +173,7 @@ namespace NUnit.Framework.Internal
             [SecuritySafeCritical]
             get
             {
-                var context = CallContext.GetData(NUnitCallContext.TestExecutionContextKey) as TestExecutionContext;
-
-                if (context == null)
+                if (!(CallContext.GetData(NUnitCallContext.TestExecutionContextKey) is TestExecutionContext context))
                 {
                     context = new AdhocContext();
                     CallContext.SetData(NUnitCallContext.TestExecutionContextKey, context);

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -219,8 +219,7 @@ namespace NUnit.Framework.Internal
                     ? "null"
                     : Convert.ToString(arg, System.Globalization.CultureInfo.InvariantCulture);
 
-                var argArray = arg as Array;
-                if (argArray != null && argArray.Rank == 1)
+                if (arg is Array argArray && argArray.Rank == 1)
                 {
                     if (argArray.Length == 0)
                         display = "[]";
@@ -238,9 +237,8 @@ namespace NUnit.Framework.Internal
                                 builder.Append(", ");
 
                             var element = argArray.GetValue(i);
-                            var childArray = element as Array;
 
-                            if (childArray != null && childArray.Rank == 1)
+                            if (element is Array childArray && childArray.Rank == 1)
                             {
                                 builder.Append(childArray.GetType().GetElementType().Name);
                                 builder.Append("[]");

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -491,12 +491,9 @@ namespace NUnit.Framework.Internal
         /// <returns>Value of -1, 0 or +1 depending on whether the current test is less than, equal to or greater than the other test</returns>
         public int CompareTo(object obj)
         {
-            Test other = obj as Test;
-
-            if (other == null)
-                return -1;
-
-            return this.FullName.CompareTo(other.FullName);
+            return obj is Test other
+                ? FullName.CompareTo(other.FullName)
+                : -1;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -139,8 +139,7 @@ namespace NUnit.Framework.Internal
 
                 foreach (Test test in Tests)
                 {
-                    TestSuite suite = test as TestSuite;
-                    if (suite != null)
+                    if (test is TestSuite suite)
                         suite.Sort();
                 }
             }

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -189,9 +189,8 @@ namespace NUnitLite
         private void StartTestElement(ITestResult result)
         {
             ITest test = result.Test;
-            TestSuite suite = test as TestSuite;
 
-            if (suite != null)
+            if (test is TestSuite suite)
             {
                 xmlWriter.WriteStartElement("test-suite");
                 xmlWriter.WriteAttributeString("type", suite.TestType == "ParameterizedMethod" ? "ParameterizedTest" : suite.TestType);

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -603,14 +603,7 @@ namespace NUnit.Framework.Assertions
 
         public override bool Equals(object obj)
         {
-            if (obj == null)
-                return false;
-
-            var other = obj as ThrowsIfToStringIsCalled;
-            if (other == null)
-                return false;
-
-            return _x == other._x;
+            return obj is ThrowsIfToStringIsCalled other && _x == other._x;
         }
 
         public override int GetHashCode()

--- a/src/NUnitFramework/tests/HelperConstraints.cs
+++ b/src/NUnitFramework/tests/HelperConstraints.cs
@@ -52,9 +52,7 @@ namespace NUnit.Framework
 
             public override ConstraintResult ApplyTo<TActual>(TActual actual)
             {
-                var @delegate = actual as Delegate;
-                if (@delegate == null)
-                    throw new ArgumentException("Actual value must be a delegate.", nameof(actual));
+                var @delegate = ConstraintUtils.RequireActual<Delegate>(actual, nameof(actual));
 
                 var invokeMethod = @delegate.GetType().GetTypeInfo().GetMethod("Invoke");
                 if (invokeMethod.GetParameters().Length != 0)

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -182,8 +182,7 @@ namespace NUnit.Framework.Internal
 
             if (recursive)
             {
-                TestSuite suite = test as TestSuite;
-                if (suite != null)
+                if (test is TestSuite suite)
                 {
                     foreach (Test child in suite.Tests)
                     {

--- a/src/NUnitFramework/tests/TestUtilities/TestFinder.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestFinder.cs
@@ -40,8 +40,7 @@ namespace NUnit.TestUtilities
                     return child;
                 if (recursive)
                 {
-                    TestSuite childSuite = child as TestSuite;
-                    if (childSuite != null)
+                    if (child is TestSuite childSuite)
                     {
                         Test grandchild = Find(name, childSuite, true);
                         if (grandchild != null)


### PR DESCRIPTION
This pull request uses the C# 7.0 pattern matching feature to reduce repetition and clarify code. I wrote these changes in the original pull request before splitting into multiple pull requests.

The pattern matching language feature is built around the concept of declaring new variables in a very similar manner to `out` declarations which we are still discussing in https://github.com/nunit/nunit/pull/3272. Therefore, I applied the **awaiting:discussion** label so that we don't merge until we've discussed whether we as a team want all, some, or none of these changes. cc: @rprouse 

@oznetmaster Like the other PR, I'm tagging you to get your feedback on the code itself since you've mentioned disliking certain (most?) uses of it. I'd decidedly rather not introduce changes that make you hate the codebase.