### PR TITLE
Simplify code in EventListenerTextWriter

### DIFF
--- a/NUnit.sln.DotSettings
+++ b/NUnit.sln.DotSettings
@@ -202,4 +202,5 @@ namespace $NAMESPACE$&#xD;
 			$END$&#xD;
 		}&#xD;
 	}&#xD;
-}</s:String></wpf:ResourceDictionary>
+}</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -113,9 +113,8 @@ namespace NUnit.Framework.Internal.Execution
         {
             if (value != null)
             {
-                IFormattable f = value as IFormattable;
-                var stringValue = f != null
-                    ? f.ToString(null, FormatProvider)
+                var stringValue = value is IFormattable formattable
+                    ? formattable.ToString(null, FormatProvider)
                     : value.ToString();
 
                 if (TrySendToListener(stringValue))

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -119,11 +119,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public override void Write(object value)
         {
-            if (value != null)
-            {
-                if (TrySendToListener(FormatForListener(value)))
-                    return;
-            }
+            if (value != null && TrySendToListener(FormatForListener(value)))
+                return;
 
             _defaultWriter.Write(value);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -34,21 +34,21 @@ namespace NUnit.Framework.Internal.Execution
     /// listener is active in the context, or if there is no context,
     /// the output is forwarded to the supplied default writer.
     /// </summary>
-	public class EventListenerTextWriter : TextWriter
-	{
+    public class EventListenerTextWriter : TextWriter
+    {
         private readonly TextWriter _defaultWriter;
-		private readonly string _streamName;
+        private readonly string _streamName;
 
         /// <summary>
         /// Construct an EventListenerTextWriter
         /// </summary>
         /// <param name="streamName">The name of the stream to use for events</param>
         /// <param name="defaultWriter">The default writer to use if no listener is available</param>
-		public EventListenerTextWriter( string streamName, TextWriter defaultWriter )
-		{
-			_streamName = streamName;
+        public EventListenerTextWriter( string streamName, TextWriter defaultWriter )
+        {
+            _streamName = streamName;
             _defaultWriter = defaultWriter;
-		}
+        }
 
         /// <summary>
         /// Get the Encoding for this TextWriter
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal.Execution
             if (context == null || context.Listener == null)
                 return false;
 
-            context.Listener.TestOutput(new TestOutput(text, _streamName, 
+            context.Listener.TestOutput(new TestOutput(text, _streamName,
                 context.CurrentTest?.Id, context.CurrentTest?.FullName));
 
             return true;

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -114,15 +114,9 @@ namespace NUnit.Framework.Internal.Execution
             if (value != null)
             {
                 IFormattable f = value as IFormattable;
-                string stringValue;
-                if (f != null)
-                {
-                    stringValue = f.ToString(null, FormatProvider);
-                }
-                else
-                {
-                    stringValue = value.ToString();
-                }
+                var stringValue = f != null
+                    ? f.ToString(null, FormatProvider)
+                    : value.ToString();
 
                 if (TrySendToListener(stringValue))
                     return;

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -55,6 +55,14 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public override Encoding Encoding { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+        private string FormatForListener(object value)
+        {
+            return
+                value is null ? string.Empty :
+                value is IFormattable formattable ? formattable.ToString(null, FormatProvider) :
+                value.ToString();
+        }
+
         private bool TrySendToListener(string text)
         {
             var context = TestExecutionContext.CurrentContext;
@@ -113,11 +121,7 @@ namespace NUnit.Framework.Internal.Execution
         {
             if (value != null)
             {
-                var stringValue = value is IFormattable formattable
-                    ? formattable.ToString(null, FormatProvider)
-                    : value.ToString();
-
-                if (TrySendToListener(stringValue))
+                if (TrySendToListener(FormatForListener(value)))
                     return;
             }
 

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -114,16 +114,18 @@ namespace NUnit.Framework.Internal.Execution
             if (value != null)
             {
                 IFormattable f = value as IFormattable;
+                string stringValue;
                 if (f != null)
                 {
-                    if (TrySendToListener(f.ToString(null, FormatProvider)))
-                        return;
+                    stringValue = f.ToString(null, FormatProvider);
                 }
                 else
                 {
-                    if (TrySendToListener(value.ToString()))
-                        return;
+                    stringValue = value.ToString();
                 }
+
+                if (TrySendToListener(stringValue))
+                    return;
             }
 
             _defaultWriter.Write(value);

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -116,19 +116,17 @@ namespace NUnit.Framework.Internal.Execution
                 IFormattable f = value as IFormattable;
                 if (f != null)
                 {
-                    if (!TrySendToListener(f.ToString(null, FormatProvider)))
-                        _defaultWriter.Write(value);
+                    if (TrySendToListener(f.ToString(null, FormatProvider)))
+                        return;
                 }
                 else
                 {
-                    if (!TrySendToListener(value.ToString()))
-                        _defaultWriter.Write(value);
+                    if (TrySendToListener(value.ToString()))
+                        return;
                 }
             }
-            else
-            {
-                _defaultWriter.Write(value);
-            }
+
+            _defaultWriter.Write(value);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -256,25 +256,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public override void WriteLine(object value)
         {
-            if (value == null)
-            {
-                if (!TrySendLineToListener(string.Empty))
-                    _defaultWriter.WriteLine(value);
-            }
-            else
-            {
-                IFormattable f = value as IFormattable;
-                if (f != null)
-                {
-                    if (!TrySendLineToListener(f.ToString(null, FormatProvider)))
-                        _defaultWriter.WriteLine(value);
-                }
-                else
-                {
-                    if (!TrySendLineToListener(value.ToString()))
-                        _defaultWriter.WriteLine(value);
-                }
-            }
+            if (!TrySendLineToListener(FormatForListener(value)))
+                _defaultWriter.WriteLine(value);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventListenerTextWriter.cs
@@ -119,10 +119,8 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public override void Write(object value)
         {
-            if (value != null && TrySendToListener(FormatForListener(value)))
-                return;
-
-            _defaultWriter.Write(value);
+            if (value == null || !TrySendToListener(FormatForListener(value)))
+                _defaultWriter.Write(value);
         }
 
         /// <summary>


### PR DESCRIPTION
The first commit fixes the whitespace in EventListenerTextWriter. Probably best to avoid including this in the diffs you look at.

The remaining commits show each step in the process of removing duplicated code in EventListenerTextWriter.