### PR TITLE
No need to mention the wiki instructions since debugging lights up whenever Just My Code is off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,7 @@ Issues that need confirmation will have the **confirm** label or be unlabeled an
 - Create unit tests to demonstrate the issue
 - Test issues and provide feedback
 
-As of version 3.10, the NUnit and NUnitLite NuGet packages support **debugger source-stepping** for each binary from the repository. Debuggers can step into the source code, set breakpoints, watch variables, etc. If you’re getting ready to report a bug in NUnit, figuring out how to create a minimal repro is much easier since you aren’t dealing with a black box!
-
-To easily drop into NUnit code from your project any time, [follow these steps](https://github.com/nunit/docs/wiki/Debugger-Source-Stepping).
+If you’re getting ready to report a bug in NUnit, figuring out how to create a minimal repro is easier if you temporarily disable the debugger’ [Just My Code](https://docs.microsoft.com/en-us/visualstudio/debugger/just-my-code) setting. This allows you to step into NUnit's source code, set breakpoints, watch variables, etc.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ NUnit is a unit-testing framework for all .NET languages. Initially ported from 
 - [Downloads](#downloads)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
-- [Debugger source-stepping](#debugger-source-stepping)
 - [License](#license)
 - [NUnit Projects](#nunit-projects)
 
@@ -35,12 +34,6 @@ For more information on contributing to the NUnit project, please see [CONTRIBUT
 NUnit 3.0 was created by [Charlie Poole](https://github.com/CharliePoole), [Rob Prouse](https://github.com/rprouse), [Simone Busoli](https://github.com/simoneb), [Neil Colvin](https://github.com/oznetmaster) and numerous community contributors. A complete list of contributors since NUnit migrated to GitHub can be [found on GitHub](https://github.com/nunit/nunit/graphs/contributors).
 
 Earlier versions of NUnit were developed by Charlie Poole, James W. Newkirk, Alexei A. Vorontsov, Michael C. Two and Philip A. Craig.
-
-## Debugger source-stepping ##
-
-The NUnit and NUnitLite NuGet packages contain a source-indexed PDB for each binary from this repository.
-If you’re in the middle of a debugging session and realize you’d like to be able to step into NUnit code,
-set breakpoints and watch variables, [follow these steps](https://github.com/nunit/docs/wiki/Debugger-Source-Stepping).
 
 ## License ##
 


### PR DESCRIPTION
Following up from #3464. Also need to remove https://github.com/nunit/docs/wiki/Debugger-Source-Stepping.