### PR TITLE
Nullability annotations for the Assert class

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,7 +6,7 @@ There are two ways to build NUnit: using the solution file in an IDE or through 
 
 ## Solution Build
 
-The framework is built using a single Visual Studio solution, `nunit.sln`, which may be built with [Visual Studio 2017](https://www.visualstudio.com/vs/) on Windows and [Visual Studio for Mac](https://www.visualstudio.com/vs/) on macOS. Currently, MonoDevelop does not support the new multi-targeted `csproj` project format. Once MonoDevelop is updated, it should start working again. Until then, we recommend [Visual Studio Code](https://code.visualstudio.com/) and compiling using the build scripts on non-Windows platforms.
+The framework is built using a single Visual Studio solution, `nunit.sln`, which may be built with [Visual Studio 2019](https://www.visualstudio.com/vs/) on Windows and [Visual Studio for Mac](https://www.visualstudio.com/vs/) on macOS. Currently, MonoDevelop does not support the new multi-targeted `csproj` project format. Once MonoDevelop is updated, it should start working again. Until then, we recommend [Visual Studio Code](https://code.visualstudio.com/) and compiling using the build scripts on non-Windows platforms.
 
 On all platforms, you will need to install [.NET Core 2.0.3 SDK](https://www.microsoft.com/net/download/windows) or newer. On Mac or Linux, you will need to install [Mono 5.2.0](https://www.mono-project.com/download/). Currently (as of 5.4.1), newer versions of Mono are broken and crash during the compile.
 

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">7</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">8</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/framework/Assert.Conditions.cs
+++ b/src/NUnitFramework/framework/Assert.Conditions.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System.Collections;
 using NUnit.Framework.Constraints;
 using System;
@@ -32,32 +34,29 @@ namespace NUnit.Framework
         #region True
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void True(bool? condition, string message, params object[] args)
+        public static void True(bool? condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.True ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void True(bool condition, string message, params object[] args)
+        public static void True(bool condition, string? message, params object?[]? args)
         {
            Assert.That(condition, Is.True, message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void True(bool? condition)
@@ -66,8 +65,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void True(bool condition)
@@ -76,32 +74,29 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsTrue(bool? condition, string message, params object[] args)
+        public static void IsTrue(bool? condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.True ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsTrue(bool condition, string message, params object[] args)
+        public static void IsTrue(bool condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.True ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void IsTrue(bool? condition)
@@ -110,8 +105,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void IsTrue(bool condition)
@@ -124,32 +118,31 @@ namespace NUnit.Framework
         #region False
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void False(bool? condition, string message, params object[] args)
+        public static void False(bool? condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.False ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void False(bool condition, string message, params object[] args)
+        public static void False(bool condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.False ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         public static void False(bool? condition)
@@ -158,8 +151,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         public static void False(bool condition)
@@ -168,32 +161,32 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsFalse(bool? condition, string message, params object[] args)
+        public static void IsFalse(bool? condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.False ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsFalse(bool condition, string message, params object[] args)
+        public static void IsFalse(bool condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.False ,message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         public static void IsFalse(bool? condition)
@@ -202,8 +195,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is false. If the condition is true the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is false. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         public static void IsFalse(bool condition)
@@ -216,49 +209,45 @@ namespace NUnit.Framework
         #region NotNull
 
         /// <summary>
-        /// Verifies that the object that is passed in is not equal to <code>null</code>
-        /// If the object is <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is not equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotNull(object anObject, string message, params object[] args)
+        public static void NotNull(object? anObject, string? message, params object?[]? args)
         {
             Assert.That(anObject, Is.Not.Null ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is not equal to <code>null</code>
-        /// If the object is <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is not equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void NotNull(object anObject)
+        public static void NotNull(object? anObject)
         {
             Assert.That(anObject, Is.Not.Null ,null, null);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is not equal to <code>null</code>
-        /// If the object is <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is not equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotNull(object anObject, string message, params object[] args)
+        public static void IsNotNull(object? anObject, string? message, params object?[]? args)
         {
             Assert.That(anObject, Is.Not.Null ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is not equal to <code>null</code>
-        /// If the object is <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is not equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void IsNotNull(object anObject)
+        public static void IsNotNull(object? anObject)
         {
             Assert.That(anObject, Is.Not.Null ,null, null);
         }
@@ -268,49 +257,45 @@ namespace NUnit.Framework
         #region Null
 
         /// <summary>
-        /// Verifies that the object that is passed in is equal to <code>null</code>
-        /// If the object is not <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Null(object anObject, string message, params object[] args)
+        public static void Null(object? anObject, string? message, params object?[]? args)
         {
             Assert.That(anObject, Is.Null ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is equal to <code>null</code>
-        /// If the object is not <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void Null(object anObject)
+        public static void Null(object? anObject)
         {
             Assert.That(anObject, Is.Null ,null, null);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is equal to <code>null</code>
-        /// If the object is not <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNull(object anObject, string message, params object[] args)
+        public static void IsNull(object? anObject, string? message, params object?[]? args)
         {
             Assert.That(anObject, Is.Null ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the object that is passed in is equal to <code>null</code>
-        /// If the object is not <code>null</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the object that is passed in is equal to <code>null</code>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void IsNull(object anObject)
+        public static void IsNull(object? anObject)
         {
             Assert.That(anObject, Is.Null ,null, null);
         }
@@ -320,22 +305,20 @@ namespace NUnit.Framework
         #region IsNaN
 
         /// <summary>
-        /// Verifies that the double that is passed in is an <code>NaN</code> value.
-        /// If the object is not <code>NaN</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the double that is passed in is an <code>NaN</code> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNaN(double aDouble, string message, params object[] args)
+        public static void IsNaN(double aDouble, string? message, params object?[]? args)
         {
             Assert.That(aDouble, Is.NaN ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the double that is passed in is an <code>NaN</code> value.
-        /// If the object is not <code>NaN</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the double that is passed in is an <code>NaN</code> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double aDouble)
@@ -344,22 +327,20 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Verifies that the double that is passed in is an <code>NaN</code> value.
-        /// If the object is not <code>NaN</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the double that is passed in is an <code>NaN</code> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNaN(double? aDouble, string message, params object[] args)
+        public static void IsNaN(double? aDouble, string? message, params object?[]? args)
         {
             Assert.That(aDouble, Is.NaN ,message, args);
         }
 
         /// <summary>
-        /// Verifies that the double that is passed in is an <code>NaN</code> value.
-        /// If the object is not <code>NaN</code> then an <see cref="AssertionException"/>
-        /// is thrown.
+        /// Verifies that the double that is passed in is an <code>NaN</code> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double? aDouble)
@@ -374,21 +355,21 @@ namespace NUnit.Framework
         #region String
 
         /// <summary>
-        /// Assert that a string is empty - that is equal to string.Empty
+        /// Assert that a string is empty. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsEmpty(string aString, string message, params object[] args)
+        public static void IsEmpty(string? aString, string? message, params object?[]? args)
         {
             Assert.That(aString, new EmptyStringConstraint() ,message, args);
         }
 
         /// <summary>
-        /// Assert that a string is empty - that is equal to string.Empty
+        /// Assert that a string is empty. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aString">The string to be tested</param>
-        public static void IsEmpty(string aString)
+        public static void IsEmpty(string? aString)
         {
             Assert.That(aString, new EmptyStringConstraint() ,null, null);
         }
@@ -398,18 +379,20 @@ namespace NUnit.Framework
         #region Collection
 
         /// <summary>
-        /// Assert that an array, list or other collection is empty
+        /// Assert that an array, list or other collection is empty. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsEmpty(IEnumerable collection, string message, params object[] args)
+        public static void IsEmpty(IEnumerable collection, string? message, params object?[]? args)
         {
             Assert.That(collection, new EmptyCollectionConstraint() ,message, args);
         }
 
         /// <summary>
-        /// Assert that an array, list or other collection is empty
+        /// Assert that an array, list or other collection is empty. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         public static void IsEmpty(IEnumerable collection)
@@ -426,21 +409,23 @@ namespace NUnit.Framework
         #region String
 
         /// <summary>
-        /// Assert that a string is not empty - that is not equal to string.Empty
+        /// Assert that a string is not empty. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotEmpty(string aString, string message, params object[] args)
+        public static void IsNotEmpty(string? aString, string? message, params object?[]? args)
         {
             Assert.That(aString, Is.Not.Empty ,message, args);
         }
 
         /// <summary>
-        /// Assert that a string is not empty - that is not equal to string.Empty
+        /// Assert that a string is not empty. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="aString">The string to be tested</param>
-        public static void IsNotEmpty(string aString)
+        public static void IsNotEmpty(string? aString)
         {
             Assert.That(aString, Is.Not.Empty ,null, null);
         }
@@ -450,18 +435,20 @@ namespace NUnit.Framework
         #region Collection
 
         /// <summary>
-        /// Assert that an array, list or other collection is not empty
+        /// Assert that an array, list or other collection is not empty. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotEmpty(IEnumerable collection, string message, params object[] args)
+        public static void IsNotEmpty(IEnumerable collection, string? message, params object?[]? args)
         {
             Assert.That(collection, Is.Not.Empty ,message, args);
         }
 
         /// <summary>
-        /// Assert that an array, list or other collection is not empty
+        /// Assert that an array, list or other collection is not empty. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         public static void IsNotEmpty(IEnumerable collection)
@@ -478,7 +465,7 @@ namespace NUnit.Framework
         #region Ints
 
         /// <summary>
-        /// Asserts that an int is zero.
+        /// Asserts that an int is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Zero(int actual)
@@ -487,12 +474,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an int is zero.
+        /// Asserts that an int is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(int actual, string message, params object[] args)
+        public static void Zero(int actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -502,7 +489,8 @@ namespace NUnit.Framework
         #region UnsignedInts
 
         /// <summary>
-        /// Asserts that an unsigned int is zero.
+        /// Asserts that an unsigned int is zero. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -512,13 +500,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned int is zero.
+        /// Asserts that an unsigned int is zero. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Zero(uint actual, string message, params object[] args)
+        public static void Zero(uint actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -528,7 +517,7 @@ namespace NUnit.Framework
         #region Longs
 
         /// <summary>
-        /// Asserts that a Long is zero.
+        /// Asserts that a Long is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Zero(long actual)
@@ -537,12 +526,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a Long is zero.
+        /// Asserts that a Long is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(long actual, string message, params object[] args)
+        public static void Zero(long actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -552,7 +541,8 @@ namespace NUnit.Framework
         #region UnsignedLongs
 
         /// <summary>
-        /// Asserts that an unsigned Long is zero.
+        /// Asserts that an unsigned Long is zero. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -562,13 +552,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned Long is zero.
+        /// Asserts that an unsigned Long is zero. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Zero(ulong actual, string message, params object[] args)
+        public static void Zero(ulong actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -578,7 +569,7 @@ namespace NUnit.Framework
         #region Decimals
 
         /// <summary>
-        /// Asserts that a decimal is zero.
+        /// Asserts that a decimal is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Zero(decimal actual)
@@ -587,12 +578,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a decimal is zero.
+        /// Asserts that a decimal is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(decimal actual, string message, params object[] args)
+        public static void Zero(decimal actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -602,7 +593,7 @@ namespace NUnit.Framework
         #region Doubles
 
         /// <summary>
-        /// Asserts that a double is zero.
+        /// Asserts that a double is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Zero(double actual)
@@ -611,12 +602,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a double is zero.
+        /// Asserts that a double is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(double actual, string message, params object[] args)
+        public static void Zero(double actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -626,7 +617,7 @@ namespace NUnit.Framework
         #region Floats
 
         /// <summary>
-        /// Asserts that a float is zero.
+        /// Asserts that a float is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Zero(float actual)
@@ -635,12 +626,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a float is zero.
+        /// Asserts that a float is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(float actual, string message, params object[] args)
+        public static void Zero(float actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Zero, message, args);
         }
@@ -654,7 +645,7 @@ namespace NUnit.Framework
         #region Ints
 
         /// <summary>
-        /// Asserts that an int is not zero.
+        /// Asserts that an int is not zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void NotZero(int actual)
@@ -663,12 +654,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an int is not zero.
+        /// Asserts that an int is not zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(int actual, string message, params object[] args)
+        public static void NotZero(int actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -678,7 +669,8 @@ namespace NUnit.Framework
         #region UnsignedInts
 
         /// <summary>
-        /// Asserts that an unsigned int is not zero.
+        /// Asserts that an unsigned int is not zero. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -688,13 +680,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned int is not zero.
+        /// Asserts that an unsigned int is not zero. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void NotZero(uint actual, string message, params object[] args)
+        public static void NotZero(uint actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -704,7 +697,7 @@ namespace NUnit.Framework
         #region Longs
 
         /// <summary>
-        /// Asserts that a Long is not zero.
+        /// Asserts that a Long is not zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void NotZero(long actual)
@@ -713,12 +706,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a Long is not zero.
+        /// Asserts that a Long is not zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(long actual, string message, params object[] args)
+        public static void NotZero(long actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -728,7 +721,8 @@ namespace NUnit.Framework
         #region UnsignedLongs
 
         /// <summary>
-        /// Asserts that an unsigned Long is not zero.
+        /// Asserts that an unsigned Long is not zero. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -738,13 +732,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned Long is not zero.
+        /// Asserts that an unsigned Long is not zero. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void NotZero(ulong actual, string message, params object[] args)
+        public static void NotZero(ulong actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -754,7 +749,7 @@ namespace NUnit.Framework
         #region Decimals
 
         /// <summary>
-        /// Asserts that a decimal is zero.
+        /// Asserts that a decimal is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void NotZero(decimal actual)
@@ -763,12 +758,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a decimal is zero.
+        /// Asserts that a decimal is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(decimal actual, string message, params object[] args)
+        public static void NotZero(decimal actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -778,7 +773,7 @@ namespace NUnit.Framework
         #region Doubles
 
         /// <summary>
-        /// Asserts that a double is zero.
+        /// Asserts that a double is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void NotZero(double actual)
@@ -787,12 +782,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a double is zero.
+        /// Asserts that a double is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(double actual, string message, params object[] args)
+        public static void NotZero(double actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -802,7 +797,7 @@ namespace NUnit.Framework
         #region Floats
 
         /// <summary>
-        /// Asserts that a float is zero.
+        /// Asserts that a float is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void NotZero(float actual)
@@ -811,12 +806,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a float is zero.
+        /// Asserts that a float is zero. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(float actual, string message, params object[] args)
+        public static void NotZero(float actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.Zero, message, args);
         }
@@ -830,7 +825,7 @@ namespace NUnit.Framework
         #region Ints
 
         /// <summary>
-        /// Asserts that an int is positive.
+        /// Asserts that an int is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Positive(int actual)
@@ -839,12 +834,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an int is positive.
+        /// Asserts that an int is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(int actual, string message, params object[] args)
+        public static void Positive(int actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -854,7 +849,8 @@ namespace NUnit.Framework
         #region UnsignedInts
 
         /// <summary>
-        /// Asserts that an unsigned int is positive.
+        /// Asserts that an unsigned int is positive. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -864,13 +860,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned int is positive.
+        /// Asserts that an unsigned int is positive. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Positive(uint actual, string message, params object[] args)
+        public static void Positive(uint actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -880,7 +877,7 @@ namespace NUnit.Framework
         #region Longs
 
         /// <summary>
-        /// Asserts that a Long is positive.
+        /// Asserts that a Long is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Positive(long actual)
@@ -889,12 +886,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a Long is positive.
+        /// Asserts that a Long is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(long actual, string message, params object[] args)
+        public static void Positive(long actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -904,7 +901,8 @@ namespace NUnit.Framework
         #region UnsignedLongs
 
         /// <summary>
-        /// Asserts that an unsigned Long is positive.
+        /// Asserts that an unsigned Long is positive. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -914,13 +912,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned Long is positive.
+        /// Asserts that an unsigned Long is positive. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Positive(ulong actual, string message, params object[] args)
+        public static void Positive(ulong actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -930,7 +929,8 @@ namespace NUnit.Framework
         #region Decimals
 
         /// <summary>
-        /// Asserts that a decimal is positive.
+        /// Asserts that a decimal is positive. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Positive(decimal actual)
@@ -939,12 +939,13 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a decimal is positive.
+        /// Asserts that a decimal is positive. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(decimal actual, string message, params object[] args)
+        public static void Positive(decimal actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -954,7 +955,8 @@ namespace NUnit.Framework
         #region Doubles
 
         /// <summary>
-        /// Asserts that a double is positive.
+        /// Asserts that a double is positive. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Positive(double actual)
@@ -963,12 +965,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a double is positive.
+        /// Asserts that a double is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(double actual, string message, params object[] args)
+        public static void Positive(double actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -978,7 +980,7 @@ namespace NUnit.Framework
         #region Floats
 
         /// <summary>
-        /// Asserts that a float is positive.
+        /// Asserts that a float is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Positive(float actual)
@@ -987,12 +989,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a float is positive.
+        /// Asserts that a float is positive. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(float actual, string message, params object[] args)
+        public static void Positive(float actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Positive, message, args);
         }
@@ -1006,7 +1008,7 @@ namespace NUnit.Framework
         #region Ints
 
         /// <summary>
-        /// Asserts that an int is negative.
+        /// Asserts that an int is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Negative(int actual)
@@ -1015,12 +1017,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an int is negative.
+        /// Asserts that an int is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(int actual, string message, params object[] args)
+        public static void Negative(int actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1030,7 +1032,8 @@ namespace NUnit.Framework
         #region UnsignedInts
 
         /// <summary>
-        /// Asserts that an unsigned int is negative.
+        /// Asserts that an unsigned int is negative. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -1040,13 +1043,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned int is negative.
+        /// Asserts that an unsigned int is negative. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Negative(uint actual, string message, params object[] args)
+        public static void Negative(uint actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1056,7 +1060,7 @@ namespace NUnit.Framework
         #region Longs
 
         /// <summary>
-        /// Asserts that a Long is negative.
+        /// Asserts that a Long is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Negative(long actual)
@@ -1065,12 +1069,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a Long is negative.
+        /// Asserts that a Long is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(long actual, string message, params object[] args)
+        public static void Negative(long actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1080,7 +1084,8 @@ namespace NUnit.Framework
         #region UnsignedLongs
 
         /// <summary>
-        /// Asserts that an unsigned Long is negative.
+        /// Asserts that an unsigned Long is negative. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         [CLSCompliant(false)]
@@ -1090,13 +1095,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that an unsigned Long is negative.
+        /// Asserts that an unsigned Long is negative. Returns without throwing an exception when inside a multiple
+        /// assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Negative(ulong actual, string message, params object[] args)
+        public static void Negative(ulong actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1106,7 +1112,8 @@ namespace NUnit.Framework
         #region Decimals
 
         /// <summary>
-        /// Asserts that a decimal is negative.
+        /// Asserts that a decimal is negative. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Negative(decimal actual)
@@ -1115,12 +1122,13 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a decimal is negative.
+        /// Asserts that a decimal is negative. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(decimal actual, string message, params object[] args)
+        public static void Negative(decimal actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1130,7 +1138,8 @@ namespace NUnit.Framework
         #region Doubles
 
         /// <summary>
-        /// Asserts that a double is negative.
+        /// Asserts that a double is negative. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Negative(double actual)
@@ -1139,12 +1148,13 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a double is negative.
+        /// Asserts that a double is negative. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(double actual, string message, params object[] args)
+        public static void Negative(double actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }
@@ -1154,7 +1164,7 @@ namespace NUnit.Framework
         #region Floats
 
         /// <summary>
-        /// Asserts that a float is negative.
+        /// Asserts that a float is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         public static void Negative(float actual)
@@ -1163,12 +1173,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a float is negative.
+        /// Asserts that a float is negative. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(float actual, string message, params object[] args)
+        public static void Negative(float actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Negative, message, args);
         }

--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -21,8 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using NUnit.Framework.Internal;
+#nullable enable
 
 namespace NUnit.Framework
 {
@@ -33,67 +32,59 @@ namespace NUnit.Framework
         #region Doubles
 
         /// <summary>
-        /// Verifies that two doubles are equal considering a delta. If the
-        /// expected value is infinity then the delta value is ignored. If 
-        /// they are not equal then an <see cref="AssertionException"/> is
-        /// thrown.
+        /// Verifies that two doubles are equal considering a delta. If the expected value is infinity then the delta
+        /// value is ignored. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
-        /// <param name="delta">The maximum acceptable difference between the
-        /// the expected and the actual</param>
+        /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(double expected, double actual, double delta, string message, params object[] args)
+        public static void AreEqual(double expected, double actual, double delta, string? message, params object?[]? args)
         {
             AssertDoublesAreEqual(expected, actual, delta, message, args);
         }
 
         /// <summary>
-        /// Verifies that two doubles are equal considering a delta. If the
-        /// expected value is infinity then the delta value is ignored. If 
-        /// they are not equal then an <see cref="AssertionException"/> is
-        /// thrown.
+        /// Verifies that two doubles are equal considering a delta. If the expected value is infinity then the delta
+        /// value is ignored. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
-        /// <param name="delta">The maximum acceptable difference between the
-        /// the expected and the actual</param>
+        /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         public static void AreEqual(double expected, double actual, double delta)
         {
             AssertDoublesAreEqual(expected, actual, delta, null, null);
         }
 
         /// <summary>
-        /// Verifies that two doubles are equal considering a delta. If the
-        /// expected value is infinity then the delta value is ignored. If 
-        /// they are not equal then an <see cref="AssertionException"/> is
-        /// thrown.
+        /// Verifies that two doubles are equal considering a delta. If the expected value is infinity then the delta
+        /// value is ignored. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
-        /// <param name="delta">The maximum acceptable difference between the
-        /// the expected and the actual</param>
+        /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(double expected, double? actual, double delta, string message, params object[] args)
+        public static void AreEqual(double expected, double? actual, double delta, string? message, params object?[]? args)
         {
-            AssertDoublesAreEqual(expected, (double)actual, delta, message, args);
+            // TODO: https://github.com/nunit/nunit/issues/3449
+            //                                    ↓↓↓↓↓↓↓
+            AssertDoublesAreEqual(expected, actual!.Value, delta, message, args);
         }
 
         /// <summary>
-        /// Verifies that two doubles are equal considering a delta. If the
-        /// expected value is infinity then the delta value is ignored. If 
-        /// they are not equal then an <see cref="AssertionException"/> is
-        /// thrown.
+        /// Verifies that two doubles are equal considering a delta. If the expected value is infinity then the delta
+        /// value is ignored. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
-        /// <param name="delta">The maximum acceptable difference between the
-        /// the expected and the actual</param>
+        /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         public static void AreEqual(double expected, double? actual, double delta)
         {
-            AssertDoublesAreEqual(expected, (double)actual, delta, null, null);
+            // TODO: https://github.com/nunit/nunit/issues/3449
+            //                                    ↓↓↓↓↓↓↓
+            AssertDoublesAreEqual(expected, actual!.Value, delta, null, null);
         }
 
         #endregion
@@ -101,29 +92,27 @@ namespace NUnit.Framework
         #region Objects
 
         /// <summary>
-        /// Verifies that two objects are equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are not equal an <see cref="AssertionException"/> is thrown.
+        /// Verifies that two objects are equal. Two objects are considered equal if both are null, or if both have the
+        /// same value. NUnit has special semantics for some object types. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(object expected, object actual, string message, params object[] args)
+        public static void AreEqual(object? expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.EqualTo(expected), message, args);
         }
 
         /// <summary>
-        /// Verifies that two objects are equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are not equal an <see cref="AssertionException"/> is thrown.
+        /// Verifies that two objects are equal. Two objects are considered equal if both are null, or if both have the
+        /// same value. NUnit has special semantics for some object types. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
-        public static void AreEqual(object expected, object actual)
+        public static void AreEqual(object? expected, object? actual)
         {
             Assert.That(actual, Is.EqualTo(expected), null, null);
         }
@@ -137,29 +126,27 @@ namespace NUnit.Framework
         #region Objects
 
         /// <summary>
-        /// Verifies that two objects are not equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are equal an <see cref="AssertionException"/> is thrown.
+        /// Verifies that two objects are not equal. Two objects are considered equal if both are null, or if both have
+        /// the same value. NUnit has special semantics for some object types. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreNotEqual(object expected, object actual, string message, params object[] args)
+        public static void AreNotEqual(object? expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.EqualTo(expected), message, args);
         }
 
         /// <summary>
-        /// Verifies that two objects are not equal.  Two objects are considered
-        /// equal if both are null, or if both have the same value. NUnit
-        /// has special semantics for some object types.
-        /// If they are equal an <see cref="AssertionException"/> is thrown.
+        /// Verifies that two objects are not equal. Two objects are considered equal if both are null, or if both have
+        /// the same value. NUnit has special semantics for some object types. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The value that is expected</param>
         /// <param name="actual">The actual value</param>
-        public static void AreNotEqual(object expected, object actual)
+        public static void AreNotEqual(object? expected, object? actual)
         {
             Assert.That(actual, Is.Not.EqualTo(expected), null, null);
         }
@@ -171,25 +158,25 @@ namespace NUnit.Framework
         #region AreSame
 
         /// <summary>
-        /// Asserts that two objects refer to the same object. If they
-        /// are not the same an <see cref="AssertionException"/> is thrown.
+        /// Asserts that two objects refer to the same object. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The actual object</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreSame(object expected, object actual, string message, params object[] args)
+        public static void AreSame(object? expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.SameAs(expected), message, args);
         }
 
         /// <summary>
-        /// Asserts that two objects refer to the same object. If they
-        /// are not the same an <see cref="AssertionException"/> is thrown.
+        /// Asserts that two objects refer to the same object. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The actual object</param>
-        public static void AreSame(object expected, object actual)
+        public static void AreSame(object? expected, object? actual)
         {
             Assert.That(actual, Is.SameAs(expected), null, null);
         }
@@ -199,25 +186,25 @@ namespace NUnit.Framework
         #region AreNotSame
 
         /// <summary>
-        /// Asserts that two objects do not refer to the same object. If they
-        /// are the same an <see cref="AssertionException"/> is thrown.
+        /// Asserts that two objects do not refer to the same object. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The actual object</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreNotSame(object expected, object actual, string message, params object[] args)
+        public static void AreNotSame(object? expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.SameAs(expected), message, args);
         }
 
         /// <summary>
-        /// Asserts that two objects do not refer to the same object. If they
-        /// are the same an <see cref="AssertionException"/> is thrown.
+        /// Asserts that two objects do not refer to the same object. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The actual object</param>
-        public static void AreNotSame(object expected, object actual)
+        public static void AreNotSame(object? expected, object? actual)
         {
             Assert.That(actual, Is.Not.SameAs(expected), null, null);
         }
@@ -236,7 +223,7 @@ namespace NUnit.Framework
         /// the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        protected static void AssertDoublesAreEqual(double expected, double actual, double delta, string message, object[] args)
+        protected static void AssertDoublesAreEqual(double expected, double actual, double delta, string? message, object?[]? args)
         {
             if (double.IsNaN(expected) || double.IsInfinity(expected))
                 Assert.That(actual, Is.EqualTo(expected), message, args);

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -22,10 +22,12 @@
 // ***********************************************************************
 
 #if TASK_PARALLEL_LIBRARY_API
+
+#nullable enable
+
 using System;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
-
 
 namespace NUnit.Framework
 {
@@ -34,15 +36,16 @@ namespace NUnit.Framework
         #region ThrowsAsync
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expression">A constraint to be satisfied by the exception</param>
         /// <param name="code">A TestSnippet delegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string message, params object[] args)
+        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string? message, params object?[]? args)
         {
-            Exception caughtException = null;
+            Exception? caughtException = null;
             try
             {
                 AsyncToSyncAdapter.Await(code.Invoke);
@@ -58,33 +61,36 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expression">A constraint to be satisfied by the exception</param>
         /// <param name="code">A TestSnippet delegate</param>
-        public static Exception ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
+        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
         {
             return ThrowsAsync(expression, code, string.Empty, null);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The exception Type expected</param>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object[] args)
+        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The exception Type expected</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
         {
             return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, string.Empty, null);
         }
@@ -94,23 +100,25 @@ namespace NUnit.Framework
         #region ThrowsAsync<TActual>
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">Type of the expected exception</typeparam>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object[] args) where TActual : Exception
+        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
         {
-            return (TActual)ThrowsAsync(typeof (TActual), code, message, args);
+            return (TActual?)ThrowsAsync(typeof (TActual), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws a particular exception when called.
+        /// Verifies that an async delegate throws a particular exception when called. The returned exception may be
+        /// <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">Type of the expected exception</typeparam>
         /// <param name="code">A TestDelegate</param>
-        public static TActual ThrowsAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
+        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
         {
             return ThrowsAsync<TActual>(code, string.Empty, null);
         }
@@ -120,47 +128,47 @@ namespace NUnit.Framework
         #region CatchAsync
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception when called
-        /// and returns it.
+        /// Verifies that an async delegate throws an exception when called and returns it. The returned exception may
+        /// be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception CatchAsync(AsyncTestDelegate code, string message, params object[] args)
+        public static Exception? CatchAsync(AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception when called
-        /// and returns it.
+        /// Verifies that an async delegate throws an exception when called and returns it. The returned exception may
+        /// be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static Exception CatchAsync(AsyncTestDelegate code)
+        public static Exception? CatchAsync(AsyncTestDelegate code)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that an async delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The expected Exception Type</param>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object[] args)
+        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that an async delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The expected Exception Type</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception CatchAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code);
         }
@@ -170,25 +178,25 @@ namespace NUnit.Framework
         #region CatchAsync<TActual>
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that an async delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual CatchAsync<TActual>(AsyncTestDelegate code, string message, params object[] args) where TActual : Exception
+        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
         {
-            return (TActual)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code, message, args);
+            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that an async delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that an async delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static TActual CatchAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
+        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
         {
-            return (TActual)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code);
+            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code);
         }
 
         #endregion
@@ -201,7 +209,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void DoesNotThrowAsync(AsyncTestDelegate code, string message, params object[] args)
+        public static void DoesNotThrowAsync(AsyncTestDelegate code, string? message, params object?[]? args)
         {
             Assert.That(code, new ThrowsNothingConstraint(), message, args);
         }

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
@@ -31,15 +33,16 @@ namespace NUnit.Framework
     {
         #region Throws
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expression">A constraint to be satisfied by the exception</param>
         /// <param name="code">A TestSnippet delegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception Throws(IResolveConstraint expression, TestDelegate code, string message, params object[] args)
+        public static Exception? Throws(IResolveConstraint expression, TestDelegate code, string? message, params object?[]? args)
         {
-            Exception caughtException = null;
+            Exception? caughtException = null;
 
             // Since TestDelegate returns void, it’s always async void if it’s async at all.
             Guard.ArgumentNotAsyncVoid(code, nameof(code));
@@ -62,33 +65,36 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expression">A constraint to be satisfied by the exception</param>
         /// <param name="code">A TestSnippet delegate</param>
-        public static Exception Throws(IResolveConstraint expression, TestDelegate code)
+        public static Exception? Throws(IResolveConstraint expression, TestDelegate code)
         {
             return Throws(expression, code, string.Empty, null);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The exception Type expected</param>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception Throws(Type expectedExceptionType, TestDelegate code, string message, params object[] args)
+        public static Exception? Throws(Type expectedExceptionType, TestDelegate code, string? message, params object?[]? args)
         {
             return Throws(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The exception Type expected</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception Throws(Type expectedExceptionType, TestDelegate code)
+        public static Exception? Throws(Type expectedExceptionType, TestDelegate code)
         {
             return Throws(new ExceptionTypeConstraint(expectedExceptionType), code, string.Empty, null);
         }
@@ -98,23 +104,25 @@ namespace NUnit.Framework
         #region Throws<TActual>
 
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">Type of the expected exception</typeparam>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual Throws<TActual>(TestDelegate code, string message, params object[] args) where TActual : Exception
+        public static TActual? Throws<TActual>(TestDelegate code, string? message, params object?[]? args) where TActual : Exception
         {
-            return (TActual)Throws(typeof(TActual), code, message, args);
+            return (TActual?)Throws(typeof(TActual), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws a particular exception when called.
+        /// Verifies that a delegate throws a particular exception when called. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">Type of the expected exception</typeparam>
         /// <param name="code">A TestDelegate</param>
-        public static TActual Throws<TActual>(TestDelegate code) where TActual : Exception
+        public static TActual? Throws<TActual>(TestDelegate code) where TActual : Exception
         {
             return Throws<TActual>(code, string.Empty, null);
         }
@@ -123,47 +131,47 @@ namespace NUnit.Framework
 
         #region Catch
         /// <summary>
-        /// Verifies that a delegate throws an exception when called
-        /// and returns it.
+        /// Verifies that a delegate throws an exception when called and returns it. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception Catch(TestDelegate code, string message, params object[] args)
+        public static Exception? Catch(TestDelegate code, string? message, params object?[]? args)
         {
             return Throws(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws an exception when called
-        /// and returns it.
+        /// Verifies that a delegate throws an exception when called and returns it. The returned exception may be <see
+        /// langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static Exception Catch(TestDelegate code)
+        public static Exception? Catch(TestDelegate code)
         {
             return Throws(new InstanceOfTypeConstraint(typeof(Exception)), code);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that a delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The expected Exception Type</param>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception Catch(Type expectedExceptionType, TestDelegate code, string message, params object[] args)
+        public static Exception? Catch(Type expectedExceptionType, TestDelegate code, string? message, params object?[]? args)
         {
             return Throws(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that a delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="expectedExceptionType">The expected Exception Type</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception Catch(Type expectedExceptionType, TestDelegate code)
+        public static Exception? Catch(Type expectedExceptionType, TestDelegate code)
         {
             return Throws(new InstanceOfTypeConstraint(expectedExceptionType), code);
         }
@@ -172,25 +180,25 @@ namespace NUnit.Framework
         #region Catch<TActual>
 
         /// <summary>
-        /// Verifies that a delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that a delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual Catch<TActual>(TestDelegate code, string message, params object[] args) where TActual : System.Exception
+        public static TActual? Catch<TActual>(TestDelegate code, string? message, params object?[]? args) where TActual : System.Exception
         {
-            return (TActual)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
+            return (TActual?)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
         }
 
         /// <summary>
-        /// Verifies that a delegate throws an exception of a certain Type
-        /// or one derived from it when called and returns it.
+        /// Verifies that a delegate throws an exception of a certain Type or one derived from it when called and
+        /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static TActual Catch<TActual>(TestDelegate code) where TActual : System.Exception
+        public static TActual? Catch<TActual>(TestDelegate code) where TActual : System.Exception
         {
-            return (TActual)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code);
+            return (TActual?)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code);
         }
 
         #endregion
@@ -203,7 +211,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void DoesNotThrow(TestDelegate code, string message, params object[] args)
+        public static void DoesNotThrow(TestDelegate code, string? message, params object?[]? args)
         {
             Assert.That(code, new ThrowsNothingConstraint(), message, args);
         }

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -21,9 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
@@ -38,20 +39,18 @@ namespace NUnit.Framework
         #region Boolean
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That(bool condition, string message, params object[] args)
+        public static void That(bool condition, string? message, params object?[]? args)
         {
             Assert.That(condition, Is.True, message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         public static void That(bool condition)
@@ -60,8 +59,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary> 
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
@@ -75,20 +73,18 @@ namespace NUnit.Framework
         #region Lambda returning Boolean
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary> 
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That(Func<bool> condition, string message, params object[] args)
+        public static void That(Func<bool> condition, string? message, params object?[]? args)
         {
             Assert.That(condition.Invoke(), Is.True, message, args);
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         public static void That(Func<bool> condition)
@@ -97,8 +93,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false the method throws
-        /// an <see cref="AssertionException"/>.
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary> 
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
@@ -112,8 +107,7 @@ namespace NUnit.Framework
         #region ActualValueDelegate
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
@@ -124,15 +118,14 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string message, params object[] args)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message, params object?[]? args)
         {
             var constraint = expr.Resolve();
 
@@ -143,8 +136,7 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
@@ -168,8 +160,7 @@ namespace NUnit.Framework
         #region TestDelegate
 
         /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
@@ -179,21 +170,19 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, string message, params object[] args)
+        public static void That(TestDelegate code, IResolveConstraint constraint, string? message, params object?[]? args)
         {
             Assert.That((object)code, constraint, message, args);
         }
 
         /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
@@ -210,8 +199,8 @@ namespace NUnit.Framework
         #region Assert.That<TActual>
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
@@ -222,15 +211,15 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string message, params object[] args)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message, params object?[]? args)
         {
             var constraint = expression.Resolve();
 
@@ -241,8 +230,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block.
         /// </summary>
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
@@ -266,33 +255,31 @@ namespace NUnit.Framework
         #region Assert.ByVal
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure.
-        /// Used as a synonym for That in rare cases where a private setter 
-        /// causes a Visual Basic compilation error.
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block. Used as a synonym for That in rare cases where a private setter causes a Visual Basic compilation
+        /// error.
         /// </summary>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void ByVal(object actual, IResolveConstraint expression)
+        public static void ByVal(object? actual, IResolveConstraint expression)
         {
             Assert.That(actual, expression, null, null);
         }
 
         /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an assertion exception on failure. 
-        /// Used as a synonym for That in rare cases where a private setter 
-        /// causes a Visual Basic compilation error.
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block. Used as a synonym for That in rare cases where a private setter causes a Visual Basic compilation
+        /// error.
         /// </summary>
         /// <remarks>
-        /// This method is provided for use by VB developers needing to test
-        /// the value of properties with private setters.
+        /// This method is provided for use by VB developers needing to test the value of properties with private
+        /// setters.
         /// </remarks>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void ByVal(object actual, IResolveConstraint expression, string message, params object[] args)
+        public static void ByVal(object? actual, IResolveConstraint expression, string? message, params object?[]? args)
         {
             Assert.That(actual, expression, message, args);
         }

--- a/src/NUnitFramework/framework/Assert.Types.cs
+++ b/src/NUnitFramework/framework/Assert.Types.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -30,23 +32,25 @@ namespace NUnit.Framework
         #region IsAssignableFrom
 
         /// <summary>
-        /// Asserts that an object may be assigned a value of a given Type.
+        /// Asserts that an object may be assigned a value of a given Type. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type.</param>
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsAssignableFrom(Type expected, object actual, string message, params object[] args)
+        public static void IsAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.AssignableFrom(expected) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object may be assigned a value of a given Type.
+        /// Asserts that an object may be assigned a value of a given Type. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type.</param>
         /// <param name="actual">The object under examination</param>
-        public static void IsAssignableFrom(Type expected, object actual)
+        public static void IsAssignableFrom(Type expected, object? actual)
         {
             Assert.That(actual, Is.AssignableFrom(expected) ,null, null);
         }
@@ -56,23 +60,25 @@ namespace NUnit.Framework
         #region IsAssignableFrom<TExpected>
 
         /// <summary>
-        /// Asserts that an object may be assigned a value of a given Type.
+        /// Asserts that an object may be assigned a value of a given Type. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type.</typeparam>
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsAssignableFrom<TExpected>(object actual, string message, params object[] args)
+        public static void IsAssignableFrom<TExpected>(object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.AssignableFrom(typeof(TExpected)) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object may be assigned a value of a given Type.
+        /// Asserts that an object may be assigned a value of a given Type. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type.</typeparam>
         /// <param name="actual">The object under examination</param>
-        public static void IsAssignableFrom<TExpected>(object actual)
+        public static void IsAssignableFrom<TExpected>(object? actual)
         {
             Assert.That(actual, Is.AssignableFrom(typeof(TExpected)) ,null, null);
         }
@@ -82,23 +88,25 @@ namespace NUnit.Framework
         #region IsNotAssignableFrom
 
         /// <summary>
-        /// Asserts that an object may not be assigned a value of a given Type.
+        /// Asserts that an object may not be assigned a value of a given Type. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type.</param>
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotAssignableFrom(Type expected, object actual, string message, params object[] args)
+        public static void IsNotAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.AssignableFrom(expected) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object may not be assigned a value of a given Type.
+        /// Asserts that an object may not be assigned a value of a given Type. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type.</param>
         /// <param name="actual">The object under examination</param>
-        public static void IsNotAssignableFrom(Type expected, object actual)
+        public static void IsNotAssignableFrom(Type expected, object? actual)
         {
             Assert.That(actual, Is.Not.AssignableFrom(expected) ,null, null);
         }
@@ -108,23 +116,25 @@ namespace NUnit.Framework
         #region IsNotAssignableFrom<TExpected>
 
         /// <summary>
-        /// Asserts that an object may not be assigned a value of a given Type.
+        /// Asserts that an object may not be assigned a value of a given Type. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type.</typeparam>
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotAssignableFrom<TExpected>(object actual, string message, params object[] args)
+        public static void IsNotAssignableFrom<TExpected>(object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.AssignableFrom(typeof(TExpected)) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object may not be assigned a value of a given Type.
+        /// Asserts that an object may not be assigned a value of a given Type. Returns without throwing an exception
+        /// when inside a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type.</typeparam>
         /// <param name="actual">The object under examination</param>
-        public static void IsNotAssignableFrom<TExpected>(object actual)
+        public static void IsNotAssignableFrom<TExpected>(object? actual)
         {
             Assert.That(actual, Is.Not.AssignableFrom(typeof(TExpected)) ,null, null);
         }
@@ -134,23 +144,25 @@ namespace NUnit.Framework
         #region IsInstanceOf
 
         /// <summary>
-        /// Asserts that an object is an instance of a given type.
+        /// Asserts that an object is an instance of a given type. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type</param>
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsInstanceOf(Type expected, object actual, string message, params object[] args)
+        public static void IsInstanceOf(Type expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.InstanceOf(expected) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object is an instance of a given type.
+        /// Asserts that an object is an instance of a given type. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type</param>
         /// <param name="actual">The object being examined</param>
-        public static void IsInstanceOf(Type expected, object actual)
+        public static void IsInstanceOf(Type expected, object? actual)
         {
             Assert.That(actual, Is.InstanceOf(expected) ,null, null);
         }
@@ -160,23 +172,25 @@ namespace NUnit.Framework
         #region IsInstanceOf<TExpected>
 
         /// <summary>
-        /// Asserts that an object is an instance of a given type.
+        /// Asserts that an object is an instance of a given type. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type</typeparam>
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsInstanceOf<TExpected>(object actual, string message, params object[] args)
+        public static void IsInstanceOf<TExpected>(object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.InstanceOf(typeof(TExpected)) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object is an instance of a given type.
+        /// Asserts that an object is an instance of a given type. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type</typeparam>
         /// <param name="actual">The object being examined</param>
-        public static void IsInstanceOf<TExpected>(object actual)
+        public static void IsInstanceOf<TExpected>(object? actual)
         {
             Assert.That(actual, Is.InstanceOf(typeof(TExpected)) ,null, null);
         }
@@ -186,23 +200,25 @@ namespace NUnit.Framework
         #region IsNotInstanceOf
 
         /// <summary>
-        /// Asserts that an object is not an instance of a given type.
+        /// Asserts that an object is not an instance of a given type. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type</param>
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotInstanceOf(Type expected, object actual, string message, params object[] args)
+        public static void IsNotInstanceOf(Type expected, object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.InstanceOf(expected) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object is not an instance of a given type.
+        /// Asserts that an object is not an instance of a given type. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <param name="expected">The expected Type</param>
         /// <param name="actual">The object being examined</param>
-        public static void IsNotInstanceOf(Type expected, object actual)
+        public static void IsNotInstanceOf(Type expected, object? actual)
         {
             Assert.That(actual, Is.Not.InstanceOf(expected) ,null, null);
         }
@@ -212,23 +228,25 @@ namespace NUnit.Framework
         #region IsNotInstanceOf<TExpected>
 
         /// <summary>
-        /// Asserts that an object is not an instance of a given type.
+        /// Asserts that an object is not an instance of a given type. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type</typeparam>
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotInstanceOf<TExpected>(object actual, string message, params object[] args)
+        public static void IsNotInstanceOf<TExpected>(object? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, Is.Not.InstanceOf(typeof(TExpected)) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object is not an instance of a given type.
+        /// Asserts that an object is not an instance of a given type. Returns without throwing an exception when inside
+        /// a multiple assert block.
         /// </summary>
         /// <typeparam name="TExpected">The expected Type</typeparam>
         /// <param name="actual">The object being examined</param>
-        public static void IsNotInstanceOf<TExpected>(object actual)
+        public static void IsNotInstanceOf<TExpected>(object? actual)
         {
             Assert.That(actual, Is.Not.InstanceOf(typeof(TExpected)) ,null, null);
         }

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -21,11 +21,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -92,7 +92,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void Pass(string message, params object[] args)
+        static public void Pass(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
             else if (args != null && args.Length > 0)
@@ -111,7 +111,7 @@ namespace NUnit.Framework
         /// of success returned to NUnit.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        static public void Pass(string message)
+        static public void Pass(string? message)
         {
             Assert.Pass(message, null);
         }
@@ -131,12 +131,12 @@ namespace NUnit.Framework
         #region Fail
 
         /// <summary>
-        /// Throws an <see cref="AssertionException"/> with the message and arguments
-        /// that are passed in. This is used by the other Assert functions.
+        /// Marks the test as failed with the message and arguments that are passed in. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void Fail(string message, params object[] args)
+        static public void Fail(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
             else if (args != null && args.Length > 0)
@@ -146,18 +146,17 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Throws an <see cref="AssertionException"/> with the message that is
-        /// passed in. This is used by the other Assert functions.
+        /// Marks the test as failed with the message that is passed in. Returns without throwing an exception when
+        /// inside a multiple assert block.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        static public void Fail(string message)
+        static public void Fail(string? message)
         {
             Assert.Fail(message, null);
         }
 
         /// <summary>
-        /// Throws an <see cref="AssertionException"/>.
-        /// This is used by the other Assert functions.
+        /// Marks the test as failed. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         static public void Fail()
         {
@@ -173,7 +172,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to display.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void Warn(string message, params object[] args)
+        static public void Warn(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
             else if (args != null && args.Length > 0)
@@ -186,7 +185,7 @@ namespace NUnit.Framework
         /// Issues a warning using the message provided.
         /// </summary>
         /// <param name="message">The message to display.</param>
-        static public void Warn(string message)
+        static public void Warn(string? message)
         {
             IssueWarning(message);
         }
@@ -201,7 +200,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void Ignore(string message, params object[] args)
+        static public void Ignore(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
             else if (args != null && args.Length > 0)
@@ -219,7 +218,7 @@ namespace NUnit.Framework
         /// passed in. This causes the test to be reported as ignored.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        static public void Ignore(string message)
+        static public void Ignore(string? message)
         {
             Assert.Ignore(message, null);
         }
@@ -243,7 +242,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="InconclusiveException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        static public void Inconclusive(string message, params object[] args)
+        static public void Inconclusive(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
             else if (args != null && args.Length > 0)
@@ -261,7 +260,7 @@ namespace NUnit.Framework
         /// passed in. This causes the test to be reported as inconclusive.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="InconclusiveException"/> with.</param>
-        static public void Inconclusive(string message)
+        static public void Inconclusive(string? message)
         {
             Assert.Inconclusive(message, null);
         }
@@ -280,23 +279,25 @@ namespace NUnit.Framework
         #region Contains
 
         /// <summary>
-        /// Asserts that an object is contained in a collection.
+        /// Asserts that an object is contained in a collection. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The collection to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Contains(object expected, ICollection actual, string message, params object[] args)
+        public static void Contains(object? expected, ICollection? actual, string? message, params object?[]? args)
         {
             Assert.That(actual, new SomeItemsConstraint(new EqualConstraint(expected)) ,message, args);
         }
 
         /// <summary>
-        /// Asserts that an object is contained in a collection.
+        /// Asserts that an object is contained in a collection. Returns without throwing an exception when inside a
+        /// multiple assert block.
         /// </summary>
         /// <param name="expected">The expected object</param>
         /// <param name="actual">The collection to be examined</param>
-        public static void Contains(object expected, ICollection actual)
+        public static void Contains(object? expected, ICollection? actual)
         {
             Assert.That(actual, new SomeItemsConstraint(new EqualConstraint(expected)) ,null, null);
         }
@@ -313,8 +314,8 @@ namespace NUnit.Framework
         /// <param name="testDelegate">A TestDelegate to be executed in Multiple Assertion mode.</param>
         public static void Multiple(TestDelegate testDelegate)
         {
-            TestExecutionContext context = TestExecutionContext.CurrentContext;
-            Guard.OperationValid(context != null, "There is no current test execution context.");
+            TestExecutionContext context = TestExecutionContext.CurrentContext
+                ?? throw new InvalidOperationException("There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 
@@ -343,8 +344,8 @@ namespace NUnit.Framework
         /// <param name="testDelegate">A TestDelegate to be executed in Multiple Assertion mode.</param>
         public static void Multiple(AsyncTestDelegate testDelegate)
         {
-            TestExecutionContext context = TestExecutionContext.CurrentContext;
-            Guard.OperationValid(context != null, "There is no current test execution context.");
+            TestExecutionContext context = TestExecutionContext.CurrentContext
+                ?? throw new InvalidOperationException("There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 
@@ -369,12 +370,12 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        private static void ReportFailure(ConstraintResult result, string message)
+        private static void ReportFailure(ConstraintResult result, string? message)
         {
             ReportFailure(result, message, null);
         }
 
-        private static void ReportFailure(ConstraintResult result, string message, params object[] args)
+        private static void ReportFailure(ConstraintResult result, string? message, params object?[]? args)
         {
             MessageWriter writer = new TextMessageWriter(message, args);
             result.WriteMessageTo(writer);
@@ -382,7 +383,7 @@ namespace NUnit.Framework
             ReportFailure(writer.ToString());
         }
 
-        private static void ReportFailure(string message)
+        private static void ReportFailure(string? message)
         {
             // Record the failure in an <assertion> element
             var result = TestExecutionContext.CurrentContext.CurrentResult;
@@ -394,7 +395,7 @@ namespace NUnit.Framework
                 throw new AssertionException(result.Message);
         }
 
-        private static void IssueWarning(string message)
+        private static void IssueWarning(string? message)
         {
             var result = TestExecutionContext.CurrentContext.CurrentResult;
             result.RecordAssertion(AssertionStatus.Warning, message, GetStackTrace());


### PR DESCRIPTION
Annotating any more than a class at a time will be overwhelming to review. I'm starting with the most-seen types.

The intent with all annotations is to reflect current behavior. If `null` is tolerated, I'm marking the parameter as nullable. If it causes ArgumentNullException, NullReferenceException, etc, I'm marking as non-nullable.