### PR TITLE
Remove StringBuilder in favour of fixed length array

### DIFF
--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -519,15 +519,12 @@ namespace NUnit.Framework.Internal
         /// <returns>A random string of arbitrary length</returns>
         public string GetString(int outputLength, string allowedChars)
         {
+            var data = new char[outputLength];
 
-            var sb = new StringBuilder(outputLength);
+            for (int i = 0; i < data.Length; i++)
+                data[i] = allowedChars[Next(0, allowedChars.Length)];
 
-            for (int i = 0; i < outputLength ; i++)
-            {
-                sb.Append(allowedChars[Next(0,allowedChars.Length)]);
-            }
-
-            return sb.ToString();
+            return new string(data);
         }
 
         /// <summary>


### PR DESCRIPTION
Small refactoring to give a bit (13%) speed-up.
Fixes #3395 

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
        Intel Core i5-7200U CPU 2.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
        .NET Core SDK=3.0.100
          [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
          DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


        |             Method |    N |        Mean |      Error |     StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
        |------------------- |----- |------------:|-----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
        |      GetString_New |   25 |    382.2 ns |   4.062 ns |   3.601 ns |  0.87 |    0.01 | 0.0958 |     - |     - |     152 B |
        | GetString_Original |   25 |    440.5 ns |   5.557 ns |   4.926 ns |  1.00 |    0.00 | 0.1273 |     - |     - |     200 B |
        |                    |      |             |            |            |       |         |        |       |       |           |
        |      GetString_New |  128 |  1,861.8 ns |  36.338 ns |  57.635 ns |  0.87 |    0.03 | 0.3567 |     - |     - |     560 B |
        | GetString_Original |  128 |  2,143.0 ns |  19.885 ns |  18.600 ns |  1.00 |    0.00 | 0.3815 |     - |     - |     608 B |
        |                    |      |             |            |            |       |         |        |       |       |           |
        |      GetString_New | 1024 | 14,677.8 ns | 243.289 ns | 215.669 ns |  0.87 |    0.02 | 2.6245 |     - |     - |    4144 B |
        | GetString_Original | 1024 | 16,830.8 ns | 309.796 ns | 391.792 ns |  1.00 |    0.00 | 2.6550 |     - |     - |    4192 B |
```