### PR TITLE
.NET Core 2.2 and 3.0 are no longer supported and we should test 3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,6 @@ jobs:
       packageType: runtime
       version: 2.1.x
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core runtime 2.2'
-    inputs:
-      packageType: runtime
-      version: 2.2.x
-
   - bash: sudo apt-get install fsharp
     displayName: Install F# for Mono
 
@@ -81,12 +75,6 @@ jobs:
     inputs:
       packageType: runtime
       version: 2.1.x
-
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core runtime 2.2'
-    inputs:
-      packageType: runtime
-      version: 2.2.x
 
   - bash: |
      curl -o mono.pkg -sSL https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg

--- a/build.cake
+++ b/build.cake
@@ -38,8 +38,7 @@ var AllFrameworks = new string[]
 var NetCoreTests = new String[]
 {
     "netcoreapp2.1",
-    "netcoreapp2.2",
-    "netcoreapp3.0"
+    "netcoreapp3.1"
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -226,7 +225,7 @@ Task("Test35")
 var testNetStandard20 = Task("TestNetStandard20")
     .Description("Tests the .NET Standard 2.0 version of the framework");
 
-foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp2.2", "netcoreapp3.0" })
+foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp3.1" })
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100",
+    "version": "3.1.100",
     "rollForward": "major"
   }
 }

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -55,8 +55,7 @@ How to use this package:
     <file src="bin/net40/nunitlite-runner.exe" target="tools\net40" />
     <file src="bin/net45/nunitlite-runner.exe" target="tools\net45" />
     <file src="bin/netcoreapp2.1/nunitlite-runner.dll" target="tools\netcoreapp2.1" />
-    <file src="bin/netcoreapp2.2/nunitlite-runner.dll" target="tools\netcoreapp2.2" />
-    <file src="bin/netcoreapp3.0/nunitlite-runner.dll" target="tools\netcoreapp3.0" />
+    <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="tools\netcoreapp3.1" />
     <file src="../../nuget/nunitlite/Program.cs" target="content" />
     <file src="../../nuget/nunitlite/Program.vb" target="content" />
     <file src="../../nuget/nunitlite/install.ps1" target="tools" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -42,10 +42,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
 #elif NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Core 2.1 Debug")]
-#elif NETCOREAPP2_2
-[assembly: AssemblyConfiguration(".NET Core 2.2 Debug")]
-#elif NETCOREAPP3_0
-[assembly: AssemblyConfiguration(".NET Core 3.0 Debug")]
+#elif NETCOREAPP3_1
+[assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.
 #endif
@@ -60,10 +58,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Standard 2.0")]
 #elif NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Core 2.1")]
-#elif NETCOREAPP2_2
-[assembly: AssemblyConfiguration(".NET Core 2.2")]
-#elif NETCOREAPP3_0
-[assembly: AssemblyConfiguration(".NET Core 3.0")]
+#elif NETCOREAPP3_1
+[assembly: AssemblyConfiguration(".NET Core 3.1")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.
 #endif

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -21,8 +21,7 @@
 
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard2.0'
                             and '$(TargetFramework)' != 'netcoreapp2.1'
-                            and '$(TargetFramework)' != 'netcoreapp2.2'
-                            and '$(TargetFramework)' != 'netcoreapp3.0'">$(DefineConstants);THREAD_ABORT</DefineConstants>
+                            and '$(TargetFramework)' != 'netcoreapp3.1'">$(DefineConstants);THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
   <!-- We always want a good debugging experience in tests -->

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
   </PropertyGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
 
     <!-- Either NUnit or NUnitLite is not loading assemblies in a way that properly respects the


### PR DESCRIPTION
Table at https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle

Relevant part:

| Version        | Original Release Date  | Support Level  | End of Support    |
|:---------------|:-----------------------|:---------------|:------------------|
| .NET Core 3.1  | December 3, 2019       | LTS            | December 3, 2022  |
| .NET Core 3.0  | September 23, 2019     | EOL            | March 3, 2020     |
| .NET Core 2.2  | December 4, 2018       | EOL            | December 23, 2019 |
| .NET Core 2.1  | May 30, 2018           | LTS            | August 21, 2021   |