### PR TITLE
Azure CI: Still publish test results on failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Save test results artifacts
+    condition: always()
     inputs:
       PathtoPublish: test-results
       ArtifactName: Test results (Windows)
@@ -57,6 +58,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Save test results artifacts
+    condition: always()
     inputs:
       PathtoPublish: test-results
       ArtifactName: Test results (Linux)
@@ -95,6 +97,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Save test results artifacts
+    condition: always()
     inputs:
       PathtoPublish: test-results
       ArtifactName: Test results (macOS)


### PR DESCRIPTION
Found while looking at #3414, currently if any tests fail, Azure doesn't upload the test results. I _think_ this will fix it - pushing this while CI is still failing to test! Edit: Checked, it did. 👍 

Unfortunately it looks like Azure currently only runs on PR's and not branches, so I need a PR to test this. I'm not sure why that is - @rprouse - can you check the repo settings that Azure is getting notified on `push` as well as `pull_request`, please? Should be under Settings > Webhooks

(Edit: I've found I can manually kick off branch builds, which is ok. Maybe this is 'behaviour as intended'.)

CI will be fixed after merging #3416