### PR TITLE
Contains.Key now working for IDictionary

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -93,19 +93,27 @@ namespace NUnit.Framework.Constraints
         {
             if (_isDeprecatedMode)
             {
-                var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
-                foreach (object obj in dictionary.Keys)
-                    if (ItemsEqual(obj, Expected))
-                        return true;
-
-                return false;
+                var requiredDictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
+                return MatchesKeysIteratively(requiredDictionary);
             }
 
             var method = GetContainsKeyMethod(actual);
             if (method != null)
                 return (bool)method.Invoke(actual, new[] { Expected });
 
+            if (actual is IDictionary dictionary)
+                return MatchesKeysIteratively(dictionary);
+
             throw new ArgumentException($"The {TypeHelper.GetDisplayName(actual.GetType())} value must have a ContainsKey or Contains(TKey) method.");
+        }
+
+        private bool MatchesKeysIteratively(IDictionary dictionary)
+        {
+            foreach (var obj in dictionary.Keys)
+                if (ItemsEqual(obj, Expected))
+                    return true;
+
+            return false;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -231,7 +231,7 @@ namespace NUnit.Framework.Constraints
             var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
             var method = methods.FirstOrDefault(m =>
                 m.ReturnType == typeof(bool)
-                && (m.Name == "ContainsKey" || (m.Name == "Contains" && m.DeclaringType == typeof(IDictionary)))
+                && (m.Name == "ContainsKey" || (m.Name == nameof(IDictionary.Contains) && m.DeclaringType == typeof(IDictionary)))
                 && !m.IsGenericMethod
                 && m.GetParameters().Length == 1);
 

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Constraints
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
             Assert.That(dictionary, Does.Not.ContainKey("NotKey"));
         }
+
         [Test]
         public void FailsWhenKeyIsMissing()
         {
@@ -189,7 +190,7 @@ namespace NUnit.Framework.Constraints
         {
             var dictionary = new TestNonGenericDictionary(99);
 
-            Assert.Catch<ArgumentException>(() => Assert.That(dictionary, Does.ContainKey(99)));
+            Assert.That(dictionary, Does.ContainKey(99));
         }
 
         [Test]
@@ -448,6 +449,7 @@ namespace NUnit.Framework.Constraints
             public TestNonGenericDictionary(int key)
             {
                 _key = key;
+                Keys = new[] { key };
             }
 
             public bool Contains(object key)

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -449,7 +449,7 @@ namespace NUnit.Framework.Constraints
             public TestNonGenericDictionary(int key)
             {
                 _key = key;
-                Keys = new[] { key };
+                //Keys = new[] { key };
             }
 
             public bool Contains(object key)

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -191,6 +191,7 @@ namespace NUnit.Framework.Constraints
             var dictionary = new TestNonGenericDictionary(99);
 
             Assert.That(dictionary, Does.ContainKey(99));
+            Assert.That(dictionary, !Does.ContainKey(35));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -449,7 +449,6 @@ namespace NUnit.Framework.Constraints
             public TestNonGenericDictionary(int key)
             {
                 _key = key;
-                //Keys = new[] { key };
             }
 
             public bool Contains(object key)


### PR DESCRIPTION
Fixes #3331 
This PR fixes a regression in `3.11` where using a DictionaryContainsKeyConstraint on a non-generic dictionary would fail. All existing tests pass (except for one which was testing that this specific case threw an exception).