### PR TITLE
Manually update .NET Core SDK for ADO Linux image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,11 @@ jobs:
     vmImage: ubuntu-16.04
   steps:
   - bash: |
+     wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+     sudo dpkg -i packages-microsoft-prod.deb
+     sudo apt-get install apt-transport-https
+     sudo apt-get update
+     sudo apt-get install dotnet-sdk-2.2
      dotnet tool install --global Cake.Tool
      export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
      ~/.dotnet/tools/dotnet-cake --target=Test --test-run-name=Linux --configuration=Release


### PR DESCRIPTION
Fixes #3338. Fix Linux build on Azure Dev Ops, by manually updating the .NET Core SDK.

I haven't looked in a lot of detail, but it appears this type of error can happen with certain incompatible version of the .NET Core SDK and NuGet. I assume the Azure image was updated for one of these which caused the failure, updating the image manually to the latest .NET Core SDK seems to fix the issue. 