### PR TITLE
change error message : replaced 'internal' with 'protected' to fit th…

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -310,7 +310,7 @@ namespace NUnit.Framework.Internal
                 }
                 else if (!(method.IsPublic || method.IsFamily))
                 {
-                    MakeInvalid("SetUp and TearDown methods must be public or internal: " + method.Name);
+                    MakeInvalid("SetUp and TearDown methods must be public or protected: " + method.Name);
                 }
                 else if (method.GetParameters().Length != 0)
                 {


### PR DESCRIPTION
I changed the error message. I replaced 'internal' with 'protected' to fit the meaning of 'isFamily'.
see #3453 

