### PR TITLE
Prevent ExecutionContext from flowing between test cases

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -25,9 +25,4 @@
                             and '$(TargetFramework)' != 'netcoreapp3.0'">$(DefineConstants);THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
-    <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -162,17 +162,7 @@ namespace NUnit.Framework
 
             try
             {
-                IEnumerable source;
-
-                var previousState = SandboxedThreadState.Capture();
-                try
-                {
-                    source = GetTestCaseSource(method);
-                }
-                finally
-                {
-                    previousState.Restore();
-                }
+                IEnumerable source = ContextUtils.DoIsolated(() => GetTestCaseSource(method));
 
                 if (source != null)
                 {

--- a/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValueSourceAttribute.cs
@@ -102,7 +102,7 @@ namespace NUnit.Framework
             MemberInfo[] members = sourceType.GetMember(SourceName,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
 
-            var dataSource = GetDataSourceValue(members);
+            var dataSource = ContextUtils.DoIsolated(() => GetDataSourceValue(members));
 
             if (dataSource == null)
             {

--- a/src/NUnitFramework/framework/Internal/ContextUtils.cs
+++ b/src/NUnitFramework/framework/Internal/ContextUtils.cs
@@ -1,0 +1,64 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Security;
+using System.Threading;
+
+namespace NUnit.Framework.Internal
+{
+    internal static class ContextUtils
+    {
+        public static void DoIsolated(Action action)
+        {
+            DoIsolated(state => ((Action)state).Invoke(), state: action);
+        }
+
+        public static T DoIsolated<T>(Func<T> func)
+        {
+            var returnValue = default(T);
+            DoIsolated(_ => returnValue = func.Invoke(), state: null);
+            return returnValue;
+        }
+
+        [SecuritySafeCritical]
+        public static void DoIsolated(ContextCallback callback, object state)
+        {
+            var previousState = SandboxedThreadState.Capture();
+            try
+            {
+                var executionContext = ExecutionContext.Capture()
+                    ?? throw new InvalidOperationException("Execution context flow must not be suppressed.");
+
+                using ((object)executionContext as IDisposable)
+                {
+                    ExecutionContext.Run(executionContext, callback, state);
+                }
+            }
+            finally
+            {
+                previousState.Restore();
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -55,7 +55,11 @@ namespace NUnit.Framework.Internal.Execution
         {
             try
             {
-                Result = MakeTestCommand().Execute(Context);
+                var testCommand = MakeTestCommand();
+
+                // Isolate the Execute call because the WorkItemComplete below will run one-time teardowns. Execution
+                // context values should not flow from a particular test case into the shared one-time teardown.
+                Result = ContextUtils.DoIsolated(() => testCommand.Execute(Context));
             }
             catch (Exception ex)
             {

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -475,21 +475,18 @@ namespace NUnit.Framework.Internal.Execution
         [SecuritySafeCritical]
         private void RunOnCurrentThread()
         {
-            ContextUtils.DoIsolated(() =>
-            {
-                Context.CurrentTest = this.Test;
-                Context.CurrentResult = this.Result;
-                Context.Listener.TestStarted(this.Test);
-                Context.StartTime = DateTime.UtcNow;
-                Context.StartTicks = Stopwatch.GetTimestamp();
-                Context.TestWorker = this.TestWorker;
+            Context.CurrentTest = this.Test;
+            Context.CurrentResult = this.Result;
+            Context.Listener.TestStarted(this.Test);
+            Context.StartTime = DateTime.UtcNow;
+            Context.StartTicks = Stopwatch.GetTimestamp();
+            Context.TestWorker = this.TestWorker;
 
-                Context.EstablishExecutionEnvironment();
+            Context.EstablishExecutionEnvironment();
 
-                State = WorkItemState.Running;
+            State = WorkItemState.Running;
 
-                PerformWork();
-            });
+            PerformWork();
         }
 
         private ParallelExecutionStrategy GetExecutionStrategy()

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -58,13 +58,13 @@ namespace NUnit.Framework.Internal
         #region Get Methods of a type
 
         /// <summary>
-        /// Examine a fixture type and return an array of methods having a
-        /// particular attribute. The array is order with base methods first.
+        /// Returns all methods declared by the specified fixture type that have the specified attribute, optionally
+        /// including base classes. Methods from a base class are always returned before methods from a class that
+        /// inherits from it.
         /// </summary>
-        /// <param name="fixtureType">The type to examine</param>
-        /// <param name="attributeType">The attribute Type to look for</param>
-        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain</param>
-        /// <returns>The array of methods found</returns>
+        /// <param name="fixtureType">The type to examine.</param>
+        /// <param name="attributeType">Only methods to which this attribute is applied will be returned.</param>
+        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
         public static MethodInfo[] GetMethodsWithAttribute(Type fixtureType, Type attributeType, bool inherit)
         {
             if (!inherit)

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="Schemas\*.xsd" CopyToOutputDirectory="Always" />
   </ItemGroup>
 

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
     <ProjectReference Include="..\nunitlite\nunitlite.csproj" />
   </ItemGroup>

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -10,6 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\framework\Schemas\*.xsd" LinkBase="Schemas" CopyToOutputDirectory="Always" />
     <None Update="Schemas\*.xsd" CopyToOutputDirectory="Always" />
   </ItemGroup>

--- a/src/NUnitFramework/testdata/ExecutionContextFixture.cs
+++ b/src/NUnitFramework/testdata/ExecutionContextFixture.cs
@@ -1,0 +1,53 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+#if NET35 || NET40
+using System.Runtime.Remoting.Messaging;
+#else
+using System.Threading;
+#endif
+
+namespace NUnit.TestData
+{
+    public static class ExecutionContextFixture
+    {
+#if !(NET35 || NET40)
+        private static readonly AsyncLocal<bool> WasExecutionContextUsed = new AsyncLocal<bool>();
+#endif
+
+        public static void ExecutionContextIsNotSharedBetweenTestCases([Range(1, 2)] int testCase)
+        {
+#if NET35 || NET40
+            Assert.Null(CallContext.LogicalGetData("WasUsed"));
+
+            CallContext.LogicalSetData("WasUsed", true);
+#else
+            Assert.That(!WasExecutionContextUsed.Value);
+
+            WasExecutionContextUsed.Value = true;
+#endif
+        }
+    }
+}

--- a/src/NUnitFramework/testdata/ExecutionContextFixture.cs
+++ b/src/NUnitFramework/testdata/ExecutionContextFixture.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using NUnit.Framework;
+using System.Collections.Generic;
 
 #if NET35 || NET40
 using System.Runtime.Remoting.Messaging;
@@ -37,7 +38,43 @@ namespace NUnit.TestData
         private static readonly AsyncLocal<bool> WasExecutionContextUsed = new AsyncLocal<bool>();
 #endif
 
+        public static IEnumerable<int> Source1
+        {
+            get
+            {
+                AssertAndUseCurrentExecutionContext();
+                return new[] { 1 };
+            }
+        }
+
+        public static IEnumerable<int> Source2
+        {
+            get
+            {
+                AssertAndUseCurrentExecutionContext();
+                return new[] { 2 };
+            }
+        }
+
+        [TestCaseSource(nameof(Source1))]
+        [TestCaseSource(nameof(Source2))]
+        public static void TestCaseSourceExecutionContextIsNotShared(int testCase)
+        {
+            AssertAndUseCurrentExecutionContext();
+        }
+
+        [Test]
+        public static void ValueSourceExecutionContextIsNotShared([ValueSource(nameof(Source1)), ValueSource(nameof(Source2))] int testCase)
+        {
+            AssertAndUseCurrentExecutionContext();
+        }
+
         public static void ExecutionContextIsNotSharedBetweenTestCases([Range(1, 2)] int testCase)
+        {
+            AssertAndUseCurrentExecutionContext();
+        }
+
+        private static void AssertAndUseCurrentExecutionContext()
         {
 #if NET35 || NET40
             Assert.Null(CallContext.LogicalGetData("WasUsed"));

--- a/src/NUnitFramework/testdata/ExecutionContextFlowFixture.cs
+++ b/src/NUnitFramework/testdata/ExecutionContextFlowFixture.cs
@@ -1,0 +1,337 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework;
+
+#if NET35 || NET40
+using System.Runtime.Remoting.Messaging;
+#else
+using System.Threading;
+#endif
+
+namespace NUnit.TestData
+{
+    public sealed class ExecutionContextFlowFixture : IDisposable
+    {
+        // Constructor/Dispose and one-time setup/teardown may need to start flowing differently when we implement
+        // instance-per-test-case.
+
+#if !(NET35 || NET40)
+        private static readonly AsyncLocal<bool> FromConstructor = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromOneTimeSetUp1 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromOneTimeSetUp2 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromSetUp1 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromSetUp2 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromTestMethod = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromTearDown1 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromTearDown2 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromOneTimeTearDown1 = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> FromOneTimeTearDown2 = new AsyncLocal<bool>();
+#endif
+
+        public ExecutionContextFlowFixture()
+        {
+#if NET35 || NET40
+            CallContext.LogicalSetData("Constructor", true);
+#else
+            FromConstructor.Value = true;
+#endif
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp1()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+
+            CallContext.LogicalSetData("OneTimeSetUp1", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+
+            FromOneTimeSetUp1.Value = true;
+#endif
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp2()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+
+            CallContext.LogicalSetData("OneTimeSetUp2", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+
+            FromOneTimeSetUp2.Value = true;
+#endif
+        }
+
+        [SetUp]
+        public void SetUp1()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("SetUp1", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+
+            Assert.That(FromSetUp1.Value, Is.False);
+            Assert.That(FromSetUp2.Value, Is.False);
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromSetUp1.Value = true;
+#endif
+        }
+
+        [SetUp]
+        public void SetUp2()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("SetUp2", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+            Assert.That(FromSetUp1.Value, Is.True);
+
+            Assert.That(FromSetUp2.Value, Is.False);
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromSetUp2.Value = true;
+#endif
+        }
+
+        [Test]
+        public void TestMethod([Range(1, 2)] int testCase)
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("TestMethod", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+            Assert.That(FromSetUp1.Value, Is.True);
+            Assert.That(FromSetUp2.Value, Is.True);
+
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromTestMethod.Value = true;
+#endif
+        }
+
+        [TearDown]
+        public void TearDown2()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.True);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("TearDown2", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+            Assert.That(FromSetUp1.Value, Is.True);
+            Assert.That(FromSetUp2.Value, Is.True);
+            Assert.That(FromTestMethod.Value, Is.True);
+            Assert.That(FromTearDown1.Value, Is.True);
+
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromTearDown2.Value = true;
+#endif
+        }
+
+        [TearDown]
+        public void TearDown1()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.True);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("TearDown1", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+            Assert.That(FromSetUp1.Value, Is.True);
+            Assert.That(FromSetUp2.Value, Is.True);
+            Assert.That(FromTestMethod.Value, Is.True);
+
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromTearDown1.Value = true;
+#endif
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown2()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            Assert.That(CallContext.LogicalGetData("OneTimeTearDown1"), Is.True);
+
+            CallContext.LogicalSetData("OneTimeTearDown2", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+
+            Assert.That(FromSetUp1.Value, Is.False);
+            Assert.That(FromSetUp2.Value, Is.False);
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            Assert.That(FromOneTimeTearDown1.Value, Is.True);
+
+            FromOneTimeTearDown2.Value = true;
+#endif
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown1()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            CallContext.LogicalSetData("OneTimeTearDown1", true);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+
+            Assert.That(FromSetUp1.Value, Is.False);
+            Assert.That(FromSetUp2.Value, Is.False);
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            FromOneTimeTearDown1.Value = true;
+#endif
+        }
+
+        public void Dispose()
+        {
+#if NET35 || NET40
+            Assert.That(CallContext.LogicalGetData("Constructor"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeSetUp2"), Is.True);
+
+            Assert.That(CallContext.LogicalGetData("SetUp1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("SetUp2"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TestMethod"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown1"), Is.Null);
+            Assert.That(CallContext.LogicalGetData("TearDown2"), Is.Null);
+
+            Assert.That(CallContext.LogicalGetData("OneTimeTearDown1"), Is.True);
+            Assert.That(CallContext.LogicalGetData("OneTimeTearDown2"), Is.True);
+#else
+            Assert.That(FromConstructor.Value, Is.True);
+            Assert.That(FromOneTimeSetUp1.Value, Is.True);
+            Assert.That(FromOneTimeSetUp2.Value, Is.True);
+
+            Assert.That(FromSetUp1.Value, Is.False);
+            Assert.That(FromSetUp2.Value, Is.False);
+            Assert.That(FromTestMethod.Value, Is.False);
+            Assert.That(FromTearDown1.Value, Is.False);
+            Assert.That(FromTearDown2.Value, Is.False);
+
+            Assert.That(FromOneTimeTearDown1.Value, Is.True);
+            Assert.That(FromOneTimeTearDown2.Value, Is.True);
+#endif
+        }
+    }
+}

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net46;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>NUnit.TestData</RootNamespace>
 
     <!-- Needed because we test stack traces and don't want to have to put

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Internal;
 
-#if NET35 || NET40 || NET45
+#if NET35 || NET40 || NET45 || NET46 // NET46 should be removed when the framework project adds a net46 target
 using System.Runtime.Remoting.Messaging;
 #endif
 
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Assertions
                 throw testException;
         }
 
-#if !(NET35 || NET40 || NET45)
+#if !(NET35 || NET40 || NET45 || NET46) // NET46 should be removed when the framework project adds a net46 target
         private TestExecutionContext ClearExecutionContext()
         {
             var savedContext = TestExecutionContext.CurrentContext;

--- a/src/NUnitFramework/tests/Compatibility/AttributeHelperTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/AttributeHelperTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Compatibility
         [Test]
         public void CanGetAttributesOnAssemblies()
         {
-            var assembly = typeof(AttributeHelperTests).GetTypeInfo().Assembly;
+            var assembly = typeof(TestAttribute).GetTypeInfo().Assembly;
             Assert.That(assembly, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(assembly, typeof(AssemblyCompanyAttribute), true);
             Assert.That(attr, Is.Not.Null);

--- a/src/NUnitFramework/tests/ExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/ExecutionContextTests.cs
@@ -1,0 +1,41 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.TestData;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework
+{
+    public static class ExecutionContextTests
+    {
+        [Test]
+        public static void ExecutionContextIsNotSharedBetweenTestCases()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(
+                typeof(ExecutionContextFixture),
+                nameof(ExecutionContextFixture.ExecutionContextIsNotSharedBetweenTestCases));
+
+            result.AssertPassed();
+        }
+    }
+}

--- a/src/NUnitFramework/tests/ExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/ExecutionContextTests.cs
@@ -37,5 +37,25 @@ namespace NUnit.Framework
 
             result.AssertPassed();
         }
+
+        [Test]
+        public static void TestCaseSourceExecutionContextIsNotShared()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(
+                typeof(ExecutionContextFixture),
+                nameof(ExecutionContextFixture.TestCaseSourceExecutionContextIsNotShared));
+
+            result.AssertPassed();
+        }
+
+        [Test]
+        public static void ValueSourceExecutionContextIsNotShared()
+        {
+            var result = TestBuilder.RunParameterizedMethodSuite(
+                typeof(ExecutionContextFixture),
+                nameof(ExecutionContextFixture.ValueSourceExecutionContextIsNotShared));
+
+            result.AssertPassed();
+        }
     }
 }

--- a/src/NUnitFramework/tests/ExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/ExecutionContextTests.cs
@@ -57,5 +57,13 @@ namespace NUnit.Framework
 
             result.AssertPassed();
         }
+
+        [Test]
+        public static void ExecutionContextFlow()
+        {
+            var result = TestBuilder.RunTestFixture(typeof(ExecutionContextFlowFixture));
+
+            result.AssertPassed();
+        }
     }
 }

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -158,7 +158,7 @@ namespace NUnit.Framework
             {
                 apiAdapter.Execute(() =>
                 {
-                    Assert.That(SynchronizationContext.Current, Is.SameAs(createdOnThisThread));
+                    Assert.That(SynchronizationContext.Current, Is.TypeOf(knownSynchronizationContextType));
                     return TaskEx.FromResult<object>(null);
                 });
             }
@@ -175,7 +175,7 @@ namespace NUnit.Framework
             {
                 apiAdapter.Execute(async () => await TaskEx.Yield());
 
-                Assert.That(SynchronizationContext.Current, Is.SameAs(createdOnThisThread));
+                Assert.That(SynchronizationContext.Current, Is.TypeOf(knownSynchronizationContextType));
             }
         }
 #endif

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework
             });
         }
 
-#if NET40 || NET45
+#if NETFRAMEWORK
         // TODO: test a custom awaitable type whose awaiter executes continuations on a brand new thread
         // to ensure that the message pump is shut down on the correct thread.
 

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <DebugType>Full</DebugType>
 


### PR DESCRIPTION
Fixes #3283, plus:

- ValuesSource is now isolated the same way as TestCaseSource (missed in https://github.com/nunit/nunit/pull/2966).

- Setup and teardown methods were being executed out of order on .NET 3.5 and 4.0. They were being sorted using a BaseTypesFirstComparer implementation that broke the `IComparer<>.Compare` invariants of reflexivity, symmetry, and transitivity. This means that any .NET sorting method that used it was specified to have undefined behavior.
  I fixed it in this PR because the differing order of execution depending on target framework made it impossible to write [`ExecutionContextFlowFixture.cs`](https://github.com/nunit/nunit/pull/3465/files#diff-9621d3098df833cc8f0b0fb0713e4406) clearly.