### PR TITLE
Fix issues with Pass method on TestFilter's (issue #3328 )

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -42,20 +43,20 @@ namespace NUnit.Framework.Internal.Filters
         /// Constructs an AndFilter from an array of filters
         /// </summary>
         /// <param name="filters"></param>
-        public AndFilter(params ITestFilter[] filters) : base(filters) { }
+        public AndFilter(params TestFilter[] filters) : base(filters) { }
 
         /// <summary>
         /// Checks whether the AndFilter is matched by a test
         /// </summary>
         /// <param name="test">The test to be matched</param>
+        /// <param name="negated">If set to <c>true</c> we are carrying a negation through</param>
         /// <returns>True if all the component filters pass, otherwise false</returns>
-        public override bool Pass( ITest test )
+        public override bool Pass( ITest test, bool negated )
         {
-            foreach( ITestFilter filter in Filters )
-                if ( !filter.Pass( test ) )
-                    return false;
+            if (negated)
+                return Filters.Any(f => f.Pass(test, negated));
 
-            return true;
+            return Filters.All(f => f.Pass(test, negated));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -37,23 +37,23 @@ namespace NUnit.Framework.Internal.Filters
         /// </summary>
         public CompositeFilter()
         {
-            Filters = new List<ITestFilter>();
+            Filters = new List<TestFilter>();
         }
 
         /// <summary>
         /// Constructs a CompositeFilter from an array of filters
         /// </summary>
         /// <param name="filters"></param>
-        public CompositeFilter( params ITestFilter[] filters )
+        public CompositeFilter( params TestFilter[] filters )
         {
-            Filters = new List<ITestFilter>(filters);
+            Filters = new List<TestFilter>(filters);
         }
 
         /// <summary>
         /// Adds a filter to the list of filters
         /// </summary>
         /// <param name="filter">The filter to be added</param>
-        public void Add(ITestFilter filter)
+        public void Add(TestFilter filter)
         {
             Filters.Add(filter);
         }
@@ -61,13 +61,14 @@ namespace NUnit.Framework.Internal.Filters
         /// <summary>
         /// Return a list of the composing filters.
         /// </summary>
-        public IList<ITestFilter> Filters { get; }
+        public IList<TestFilter> Filters { get; }
 
         /// <summary>
         /// Checks whether the CompositeFilter is matched by a test.
         /// </summary>
         /// <param name="test">The test to be matched</param>
-        public abstract override bool Pass(ITest test);
+        /// <param name="negated">If set to <c>true</c> we are carrying a negation through</param>
+        public abstract override bool Pass(ITest test, bool negated);
 
         /// <summary>
         /// Checks whether the CompositeFilter is matched by a test.

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -47,20 +47,13 @@ namespace NUnit.Framework.Internal.Filters
 
         /// <summary>
         /// Determine if a particular test passes the filter criteria.
-        /// 
-        /// Overriden in NotFilter so that
-        /// 1. Two nested NotFilters are simply ignored
-        /// 2. Otherwise, we only look at the test itself and parents, ignoring
-        /// any child test matches.
         /// </summary>
         /// <param name="test">The test to which the filter is applied</param>
+        /// <param name="negated">If set to <c>true</c> we are carrying a negation through</param>
         /// <returns>True if the test passes the filter, otherwise false</returns>
-        public override bool Pass(ITest test)
+        public override bool Pass(ITest test, bool negated)
         {
-            var secondNotFilter = BaseFilter as NotFilter;
-            return secondNotFilter != null
-                ? secondNotFilter.BaseFilter.Pass(test) 
-                : !BaseFilter.Match (test) && !BaseFilter.MatchParent (test);
+            return BaseFilter.Pass(test, !negated);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -42,20 +43,20 @@ namespace NUnit.Framework.Internal.Filters
         /// Constructs an AndFilter from an array of filters
         /// </summary>
         /// <param name="filters"></param>
-        public OrFilter( params ITestFilter[] filters ) : base(filters) { }
+        public OrFilter( params TestFilter[] filters ) : base(filters) { }
 
         /// <summary>
         /// Checks whether the OrFilter is matched by a test
         /// </summary>
         /// <param name="test">The test to be matched</param>
+        /// <param name="negated">If set to <c>true</c> we are carrying a negation through</param>
         /// <returns>True if any of the component filters pass, otherwise false</returns>
-        public override bool Pass( ITest test )
+        public override bool Pass( ITest test, bool negated )
         {
-            foreach( ITestFilter filter in Filters )
-                if ( filter.Pass( test ) )
-                    return true;
+            if (negated)
+                return Filters.All(f => f.Pass(test, negated));
 
-            return false;
+            return Filters.Any(f => f.Pass(test, negated));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -65,6 +65,24 @@ namespace NUnit.Framework.Internal
         /// <returns>True if the test passes the filter, otherwise false</returns>
         public virtual bool Pass(ITest test)
         {
+            return Pass(test, false);
+        }
+
+        /// <summary>
+        /// Determine if a particular test passes the filter criteria. The default
+        /// implementation checks the test itself, its parents and any descendants.
+        ///
+        /// Derived classes may override this method or any of the Match methods
+        /// to change the behavior of the filter.
+        /// </summary>
+        /// <param name="test">The test to which the filter is applied</param>
+        /// <param name="negated">If set to <c>true</c> we are carrying a negation through</param>
+        /// <returns>True if the test passes the filter, otherwise false</returns>
+        public virtual bool Pass(ITest test, bool negated)
+        {
+            if (negated)
+                return !Match(test) && !MatchParent(test);
+
             return Match(test) || MatchParent(test) || MatchDescendant(test);
         }
 
@@ -211,7 +229,7 @@ namespace NUnit.Framework.Internal
                 return true;
             }
 
-            public override bool Pass( ITest test )
+            public override bool Pass( ITest test, bool negated )
             {
                 return true;
             }

--- a/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
@@ -1,0 +1,100 @@
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters {
+    public class DeMorganOnFiltersTest : TestFilterTests
+    {
+        private static List<TestFilter[]> filterPairs;
+
+        static DeMorganOnFiltersTest()
+        {
+            var filterParts = new TestFilter[]
+            {
+                new CategoryFilter("Dummy"),
+                new MethodNameFilter("Test1"),
+                new PropertyFilter("Priority", "High"),
+                new PropertyFilter("Priority", "Low")
+            };
+
+            filterPairs = new List<TestFilter[]>();
+            foreach (var part1 in filterParts)
+            foreach (var part2 in filterParts)
+            {
+                var and = new AndFilter(part1, new NotFilter(part2));
+                var or = new OrFilter(new NotFilter(part1), part2);
+                filterPairs.Add(new TestFilter[2] {new NotFilter(and), or});
+                filterPairs.Add(new TestFilter[2] {and, new NotFilter(or)});
+            }
+        }
+
+        private IEnumerable<ITest> GetTests()
+        {
+            var q = new Queue<ITest>();
+            q.Enqueue(_topLevelSuite);
+            while (q.Count > 0)
+            {
+                var test = q.Dequeue();
+                foreach (var child in test.Tests)
+                    q.Enqueue(child);
+                yield return test;
+            }
+        }
+
+        private string CaseErrorMessage(string method, TestFilter andFilter, TestFilter orFilter)
+        {
+            return $"Tests on which the {method} methods of the following filters fails to agree:\n{andFilter.ToXml(true).OuterXml}\n{orFilter.ToXml(true).OuterXml}";
+        }
+
+        [Test]
+        [TestCaseSource(nameof(filterPairs))]
+        public void DeMorganPassTests(TestFilter andFilter, TestFilter orFilter)
+        {
+
+            var disagreements = new List<string>();
+            foreach (var test in GetTests())
+            {
+                if (andFilter.Pass(test) != orFilter.Pass(test))
+                    disagreements.Add(test.FullName);
+            }
+            var message = CaseErrorMessage("Pass", andFilter, orFilter);
+            Assert.IsEmpty(disagreements, message);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(filterPairs))]
+        public void DeMorganMatchTests(TestFilter andFilter, TestFilter orFilter)
+        {
+            var disagreements = new List<string>();
+            foreach (var test in GetTests())
+            {
+                if (andFilter.Match(test) != orFilter.Match(test))
+                    disagreements.Add(test.FullName);
+            }
+            var message = CaseErrorMessage("Match", andFilter, orFilter);
+            Assert.IsEmpty(disagreements, message);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Internal.Filters
             return AssertAndGetEquality(test, MatchFunction.IsExplicitMatch);
         }
 
-        public override bool Pass(ITest test)
+        public override bool Pass(ITest test, bool negated)
         {
             return AssertAndGetEquality(test, MatchFunction.Pass);
         }

--- a/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
+
+using System;
+using System.Collections;
 
 namespace NUnit.Framework.Internal.Filters
 {
@@ -106,7 +109,7 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void TestLotsOfNestedOrFilters()
+        public void TestLotsOfNestedNotFilters()
         {
             var filter = new NotFilter(
                 new NotFilter(
@@ -124,6 +127,56 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.False(filter.Match(_explicitFixture));
             Assert.False(filter.IsExplicitMatch(_explicitFixture));
+        }
+
+        [Test]
+        public void NotOrNotFilterTests()
+        {
+            var filter = new NotFilter(
+                new OrFilter(
+                    new NotFilter(
+                        new CategoryFilter("Dummy")),
+                    new MethodNameFilter("Test1")));
+
+            Assert.That(filter.Pass(_topLevelSuite));
+            Assert.False(filter.Match(_topLevelSuite));
+
+            Assert.That(filter.Pass(_fixtureWithMultipleTests));
+            Assert.False(filter.Match(_fixtureWithMultipleTests));
+
+            var test1 = _fixtureWithMultipleTests.Tests[0];
+            Assert.False(filter.Pass(test1));
+            Assert.False(filter.Match(test1));
+
+            var test2 = _fixtureWithMultipleTests.Tests[1];
+            Assert.That(filter.Pass(test2));
+            Assert.False(filter.IsExplicitMatch(test2));
+            Assert.That(filter.Match(test2));
+        }
+
+        [Test]
+        public void NotAndNotFilterTests()
+        {
+            var filter = new NotFilter(
+                new AndFilter(
+                    new NotFilter(
+                        new CategoryFilter("Dummy")),
+                    new MethodNameFilter("Test1")));
+
+            Assert.That(filter.Pass(_topLevelSuite));
+            Assert.That(filter.Match(_topLevelSuite));
+
+            Assert.That(filter.Pass(_fixtureWithMultipleTests));
+            Assert.That(filter.Match(_fixtureWithMultipleTests));
+
+            var test1 = _fixtureWithMultipleTests.Tests[0];
+            Assert.False(filter.Pass(test1));
+            Assert.False(filter.Match(test1));
+
+            var test2 = _fixtureWithMultipleTests.Tests[1];
+            Assert.That(filter.Pass(test2));
+            Assert.False(filter.IsExplicitMatch(test2));
+            Assert.That(filter.Match(test2));
         }
     }
 }


### PR DESCRIPTION
This fixes #3328 

The problem was the difference in whether we are using a filter to exclude tests or include them when calling `Pass`. In the former case, we want to look back through parents only, but in the latter case, we want to look forward through children as well.

This fix makes sure that this decision is taken by the inner most filters (leafs I guess) by applying De Morgan to ensure that negations are pushed through `AndFilters` and `NotFilters`.

If I forgot something, please let me know. This is my first time contributing.