### PR TITLE
Show names of parameters

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -609,16 +609,26 @@ namespace NUnit.Framework.Internal
 
                 for (int i = 0; i < count; i++)
                 {
+                    if(i < parameters.Length)
+                    {
+                        if (parameters[i].IsOptional)
+                        {
+                            if(i >= args.Length)
+                            {
+                                continue;
+                            }
+                        }
+                    }
+
                     if (i > 0) sb.Append(", ");
 
-                    var paramName = GetDisplayString(parameters.Length > i ? parameters[i].Name : "?", _maxStringLength).Trim('\"');
+                    var paramName = i < parameters.Length ? parameters[i].Name : "?";
                     sb.Append(paramName);
                     sb.Append(": ");
-                    sb.Append(args.Length > i ? GetDisplayString(args[i], _maxStringLength) : "?");
+                    sb.Append(i < args.Length ? GetDisplayString(args[i], _maxStringLength) : "?");
                 }
 
                 sb.Append(')');
-
 
                 return sb.ToString();
             }

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -600,36 +600,28 @@ namespace NUnit.Framework.Internal
             public override string GetText(MethodInfo method, object[] args)
             {
                 var sb = new StringBuilder();
-                args = args ?? new object[0];
 
-                var parameters = method.GetParameters();
-
-                sb.Append('(');
-                var count = Math.Max(args.Length, parameters.Length);
-
-                for (int i = 0; i < count; i++)
+                if (args != null)
                 {
-                    if(i < parameters.Length)
+                    sb.Append('(');
+
+                    var parameters = method.GetParameters();
+                    
+                    for (int i = 0; i < args.Length; i++)
                     {
-                        if (parameters[i].IsOptional)
+                        if (i > 0) sb.Append(", ");
+
+                        if (i < parameters.Length)
                         {
-                            if(i >= args.Length)
-                            {
-                                continue;
-                            }
+                            sb.Append(parameters[i].Name);
+                            sb.Append(": ");
                         }
+
+                        sb.Append(GetDisplayString(args[i], _maxStringLength));
                     }
 
-                    if (i > 0) sb.Append(", ");
-
-                    var paramName = i < parameters.Length ? parameters[i].Name : "?";
-                    sb.Append(paramName);
-                    sb.Append(": ");
-                    sb.Append(i < args.Length ? GetDisplayString(args[i], _maxStringLength) : "?");
+                    sb.Append(')');
                 }
-
-                sb.Append(')');
-
                 return sb.ToString();
             }
         }

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -614,7 +614,7 @@ namespace NUnit.Framework.Internal
                     var paramName = GetDisplayString(parameters.Length > i ? parameters[i].Name : "?", _maxStringLength).Trim('\"');
                     sb.Append(paramName);
                     sb.Append(": ");
-                    sb.Append(GetDisplayString(args.Length > i ? args[i] : "?", _maxStringLength));
+                    sb.Append(args.Length > i ? GetDisplayString(args[i], _maxStringLength) : "?");
                 }
 
                 sb.Append(')');

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -89,9 +89,9 @@ namespace NUnit.Framework.Internal
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, args);
         }
 
-        [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethod(a: 1, b: ?)")]
-        [TestCase("{m}{p}", new object[] { 1, 2 }, ExpectedResult = "TestMethod(a: 1, b: 2)")]
-        [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethod(a: 1, b: 2, ?: 3)")]
+        [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: ?)")]
+        [TestCase("{m}{p}", new object[] { 1, 2 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2)")]
+        [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, ?: 3)")]
         public string ParameterizedTestsWithArgs(string pattern, object[] args)
         {
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTestWithArgs, args);

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -89,10 +89,10 @@ namespace NUnit.Framework.Internal
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, args);
         }
 
-        [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: ?)")]
+        [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethodWithArgs(a: 1)")]
         [TestCase("{m}{p}", new object[] { 1, 2 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2)")]
         [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, c: 3)")]
-        [TestCase("{m}{p}", new object[] { 1, 2, 3, 4 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, c: 3, ?: 4)")]
+        [TestCase("{m}{p}", new object[] { 1, 2, 3, 4 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, c: 3, 4)")]
         public string ParameterizedTestsWithArgs(string pattern, object[] args)
         {
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTestWithArgs, args);

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -29,6 +29,7 @@ namespace NUnit.Framework.Internal
     public class TestNameGeneratorTests
     {
         private TestMethod _simpleTest;
+        private TestMethod _simpleTestWithArgs;
         private TestMethod _genericTest;
 
         [SetUp]
@@ -36,8 +37,10 @@ namespace NUnit.Framework.Internal
         {
             Type thisType = GetType();
             var simpleMethod = thisType.GetMethod("TestMethod", BindingFlags.NonPublic | BindingFlags.Instance);
+            var simpleMethodWithArgs = thisType.GetMethod("TestMethodWithArgs", BindingFlags.NonPublic | BindingFlags.Instance);
             var genericMethod = thisType.GetMethod("GenericTest", BindingFlags.NonPublic | BindingFlags.Instance);
             _simpleTest = new TestMethod(new MethodWrapper(thisType, simpleMethod));
+            _simpleTestWithArgs = new TestMethod(new MethodWrapper(thisType, simpleMethodWithArgs));
             _genericTest = new TestMethod(new MethodWrapper(thisType, genericMethod));
             _simpleTest.Id = "THE_ID";
         }
@@ -84,6 +87,14 @@ namespace NUnit.Framework.Internal
         public string ParameterizedTests(string pattern, object[] args)
         {
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTest, args);
+        }
+
+        [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethod(a: 1, b: ?)")]
+        [TestCase("{m}{p}", new object[] { 1, 2 }, ExpectedResult = "TestMethod(a: 1, b: 2)")]
+        [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethod(a: 1, b: 2, ?: 3)")]
+        public string ParameterizedTestsWithArgs(string pattern, object[] args)
+        {
+            return new TestNameGenerator(pattern).GetDisplayName(_simpleTestWithArgs, args);
         }
 
         [TestCase("FIXED", ExpectedResult="FIXED")]
@@ -147,6 +158,8 @@ namespace NUnit.Framework.Internal
         #region Methods Used as Data
 
         private void TestMethod() { }
+
+        private void TestMethodWithArgs(Int32 a, Int32 b) { }
 
         private void GenericTest<T, U, V>() { }
 

--- a/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestNameGeneratorTests.cs
@@ -91,7 +91,8 @@ namespace NUnit.Framework.Internal
 
         [TestCase("{m}{p}", new object[] { 1 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: ?)")]
         [TestCase("{m}{p}", new object[] { 1, 2 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2)")]
-        [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, ?: 3)")]
+        [TestCase("{m}{p}", new object[] { 1, 2, 3 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, c: 3)")]
+        [TestCase("{m}{p}", new object[] { 1, 2, 3, 4 }, ExpectedResult = "TestMethodWithArgs(a: 1, b: 2, c: 3, ?: 4)")]
         public string ParameterizedTestsWithArgs(string pattern, object[] args)
         {
             return new TestNameGenerator(pattern).GetDisplayName(_simpleTestWithArgs, args);
@@ -159,7 +160,7 @@ namespace NUnit.Framework.Internal
 
         private void TestMethod() { }
 
-        private void TestMethodWithArgs(Int32 a, Int32 b) { }
+        private void TestMethodWithArgs(Int32 a, Int32 b, Int32 c = 0) { }
 
         private void GenericTest<T, U, V>() { }
 


### PR DESCRIPTION
TestNameGenerator.cs: show names of parameters. Fixes #3389 

(first try)