### PR TITLE
Unique Constraint failure message only outputs failed items

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -30,10 +30,6 @@ namespace NUnit.Framework.Constraints
         /// <summary>Result of a <see cref="CollectionTally"/> of the collections to compare for equivalence.</summary>
         private readonly CollectionTally.CollectionTallyResult _tallyResult;
 
-        /// <summary>Maximum amount of elements to write to the <see cref="MessageWriter"/> if there are
-        /// extra/missing elements from the collection.</summary>
-        private const int MaxDifferingElemsToWrite = 10;
-        
         /// <summary>Construct a <see cref="CollectionEquivalentConstraintResult"/> using a <see cref="CollectionTally.CollectionTallyResult"/>.</summary>
         /// <param name="constraint">Source <see cref="CollectionEquivalentConstraint"/>.</param>
         /// <param name="tallyResult">Result of the collection comparison.</param>
@@ -54,13 +50,13 @@ namespace NUnit.Framework.Constraints
         /// <summary>Write any additional lines (following <c>Expected:</c> and <c>But was:</c>) for a failing constraint.</summary>
         /// <param name="writer">The <see cref="MessageWriter"/> to write the failure message to.</param>
         public override void WriteAdditionalLinesTo(MessageWriter writer)
-        { 
+        {
             if (_tallyResult.MissingItems.Count > 0)
             {
                 int missingItemsCount = _tallyResult.MissingItems.Count;
 
                 string missingStr = $"Missing ({missingItemsCount}): ";
-                missingStr += MsgUtils.FormatCollection(_tallyResult.MissingItems, 0, MaxDifferingElemsToWrite);
+                missingStr += MsgUtils.FormatCollection(_tallyResult.MissingItems);
 
                 writer.WriteMessageLine(missingStr);
             }
@@ -70,7 +66,7 @@ namespace NUnit.Framework.Constraints
                 int extraItemsCount = _tallyResult.ExtraItems.Count;
 
                 string extraStr = $"Extra ({extraItemsCount}): ";
-                extraStr += MsgUtils.FormatCollection(_tallyResult.ExtraItems, 0, MaxDifferingElemsToWrite);
+                extraStr += MsgUtils.FormatCollection(_tallyResult.ExtraItems);
 
                 writer.WriteMessageLine(extraStr);
             }

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -26,7 +26,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -336,8 +335,6 @@ namespace NUnit.Framework.Constraints
 
         private sealed class CollectionOrderedConstraintResult : ConstraintResult
         {
-            private const int MaxDisplayedItems = 10;
-
             private readonly int _breakingIndex;
             private readonly object _breakingValue;
 
@@ -367,8 +364,9 @@ namespace NUnit.Framework.Constraints
 
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                int startIndex = Math.Max(0, _breakingIndex - MaxDisplayedItems + 2);
-                var actualValueMessage = MsgUtils.FormatCollection((IEnumerable)ActualValue, startIndex, MaxDisplayedItems);
+                // Choose startIndex in such way that '_breakingIndex' is always visible in message.
+                int startIndex = Math.Max(0, _breakingIndex - MsgUtils.DefaultMaxItems  + 2);
+                var actualValueMessage = MsgUtils.FormatCollection((IEnumerable)ActualValue, startIndex);
                 writer.Write(actualValueMessage);
             }
 

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -21,8 +21,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#nullable enable
+
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -33,6 +37,7 @@ namespace NUnit.Framework.Constraints
     public class CollectionSupersetConstraint : CollectionItemsEqualConstraint
     {
         private readonly IEnumerable _expected;
+        private List<object>? _missingItems;
 
         /// <summary>
         /// Construct a CollectionSupersetConstraint
@@ -69,10 +74,24 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
+            // Create tally from 'actual' collection, and remove '_expected'.
+            // ExtraItems from tally would be missing items for '_expected' collection. 
             CollectionTally tally = Tally(actual);
             tally.TryRemove(_expected);
 
-            return tally.Result.ExtraItems.Count == 0;
+            _missingItems = tally.Result.ExtraItems;
+
+            return _missingItems.Count == 0;
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value.
+        /// </summary>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            IEnumerable enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
+            bool matches = Matches(enumerable);
+            return new CollectionSupersetConstraintResult(this, actual, matches, _missingItems);
         }
 
         /// <summary>
@@ -87,5 +106,31 @@ namespace NUnit.Framework.Constraints
             base.Using(EqualityAdapter.For(invertedComparison));
             return this;
         }
+
+        #region Private CollectionSupersetConstraintResult Class
+
+        private sealed class CollectionSupersetConstraintResult : ConstraintResult
+        {
+            private readonly List<object>? _missingItems;
+
+            public CollectionSupersetConstraintResult(IConstraint constraint, object actualValue, bool isSuccess, List<object>? missingItems)
+                : base(constraint, actualValue, isSuccess)
+            {
+                _missingItems = missingItems;
+            }
+
+            public override void WriteAdditionalLinesTo(MessageWriter writer)
+            {
+                if (_missingItems?.Count > 0)
+                {
+                    string missingItemsMessage = "Missing items: ";
+                    missingItemsMessage += MsgUtils.FormatCollection(_missingItems);
+
+                    writer.WriteMessageLine(missingItemsMessage);
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Constraints
 
                 // We intentionally add one item too many because we use it to trigger
                 // the ellipsis when we call "MsgUtils.FormatCollection" later on.
-                if (itemList.Count <= ExactCountConstraintResult.MaxDisplayCount)
+                if (itemList.Count <= MsgUtils.DefaultMaxItems )
                     itemList.Add(item);
             }
 

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
@@ -31,18 +31,12 @@ namespace NUnit.Framework.Constraints
     internal sealed class ExactCountConstraintResult : ConstraintResult
     {
         /// <summary>
-        /// The maximum count of list elements that are shown on the constraint result
-        /// </summary>
-        internal const int MaxDisplayCount = 10;
-
-        /// <summary>
         /// The count of matched items of the <see cref="ExactCountConstraint"/>
         /// </summary>
         private readonly int _matchCount;
 
         /// <summary>
         /// A list with maximum count (+1) of items of the <see cref="ExactCountConstraint"/>
-        /// (The maximum count is set in <see cref="MaxDisplayCount"/>)
         /// </summary>
         private readonly ICollection<object> _itemList;
 
@@ -74,7 +68,7 @@ namespace NUnit.Framework.Constraints
             }
 
             writer.Write(_matchCount != 1 ? "{0} items " : "{0} item ", _matchCount);
-            writer.Write(MsgUtils.FormatCollection(_itemList, 0, MaxDisplayCount));
+            writer.Write(MsgUtils.FormatCollection(_itemList));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -53,6 +53,11 @@ namespace NUnit.Framework.Constraints
     internal static class MsgUtils
     {
         /// <summary>
+        /// Default amount of items used by <see cref="FormatCollection"/> method.
+        /// </summary>
+        internal const int DefaultMaxItems = 10;
+
+        /// <summary>
         /// Static string used when strings are clipped
         /// </summary>
         private const string ELLIPSIS = "...";
@@ -96,7 +101,7 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val is char ? string.Format(Fmt_Char, val) : next(val));
 
-            AddFormatter(next => val => val is IEnumerable ? FormatCollection((IEnumerable)val, 0, 10) : next(val));
+            AddFormatter(next => val => val is IEnumerable ? FormatCollection((IEnumerable)val) : next(val));
 
             AddFormatter(next => val => val is string ? FormatString((string)val) : next(val));
 
@@ -161,7 +166,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="collection">The collection containing elements to write.</param>
         /// <param name="start">The starting point of the elements to write</param>
         /// <param name="max">The maximum number of elements to write</param>
-        public static string FormatCollection(IEnumerable collection, long start, int max)
+        public static string FormatCollection(IEnumerable collection, long start = 0, int max = DefaultMaxItems)
         {
             int count = 0;
             int index = 0;

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -151,24 +151,21 @@ namespace NUnit.Framework.Constraints
 
         private static ICollection NonUniqueItemsInternal<T>(IEnumerable<T> actual, Func<T,T> hashValueFactory)
         {
-            var hash = new Dictionary<T, int>();
+            var hash = new Dictionary<T, bool>();
             var nonUniques = new List<T>();
 
             foreach (T item in actual)
             {
                 var itemToHash = hashValueFactory(item);
 
-                if (!hash.TryGetValue(itemToHash, out var itemCount))
+                if (!hash.TryGetValue(itemToHash, out var knownNonUnique))
                 {
-                    hash.Add(itemToHash, 1);
+                    hash.Add(itemToHash, false);
                 }
-                else
+                else if (!knownNonUnique)
                 {
-                    hash[itemToHash] = ++itemCount;
-                    if (itemCount == 2)
-                    {
-                        nonUniques.Add(item);
-                    }
+                    hash[itemToHash] = true;
+                    nonUniques.Add(item);
                 }
             }
 

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -221,7 +221,7 @@ namespace NUnit.Framework.Constraints
                 if (this.Status == ConstraintStatus.Failure)
                 {
                     writer.Write("  Not unique items: ");
-                    var output = MsgUtils.FormatCollection(NonUniqueItems, 0, MaxDisplayCount);
+                    var output = MsgUtils.FormatCollection(NonUniqueItems);
                     writer.WriteLine(output);
                 }
             }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -202,8 +202,13 @@ namespace NUnit.Framework.Constraints
             return null;
         }
 
-        internal class UniqueItemsContstraintResult : ConstraintResult
+        internal sealed class UniqueItemsContstraintResult : ConstraintResult
         {
+            /// <summary>
+            /// The maximum count of list elements that are shown on the constraint result
+            /// </summary>
+            internal const int MaxDisplayCount = 10;
+
             internal ICollection NonUniqueItems { get; }
 
             public UniqueItemsContstraintResult(IConstraint constraint, object actualValue, ICollection nonUniqueItems)
@@ -212,19 +217,14 @@ namespace NUnit.Framework.Constraints
                 NonUniqueItems = nonUniqueItems;
             }
 
-            public override void WriteActualValueTo(MessageWriter writer)
+            public override void WriteAdditionalLinesTo(MessageWriter writer)
             {
                 if (this.Status == ConstraintStatus.Failure)
                 {
-                    writer.Write("non-unique: ");
-
-                    // TODO: Expand MsgUtils so can write to StringWriter directly
-                    // https://github.com/nunit/nunit/issues/3498
-                    var output = MsgUtils.FormatCollection(NonUniqueItems, 0, NonUniqueItems.Count);
-                    writer.Write(output);
+                    writer.Write("  Not unique items: ");
+                    var output = MsgUtils.FormatCollection(NonUniqueItems, 0, MaxDisplayCount);
+                    writer.WriteLine(output);
                 }
-                else
-                    base.WriteActualValueTo(writer);
             }
         }
     }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -76,8 +76,18 @@ namespace NUnit.Framework.Constraints
 
             foreach (var o1 in actual)
             {
-                var isUnique = !processedItems.Any(o2 => ItemsEqual(o1, o2));
-                var unknownNonUnique = !isUnique && !nonUniques.Any(o2 => ItemsEqual(o1, o2));
+                var isUnique = true;
+                var unknownNonUnique = false;
+
+                foreach (var o2 in processedItems)
+                {
+                    if (ItemsEqual(o1, o2))
+                    {
+                        isUnique = false;
+                        unknownNonUnique = !nonUniques.Any(o2 => ItemsEqual(o1, o2));
+                        break;
+                    }
+                }
 
                 if (isUnique)
                     processedItems.Add(o1);

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -151,21 +151,20 @@ namespace NUnit.Framework.Constraints
 
         private static ICollection NonUniqueItemsInternal<T>(IEnumerable<T> actual, Func<T,T> hashValueFactory)
         {
-            var hash = new Dictionary<T, bool>();
+            var hash = new HashSet<T>();
+            var knownNonUniques = new HashSet<T>();
             var nonUniques = new List<T>();
 
             foreach (T item in actual)
             {
                 var itemToHash = hashValueFactory(item);
-
-                if (!hash.TryGetValue(itemToHash, out var knownNonUnique))
+                if (!hash.Add(itemToHash))
                 {
-                    hash.Add(itemToHash, false);
-                }
-                else if (!knownNonUnique)
-                {
-                    hash[itemToHash] = true;
-                    nonUniques.Add(item);
+                    // in order to only record 1 of each non-unique
+                    if (knownNonUniques.Add(itemToHash))
+                    {
+                        nonUniques.Add(item);
+                    }
                 }
             }
 

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -203,14 +203,15 @@ namespace NUnit.Framework.Constraints
 
         internal class CaseInsensitiveCharComparer : IEqualityComparer<char>
         {
+            private static readonly StringComparer Comparer = StringComparer.CurrentCultureIgnoreCase;
             public bool Equals(char x, char y)
             {
-                return StringComparer.CurrentCultureIgnoreCase.Equals(x, y);
+                return Comparer.Equals(x.ToString(), y.ToString());
             }
 
             public int GetHashCode(char obj)
             {
-                return char.ToLower(obj).GetHashCode();
+                return Comparer.GetHashCode(obj.ToString());
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Constraints
             typeof(UniqueItemsConstraint).GetMethod(nameof(ItemsUnique), BindingFlags.Static | BindingFlags.NonPublic);
 
         private static ICollection ItemsUnique<T>(IEnumerable<T> actual)
-            => NonUniqueItemsInternal(actual);
+            => NonUniqueItemsInternal(actual, v => v);
 
         private static ICollection StringsUniqueIgnoringCase(IEnumerable<string> actual)
             => NonUniqueItemsInternal(actual, v => v.ToLower());
@@ -149,13 +149,10 @@ namespace NUnit.Framework.Constraints
         private static ICollection CharsUniqueIgnoringCase(IEnumerable<char> actual)
             => NonUniqueItemsInternal(actual, char.ToLower);
 
-        private static ICollection NonUniqueItemsInternal<T>(IEnumerable<T> actual, Func<T,T>? hashValueFactory = null)
+        private static ICollection NonUniqueItemsInternal<T>(IEnumerable<T> actual, Func<T,T> hashValueFactory)
         {
             var hash = new Dictionary<T, int>();
             var nonUniques = new List<T>();
-
-            if (hashValueFactory == null)
-                hashValueFactory = t => t;
 
             foreach (T item in actual)
             {

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -203,11 +203,6 @@ namespace NUnit.Framework.Constraints
 
         internal sealed class UniqueItemsContstraintResult : ConstraintResult
         {
-            /// <summary>
-            /// The maximum count of list elements that are shown on the constraint result
-            /// </summary>
-            internal const int MaxDisplayCount = 10;
-
             internal ICollection NonUniqueItems { get; }
 
             public UniqueItemsContstraintResult(IConstraint constraint, object actualValue, ICollection nonUniqueItems)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -216,7 +216,7 @@ namespace NUnit.Framework.Constraints
 
         internal class UniqueItemsContstraintResult : ConstraintResult
         {
-            private ICollection NonUniqueItems { get; }
+            internal ICollection NonUniqueItems { get; }
 
             public UniqueItemsContstraintResult(IConstraint constraint, object actualValue, ICollection nonUniqueItems)
             : base(constraint, actualValue, nonUniqueItems.Count == 0)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Constraints
         {
             public bool Equals(char x, char y)
             {
-                return char.ToLower(x) == char.ToLower(y);
+                return StringComparer.CurrentCultureIgnoreCase.Equals(x, y);
             }
 
             public int GetHashCode(char obj)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -120,6 +120,9 @@ namespace NUnit.Framework.Constraints
         private static readonly MethodInfo ItemsUniqueMethod =
             typeof(UniqueItemsConstraint).GetMethod(nameof(ItemsUnique), BindingFlags.Static | BindingFlags.NonPublic);
 
+        private static readonly CaseInsensitiveCharComparer InsensitiveCharComparer =
+            new CaseInsensitiveCharComparer();
+
         private static ICollection<T> ItemsUnique<T>(IEnumerable<T> actual)
             => NonUniqueItemsInternal(actual, EqualityComparer<T>.Default);
 
@@ -127,7 +130,7 @@ namespace NUnit.Framework.Constraints
             => NonUniqueItemsInternal(actual, StringComparer.CurrentCultureIgnoreCase);
 
         private static ICollection<char> CharsUniqueIgnoringCase(IEnumerable<char> actual)
-            => NonUniqueItemsInternal(actual, new CaseInsensitiveCharComparer());
+            => NonUniqueItemsInternal(actual, InsensitiveCharComparer);
 
         private static ICollection<T> NonUniqueItemsInternal<T>(IEnumerable<T> actual, IEqualityComparer<T> comparer)
         {

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -145,7 +145,13 @@ namespace NUnit.Framework.Constraints
             => NonUniqueItemsInternal(actual, StringComparer.CurrentCultureIgnoreCase);
 
         private static ICollection CharsUniqueIgnoringCase(IEnumerable<char> actual)
-            => NonUniqueItemsInternal(actual, new CaseInsensitiveCharComparer());
+            => NonUniqueItemsInternal(CharValueFactory(actual), EqualityComparer<char>.Default);
+
+        private static IEnumerable<char> CharValueFactory(IEnumerable<char> chars)
+        {
+            foreach (var c in chars)
+                yield return char.ToLower(c);
+        }
 
         private static ICollection NonUniqueItemsInternal<T>(IEnumerable<T> actual, IEqualityComparer<T> comparer)
         {
@@ -201,19 +207,18 @@ namespace NUnit.Framework.Constraints
             return null;
         }
 
-        internal class CaseInsensitiveCharComparer : IEqualityComparer<char>
-        {
-            private static readonly StringComparer Comparer = StringComparer.CurrentCultureIgnoreCase;
-            public bool Equals(char x, char y)
-            {
-                return Comparer.Equals(x.ToString(), y.ToString());
-            }
+        //internal class CaseInsensitiveCharComparer : IEqualityComparer<char>
+        //{
+        //    public bool Equals(char x, char y)
+        //    {
+        //        return char.ToLower(x) == char.ToLower(y);
+        //    }
 
-            public int GetHashCode(char obj)
-            {
-                return Comparer.GetHashCode(obj.ToString());
-            }
-        }
+        //    public int GetHashCode(char obj)
+        //    {
+        //        return char.ToLower(obj).GetHashCode();
+        //    }
+        //}
 
         internal class UniqueItemsContstraintResult : ConstraintResult
         {

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -108,7 +108,8 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: all items unique" + Environment.NewLine +
-                "  But was:  non-unique: < \"x\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", \"x\" >" + Environment.NewLine +
+                "  Not unique items: < \"x\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", "y", "x")));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
@@ -119,10 +120,24 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: all items unique" + Environment.NewLine +
-                "  But was:  non-unique: < null >" + Environment.NewLine;
+                "  But was:  < \"x\", null, \"y\", null, \"z\" >" + Environment.NewLine +
+                "  Not unique items: < null >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void UniqueFailure_WithMultipleNonUniques()
+        {
+            var collection = new SimpleObjectCollection("x", "y", "x", "x", "z", "y");
+            var expectedMessage =
+                "  Expected: all items unique" + Environment.NewLine +
+                "  But was:  < \"x\", \"y\", \"x\", \"x\", \"z\", \"y\" >" + Environment.NewLine +
+                "  Not unique items: < \"x\", \"y\" >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: all items unique" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", \"x\" >" + Environment.NewLine;
+                "  But was:  non-unique: < \"x\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", "y", "x")));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
@@ -117,8 +117,13 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void UniqueFailure_WithTwoNulls()
         {
-            Assert.Throws<AssertionException>(
+            var expectedMessage =
+                "  Expected: all items unique" + Environment.NewLine +
+                "  But was:  non-unique: < null >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -610,7 +610,8 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: subset of < \"y\", \"z\", \"a\" >" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine +
+                "  Extra items: < \"x\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.IsSubsetOf(set1,set2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Internal;
@@ -29,7 +30,7 @@ using NUnit.TestUtilities.Collections;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class CollectionSubsetConstraintTests : ConstraintTestBase
+    public class CollectionSubsetConstraintTests : ConstraintTestBaseNoData
     {
         [SetUp]
         public void SetUp()
@@ -41,20 +42,40 @@ namespace NUnit.Framework.Constraints
 
         static object[] SuccessData = new object[] { new int[] { 1, 3, 5 }, new int[] { 1, 2, 3, 4, 5 } };
         static object[] FailureData = new object[] {
-            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" },
-            new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" } };
+            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" , "< 7 >"},
+            new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >", "< 2, 2 >" } };
+
+        [Test, TestCaseSource(nameof(SuccessData))]
+        public void SucceedsWithGoodValues(object actualValue)
+        {
+            Assert.That(actualValue, TheConstraint);
+        }
+
+        [Test, TestCaseSource(nameof(FailureData))]
+        public void FailsWithBadValues(object badActualValue, string actualMessage, string extraMessage)
+        {
+            var constraintResult = TheConstraint.ApplyTo(badActualValue);
+            Assert.IsFalse(constraintResult.IsSuccess);
+
+            TextMessageWriter writer = new TextMessageWriter();
+            constraintResult.WriteMessageTo(writer);
+            Assert.That(writer.ToString(), Is.EqualTo(
+                TextMessageWriter.Pfx_Expected + ExpectedDescription + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + actualMessage + Environment.NewLine +
+                "  Extra items: " + extraMessage + Environment.NewLine));
+        }
 
         [Test]
         [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
-        public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
+        public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
         {
-            var constraint = new CollectionSubsetConstraint( expected ).IgnoreCase;
-            var constraintResult = constraint.ApplyTo( actual );
-            if ( !constraintResult.IsSuccess )
+            var constraint = new CollectionSubsetConstraint(expected).IgnoreCase;
+            var constraintResult = constraint.ApplyTo(actual);
+            if (!constraintResult.IsSuccess)
             {
                 MessageWriter writer = new TextMessageWriter();
-                constraintResult.WriteMessageTo( writer );
-                Assert.Fail( writer.ToString() );
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
             }
         }
 
@@ -65,17 +86,17 @@ namespace NUnit.Framework.Constraints
                 get
                 {
                     yield return new TestCaseData(new SimpleObjectCollection("w", "x", "y", "z"), new SimpleObjectCollection("z", "Y", "X"));
-                    yield return new TestCaseData(new[] {'A', 'B', 'C', 'D', 'E'}, new object[] {'a', 'b', 'c'});
-                    yield return new TestCaseData(new[] {"a", "b", "c", "d", "e"}, new object[] {"A", "C", "B"});
-                    yield return new TestCaseData(new Dictionary<int, string> {{1, "a"}, {2, "b"}}, new Dictionary<int, string> {{1, "A"}});
-                    yield return new TestCaseData(new Dictionary<int, char> {{1, 'A'}, {2, 'B'}}, new Dictionary<int, char> {{1, 'a'}});
-                    yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"b", 2}});
-                    yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }, {'B', 2}}, new Dictionary<char, int> {{'a', 1}});
+                    yield return new TestCaseData(new[] { 'A', 'B', 'C', 'D', 'E' }, new object[] { 'a', 'b', 'c' });
+                    yield return new TestCaseData(new[] { "a", "b", "c", "d", "e" }, new object[] { "A", "C", "B" });
+                    yield return new TestCaseData(new Dictionary<int, string> { { 1, "a" }, { 2, "b" } }, new Dictionary<int, string> { { 1, "A" } });
+                    yield return new TestCaseData(new Dictionary<int, char> { { 1, 'A' }, { 2, 'B' } }, new Dictionary<int, char> { { 1, 'a' } });
+                    yield return new TestCaseData(new Dictionary<string, int> { { "b", 2 }, { "a", 1 } }, new Dictionary<string, int> { { "b", 2 } });
+                    yield return new TestCaseData(new Dictionary<char, int> { { 'A', 1 }, { 'B', 2 } }, new Dictionary<char, int> { { 'a', 1 } });
 
-                    yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"}});
-                    yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{2, 'b'}});
-                    yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}});
-                    yield return new TestCaseData(new Hashtable {{'A', 1}, {'B', 2}}, new Hashtable {{'a', 1}});
+                    yield return new TestCaseData(new Hashtable { { 1, "a" }, { 2, "b" } }, new Hashtable { { 1, "A" } });
+                    yield return new TestCaseData(new Hashtable { { 1, 'A' }, { 2, 'B' } }, new Hashtable { { 2, 'b' } });
+                    yield return new TestCaseData(new Hashtable { { "b", 2 }, { "a", 1 } }, new Hashtable { { "A", 1 } });
+                    yield return new TestCaseData(new Hashtable { { 'A', 1 }, { 'B', 2 } }, new Hashtable { { 'a', 1 } });
                 }
             }
         }

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Internal;
@@ -29,7 +30,7 @@ using NUnit.TestUtilities.Collections;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class CollectionSupersetConstraintTests : ConstraintTestBase
+    public class CollectionSupersetConstraintTests : ConstraintTestBaseNoData
     {
         [SetUp]
         public void SetUp()
@@ -49,23 +50,43 @@ namespace NUnit.Framework.Constraints
 
         static object[] FailureData = new object[]
         {
-            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" }
-            , new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" }
-            , new object[] { new int[] { 1, 2, 3, 5 }, "< 1, 2, 3, 5 >" }
-            , new object[] { new int[] { 1, 2, 3, 5, 7 }, "< 1, 2, 3, 5, 7 >" }
+            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >", "< 2, 4, 5 >" }
+            , new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >", "< 3, 4 >" }
+            , new object[] { new int[] { 1, 2, 3, 5 }, "< 1, 2, 3, 5 >", "< 4 >" }
+            , new object[] { new int[] { 1, 2, 3, 5, 7 }, "< 1, 2, 3, 5, 7 >", "< 4 >" }
         };
+
+        [Test, TestCaseSource(nameof(SuccessData))]
+        public void SucceedsWithGoodValues(object actualValue)
+        {
+            Assert.That(actualValue, TheConstraint);
+        }
+
+        [Test, TestCaseSource(nameof(FailureData))]
+        public void FailsWithBadValues(object badActualValue, string actualMessage, string missingMessage)
+        {
+            var constraintResult = TheConstraint.ApplyTo(badActualValue);
+            Assert.IsFalse(constraintResult.IsSuccess);
+
+            TextMessageWriter writer = new TextMessageWriter();
+            constraintResult.WriteMessageTo(writer);
+            Assert.That(writer.ToString(), Is.EqualTo(
+                TextMessageWriter.Pfx_Expected + ExpectedDescription + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + actualMessage + Environment.NewLine +
+                "  Missing items: " + missingMessage + Environment.NewLine));
+        }
 
         [Test]
         [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
-        public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
+        public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
         {
-            var constraint = new CollectionSupersetConstraint( expected ).IgnoreCase;
-            var constraintResult = constraint.ApplyTo( actual );
-            if ( !constraintResult.IsSuccess )
+            var constraint = new CollectionSupersetConstraint(expected).IgnoreCase;
+            var constraintResult = constraint.ApplyTo(actual);
+            if (!constraintResult.IsSuccess)
             {
                 MessageWriter writer = new TextMessageWriter();
-                constraintResult.WriteMessageTo( writer );
-                Assert.Fail( writer.ToString() );
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
             }
         }
 
@@ -76,7 +97,7 @@ namespace NUnit.Framework.Constraints
                 get
                 {
                     yield return new TestCaseData(new SimpleObjectCollection("z", "Y", "X"), new SimpleObjectCollection("w", "x", "y", "z"));
-                    yield return new TestCaseData(new object[] {'a', 'b', 'c'}, new[] {'A', 'B', 'C', 'D', 'E'});
+                    yield return new TestCaseData(new object[] { 'a', 'b', 'c' }, new[] { 'A', 'B', 'C', 'D', 'E' });
                     yield return new TestCaseData(new object[] { "A", "C", "B" }, new[] { "a", "b", "c", "d", "e" });
                     yield return new TestCaseData(new Dictionary<int, string> { { 1, "A" } }, new Dictionary<int, string> { { 1, "a" }, { 2, "b" } });
                     yield return new TestCaseData(new Dictionary<int, char> { { 1, 'a' } }, new Dictionary<int, char> { { 1, 'A' }, { 2, 'B' } });

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
         }
 
         static object[] SuccessData = new object[] { new int[] { 1, 3, 17, -2, 34 }, new object[0] };
-        static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "< 1, 3, 17, 3, 34 >" } };
+        static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "non-unique: < 3 >" } };
 
         [Test]
         [TestCaseSource( nameof(IgnoreCaseData) )]

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -32,7 +32,7 @@ using static NUnit.Framework.Constraints.UniqueItemsConstraint;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class UniqueItemsTests : ConstraintTestBase
+    public class UniqueItemsConstraintTests : ConstraintTestBase
     {
         [SetUp]
         public void SetUp()
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
             "< 1, 3, 17, 3, 34 >" + Environment.NewLine + "  Not unique items: < 3 >" }
         };
 
-        [Test]
+        [Test, SetCulture("en-US")]
         [TestCaseSource( nameof(IgnoreCaseData) )]
         public void HonorsIgnoreCase( IEnumerable actual )
         {
@@ -93,13 +93,14 @@ namespace NUnit.Framework.Constraints
                     Assert.That(values, Is.Unique.IgnoreCase);
                 else
                     Assert.That(values, Is.Unique);
-            }, HelperConstraints.HasMaxTime(100));
+            }, HelperConstraints.HasMaxTime(150));
         }
 
         [TestCaseSource(nameof(DuplicateItemsData))]
         public void DuplicateItemsTests(IEnumerable items, IEnumerable expectedFailures)
         {
-            var result = Is.Unique.ApplyTo(items) as UniqueItemsContstraintResult;
+            var constraint = new UniqueItemsConstraint().IgnoreCase;
+            var result = constraint.ApplyTo(items) as UniqueItemsContstraintResult;
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.NonUniqueItems, Is.EqualTo(expectedFailures));

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
                     Assert.That(values, Is.Unique.IgnoreCase);
                 else
                     Assert.That(values, Is.Unique);
-            }, HelperConstraints.HasMaxTime(150));
+            }, HelperConstraints.HasMaxTime(100));
         }
 
         [TestCaseSource(nameof(DuplicateItemsData))]

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.TestUtilities;
 using NUnit.TestUtilities.Collections;
+using static NUnit.Framework.Constraints.UniqueItemsConstraint;
 
 namespace NUnit.Framework.Constraints
 {
@@ -57,6 +58,13 @@ namespace NUnit.Framework.Constraints
             new object[] {new[] {"a", "b", "c", "C"}}
         };
 
+        private static readonly object[] DuplicateItemsData =
+        {
+            new object[] {new[] { 1, 2, 3, 2 }, new[] { 2 }},
+            new object[] {new[] { 2, 1, 2, 3, 2 }, new[] { 2 }},
+            new object[] {new[] { 2, 1, 2, 3, 3 }, new[] { 2, 3 }}
+        };
+
         static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);
 
         static readonly TestCaseData[] PerformanceData =
@@ -78,6 +86,15 @@ namespace NUnit.Framework.Constraints
                 else
                     Assert.That(values, Is.Unique);
             }, HelperConstraints.HasMaxTime(100));
+        }
+
+        [TestCaseSource(nameof(DuplicateItemsData))]
+        public void DuplicateItemsTests(IEnumerable items, IEnumerable expectedFailures)
+        {
+            var result = Is.Unique.ApplyTo(items) as UniqueItemsContstraintResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.NonUniqueItems, Is.EqualTo(expectedFailures));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -69,7 +69,8 @@ namespace NUnit.Framework.Constraints
         {
             new object[] {new[] { 1, 2, 3, 2 }, new[] { 2 }},
             new object[] {new[] { 2, 1, 2, 3, 2 }, new[] { 2 }},
-            new object[] {new[] { 2, 1, 2, 3, 3 }, new[] { 2, 3 }}
+            new object[] {new[] { 2, 1, 2, 3, 3 }, new[] { 2, 3 }},
+            new object[] {new[] { "x", null, "x" }, new[] { "x" }}
         };
 
         static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10000);

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +43,10 @@ namespace NUnit.Framework.Constraints
         }
 
         static object[] SuccessData = new object[] { new int[] { 1, 3, 17, -2, 34 }, new object[0] };
-        static object[] FailureData = new object[] { new object[] { new int[] { 1, 3, 17, 3, 34 }, "non-unique: < 3 >" } };
+        static object[] FailureData = new object[] { new object[] {
+            new int[] { 1, 3, 17, 3, 34 }, 
+            "< 1, 3, 17, 3, 34 >" + Environment.NewLine + "  Not unique items: < 3 >" }
+        };
 
         [Test]
         [TestCaseSource( nameof(IgnoreCaseData) )]

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -48,7 +48,10 @@ namespace NUnit.Framework.Constraints
         [TestCaseSource( nameof(IgnoreCaseData) )]
         public void HonorsIgnoreCase( IEnumerable actual )
         {
-            Assert.That( new UniqueItemsConstraint().IgnoreCase.ApplyTo( actual ).IsSuccess, Is.False, "{0} should not be unique ignoring case", actual );
+            var constraint = new UniqueItemsConstraint().IgnoreCase;
+            var result = constraint.ApplyTo(actual);
+
+            Assert.That(result.IsSuccess, Is.False, "{0} should not be unique ignoring case", actual );
         }
 
         private static readonly object[] IgnoreCaseData =
@@ -85,7 +88,7 @@ namespace NUnit.Framework.Constraints
                     Assert.That(values, Is.Unique.IgnoreCase);
                 else
                     Assert.That(values, Is.Unique);
-            }, HelperConstraints.HasMaxTime(100));
+            }, HelperConstraints.HasMaxTime(150));
         }
 
         [TestCaseSource(nameof(DuplicateItemsData))]


### PR DESCRIPTION
Fixes #3279 

This PR updates the constraint result of a unique check to only output the _distinct_ non-unique items from a collection, rather than the entire thing. This means that, no matter how many times a given value occurs, it will only appear once in the output (please let me know if this is desired).
It will output all different non-unique values, rather than just the first one found