### PR TITLE
Print cultures using display name rather than ToString()

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -365,8 +365,8 @@ namespace NUnit.Framework.Api
             env.AddAttribute("machine-name", Environment.MachineName);
             env.AddAttribute("user", Environment.UserName);
             env.AddAttribute("user-domain", Environment.UserDomainName);
-            env.AddAttribute("culture", CultureInfo.CurrentCulture.ToString());
-            env.AddAttribute("uiculture", CultureInfo.CurrentUICulture.ToString());
+            env.AddAttribute("culture", CultureInfo.CurrentCulture.DisplayName);
+            env.AddAttribute("uiculture", CultureInfo.CurrentUICulture.DisplayName);
             env.AddAttribute("os-architecture", GetProcessorArchitecture());
 
             return env;

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -158,18 +158,8 @@ namespace NUnitLite.Tests
         public void CultureInfo_HasRequiredAttribute(string name)
         {
             string cultureName = RequiredAttribute(envNode, name);
-            System.Globalization.CultureInfo culture = null;
-
-            try
-            {
-                culture = System.Globalization.CultureInfo.CreateSpecificCulture(cultureName);
-            }
-            catch (ArgumentException)
-            {
-                // Do nothing - culture will be null
-            }
-
-            Assert.That(culture, Is.Not.Null, "Invalid value for {0}: {1}", name, cultureName);
+            Assert.That(CultureInfo.GetCultures(CultureTypes.AllCultures),
+                Has.Some.Property(nameof(CultureInfo.DisplayName)).EqualTo(cultureName));
         }
 
         [Test]


### PR DESCRIPTION
When working on #3414 - I got a little confused as the test results were displaying `culture=""`. Turns out the empty string is used when you ToString the Invariant Culture.

This doesn't seem like the most friendly way to record culture information - even though the four char codes are nice to work with. I've switched to `DisplayName`, which prints a friendly name instead (e.g. `English (United Kingdom)`. 

What do people think? I had to change a test for this, but I don't think the behaviour of the test was particularly important. I didn't change the NUnit 2 result writer, which has the same issue.

CI should be fixed after #3416 is merged. 👍 