### PR TITLE
Fix usage of Thread.CurrentPrincipal in Mono.WASM

### DIFF
--- a/src/NUnitFramework/framework/Internal/SandboxedThreadState.cs
+++ b/src/NUnitFramework/framework/Internal/SandboxedThreadState.cs
@@ -34,6 +34,11 @@ namespace NUnit.Framework.Internal
     {
         public CultureInfo Culture { get; }
         public CultureInfo UICulture { get; }
+
+        /// <summary>
+        /// Thread principal.
+        /// This will be null on platforms that don't support <see cref="Thread.CurrentPrincipal"/>.
+        /// </summary>
         public System.Security.Principal.IPrincipal Principal { get; }
         private readonly SynchronizationContext _synchronizationContext;
 
@@ -57,7 +62,7 @@ namespace NUnit.Framework.Internal
             return new SandboxedThreadState(
                 CultureInfo.CurrentCulture,
                 CultureInfo.CurrentUICulture,
-                Thread.CurrentPrincipal,
+                ThreadUtility.GetCurrentThreadPrincipal(),
                 SynchronizationContext.Current);
         }
 
@@ -69,7 +74,7 @@ namespace NUnit.Framework.Internal
         {
             Thread.CurrentThread.CurrentCulture = Culture;
             Thread.CurrentThread.CurrentUICulture = UICulture;
-            Thread.CurrentPrincipal = Principal;
+            ThreadUtility.SetCurrentThreadPrincipal(Principal);
 
             SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
         }

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -376,7 +376,7 @@ namespace NUnit.Framework.Internal
             set
             {
                 _sandboxedThreadState = _sandboxedThreadState.WithPrincipal(value);
-                Thread.CurrentPrincipal = value;
+                ThreadUtility.SetCurrentThreadPrincipal(value);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -132,7 +132,7 @@ namespace NUnit.Framework.Internal
 #pragma warning restore 0618,0612   // Thread.Resume has been deprecated
             }
 
-            if ( (thread.ThreadState & ThreadState.WaitSleepJoin) != 0 )
+            if ((thread.ThreadState & ThreadState.WaitSleepJoin) != 0)
                 thread.Interrupt();
         }
 
@@ -230,5 +230,30 @@ namespace NUnit.Framework.Internal
             CLOSE = 0x0010
         }
 #endif
+
+        /// <summary>Gets <see cref="Thread.CurrentPrincipal"/> or <see langword="null" /> if the current platform does not support it.</summary>
+        public static System.Security.Principal.IPrincipal GetCurrentThreadPrincipal()
+        {
+            try
+            {
+                return Thread.CurrentPrincipal;
+            }
+            catch (PlatformNotSupportedException) //E.g. Mono.WASM
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Sets <see cref="Thread.CurrentPrincipal"/> if current platform supports it.</summary>
+        /// <param name="principal">Value to set. If the current platform does not support <see cref="Thread.CurrentPrincipal"/> then the only allowed value is <see langword="null"/>.</param>
+        public static void SetCurrentThreadPrincipal(System.Security.Principal.IPrincipal principal)
+        {
+            try
+            {
+                Thread.CurrentPrincipal = principal;
+            }
+            catch (PlatformNotSupportedException) when (principal == null) //E.g. Mono.WASM
+            { }
+        }
     }
 }


### PR DESCRIPTION
Fixes #3392 https://github.com/nunit/nunit/issues/3392  by catching `PlatformNotSupportedException` for access to `Thread.CurrentPrincipal`