### PR TITLE
Fix AwaitAdapter terminology

### DIFF
--- a/NUnit.sln.DotSettings
+++ b/NUnit.sln.DotSettings
@@ -203,4 +203,5 @@ namespace $NAMESPACE$&#xD;
 		}&#xD;
 	}&#xD;
 }</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=awaiters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -49,15 +49,15 @@ namespace NUnit.Framework.Internal
 
             using (InitializeExecutionEnvironment())
             {
-                var awaitAdapter = AwaitAdapter.FromAwaitable(invoke.Invoke());
+                var awaiter = AwaitAdapter.FromAwaitable(invoke.Invoke());
 
-                if (!awaitAdapter.IsCompleted)
+                if (!awaiter.IsCompleted)
                 {
                     var waitStrategy = MessagePumpStrategy.FromCurrentSynchronizationContext();
-                    waitStrategy.WaitForCompletion(awaitAdapter);
+                    waitStrategy.WaitForCompletion(awaiter);
                 }
 
-                return awaitAdapter.GetResult();
+                return awaiter.GetResult();
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -25,6 +25,9 @@ using System;
 
 namespace NUnit.Framework.Internal
 {
+    /// <summary>
+    /// Adapts various styles of asynchronous waiting to a common API.
+    /// </summary>
     internal abstract class AwaitAdapter
     {
         public abstract bool IsCompleted { get; }

--- a/src/NUnitFramework/framework/Internal/DefaultBlockingAwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/DefaultBlockingAwaitAdapter.cs
@@ -26,7 +26,7 @@ using System.Threading;
 namespace NUnit.Framework.Internal
 {
     /// <summary>
-    /// Useful when wrapping awaitables whose <c>GetResult</c> method does not block until complete.
+    /// Useful when wrapping awaiters whose <c>GetResult</c> method does not block until complete.
     /// Contains a default mechanism to implement <see cref="AwaitAdapter.BlockUntilCompleted"/>
     /// via <see cref="AwaitAdapter.IsCompleted"/> and <see cref="AwaitAdapter.OnCompleted"/>.
     /// </summary>


### PR DESCRIPTION
The line is blurred because an await adapter is not an awaiter and not an awaitable. An await adapter is an object which adapts various entire *styles* of asynchronous waiting to a common API.

Calling the variables `awaitAdapter` is a bit of a mouthful and `adapter` is too bland. If you squint, you can think of the instance methods as similar in spirit to the C# language concept of an awaiter. Even though it's not the same thing, I think it's close enough to justify the variable name.

Also, if we ever passed these instances to a public API, we'd probably pass them as `IAwaiterObject awaiter`. I saw this in https://github.com/nunit/nunit/pull/3037 and really liked it. (AwaitAdapter is still a better name for the class because the class specifically exists in order to adapt, whereas the interface could be used on things that are not adapters.)