### PR TITLE
Annotate exceptions

### DIFF
--- a/src/NUnitFramework/framework/Exceptions/AssertionException.cs
+++ b/src/NUnitFramework/framework/Exceptions/AssertionException.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -35,14 +37,14 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        public AssertionException (string message) : base(message)
+        public AssertionException(string? message) : base(message)
         {}
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public AssertionException(string message, Exception inner) :
+        public AssertionException(string? message, Exception? inner) :
             base(message, inner)
         {}
 

--- a/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
+++ b/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -34,14 +36,14 @@ namespace NUnit.Framework
     public class IgnoreException : ResultStateException
     {
         /// <param name="message"></param>
-        public IgnoreException (string message) : base(message)
+        public IgnoreException(string? message) : base(message)
         {}
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public IgnoreException(string message, Exception inner) :
+        public IgnoreException(string? message, Exception? inner) :
             base(message, inner)
         {}
 

--- a/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
+++ b/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -35,7 +37,7 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        public InconclusiveException(string message)
+        public InconclusiveException(string? message)
             : base(message)
         { }
 
@@ -43,7 +45,7 @@ namespace NUnit.Framework
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public InconclusiveException(string message, Exception inner)
+        public InconclusiveException(string? message, Exception? inner)
             :
             base(message, inner)
         { }

--- a/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
+++ b/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -34,11 +36,6 @@ namespace NUnit.Framework
     public class MultipleAssertException : ResultStateException
     {
         /// <summary>
-        /// Default Constructor
-        /// </summary>
-        public MultipleAssertException(string message) : base(message) { }
-
-        /// <summary>
         /// Construct based on the TestResult so far. This is the constructor
         /// used normally, when exiting the multiple assert block with failures.
         /// Not used internally but provided to facilitate debugging.
@@ -50,24 +47,19 @@ namespace NUnit.Framework
         public MultipleAssertException(ITestResult testResult)
             : base(testResult?.Message)
         {
-            Guard.ArgumentNotNull(testResult, "testResult");
+            Guard.ArgumentNotNull(testResult!, "testResult");
             TestResult = testResult;
         }
 
-        /// <param name="message">The error message that explains
-        /// the reason for the exception</param>
-        /// <param name="inner">The exception that caused the
-        /// current exception</param>
-        public MultipleAssertException(string message, Exception inner) :
-            base(message, inner)
-        {}
-
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
         /// <summary>
         /// Serialization Constructor
         /// </summary>
         protected MultipleAssertException(System.Runtime.Serialization.SerializationInfo info,
             System.Runtime.Serialization.StreamingContext context) : base(info,context)
-        {}
+        {
+        }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 
         /// <summary>
         /// Gets the <see cref="ResultState"/> provided by this exception.

--- a/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
+++ b/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -35,14 +37,14 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        public ResultStateException (string message) : base(message)
+        public ResultStateException(string? message) : base(message)
         {}
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public ResultStateException(string message, Exception inner) :
+        public ResultStateException(string? message, Exception? inner) :
             base(message, inner)
         {}
 

--- a/src/NUnitFramework/framework/Exceptions/SuccessException.cs
+++ b/src/NUnitFramework/framework/Exceptions/SuccessException.cs
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
+
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework
@@ -33,7 +36,7 @@ namespace NUnit.Framework
     public class SuccessException : ResultStateException
     {
         /// <param name="message"></param>
-        public SuccessException(string message)
+        public SuccessException(string? message)
             : base(message)
         { }
 
@@ -41,7 +44,7 @@ namespace NUnit.Framework
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public SuccessException(string message, Exception inner)
+        public SuccessException(string? message, Exception? inner)
             :
             base(message, inner)
         { }


### PR DESCRIPTION
Removes two constructors as suggested in #3485 by @rprouse. Our other option which I'd be happy to do is to obsolete them.

Closes #3485