### PR TITLE
use base method instead of as

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -382,7 +382,7 @@ namespace NUnit.Framework
             /// </summary>
             public string? MethodName
             {
-                get { return (_test as TestMethod)?.Method.Name; }
+                get { return _test.Method?.Name; }
             }
 
             /// <summary>


### PR DESCRIPTION
isnt the downcast redundant, and instead the base can be used?