### PR TITLE
Remove implicit cast from ITestResult to TestResult

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -404,7 +404,7 @@ namespace NUnit.Framework.Internal
                 AddAttachmentsElement(thisNode);
 
             if (recursive && HasChildren)
-                foreach (TestResult child in Children)
+                foreach (var child in Children)
                     child.AddToXml(thisNode, recursive);
 
             return thisNode;


### PR DESCRIPTION
Relates to #3423 

There was an implicit cast in `TestResult.AddToXml` that could cause exceptions to be thrown when used with custom-derived implementations of `ITestResult`. This is a short-term fix to avoid the crash, but doesn't address the main point from @CharliePoole here: https://github.com/nunit/nunit/issues/3423#issuecomment-552968884