### PR TITLE
Set culture on tests where comparing case of US English strings

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -512,7 +512,7 @@ namespace NUnitLite.Tests
             Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
         }
 
-        [Test]
+        [Test, SetCulture("en-US")]
         public void InvalidResultSpecRecordsError()
         {
             var options = new NUnitLiteOptions("test.dll", "-result:userspecifed.xml;format=nunit2;format=nunit3");

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Constraints
             ICollection set2 = new SimpleObjectCollection("z", "Y", "X");
 
             Assert.That(new CollectionEquivalentConstraint(set1)
-                .Using<string>((x, y) => StringUtil.Compare(x, y, true))
+                .Using<string>((x, y) => StringComparer.InvariantCultureIgnoreCase.Compare(x, y))
                 .ApplyTo(set2).IsSuccess);
         }
 

--- a/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(result.IsSuccess);
         }
 
-        [Test]
+        [Test, SetCulture("en-US")]
         public void HonorsIgnoreCaseForString()
         {
             var actualString = "ABCdef";

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Constraints
         }
 
 #pragma warning disable CS0618 // DictionaryContainsKeyConstraint.IgnoreCase and .Using are deprecated
-
+        [Test, SetCulture("en-US")]
         public void IgnoreCaseIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyConstraint("HELLO").IgnoreCase);
         }
 
-        [Test]
+        [Test, SetCulture("en-US")]
         public void UsingIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -49,6 +49,7 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
         }
+
         [Test]
         public void SucceedsWhenValueIsPresentUsingContainKey()
         {
@@ -62,6 +63,7 @@ namespace NUnit.Framework.Constraints
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
             Assert.That(dictionary, Does.Not.ContainValue("NotValue"));
         }
+
         [Test]
         public void FailsWhenNotUsedAgainstADictionary()
         {
@@ -81,7 +83,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsValueConstraint("Universe"));
         }
 
-        [Test]
+        [Test, SetCulture("en-US")]
         public void IgnoreCaseIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
@@ -89,7 +91,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsValueConstraint("UNIVERSE").IgnoreCase);
         }
 
-        [Test]
+        [Test, SetCulture("en-US")]
         public void UsingIsHonored()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -587,7 +587,7 @@ namespace NUnit.Framework.Constraints
                 Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.CompareTo(y)));
             }
 
-            [Test]
+            [Test, SetCulture("en-US")]
             public void UsesProvidedLambda_StringArgs()
             {
                 Assert.That("hello", Is.EqualTo("HELLO").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
@@ -652,7 +652,7 @@ namespace NUnit.Framework.Constraints
                 Assert.That(strings, Has.Member(2).Using<string, int>((s, i) => i.ToString() == s));
             }
 
-            [Test]
+            [Test, SetCulture("en-US")]
             public void UsesProvidedPredicateForItemComparison()
             {
                 var expected = new[] { "yeti", "łysy", "rysiu" };

--- a/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// Summary description for PathConstraintTests.
     /// </summary>]
-    [TestFixture]
+    [TestFixture, Platform("Win")]
     public class SamePathTest_Windows : StringConstraintTests
     {
         [SetUp]
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    [TestFixture]
+    [TestFixture, Platform("Unix")]
     public class SamePathTest_Linux : StringConstraintTests
     {
         [SetUp]
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    [TestFixture]
+    [TestFixture, Platform("Win")]
     public class SubPathTest_Windows : ConstraintTestBase
     {
         [SetUp]
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    [TestFixture]
+    [TestFixture, Platform("Unix")]
     public class SubPathTest_Linux : ConstraintTestBase
     {
         [SetUp]
@@ -179,7 +179,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    [TestFixture]
+    [TestFixture, Platform("Win")]
     public class SamePathOrUnderTest_Windows : StringConstraintTests
     {
         [SetUp]
@@ -211,7 +211,7 @@ namespace NUnit.Framework.Constraints
             };
     }
 
-    [TestFixture]
+    [TestFixture, Platform("Unix")]
     public class SamePathOrUnderTest_Linux : StringConstraintTests
     {
         [SetUp]

--- a/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class SubstringConstraintTestsIgnoringCase : StringConstraintTests
     {
         [SetUp]
@@ -148,22 +148,4 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( string.Empty, "<string.Empty>" ),
             new TestCaseData( null, "null" ) };
     }
-
-    //[TestFixture]
-    //public class EqualIgnoringCaseTest : ConstraintTest
-    //{
-    //    [SetUp]
-    //    public void SetUp()
-    //    {
-    //        Matcher = new EqualConstraint("Hello World!").IgnoreCase;
-    //        Description = "\"Hello World!\", ignoring case";
-    //    }
-
-    //    static object[] SuccessData = new object[] { "hello world!", "Hello World!", "HELLO world!" };
-
-    //    static object[] FailureData = new object[] { "goodbye", "Hello Friends!", string.Empty, null };
-
-
-    //    string[] ActualValues = new string[] { "\"goodbye\"", "\"Hello Friends!\"", "<string.Empty>", "null" };
-    //}
 }


### PR DESCRIPTION
Fixes #3414 (Pending Azure CI run on PR!).

An OS upgrade on Azure changed the default culture our tests ran in from en-US to en-US-POSIX. Our tests shouldn't be sensitive to this sort of change. 🙂 