### PR TITLE
Disables the DOC100 suggestion and reverts the added paragraph elements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,3 +116,6 @@ dotnet_sort_system_directives_first = true
 # https://github.com/nunit/docs/wiki/Coding-Standards#use-of-the-var-keyword
 # Would be true:warning, except that that so much existing code is not consistent with the coding standard.
 csharp_style_var_when_type_is_apparent = true:suggestion
+
+# DOC100: Place text in paragraphs
+dotnet_diagnostic.DOC100.severity = silent

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -581,7 +581,7 @@ namespace NUnit.Framework.Api
             /// <param name="controller">The FrameworkController for which a run is to be stopped.</param>
             /// <param name="force">True the stop should be forced, false for a cooperative stop.</param>
             /// <param name="handler">>A callback handler used to report results</param>
-            /// <remarks><para>A forced stop will cause threads and processes to be killed as needed.</para></remarks>
+            /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
             public StopRunAction(FrameworkController controller, bool force, object handler)
             {
                 controller.StopRun((ICallbackEventHandler)handler, force);

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -219,8 +219,8 @@ namespace NUnit.Framework.Api
         /// <param name="listener">Interface to receive EventListener notifications.</param>
         /// <param name="filter">A test filter used to select tests to be run</param>
         /// <remarks>
-        /// <para>RunAsync is a template method, calling various abstract and
-        /// virtual methods to be overridden by derived classes.</para>
+        /// RunAsync is a template method, calling various abstract and
+        /// virtual methods to be overridden by derived classes.
         /// </remarks>
         public void RunAsync(ITestListener listener, ITestFilter filter)
         {

--- a/src/NUnitFramework/framework/Assert.Conditions.cs
+++ b/src/NUnitFramework/framework/Assert.Conditions.cs
@@ -209,8 +209,8 @@ namespace NUnit.Framework
         #region NotNull
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -221,8 +221,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         public static void NotNull(object? anObject)
@@ -231,8 +231,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -243,8 +243,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         public static void IsNotNull(object? anObject)
@@ -257,8 +257,8 @@ namespace NUnit.Framework
         #region Null
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -269,8 +269,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         public static void Null(object? anObject)
@@ -279,8 +279,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -291,8 +291,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the object that is passed in is equal to <see langword="null"/> . Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the object that is passed in is equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
         public static void IsNull(object? anObject)
@@ -305,8 +305,8 @@ namespace NUnit.Framework
         #region IsNaN
 
         /// <summary>
-        /// <para>Verifies that the double that is passed in is an <c>NaN</c>. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the double that is passed in is an <c>NaN</c>. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -317,8 +317,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double aDouble)
@@ -327,8 +327,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
@@ -339,8 +339,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// <para>Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
-        /// exception when inside a multiple assert block.</para>
+        /// Verifies that the double that is passed in is an <c>NaN</c> value. Returns without throwing an
+        /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double? aDouble)

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -272,8 +272,8 @@ namespace NUnit.Framework
         /// error.
         /// </summary>
         /// <remarks>
-        /// <para>This method is provided for use by VB developers needing to test the value of properties with private
-        /// setters.</para>
+        /// This method is provided for use by VB developers needing to test the value of properties with private
+        /// setters.
         /// </remarks>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -56,9 +56,9 @@ namespace NUnit.Framework
         /// "2014-12-25". If just a date is given, the Ignore will expire at midnight UTC.
         /// </summary>
         /// <remarks>
-        /// <para>Once the ignore until date has passed, the test will be marked
+        /// Once the ignore until date has passed, the test will be marked
         /// as runnable. Tests with an ignore until date will have an IgnoreUntilDate
-        /// property set which will appear in the test results.</para>
+        /// property set which will appear in the test results.
         /// </remarks>
         /// <exception cref="FormatException">The string does not contain a valid string representation of a date and time.</exception> 
         public string? Until

--- a/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
+++ b/src/NUnitFramework/framework/Compatibility/ReflectionExtensions.cs
@@ -32,8 +32,8 @@ namespace NUnit.Compatibility
     /// across multiple frameworks
     /// </summary>
     /// <remarks>
-    /// <para>This version of the class supplies GetTypeInfo() on platforms
-    /// that don't support it.</para>
+    /// This version of the class supplies GetTypeInfo() on platforms
+    /// that don't support it.
     /// </remarks>
     public static class TypeExtensions
     {

--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/ConcurrentQueue.cs
@@ -38,8 +38,8 @@ namespace System.Collections.Concurrent
     /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the queue.</typeparam>
     /// <remarks>
-    /// <para>All public  and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
-    /// concurrently from multiple threads.</para>
+    /// All public  and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
+    /// concurrently from multiple threads.
     /// </remarks>
     [ComVisible(false)]
     [DebuggerDisplay("Count = {Count}")]
@@ -224,9 +224,9 @@ namespace System.Collections.Concurrent
         /// reference (Nothing in Visual Basic) for reference types.
         /// </param>
         /// <returns>true if the object was added successfully; otherwise, false.</returns>
-        /// <remarks><para>For <see cref="ConcurrentQueue{T}"/>, this operation will always add the object to the
+        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will always add the object to the
         /// end of the <see cref="ConcurrentQueue{T}"/>
-        /// and return true.</para></remarks>
+        /// and return true.</remarks>
         bool IProducerConsumerCollection<T>.TryAdd(T item)
         {
             Enqueue(item);
@@ -242,8 +242,8 @@ namespace System.Collections.Concurrent
         /// object removed. If no object was available to be removed, the value is unspecified.
         /// </param>
         /// <returns>true if an element was removed and returned successfully; otherwise, false.</returns>
-        /// <remarks><para>For <see cref="ConcurrentQueue{T}"/>, this operation will attempt to remove the object
-        /// from the beginning of the <see cref="ConcurrentQueue{T}"/>.</para>
+        /// <remarks>For <see cref="ConcurrentQueue{T}"/>, this operation will attempt to remove the object
+        /// from the beginning of the <see cref="ConcurrentQueue{T}"/>.
         /// </remarks>
         bool IProducerConsumerCollection<T>.TryTake(out T item)
         {
@@ -255,11 +255,11 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <value>true if the <see cref="ConcurrentQueue{T}"/> is empty; otherwise, false.</value>
         /// <remarks>
-        /// <para>For determining whether the collection contains any items, use of this property is recommended
+        /// For determining whether the collection contains any items, use of this property is recommended
         /// rather than retrieving the number of items from the <see cref="Count"/> property and comparing it
         /// to 0.  However, as this collection is intended to be accessed concurrently, it may be the case
         /// that another thread will modify the collection after <see cref="IsEmpty"/> returns, thus invalidating
-        /// the result.</para>
+        /// the result.
         /// </remarks>
         public bool IsEmpty
         {
@@ -388,9 +388,9 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <value>The number of elements contained in the <see cref="ConcurrentQueue{T}"/>.</value>
         /// <remarks>
-        /// <para>For determining whether the collection contains any items, use of the <see cref="IsEmpty"/>
+        /// For determining whether the collection contains any items, use of the <see cref="IsEmpty"/>
         /// property is recommended rather than retrieving the number of items from the <see cref="Count"/>
-        /// property and comparing it to 0.</para>
+        /// property and comparing it to 0.
         /// </remarks>
         public int Count
         {
@@ -461,10 +461,10 @@ namespace System.Collections.Concurrent
         /// <returns>An enumerator for the contents of the <see
         /// cref="ConcurrentQueue{T}"/>.</returns>
         /// <remarks>
-        /// <para>The enumeration represents a moment-in-time snapshot of the contents
+        /// The enumeration represents a moment-in-time snapshot of the contents
         /// of the queue.  It does not reflect any updates to the collection after
         /// GetEnumerator was called.  The enumerator is safe to use
-        /// concurrently with reads from and writes to the queue.</para>
+        /// concurrently with reads from and writes to the queue.
         /// </remarks>
         public IEnumerator<T> GetEnumerator()
         {
@@ -763,8 +763,8 @@ namespace System.Collections.Concurrent
             /// </summary>
             /// <param name="value">the element to append</param>
             /// <returns>true if the element is appended, false if the current segment is full</returns>
-            /// <remarks><para>if appending the specified element succeeds, and after which the segment is full,
-            /// then grow the segment</para></remarks>
+            /// <remarks>if appending the specified element succeeds, and after which the segment is full,
+            /// then grow the segment</remarks>
             internal bool TryAppend(T value)
             {
                 //quickly check if m_high is already over the boundary, if so, bail out

--- a/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Collections.Concurrent/IProducerConsumerCollection.cs
@@ -26,8 +26,8 @@ namespace System.Collections.Concurrent
     /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
     /// <remarks>
-    /// <para>All implementations of this interface must enable all members of this interface
-    /// to be used concurrently from multiple threads.</para>
+    /// All implementations of this interface must enable all members of this interface
+    /// to be used concurrently from multiple threads.
     /// </remarks>
     internal interface IProducerConsumerCollection<T> : IEnumerable<T>, ICollection
     {

--- a/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
+++ b/src/NUnitFramework/framework/Compatibility/System.Threading/SpinWait.cs
@@ -102,8 +102,8 @@ namespace System.Threading
         /// <value>Whether the next call to <see cref="SpinOnce"/> will yield the processor, triggering a
         /// forced context switch.</value>
         /// <remarks>
-        /// <para>On a single-CPU machine, <see cref="SpinOnce"/> always yields the processor. On machines with
-        /// multiple CPUs, <see cref="SpinOnce"/> may yield after an unspecified number of calls.</para>
+        /// On a single-CPU machine, <see cref="SpinOnce"/> always yields the processor. On machines with
+        /// multiple CPUs, <see cref="SpinOnce"/> may yield after an unspecified number of calls.
         /// </remarks>
         public bool NextSpinWillYield
         {
@@ -114,8 +114,8 @@ namespace System.Threading
         /// Performs a single spin.
         /// </summary>
         /// <remarks>
-        /// <para>This is typically called in a loop, and may change in behavior based on the number of times a
-        /// <see cref="SpinOnce"/> has been called thus far on this instance.</para>
+        /// This is typically called in a loop, and may change in behavior based on the number of times a
+        /// <see cref="SpinOnce"/> has been called thus far on this instance.
         /// </remarks>
         public void SpinOnce()
         {
@@ -180,9 +180,9 @@ namespace System.Threading
         /// Resets the spin counter.
         /// </summary>
         /// <remarks>
-        /// <para>This makes <see cref="SpinOnce"/> and <see cref="NextSpinWillYield"/> behave as though no calls
+        /// This makes <see cref="SpinOnce"/> and <see cref="NextSpinWillYield"/> behave as though no calls
         /// to <see cref="SpinOnce"/> had been issued on this instance. If a <see cref="SpinWait"/> instance
-        /// is reused many times, it may be useful to reset it to avoid yielding too soon.</para>
+        /// is reused many times, it may be useful to reset it to avoid yielding too soon.
         /// </remarks>
         public void Reset()
         {

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -172,8 +172,8 @@ namespace NUnit.Framework.Constraints
         /// property in comparison of two <see cref="DateTimeOffset"/> values.
         /// </summary>
         /// <remarks>
-        /// <para>Using this modifier does not allow to use the <see cref="Within"/>
-        /// constraint modifier.</para>
+        /// Using this modifier does not allow to use the <see cref="Within"/>
+        /// constraint modifier.
         /// </remarks>
         public EqualConstraint WithSameOffset
         {
@@ -190,13 +190,13 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <returns>Self.</returns>
         /// <remarks>
-        /// <para>Ulp stands for "unit in the last place" and describes the minimum
+        /// Ulp stands for "unit in the last place" and describes the minimum
         /// amount a given value can change. For any integers, an ulp is 1 whole
         /// digit. For floating point values, the accuracy of which is better
         /// for smaller numbers and worse for larger numbers, an ulp depends
         /// on the size of the number. Using ulps for comparison of floating
         /// point results instead of fixed tolerances is safer because it will
-        /// automatically compensate for the added inaccuracy of larger numbers.</para>
+        /// automatically compensate for the added inaccuracy of larger numbers.
         /// </remarks>
         public EqualConstraint Ulps
         {

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     /// <param name="next">The next formatter function</param>
     /// <returns>ValueFormatter</returns>
-    /// <remarks><para>If the given formatter is unable to handle a certain format, it must call the next formatter in the chain</para></remarks>
+    /// <remarks>If the given formatter is unable to handle a certain format, it must call the next formatter in the chain</remarks>
     public delegate ValueFormatter ValueFormatterFactory(ValueFormatter next);
 
     /// <summary>

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -144,8 +144,8 @@ namespace NUnit.Framework.Constraints
         /// property in comparison of two <see cref="DateTimeOffset"/> values.
         /// </summary>
         /// <remarks>
-        /// <para>Using this modifier does not allow to use the <see cref="Tolerance"/>
-        /// modifier.</para>
+        /// Using this modifier does not allow to use the <see cref="Tolerance"/>
+        /// modifier.
         /// </remarks>
         public bool WithSameOffset { get; set; }
         #endregion

--- a/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
+++ b/src/NUnitFramework/framework/Interfaces/ICommandWrapper.cs
@@ -32,10 +32,10 @@ namespace NUnit.Framework.Interfaces
     /// objects able to wrap a TestCommand with another command.
     /// </summary>
     /// <remarks>
-    /// <para>Attributes or other objects should implement one of the
+    /// Attributes or other objects should implement one of the
     /// derived interfaces, rather than this one, since they
     /// indicate in which part of the command chain the wrapper
-    /// should be applied.</para>
+    /// should be applied.
     /// </remarks>
     public interface ICommandWrapper
     {

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -186,7 +186,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets the assembly path from code base.
         /// </summary>
-        /// <remarks><para>Public for testing purposes</para></remarks>
+        /// <remarks>Public for testing purposes</remarks>
         /// <param name="codeBase">The code base.</param>
         /// <returns></returns>
         public static string GetAssemblyPathFromCodeBase(string codeBase)

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -138,8 +138,8 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="parms">Parameters to be used for this test, or null</param>
         /// <returns>True if the method signature is valid, false if not</returns>
         /// <remarks>
-        /// <para>The return value is no longer used internally, but is retained
-        /// for testing purposes.</para>
+        /// The return value is no longer used internally, but is retained
+        /// for testing purposes.
         /// </remarks>
         private static bool CheckTestMethodSignature(TestMethod testMethod, TestCaseParameters? parms)
         {

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -99,10 +99,10 @@ namespace NUnit.Framework.Internal.Execution
         /// before executing the WorkItem.
         /// </summary>
         /// <remarks>
-        /// <para>Originally, the context was provided in the constructor
+        /// Originally, the context was provided in the constructor
         /// but delaying initialization of the context until the item
         /// is about to be dispatched allows changes in the parent
-        /// context during OneTimeSetUp to be reflected in the child.</para>
+        /// context during OneTimeSetUp to be reflected in the child.
         /// </remarks>
         /// <param name="context">The TestExecutionContext to use</param>
         public void InitializeContext(TestExecutionContext context)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -103,13 +103,13 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Gets a list of the queues associated with this shift.
         /// </summary>
-        /// <remarks><para>Internal for testing - immutable once initialized</para></remarks>
+        /// <remarks>Internal for testing - immutable once initialized</remarks>
         internal IList<WorkItemQueue> Queues { get; } = new List<WorkItemQueue>();
 
         /// <summary>
         /// Gets the list of workers associated with this shift.
         /// </summary>
-        /// <remarks><para>Internal for testing - immutable once initialized</para></remarks>
+        /// <remarks>Internal for testing - immutable once initialized</remarks>
         internal IList<TestWorker> Workers { get; } = new List<TestWorker>();
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -107,10 +107,10 @@ namespace NUnit.Framework.Internal
         /// returned for Win 8.1 and Win 10
         /// </summary>
         /// <remarks>
-        /// <para>If an application is not manifested as Windows 8.1 or Windows 10,
+        /// If an application is not manifested as Windows 8.1 or Windows 10,
         /// the version returned from Environment.OSVersion will not be 6.3 and 10.0
         /// respectively, but will be 6.2 and 6.3. The correct value can be found in
-        /// the registry.</para>
+        /// the registry.
         /// </remarks>
         /// <param name="version">The original version</param>
         /// <returns>The correct OS version</returns>

--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -42,13 +42,13 @@ namespace NUnit.Framework.Internal
     /// the TestContext.Random property.
     /// </summary>
     /// <remarks>
-    /// <para>For consistency with the underlying Random Type, methods
+    /// For consistency with the underlying Random Type, methods
     /// returning a single value use the prefix "Next..." Those
     /// without an argument return a non-negative value up to
     /// the full positive range of the Type. Overloads are provided
     /// for specifying a maximum or a range. Methods that return
     /// arrays or strings use the prefix "Get..." to avoid
-    /// confusion with the single-value methods.</para>
+    /// confusion with the single-value methods.
     /// </remarks>
     public class Randomizer : Random
     {
@@ -508,7 +508,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Default characters for random functions.
         /// </summary>
-        /// <remarks><para>Default characters are the English alphabet (uppercase &amp; lowercase), Arabic numerals, and underscore</para></remarks>
+        /// <remarks>Default characters are the English alphabet (uppercase &amp; lowercase), Arabic numerals, and underscore</remarks>
         public const string DefaultStringChars = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ0123456789_";
 
         private const int DefaultStringLength = 25;
@@ -534,7 +534,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="outputLength">desired length of output string.</param>
         /// <returns>A random string of arbitrary length</returns>
-        /// <remarks><para>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set</para> </remarks>
+        /// <remarks>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set </remarks>
         public string GetString(int outputLength)
         {
             return GetString(outputLength, DefaultStringChars);
@@ -544,7 +544,7 @@ namespace NUnit.Framework.Internal
         /// Generate a random string based on the characters from the input string.
         /// </summary>
         /// <returns>A random string of the default length</returns>
-        /// <remarks><para>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set</para> </remarks>
+        /// <remarks>Uses <see cref="DefaultStringChars">DefaultStringChars</see> as the input character set </remarks>
         public string GetString()
         {
             return GetString(DefaultStringLength, DefaultStringChars);
@@ -641,8 +641,8 @@ namespace NUnit.Framework.Internal
         /// permitted to exceed decimal.MaxVal in the current implementation.
         /// </summary>
         /// <remarks>
-        /// <para>A limitation of this implementation is that the range from min
-        /// to max must not exceed decimal.MaxVal.</para>
+        /// A limitation of this implementation is that the range from min
+        /// to max must not exceed decimal.MaxVal.
         /// </remarks>
         public decimal NextDecimal(decimal min, decimal max)
         {

--- a/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
+++ b/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
@@ -40,8 +40,8 @@ namespace NUnitLite
         /// Default constructor using Console.Out
         /// </summary>
         /// <remarks>
-        /// <para>This constructor must be called before Console.Out is
-        /// redirected in order to work correctly under TeamCity.</para>
+        /// This constructor must be called before Console.Out is
+        /// redirected in order to work correctly under TeamCity.
         /// </remarks>
         public TeamCityEventListener() : this(Console.Out) { }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -201,8 +201,8 @@ namespace NUnit.Framework.Constraints
         /// extra and missing elements when the collections are not equivalent.
         /// </summary>
         /// <remarks>
-        /// <para>This is not intended to fully test the display of missing/extra elements, but to ensure
-        /// that the functionality is actually there.</para>
+        /// This is not intended to fully test the display of missing/extra elements, but to ensure
+        /// that the functionality is actually there.
         /// </remarks>
         [Test]
         public void TestConstraintResultMessageDisplaysMissingAndExtraElements()


### PR DESCRIPTION
Requested by @oznetmaster at https://github.com/nunit/nunit/pull/3550#issuecomment-631098546

We may end up putting some paragraph elements back in and possibly find it useful to reenable this suggestion depending on what we learn from using docfx, but I have no problem with waiting until then to add them.