### PR TITLE
Addition of DictionaryContainsKeyValuePairConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -89,7 +89,7 @@ namespace NUnit.Framework.Constraints
                 builder.Append(this);
             }
 
-            var constraint = new DictionaryContainsKeyValuePairConstraint(Expected, expected);
+            var constraint = new DictionaryContainsKeyValuePairConstraint(Expected, expectedValue);
             builder.Append(constraint);
             return constraint;
         }

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -77,6 +77,24 @@ namespace NUnit.Framework.Constraints
         protected object Expected { get; }
 
         /// <summary>
+        /// Returns a new DictionaryContainsKeyValuePairConstraint checking for the
+        /// presence of a particular key-value-pair in the dictionary.
+        /// </summary>
+        public DictionaryContainsKeyValuePairConstraint WithValue(object expected)
+        {
+            var builder = this.Builder;
+            if (builder == null)
+            {
+                builder = new ConstraintBuilder();
+                builder.Append(this);
+            }
+
+            var constraint = new DictionaryContainsKeyValuePairConstraint(Expected, expected);
+            builder.Append(constraint);
+            return constraint;
+        }
+
+        /// <summary>
         /// Flag the constraint to ignore case and return self.
         /// </summary>
         [Obsolete(ComparerMemberObsoletionMessage)]

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a new DictionaryContainsKeyValuePairConstraint checking for the
         /// presence of a particular key-value-pair in the dictionary.
         /// </summary>
-        public DictionaryContainsKeyValuePairConstraint WithValue(object expected)
+        public DictionaryContainsKeyValuePairConstraint WithValue(object expectedValue)
         {
             var builder = this.Builder;
             if (builder == null)

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -85,11 +85,11 @@ namespace NUnit.Framework.Constraints
         private bool Matches(object actual)
         {
             var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
-			foreach (DictionaryEntry entry in dictionary)
-				if (ItemsEqual(entry.Key, ExpectedKey) && ItemsEqual(entry.Value, ExpectedValue))
-					return true;
+            foreach (DictionaryEntry entry in dictionary)
+                if (ItemsEqual(entry.Key, ExpectedKey) && ItemsEqual(entry.Value, ExpectedValue))
+                    return true;
 
-			return false;
+            return false;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2018 Charlie Poole, Rob Prouse
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -1,0 +1,112 @@
+// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// DictionaryContainsKeyValuePairConstraint is used to test whether a dictionary
+    /// contains an expected object as a key-value-pair.
+    /// </summary>
+    public class DictionaryContainsKeyValuePairConstraint : CollectionItemsEqualConstraint
+    {
+        /// <summary>
+        /// Construct a DictionaryContainsKeyValuePairConstraint
+        /// </summary>
+        public DictionaryContainsKeyValuePairConstraint(object key, object value)
+            : this(new KeyValuePair<object, object>(key, value))
+        {
+        }
+
+        /// <summary>
+        /// Construct a DictionaryContainsKeyValuePairConstraint
+        /// </summary>
+        protected DictionaryContainsKeyValuePairConstraint(KeyValuePair<object, object> arg)
+            : base(arg)
+        {
+            Expected = arg;
+        }
+
+        /// <summary>
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "ContainsKeyValuePair"; } }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get { return "dictionary containing entry " + MsgUtils.FormatValue(Expected); }
+        }
+
+        /// <summary>
+        /// Gets the expected key
+        /// </summary>
+        protected object ExpectedKey { get { return Expected.Key; } }
+
+        /// <summary>
+        /// Gets the expected value
+        /// </summary>
+        protected object ExpectedValue { get { return Expected.Value; } }
+
+        /// <summary>
+        /// Gets the expected entry
+        /// </summary>
+        protected KeyValuePair<object, object> Expected { get; }
+
+        private bool Matches(object actual)
+        {
+            var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
+			foreach (DictionaryEntry entry in dictionary)
+				if (ItemsEqual(entry.Key, ExpectedKey) && ItemsEqual(entry.Value, ExpectedValue))
+					return true;
+
+			return false;
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            return new ConstraintResult(this, actual, Matches(actual));
+        }
+
+        /// <summary>
+        /// Test whether the expected key is contained in the dictionary
+        /// </summary>
+        protected override bool Matches(IEnumerable collection)
+        {
+            return Matches(collection);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -30,7 +30,7 @@ using NUnit.Framework.Internal;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class DictionaryContainsKeyValueConstraintTests
+    public class DictionaryContainsKeyValuePairConstraintTests
     {
         [Test]
         public void SucceedsWhenKeyValuePairIsPresent()

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -1,0 +1,113 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections;
+using System.Collections.Generic;
+
+using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Constraints
+{
+    [TestFixture]
+    public class DictionaryContainsKeyValueConstraintTests
+    {
+        [Test]
+        public void SucceedsWhenKeyValuePairIsPresent()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", "Universe"));
+        }
+
+        [Test]
+        public void FailsWhenKeyIsMissing()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Bye", "Universe"));
+
+            Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
+        }
+
+        [Test]
+        public void FailsWhenValueIsMissing()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hello", "Universe"));
+
+            Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValue()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsNotPresentUsingContainKeyWithValue()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.Not.ContainKey("Hello").WithValue("NotValue"));
+        }
+
+        [Test]
+        public void FailsWhenNotUsedAgainstADictionary()
+        {
+            List<KeyValuePair<string, string>> keyValuePairs = new List<KeyValuePair<string, string>>(
+                new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } });
+
+            TestDelegate act = () => Assert.That(keyValuePairs, new DictionaryContainsKeyValuePairConstraint("Hi", "Universe"));
+
+            Assert.That(act, Throws.ArgumentException.With.Message.Contains("IDictionary"));
+        }
+
+        [Test]
+        public void WorksWithNonGenericDictionary()
+        {
+            var dictionary = new Hashtable { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", "Universe"));
+        }
+
+        [Test, SetCulture("en-US")]
+        public void IgnoreCaseIsHonored()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("HI", "UNIVERSE").IgnoreCase);
+        }
+
+        [Test, SetCulture("en-US")]
+        public void UsingIsHonored()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary,
+                new DictionaryContainsKeyValuePairConstraint("HI", "UNIVERSE").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
Fixes #3470

Just a first idea to resolve it. Not sure if I implemented `WithValue` in `DictionaryContainsKeyConstraint` correctly. Also not sure if using `KeyValuePair<TKey, TValue>` is better or using the approach already used for properties (`ResolvableConstraintExpression`?) is better. This seemed to have worked for `Does.ContainKey.WithValue` and also `Does.Not.ContainKey.WithValue`.

Looking forward to feedback :)