### PR TITLE
Implement IEquatable and use recommended GetHashCode implementation

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -7,7 +7,7 @@ namespace NUnit.Framework.Interfaces
     /// <summary>
     /// The AssertionResult class represents the result of a single assertion.
     /// </summary>
-    public class AssertionResult
+    public class AssertionResult : IEquatable<AssertionResult>
     {
         /// <summary>
         /// Construct an AssertionResult
@@ -28,31 +28,39 @@ namespace NUnit.Framework.Interfaces
         /// <summary>The stack trace associated with the assertion, or null</summary>
         public string StackTrace { get; }
 
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AssertionResult);
+        }
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(AssertionResult other)
+        {
+            return other != null &&
+                Status == other.Status &&
+                Message == other.Message &&
+                StackTrace == other.StackTrace;
+        }
+
+        /// <summary>Serves as the default hash function.</summary>
+        public override int GetHashCode()
+        {
+            var hashCode = -783279553;
+            hashCode = hashCode * -1521134295 + Status.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(StackTrace);
+            return hashCode;
+        }
+
         /// <summary>
         /// ToString Override
         /// </summary>
         public override string ToString()
         {
             return string.Format("Assert {0}: {1}", Status, Message) + Environment.NewLine + StackTrace;
-        }
-
-        /// <summary>
-        /// Override GetHashCode
-        /// </summary>
-        public override int GetHashCode()
-        {
-            return ToString().GetHashCode();
-        }
-
-        /// <summary>
-        /// Override Equals
-        /// </summary>
-        /// <returns></returns>
-        public override bool Equals(object obj)
-        {
-            var other = obj as AssertionResult;
-
-            return other != null && Status == other.Status && Message == other.Message && StackTrace == other.StackTrace;
         }
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ResultState.cs
+++ b/src/NUnitFramework/framework/Interfaces/ResultState.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace NUnit.Framework.Interfaces
@@ -32,7 +34,7 @@ namespace NUnit.Framework.Interfaces
     /// skipped or was inconclusive. The Label provides a more
     /// detailed breakdown for use by client runners.
     /// </summary>
-    public class ResultState
+    public class ResultState : IEquatable<ResultState>
     {
         #region Constructors
 
@@ -83,9 +85,9 @@ namespace NUnit.Framework.Interfaces
         /// The result is inconclusive
         /// </summary>
         public readonly static ResultState Inconclusive = new ResultState(TestStatus.Inconclusive);
-        
+
         /// <summary>
-        /// The test has been skipped. 
+        /// The test has been skipped.
         /// </summary>
         public readonly static ResultState Skipped = new ResultState(TestStatus.Skipped);
 
@@ -143,7 +145,7 @@ namespace NUnit.Framework.Interfaces
         /// A suite is marked ignored because one or more child tests were ignored
         /// </summary>
         public readonly static ResultState ChildIgnored = ResultState.Ignored.WithSite(FailureSite.Child);
-        
+
         /// <summary>
         /// A suite failed in its OneTimeSetUp
         /// </summary>
@@ -206,32 +208,33 @@ namespace NUnit.Framework.Interfaces
 
         #endregion
 
-        #region Equals Override
+        #region Equality
 
-        /// <summary>
-        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
-        /// </summary>
-        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <param name="obj">The object to compare with the current object.</param>
         public override bool Equals(object obj)
         {
-            var other = obj as ResultState;
-            if (object.ReferenceEquals(other, null)) return false;
-
-            return Status.Equals(other.Status) && Label.Equals(other.Label) && Site.Equals(other.Site);
+            return Equals(obj as ResultState);
         }
 
-        /// <summary>
-        /// Returns a hash code for this instance.
-        /// </summary>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
-        /// </returns>
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(ResultState other)
+        {
+            return other != null &&
+                   Status == other.Status &&
+                   Label == other.Label &&
+                   Site == other.Site;
+        }
+
+        /// <summary>Serves as the default hash function.</summary>
         public override int GetHashCode()
         {
-            return (int)Status << 8 + (int)Site ^ Label.GetHashCode(); ;
+            var hashCode = -665355758;
+            hashCode = hashCode * -1521134295 + Status.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Label);
+            hashCode = hashCode * -1521134295 + Site.GetHashCode();
+            return hashCode;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal
     /// <summary>
     /// The Test abstract class represents a test within the framework.
     /// </summary>
-    public abstract class Test : ITest, IComparable
+    public abstract class Test : ITest, IComparable, IComparable<Test>
     {
         #region Fields
 
@@ -484,19 +484,18 @@ namespace NUnit.Framework.Internal
 
         #region IComparable Members
 
-        /// <summary>
-        /// Compares this test to another test for sorting purposes
-        /// </summary>
-        /// <param name="obj">The other test</param>
-        /// <returns>Value of -1, 0 or +1 depending on whether the current test is less than, equal to or greater than the other test</returns>
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.</summary>
+        /// <param name="obj">An object to compare with this instance. </param>
         public int CompareTo(object obj)
         {
-            Test other = obj as Test;
+            return CompareTo(obj as Test);
+        }
 
-            if (other == null)
-                return -1;
-
-            return this.FullName.CompareTo(other.FullName);
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object. </summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        public int CompareTo(Test other)
+        {
+            return other == null ? -1 : this.FullName.CompareTo(other.FullName);
         }
 
         #endregion


### PR DESCRIPTION
Implementing `IEquatable<>` and `IComparable<>` speeds up comparers wherever they are used.

These GetHashCode implementations were generated by Visual Studio's code refactoring.