### PR TITLE
Fix check for parameterless delegate

### DIFF
--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Internal
 
         /// <summary>
         /// Builds up a message, using the Message field of the specified exception
-        /// as well as any InnerExceptions. Optionally excludes exception names, 
+        /// as well as any InnerExceptions. Optionally excludes exception names,
         /// creating a more readable message.
         /// </summary>
         /// <param name="exception">The exception.</param>
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Internal
             Guard.ArgumentNotNull(parameterlessDelegate, parameterName);
 
             Guard.ArgumentValid(
-                parameterlessDelegate.GetMethodInfo().GetParameters().Length == 0,
+                parameterlessDelegate.GetType().GetMethod("Invoke").GetParameters().Length == 0,
                 $"The actual value must be a parameterless delegate but was {parameterlessDelegate.GetType().Name}.",
                 nameof(parameterName));
 

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -214,7 +214,7 @@ namespace NUnit.Framework.Internal
             Guard.ArgumentValid(
                 parameterlessDelegate.GetType().GetMethod("Invoke").GetParameters().Length == 0,
                 $"The actual value must be a parameterless delegate but was {parameterlessDelegate.GetType().Name}.",
-                nameof(parameterName));
+                parameterName);
 
             Guard.ArgumentNotAsyncVoid(parameterlessDelegate, parameterName);
 

--- a/src/NUnitFramework/tests/Internal/ExceptionHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/ExceptionHelperTests.cs
@@ -36,6 +36,14 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
+        public static void RecordExceptionThrowsForDelegateThatRequiresParameters()
+        {
+            Assert.That(
+                () => ExceptionHelper.RecordException(new Action<object>(_ => { }), "someParamName"),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("someParamName"));
+        }
+
+        [Test]
         public static void RecordExceptionHandlesDelegatesThatHaveOneFewerParameterThanTheBoundMethod()
         {
             Assert.That(


### PR DESCRIPTION
Fixes #3315 

I'm not sure how I overlooked the difference between checking the delegate signature and checking the method signature.

A delegate can have one fewer parameter than the method by binding a target value to the first parameter of a static method. (That's what we're seeing in #3315.) A delegate can also have one more parameter than the parameterize the `this` instance of a parameterless method. There is a test for each of these things.