### PR TITLE
ValueTuple tests now running if not targeting NET35

### DIFF
--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(s, Is.EqualTo(expectedResult));
         }
 
-#if NET45
+#if !NET35
         [Test]
         public static void FormatValue_EmptyValueTupleTest()
         {
@@ -207,9 +207,7 @@ namespace NUnit.Framework.Constraints
             string s = MsgUtils.FormatValue(tuple);
             Assert.That(s, Is.EqualTo("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, \"12\", 13, 14, \"15\")"));
         }
-#endif
 
-#if !NET35
         [Test]
         public static void FormatValue_OneElementTupleTest()
         {


### PR DESCRIPTION
The value tuple tests were setup to only run for NET45. Seems like they pass for me in the tests as far back as NET40, due to the inclusion of `System.ValueTuple` as a test dependency. This PR switches up the conditional compilation so that they run `#if !NET35` instead of the previous `#if NET45`.

I'm unsure if it can be expanded further so that the ValueTuple + Tuple tests are run on NET35 too.