### PR TITLE
Annotate Guard methods

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -314,8 +314,8 @@ namespace NUnit.Framework
         /// <param name="testDelegate">A TestDelegate to be executed in Multiple Assertion mode.</param>
         public static void Multiple(TestDelegate testDelegate)
         {
-            TestExecutionContext context = TestExecutionContext.CurrentContext
-                ?? throw new InvalidOperationException("There is no current test execution context.");
+            TestExecutionContext context = TestExecutionContext.CurrentContext;
+            Guard.OperationValid(context != null, "There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 
@@ -344,8 +344,8 @@ namespace NUnit.Framework
         /// <param name="testDelegate">A TestDelegate to be executed in Multiple Assertion mode.</param>
         public static void Multiple(AsyncTestDelegate testDelegate)
         {
-            TestExecutionContext context = TestExecutionContext.CurrentContext
-                ?? throw new InvalidOperationException("There is no current test execution context.");
+            TestExecutionContext context = TestExecutionContext.CurrentContext;
+            Guard.OperationValid(context != null, "There is no current test execution context.");
 
             context.MultipleAssertLevel++;
 

--- a/src/NUnitFramework/framework/Compatibility/System.Diagnostics.CodeAnalysis/NullableAttributes.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Diagnostics.CodeAnalysis/NullableAttributes.cs
@@ -1,0 +1,110 @@
+// Source: https://github.com/dotnet/runtime/blob/4c71c6cf112d5cdfe5d39485505f1b2991c6e0d5/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+
+// The MIT License (MIT)
+//
+// Copyright (c) .NET Foundation and Contributors
+//
+// All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+}

--- a/src/NUnitFramework/framework/Guard.cs
+++ b/src/NUnitFramework/framework/Guard.cs
@@ -21,7 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Internal;
@@ -39,7 +42,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="value">The value to be tested</param>
         /// <param name="name">The name of the argument</param>
-        public static void ArgumentNotNull(object value, string name)
+        public static void ArgumentNotNull([NotNull] object value, string name)
         {
             if (value == null)
                 throw new ArgumentNullException(name, "Argument " + name + " must not be null");
@@ -50,7 +53,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="value">The value to be tested</param>
         /// <param name="name">The name of the argument</param>
-        public static void ArgumentNotNullOrEmpty(string value, string name)
+        public static void ArgumentNotNullOrEmpty([NotNull] string value, string name)
         {
             ArgumentNotNull(value, name);
 
@@ -64,7 +67,7 @@ namespace NUnit.Framework
         /// <param name="condition">The condition that must be met</param>
         /// <param name="message">The exception message to be used</param>
         /// <param name="paramName">The name of the argument</param>
-        public static void ArgumentInRange(bool condition, string message, string paramName)
+        public static void ArgumentInRange([DoesNotReturnIf(false)] bool condition, string message, string paramName)
         {
             if (!condition)
                 throw new ArgumentOutOfRangeException(paramName, message);
@@ -76,7 +79,7 @@ namespace NUnit.Framework
         /// <param name="condition">The condition that must be met</param>
         /// <param name="message">The exception message to be used</param>
         /// <param name="paramName">The name of the argument</param>
-        public static void ArgumentValid(bool condition, string message, string paramName)
+        public static void ArgumentValid([DoesNotReturnIf(false)] bool condition, string message, string paramName)
         {
             if (!condition)
                 throw new ArgumentException(message, paramName);
@@ -87,7 +90,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The condition that must be met</param>
         /// <param name="message">The exception message to be used</param>
-        public static void OperationValid(bool condition, string message)
+        public static void OperationValid([DoesNotReturnIf(false)] bool condition, string message)
         {
             if (!condition)
                 throw new InvalidOperationException(message);


### PR DESCRIPTION
This enabled Assert.cs to go back to the way it was before #3450 (see diff).