### PR TITLE
Increase timeout for CI and use events rather than spin waits in tests

### DIFF
--- a/src/NUnitFramework/framework/Compatibility/System.Threading/ManualResetEventSlim.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/ManualResetEventSlim.cs
@@ -40,6 +40,8 @@ namespace System.Threading
         public void Wait() => _mres.WaitOne();
 
         public bool Wait(int millisecondsTimeout) => _mres.WaitOne(millisecondsTimeout);
+
+        public bool IsSet => _mres.WaitOne(0);
     }
 }
 #endif

--- a/src/NUnitFramework/tests/AwaitableReturnTypeTests.cs
+++ b/src/NUnitFramework/tests/AwaitableReturnTypeTests.cs
@@ -90,7 +90,7 @@ namespace NUnit.Framework
 
                 continuation.Invoke();
 
-                if (!getResultWasCalled.Wait(1000))
+                if (!getResultWasCalled.Wait(10_000))
                     Assert.Fail("GetResult was not called after the continuation passed to OnCompleted was invoked.");
             }
         }

--- a/src/NUnitFramework/tests/AwaitableReturnTypeTests.cs
+++ b/src/NUnitFramework/tests/AwaitableReturnTypeTests.cs
@@ -61,32 +61,38 @@ namespace NUnit.Framework
         [Test]
         public void GetResultIsNotCalledUntilContinued()
         {
-            var wasCalled = false;
-            var continuation = (Action)null;
-            var result = (ITestResult)null;
-
-            ThreadPool.QueueUserWorkItem(state =>
+            using (var continuationIsAvailable = new ManualResetEventSlim())
+            using (var getResultWasCalled = new ManualResetEventSlim())
             {
-                result = RunCurrentTestMethod(new AsyncWorkload(
-                    isCompleted: false,
-                    onCompleted: action => continuation = action,
-                    getResult: () => { wasCalled = true; return 42; })
-                );
-            });
+                var continuation = (Action)null;
 
-            SpinWait.SpinUntil(() => continuation != null);
+                ThreadPool.QueueUserWorkItem(state =>
+                {
+                    RunCurrentTestMethod(new AsyncWorkload(
+                        isCompleted: false,
+                        onCompleted: action =>
+                        {
+                            continuation = action;
+                            continuationIsAvailable.Set();
+                        },
+                        getResult: () =>
+                        {
+                            getResultWasCalled.Set();
+                            return 42;
+                        })
+                    );
+                });
 
-            Assert.That(wasCalled, Is.False, "GetResult was called before the continuation passed to OnCompleted was invoked.");
+                continuationIsAvailable.Wait();
 
-            continuation.Invoke();
+                if (getResultWasCalled.IsSet)
+                    Assert.Fail("GetResult was called before the continuation passed to OnCompleted was invoked.");
 
-            if (!SpinWait.SpinUntil(() => wasCalled, 1000))
-            {
-                Assert.Fail("GetResult was not called after the continuation passed to OnCompleted was invoked.");
+                continuation.Invoke();
+
+                if (!getResultWasCalled.Wait(1000))
+                    Assert.Fail("GetResult was not called after the continuation passed to OnCompleted was invoked.");
             }
-
-            SpinWait.SpinUntil(() => result != null);
-            result.AssertPassed();
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3307. Can't repro, but I think it was as simple as the 1000 timeout being too short for CI. Added a commit to increase to the standard 10_000.