### PR TITLE
Save test results as build artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,12 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)
       ArtifactName: Package
 
+  - task: PublishBuildArtifacts@1
+    displayName: Save test results artifacts
+    inputs:
+      PathtoPublish: test-results
+      ArtifactName: Test results (Windows)
+
 - job: Linux
   pool:
     vmImage: ubuntu-latest
@@ -48,6 +54,12 @@ jobs:
      dotnet tool install --global Cake.Tool
      dotnet cake --target=Test --test-run-name=Linux --configuration=Release
     displayName: Build, test, and publish results
+
+  - task: PublishBuildArtifacts@1
+    displayName: Save test results artifacts
+    inputs:
+      PathtoPublish: test-results
+      ArtifactName: Test results (Linux)
 
 - job: macOS
   pool:
@@ -80,3 +92,9 @@ jobs:
      dotnet tool install --global Cake.Tool
      dotnet cake --target=Test --test-run-name=macOS --configuration=Release
     displayName: Build, test, and publish results
+
+  - task: PublishBuildArtifacts@1
+    displayName: Save test results artifacts
+    inputs:
+      PathtoPublish: test-results
+      ArtifactName: Test results (macOS)


### PR DESCRIPTION
Good idea from @mikkelbu:

> Ps. I'm having difficulty seeing the exact tests executed on the buildservers. Filtering on Azure pipelines does not handle 105,333 tests very well 😄. Would it makes sense - in another PR - to also store the "TestResultsFiles" as artifacts?

![image](https://user-images.githubusercontent.com/8040367/67645115-2274b900-f8fd-11e9-8ce2-9cc139282573.png)

![image](https://user-images.githubusercontent.com/8040367/67645134-40421e00-f8fd-11e9-9299-58bbcc051c8b.png)
