### PR TITLE
Sign the NuGet Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ PortabilityAnalysis*.html
 project.lock.json
 *.project.lock.json
 .dotnet
+.config/dotnet-tools.json

--- a/build.cake
+++ b/build.cake
@@ -371,7 +371,7 @@ Task("InstallSigningTool")
 Task("SignPackages")
     .Description("Signs the NuGet packages")
     .IsDependentOn("InstallSigningTool")
-    //.IsDependentOn("PackageFramework")
+    .IsDependentOn("PackageFramework")
     .Does(() =>
     {
         // Get the secret.
@@ -379,14 +379,12 @@ Task("SignPackages")
         if(string.IsNullOrWhiteSpace(secret)) {
             throw new InvalidOperationException("Could not resolve signing secret.");
         }
-        Information($"Signing secret: {secret}");
 
         // Get the user.
         var user = EnvironmentVariable("SIGNING_USER");
         if(string.IsNullOrWhiteSpace(user)) {
             throw new InvalidOperationException("Could not resolve signing user.");
         }
-        Information($"Signing user: {user}");
 
         var signClientPath = Context.Tools.Resolve("SignClient.exe") ?? Context.Tools.Resolve("SignClient") ?? throw new Exception("Failed to locate sign tool");
 

--- a/build.cake
+++ b/build.cake
@@ -354,6 +354,72 @@ Task("PackageZip")
         Zip(CurrentImageDir, File(ZIP_PACKAGE), zipFiles);
     });
 
+Task("CreateToolManifest")
+    .Does(() =>
+    {
+        var result = StartProcess("dotnet.exe", new ProcessSettings {  Arguments = "new tool-manifest --force" });
+    });
+
+Task("InstallSigningTool")
+    .Description("Installs the signing tool")
+    .IsDependentOn("CreateToolManifest")
+    .Does(() =>
+    {
+        var result = StartProcess("dotnet.exe", new ProcessSettings {  Arguments = "tool install SignClient" });
+    });
+
+Task("SignPackages")
+    .Description("Signs the NuGet packages")
+    .IsDependentOn("InstallSigningTool")
+    //.IsDependentOn("PackageFramework")
+    .Does(() =>
+    {
+        // Get the secret.
+        var secret = EnvironmentVariable("SIGNING_SECRET");
+        if(string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("Could not resolve signing secret.");
+        }
+        Information($"Signing secret: {secret}");
+
+        // Get the user.
+        var user = EnvironmentVariable("SIGNING_USER");
+        if(string.IsNullOrWhiteSpace(user)) {
+            throw new InvalidOperationException("Could not resolve signing user.");
+        }
+        Information($"Signing user: {user}");
+
+        var signClientPath = Context.Tools.Resolve("SignClient.exe") ?? Context.Tools.Resolve("SignClient") ?? throw new Exception("Failed to locate sign tool");
+
+        var settings = File("./signclient.json");
+
+        // Get the files to sign.
+        var files = GetFiles(string.Concat(PACKAGE_DIR, "*.nupkg"));
+
+        foreach(var file in files)
+        {
+            Information("Signing {0}...", file.FullPath);
+
+            // Build the argument list.
+            var arguments = new ProcessArgumentBuilder()
+                .Append("sign")
+                .AppendSwitchQuoted("-c", MakeAbsolute(settings.Path).FullPath)
+                .AppendSwitchQuoted("-i", MakeAbsolute(file).FullPath)
+                .AppendSwitchQuotedSecret("-s", secret)
+                .AppendSwitchQuotedSecret("-r", user)
+                .AppendSwitchQuoted("-n", "NUnit.org")
+                .AppendSwitchQuoted("-d", "NUnit is a unit-testing framework for all .NET languages.")
+                .AppendSwitchQuoted("-u", "https://nunit.org/");
+
+            // Sign the binary.
+            var result = StartProcess(signClientPath.FullPath, new ProcessSettings {  Arguments = arguments });
+            if(result != 0)
+            {
+                // We should not recover from this.
+                throw new InvalidOperationException("Signing failed!");
+            }
+        }
+    });
+
 //////////////////////////////////////////////////////////////////////
 // UPLOAD ARTIFACTS
 //////////////////////////////////////////////////////////////////////

--- a/signclient.json
+++ b/signclient.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+      "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+    },
+    "Service": {
+      "Url": "https://codesign.dotnetfoundation.org/",
+      "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3393 

## To Sign the Packages

Set the `SIGNING_USER` and `SIGNING_SECRET` environment variables from the .NET Foundation Lastpass info. Or set as variables in the build pipeline. If using Powershell;

```powershell
$env:SIGNING_SECRET = '<password>'
$env:SIGNING_USER = '<user>'
```

Next, run the `SignPackages` build target which will create the NuGet packages and submit them for signing.

## Upload the Certificates to NuGet

If the current certificates have not been uploaded to NuGet yet, you must export them from the signed packages and upload them to your account on NuGet.org.

1. Open the signed NuGet package in NuGet Package Explorer
2. In the Metadata section, click on TIMESTAMP-SHA256-<DATE> and Install Certificate
3. Windows Key, search for Certificates and select Manage Computer Certificates
4. Browse to Other People > Certificates
5. Right click the TIMESTAMP-SHA256-<DATE>, All Tasks > Export
6. Export as a CER
7. In https://www.nuget.org/, log in
8. Account Settings > Certificates
9. Register new and upload the CER file

## Future Plans

I hope to setup a deployment or build pipeline that only builds the release branch and signs the packages. I will then put branch restrictions on the release branch so that only trusted team members can build the packages. Once this is working, we can either manually upload the packages from the resulting artifacts, or setup a deployment pipeline to NuGet.org, likely with a project lead approval stage.