### PR TITLE
Better failure messages for Subset and Superset constraints

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -30,10 +30,6 @@ namespace NUnit.Framework.Constraints
         /// <summary>Result of a <see cref="CollectionTally"/> of the collections to compare for equivalence.</summary>
         private readonly CollectionTally.CollectionTallyResult _tallyResult;
 
-        /// <summary>Maximum amount of elements to write to the <see cref="MessageWriter"/> if there are
-        /// extra/missing elements from the collection.</summary>
-        private const int MaxDifferingElemsToWrite = 10;
-        
         /// <summary>Construct a <see cref="CollectionEquivalentConstraintResult"/> using a <see cref="CollectionTally.CollectionTallyResult"/>.</summary>
         /// <param name="constraint">Source <see cref="CollectionEquivalentConstraint"/>.</param>
         /// <param name="tallyResult">Result of the collection comparison.</param>
@@ -54,13 +50,13 @@ namespace NUnit.Framework.Constraints
         /// <summary>Write any additional lines (following <c>Expected:</c> and <c>But was:</c>) for a failing constraint.</summary>
         /// <param name="writer">The <see cref="MessageWriter"/> to write the failure message to.</param>
         public override void WriteAdditionalLinesTo(MessageWriter writer)
-        { 
+        {
             if (_tallyResult.MissingItems.Count > 0)
             {
                 int missingItemsCount = _tallyResult.MissingItems.Count;
 
                 string missingStr = $"Missing ({missingItemsCount}): ";
-                missingStr += MsgUtils.FormatCollection(_tallyResult.MissingItems, 0, MaxDifferingElemsToWrite);
+                missingStr += MsgUtils.FormatCollection(_tallyResult.MissingItems);
 
                 writer.WriteMessageLine(missingStr);
             }
@@ -70,7 +66,7 @@ namespace NUnit.Framework.Constraints
                 int extraItemsCount = _tallyResult.ExtraItems.Count;
 
                 string extraStr = $"Extra ({extraItemsCount}): ";
-                extraStr += MsgUtils.FormatCollection(_tallyResult.ExtraItems, 0, MaxDifferingElemsToWrite);
+                extraStr += MsgUtils.FormatCollection(_tallyResult.ExtraItems);
 
                 writer.WriteMessageLine(extraStr);
             }

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -26,7 +26,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using NUnit.Compatibility;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -336,8 +335,6 @@ namespace NUnit.Framework.Constraints
 
         private sealed class CollectionOrderedConstraintResult : ConstraintResult
         {
-            private const int MaxDisplayedItems = 10;
-
             private readonly int _breakingIndex;
             private readonly object _breakingValue;
 
@@ -367,8 +364,9 @@ namespace NUnit.Framework.Constraints
 
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                int startIndex = Math.Max(0, _breakingIndex - MaxDisplayedItems + 2);
-                var actualValueMessage = MsgUtils.FormatCollection((IEnumerable)ActualValue, startIndex, MaxDisplayedItems);
+                // Choose startIndex in such way that '_breakingIndex' is always visible in message.
+                int startIndex = Math.Max(0, _breakingIndex - MsgUtils.DefaultMaxItems  + 2);
+                var actualValueMessage = MsgUtils.FormatCollection((IEnumerable)ActualValue, startIndex);
                 writer.Write(actualValueMessage);
             }
 

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -74,6 +74,8 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
+            // Create tally from 'actual' collection, and remove '_expected'.
+            // ExtraItems from tally would be missing items for '_expected' collection. 
             CollectionTally tally = Tally(actual);
             tally.TryRemove(_expected);
 

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Constraints
 
                 // We intentionally add one item too many because we use it to trigger
                 // the ellipsis when we call "MsgUtils.FormatCollection" later on.
-                if (itemList.Count <= ExactCountConstraintResult.MaxDisplayCount)
+                if (itemList.Count <= MsgUtils.DefaultMaxItems )
                     itemList.Add(item);
             }
 

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
@@ -31,18 +31,12 @@ namespace NUnit.Framework.Constraints
     internal sealed class ExactCountConstraintResult : ConstraintResult
     {
         /// <summary>
-        /// The maximum count of list elements that are shown on the constraint result
-        /// </summary>
-        internal const int MaxDisplayCount = 10;
-
-        /// <summary>
         /// The count of matched items of the <see cref="ExactCountConstraint"/>
         /// </summary>
         private readonly int _matchCount;
 
         /// <summary>
         /// A list with maximum count (+1) of items of the <see cref="ExactCountConstraint"/>
-        /// (The maximum count is set in <see cref="MaxDisplayCount"/>)
         /// </summary>
         private readonly ICollection<object> _itemList;
 
@@ -74,7 +68,7 @@ namespace NUnit.Framework.Constraints
             }
 
             writer.Write(_matchCount != 1 ? "{0} items " : "{0} item ", _matchCount);
-            writer.Write(MsgUtils.FormatCollection(_itemList, 0, MaxDisplayCount));
+            writer.Write(MsgUtils.FormatCollection(_itemList));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Default amount of items used by <see cref="FormatCollection"/> method.
         /// </summary>
-        private const int DefaultMaxItems = 10;
+        internal const int DefaultMaxItems = 10;
 
         /// <summary>
         /// Static string used when strings are clipped
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val is char ? string.Format(Fmt_Char, val) : next(val));
 
-            AddFormatter(next => val => val is IEnumerable ? FormatCollection((IEnumerable)val, 0, 10) : next(val));
+            AddFormatter(next => val => val is IEnumerable ? FormatCollection((IEnumerable)val) : next(val));
 
             AddFormatter(next => val => val is string ? FormatString((string)val) : next(val));
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -53,6 +53,11 @@ namespace NUnit.Framework.Constraints
     internal static class MsgUtils
     {
         /// <summary>
+        /// Default amount of items used by <see cref="FormatCollection"/> method.
+        /// </summary>
+        private const int DefaultMaxItems = 10;
+
+        /// <summary>
         /// Static string used when strings are clipped
         /// </summary>
         private const string ELLIPSIS = "...";
@@ -161,7 +166,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="collection">The collection containing elements to write.</param>
         /// <param name="start">The starting point of the elements to write</param>
         /// <param name="max">The maximum number of elements to write</param>
-        public static string FormatCollection(IEnumerable collection, long start, int max)
+        public static string FormatCollection(IEnumerable collection, long start = 0, int max = DefaultMaxItems)
         {
             int count = 0;
             int index = 0;

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -610,7 +610,8 @@ namespace NUnit.Framework.Assertions
 
             var expectedMessage =
                 "  Expected: subset of < \"y\", \"z\", \"a\" >" + Environment.NewLine +
-                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine +
+                "  Extra items: < \"x\" >" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => CollectionAssert.IsSubsetOf(set1,set2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Internal;
@@ -29,7 +30,7 @@ using NUnit.TestUtilities.Collections;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class CollectionSubsetConstraintTests : ConstraintTestBase
+    public class CollectionSubsetConstraintTests : ConstraintTestBaseNoData
     {
         [SetUp]
         public void SetUp()
@@ -41,20 +42,40 @@ namespace NUnit.Framework.Constraints
 
         static object[] SuccessData = new object[] { new int[] { 1, 3, 5 }, new int[] { 1, 2, 3, 4, 5 } };
         static object[] FailureData = new object[] {
-            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" },
-            new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" } };
+            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" , "< 7 >"},
+            new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >", "< 2, 2 >" } };
+
+        [Test, TestCaseSource(nameof(SuccessData))]
+        public void SucceedsWithGoodValues(object actualValue)
+        {
+            Assert.That(actualValue, TheConstraint);
+        }
+
+        [Test, TestCaseSource(nameof(FailureData))]
+        public void FailsWithBadValues(object badActualValue, string actualMessage, string extraMessage)
+        {
+            var constraintResult = TheConstraint.ApplyTo(badActualValue);
+            Assert.IsFalse(constraintResult.IsSuccess);
+
+            TextMessageWriter writer = new TextMessageWriter();
+            constraintResult.WriteMessageTo(writer);
+            Assert.That(writer.ToString(), Is.EqualTo(
+                TextMessageWriter.Pfx_Expected + ExpectedDescription + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + actualMessage + Environment.NewLine +
+                "  Extra items: " + extraMessage + Environment.NewLine));
+        }
 
         [Test]
         [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
-        public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
+        public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
         {
-            var constraint = new CollectionSubsetConstraint( expected ).IgnoreCase;
-            var constraintResult = constraint.ApplyTo( actual );
-            if ( !constraintResult.IsSuccess )
+            var constraint = new CollectionSubsetConstraint(expected).IgnoreCase;
+            var constraintResult = constraint.ApplyTo(actual);
+            if (!constraintResult.IsSuccess)
             {
                 MessageWriter writer = new TextMessageWriter();
-                constraintResult.WriteMessageTo( writer );
-                Assert.Fail( writer.ToString() );
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
             }
         }
 
@@ -65,17 +86,17 @@ namespace NUnit.Framework.Constraints
                 get
                 {
                     yield return new TestCaseData(new SimpleObjectCollection("w", "x", "y", "z"), new SimpleObjectCollection("z", "Y", "X"));
-                    yield return new TestCaseData(new[] {'A', 'B', 'C', 'D', 'E'}, new object[] {'a', 'b', 'c'});
-                    yield return new TestCaseData(new[] {"a", "b", "c", "d", "e"}, new object[] {"A", "C", "B"});
-                    yield return new TestCaseData(new Dictionary<int, string> {{1, "a"}, {2, "b"}}, new Dictionary<int, string> {{1, "A"}});
-                    yield return new TestCaseData(new Dictionary<int, char> {{1, 'A'}, {2, 'B'}}, new Dictionary<int, char> {{1, 'a'}});
-                    yield return new TestCaseData(new Dictionary<string, int> {{ "b", 2 }, { "a", 1 } }, new Dictionary<string, int> {{"b", 2}});
-                    yield return new TestCaseData(new Dictionary<char, int> {{'A', 1 }, {'B', 2}}, new Dictionary<char, int> {{'a', 1}});
+                    yield return new TestCaseData(new[] { 'A', 'B', 'C', 'D', 'E' }, new object[] { 'a', 'b', 'c' });
+                    yield return new TestCaseData(new[] { "a", "b", "c", "d", "e" }, new object[] { "A", "C", "B" });
+                    yield return new TestCaseData(new Dictionary<int, string> { { 1, "a" }, { 2, "b" } }, new Dictionary<int, string> { { 1, "A" } });
+                    yield return new TestCaseData(new Dictionary<int, char> { { 1, 'A' }, { 2, 'B' } }, new Dictionary<int, char> { { 1, 'a' } });
+                    yield return new TestCaseData(new Dictionary<string, int> { { "b", 2 }, { "a", 1 } }, new Dictionary<string, int> { { "b", 2 } });
+                    yield return new TestCaseData(new Dictionary<char, int> { { 'A', 1 }, { 'B', 2 } }, new Dictionary<char, int> { { 'a', 1 } });
 
-                    yield return new TestCaseData(new Hashtable {{1, "a"}, {2, "b"}}, new Hashtable {{1, "A"}});
-                    yield return new TestCaseData(new Hashtable {{1, 'A'}, {2, 'B'}}, new Hashtable {{2, 'b'}});
-                    yield return new TestCaseData(new Hashtable {{"b", 2}, {"a", 1}}, new Hashtable {{"A", 1}});
-                    yield return new TestCaseData(new Hashtable {{'A', 1}, {'B', 2}}, new Hashtable {{'a', 1}});
+                    yield return new TestCaseData(new Hashtable { { 1, "a" }, { 2, "b" } }, new Hashtable { { 1, "A" } });
+                    yield return new TestCaseData(new Hashtable { { 1, 'A' }, { 2, 'B' } }, new Hashtable { { 2, 'b' } });
+                    yield return new TestCaseData(new Hashtable { { "b", 2 }, { "a", 1 } }, new Hashtable { { "A", 1 } });
+                    yield return new TestCaseData(new Hashtable { { 'A', 1 }, { 'B', 2 } }, new Hashtable { { 'a', 1 } });
                 }
             }
         }

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework.Internal;
@@ -29,7 +30,7 @@ using NUnit.TestUtilities.Collections;
 namespace NUnit.Framework.Constraints
 {
     [TestFixture]
-    public class CollectionSupersetConstraintTests : ConstraintTestBase
+    public class CollectionSupersetConstraintTests : ConstraintTestBaseNoData
     {
         [SetUp]
         public void SetUp()
@@ -49,23 +50,43 @@ namespace NUnit.Framework.Constraints
 
         static object[] FailureData = new object[]
         {
-            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >" }
-            , new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >" }
-            , new object[] { new int[] { 1, 2, 3, 5 }, "< 1, 2, 3, 5 >" }
-            , new object[] { new int[] { 1, 2, 3, 5, 7 }, "< 1, 2, 3, 5, 7 >" }
+            new object[] { new int[] { 1, 3, 7 }, "< 1, 3, 7 >", "< 2, 4, 5 >" }
+            , new object[] { new int[] { 1, 2, 2, 2, 5 }, "< 1, 2, 2, 2, 5 >", "< 3, 4 >" }
+            , new object[] { new int[] { 1, 2, 3, 5 }, "< 1, 2, 3, 5 >", "< 4 >" }
+            , new object[] { new int[] { 1, 2, 3, 5, 7 }, "< 1, 2, 3, 5, 7 >", "< 4 >" }
         };
+
+        [Test, TestCaseSource(nameof(SuccessData))]
+        public void SucceedsWithGoodValues(object actualValue)
+        {
+            Assert.That(actualValue, TheConstraint);
+        }
+
+        [Test, TestCaseSource(nameof(FailureData))]
+        public void FailsWithBadValues(object badActualValue, string actualMessage, string missingMessage)
+        {
+            var constraintResult = TheConstraint.ApplyTo(badActualValue);
+            Assert.IsFalse(constraintResult.IsSuccess);
+
+            TextMessageWriter writer = new TextMessageWriter();
+            constraintResult.WriteMessageTo(writer);
+            Assert.That(writer.ToString(), Is.EqualTo(
+                TextMessageWriter.Pfx_Expected + ExpectedDescription + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + actualMessage + Environment.NewLine +
+                "  Missing items: " + missingMessage + Environment.NewLine));
+        }
 
         [Test]
         [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
-        public void HonorsIgnoreCase( IEnumerable expected, IEnumerable actual )
+        public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
         {
-            var constraint = new CollectionSupersetConstraint( expected ).IgnoreCase;
-            var constraintResult = constraint.ApplyTo( actual );
-            if ( !constraintResult.IsSuccess )
+            var constraint = new CollectionSupersetConstraint(expected).IgnoreCase;
+            var constraintResult = constraint.ApplyTo(actual);
+            if (!constraintResult.IsSuccess)
             {
                 MessageWriter writer = new TextMessageWriter();
-                constraintResult.WriteMessageTo( writer );
-                Assert.Fail( writer.ToString() );
+                constraintResult.WriteMessageTo(writer);
+                Assert.Fail(writer.ToString());
             }
         }
 
@@ -76,7 +97,7 @@ namespace NUnit.Framework.Constraints
                 get
                 {
                     yield return new TestCaseData(new SimpleObjectCollection("z", "Y", "X"), new SimpleObjectCollection("w", "x", "y", "z"));
-                    yield return new TestCaseData(new object[] {'a', 'b', 'c'}, new[] {'A', 'B', 'C', 'D', 'E'});
+                    yield return new TestCaseData(new object[] { 'a', 'b', 'c' }, new[] { 'A', 'B', 'C', 'D', 'E' });
                     yield return new TestCaseData(new object[] { "A", "C", "B" }, new[] { "a", "b", "c", "d", "e" });
                     yield return new TestCaseData(new Dictionary<int, string> { { 1, "A" } }, new Dictionary<int, string> { { 1, "a" }, { 2, "b" } });
                     yield return new TestCaseData(new Dictionary<int, char> { { 1, 'a' } }, new Dictionary<int, char> { { 1, 'A' }, { 2, 'B' } });


### PR DESCRIPTION
Provide extra/missing items to `CollectionSubsetConstraint` and `CollectionSupersetConstraint` failure messages.

E.g.
```
  Expected: subset of < 1, 2, 3, 4, 5 >
  But was:  < 1, 2, 2, 2, 5 >
  Extra items: < 2, 2 >        <------ ADDED
```
