### PR TITLE
Simplify ProviderCache and make it instantiable since it is intentionally not thread safe

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -35,6 +35,8 @@ namespace NUnit.Framework.Internal.Builders
     /// </summary>
     public class DatapointProvider : IParameterDataProvider
     {
+        private static readonly ProviderCache ProviderCache = new ProviderCache();
+
         #region IDataPointProvider Members
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2008 Charlie Poole, Rob Prouse
+// Copyright (c) 2008–2019 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,15 +22,13 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 
 namespace NUnit.Framework.Internal.Builders
 {
     class ProviderCache
     {
-        private static readonly Dictionary<CacheEntry, object> instances = new Dictionary<CacheEntry, object>();
+        private static readonly Dictionary<Type, object> instances = new Dictionary<Type, object>();
 
         public static object GetInstanceOf(Type providerType)
         {
@@ -39,39 +37,10 @@ namespace NUnit.Framework.Internal.Builders
 
         public static object GetInstanceOf(Type providerType, object[] providerArgs)
         {
-            CacheEntry entry = new CacheEntry(providerType, providerArgs);
-
-            object instance = instances.ContainsKey(entry)
-                ?instances[entry]
-                : null;
-
-            if (instance == null)
-                instances[entry] = instance = Reflect.Construct(providerType, providerArgs);
+            if (!instances.TryGetValue(providerType, out var instance))
+                instances.Add(providerType, instance = Reflect.Construct(providerType, providerArgs));
 
             return instance;
-        }
-
-        class CacheEntry
-        {
-            private readonly Type providerType;
-
-            public CacheEntry(Type providerType, object[] providerArgs)
-            {
-                this.providerType = providerType;
-            }
-
-            public override bool Equals(object obj)
-            {
-                CacheEntry other = obj as CacheEntry;
-                if (other == null) return false;
-
-                return this.providerType == other.providerType;
-            }
-
-            public override int GetHashCode()
-            {
-                return providerType.GetHashCode();
-            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ProviderCache.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2008–2019 Charlie Poole, Rob Prouse
+// Copyright (c) 2008â€“2019 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -26,19 +26,19 @@ using System.Collections.Generic;
 
 namespace NUnit.Framework.Internal.Builders
 {
-    class ProviderCache
+    internal sealed class ProviderCache
     {
-        private static readonly Dictionary<Type, object> instances = new Dictionary<Type, object>();
+        private readonly Dictionary<Type, object> _instances = new Dictionary<Type, object>();
 
-        public static object GetInstanceOf(Type providerType)
+        public object GetInstanceOf(Type providerType)
         {
             return GetInstanceOf(providerType, null);
         }
 
-        public static object GetInstanceOf(Type providerType, object[] providerArgs)
+        public object GetInstanceOf(Type providerType, object[] providerArgs)
         {
-            if (!instances.TryGetValue(providerType, out var instance))
-                instances.Add(providerType, instance = Reflect.Construct(providerType, providerArgs));
+            if (!_instances.TryGetValue(providerType, out var instance))
+                _instances.Add(providerType, instance = Reflect.Construct(providerType, providerArgs));
 
             return instance;
         }


### PR DESCRIPTION
I saw this file in passing in a previous refactoring and noticed the possibilities in the PR title.

Commit 1: CacheEntry would make sense as a dictionary key if it took provider arguments into account. Since it doesn't, it's a "just in case we ever do this" construct which complicates the source code. It also has a marginal negative influence on dictionary performance by not being a struct and by not implementing IEquatable<>. I figured we could wait until we need it rather than adding even more code it.

Commit 2: static mutable things are good to avoid in general but especially when the mutations are not thread safe because you take away all control from the client code to isolate it to a single thread. Now, it's the responsibility of the code that instantiates it to not share the instance somewhere that could be accessed from another thread.