### PR TITLE
Require test run id to be 2, per docs

### DIFF
--- a/src/NUnitFramework/framework/Schemas/TestResult.xsd
+++ b/src/NUnitFramework/framework/Schemas/TestResult.xsd
@@ -189,7 +189,13 @@
         <xs:element name="filter" type="TestFilterType" />
         <xs:group ref="ContainedTestGroup" minOccurs="0" maxOccurs="unbounded" />
       </xs:sequence>
-      <xs:attribute name="id" type="xs:string" use="required" />
+      <xs:attribute name="id" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="2" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="name" type="xs:string" use="required" />
       <xs:attribute name="fullname" type="xs:string" use="required" />
       <xs:attribute name="testcasecount" type="NonnegativeInt32" use="required" />

--- a/src/NUnitFramework/tests/Api/SchemaTests.cs
+++ b/src/NUnitFramework/tests/Api/SchemaTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Api
                     new XElement("command-line"),
                     new XElement("filter"),
                     frameworkXml,
-                    new XAttribute("id", 0),
+                    new XAttribute("id", 2),
                     new XAttribute("name", 0),
                     new XAttribute("fullname", 0),
                     new XAttribute("testcasecount", 0),
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Api
             Assert.Multiple(() =>
             {
                 SchemaTestUtils.AssertValidXml(@"
-                    <test-run id='0' name='0' fullname='0' testcasecount='0' result='Passed' total='0' passed='0' failed='0' inconclusive='0' skipped='0' asserts='0' random-seed='0'>
+                    <test-run id='2' name='0' fullname='0' testcasecount='0' result='Passed' total='0' passed='0' failed='0' inconclusive='0' skipped='0' asserts='0' random-seed='0'>
                       <command-line />
                       <filter />
                       <test-case result='Passed' asserts='0' id='1' name='0' fullname='0' runstate='Runnable' seed='0' />


### PR DESCRIPTION
https://github.com/nunit/docs/wiki/Test-Result-XML-Format#test-run

> - **Attributes:**
>   - **id** The unique ID of this test. For the test-run, it is hard-coded as "2".