### PR TITLE
throws async should return a task

### DIFF
--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -26,6 +26,7 @@
 #nullable enable
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
@@ -43,12 +44,12 @@ namespace NUnit.Framework
         /// <param name="code">A TestSnippet delegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static async Task<Exception?> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string? message, params object?[]? args)
         {
             Exception? caughtException = null;
             try
             {
-                AsyncToSyncAdapter.Await(code.Invoke);
+                await code();
             }
             catch (Exception e)
             {
@@ -66,7 +67,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expression">A constraint to be satisfied by the exception</param>
         /// <param name="code">A TestSnippet delegate</param>
-        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
+        public static Task<Exception?> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
         {
             return ThrowsAsync(expression, code, string.Empty, null);
         }
@@ -79,7 +80,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Task<Exception?> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -90,7 +91,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expectedExceptionType">The exception Type expected</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        public static Task<Exception?> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
         {
             return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, string.Empty, null);
         }
@@ -107,9 +108,9 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
+        public static async Task<TActual?> ThrowsAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(typeof (TActual), code, message, args);
+            return (TActual?) await ThrowsAsync(typeof (TActual), code, message, args);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <typeparam name="TActual">Type of the expected exception</typeparam>
         /// <param name="code">A TestDelegate</param>
-        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
+        public static Task<TActual?> ThrowsAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
         {
             return ThrowsAsync<TActual>(code, string.Empty, null);
         }
@@ -134,7 +135,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? CatchAsync(AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Task<Exception?> CatchAsync(AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
         }
@@ -144,7 +145,7 @@ namespace NUnit.Framework
         /// be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static Exception? CatchAsync(AsyncTestDelegate code)
+        public static Task<Exception?> CatchAsync(AsyncTestDelegate code)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code);
         }
@@ -157,7 +158,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Task<Exception?> CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -168,7 +169,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="expectedExceptionType">The expected Exception Type</param>
         /// <param name="code">A TestDelegate</param>
-        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        public static Task<Exception?> CatchAsync(Type expectedExceptionType, AsyncTestDelegate code)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code);
         }
@@ -184,9 +185,9 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
+        public static async Task<TActual?> CatchAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code, message, args);
+            return (TActual?)await ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code, message, args);
         }
 
         /// <summary>
@@ -194,9 +195,9 @@ namespace NUnit.Framework
         /// returns it. The returned exception may be <see langword="null"/> when inside a multiple assert block.
         /// </summary>
         /// <param name="code">A TestDelegate</param>
-        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
+        public static async Task<TActual?> CatchAsync<TActual>(AsyncTestDelegate code) where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code);
+            return (TActual?)await ThrowsAsync(new InstanceOfTypeConstraint(typeof (TActual)), code);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -33,19 +33,19 @@ namespace NUnit.Framework.Assertions
     public class AssertThrowsAsyncTests
     {
         [Test]
-        public void ThrowsAsyncSucceedsWithDelegate()
+        public async Task ThrowsAsyncSucceedsWithDelegate()
         {
-            Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentException);
-            Assert.ThrowsAsync(typeof(ArgumentException),
+            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentException);
+            await Assert.ThrowsAsync(typeof(ArgumentException),
                 delegate { throw new ArgumentException(); });
         }
 
         [Test]
-        public void GenericThrowsAsyncSucceedsWithDelegate()
+        public async Task GenericThrowsAsyncSucceedsWithDelegate()
         {
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 delegate { throw new ArgumentException(); });
-            Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
+            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
         }
 
         [Test]
@@ -60,26 +60,26 @@ namespace NUnit.Framework.Assertions
         public async Task AsyncRegionThrowsDoesNotDisposeAsyncRegion()
         {
             await AsyncTestDelegates.Delay(100);
-            Assert.ThrowsAsync<ArgumentException>(async () => await AsyncTestDelegates.ThrowsArgumentExceptionAsync());
+            await Assert.ThrowsAsync<ArgumentException>(async () => await AsyncTestDelegates.ThrowsArgumentExceptionAsync());
             Assert.That(async () => await AsyncTestDelegates.ThrowsArgumentExceptionAsync(), Throws.ArgumentException);
         }
 
         [Test]
-        public void ThrowsAsyncReturnsCorrectException()
+        public async Task ThrowsAsyncReturnsCorrectException()
         {
-            Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
-            Assert.ThrowsAsync(typeof(ArgumentException),
+            await Assert.ThrowsAsync(typeof(ArgumentException), AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            await Assert.ThrowsAsync(typeof(ArgumentException),
                 delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }, TaskScheduler.Default); });
 
             CheckForSpuriousAssertionResults();
         }
 
         [Test]
-        public void GenericThrowsAsyncReturnsCorrectException()
+        public async Task GenericThrowsAsyncReturnsCorrectException()
         {
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException(); }, TaskScheduler.Default); });
-            Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
 
             CheckForSpuriousAssertionResults();
         }
@@ -96,30 +96,30 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void CorrectExceptionIsReturnedToMethod()
+        public async Task CorrectExceptionIsReturnedToMethod()
         {
-            ArgumentException ex = Assert.ThrowsAsync(typeof(ArgumentException),
+            ArgumentException ex = await Assert.ThrowsAsync(typeof(ArgumentException),
                 new AsyncTestDelegate(AsyncTestDelegates.ThrowsArgumentException)) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync<ArgumentException>(
+            ex = await Assert.ThrowsAsync<ArgumentException>(
                 delegate { throw new ArgumentException("myMessage", "myParam"); });
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync(typeof(ArgumentException),
+            ex = await Assert.ThrowsAsync(typeof(ArgumentException),
                 delegate { throw new ArgumentException("myMessage", "myParam"); }) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
+            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentException);
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -127,30 +127,30 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void CorrectExceptionIsReturnedToMethodAsync()
+        public async Task CorrectExceptionIsReturnedToMethodAsync()
         {
-            ArgumentException ex = Assert.ThrowsAsync(typeof(ArgumentException),
-                new AsyncTestDelegate(AsyncTestDelegates.ThrowsArgumentExceptionAsync)) as ArgumentException;
+            ArgumentException ex = await Assert.ThrowsAsync(typeof(ArgumentException),
+                AsyncTestDelegates.ThrowsArgumentExceptionAsync) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync<ArgumentException>(
+            ex = await Assert.ThrowsAsync<ArgumentException>(
                 delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }, TaskScheduler.Default); });
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync(typeof(ArgumentException),
+            ex = await Assert.ThrowsAsync(typeof(ArgumentException),
                 delegate { return AsyncTestDelegates.Delay(5).ContinueWith(t => { throw new ArgumentException("myMessage", "myParam"); }, TaskScheduler.Default); }) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
             Assert.That(ex.ParamName, Is.EqualTo("myParam"));
 
-            ex = Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
+            ex = await Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsArgumentExceptionAsync);
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
             Assert.That(ex.Message, Does.StartWith("myMessage"));
@@ -159,9 +159,9 @@ namespace NUnit.Framework.Assertions
 
 
         [Test]
-        public void NoExceptionThrown()
+        public async Task NoExceptionThrown()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
             Assert.That(ex.Message, Is.EqualTo(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine));
@@ -170,9 +170,9 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void UnrelatedExceptionThrown()
+        public async Task UnrelatedExceptionThrown()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceException));
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
@@ -181,9 +181,9 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void UnrelatedExceptionThrownAsync()
+        public async Task UnrelatedExceptionThrownAsync()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
@@ -192,9 +192,9 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void BaseExceptionThrown()
+        public async Task BaseExceptionThrown()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemException));
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
@@ -203,18 +203,18 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void BaseExceptionThrownAsync()
+        public async Task BaseExceptionThrownAsync()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
+            var ex = await CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
         }
 
         [Test, SetUICulture("en-US")]
-        public void DerivedExceptionThrown()
+        public async Task DerivedExceptionThrown()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentException));
+            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentException));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: myMessage"));
@@ -223,9 +223,9 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test, SetUICulture("en-US")]
-        public void DerivedExceptionThrownAsync()
+        public async Task DerivedExceptionThrownAsync()
         {
-            var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
+            var ex = await CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
             Assert.That(ex.Message, Does.StartWith(
                 "  Expected: <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: myMessage"));
@@ -262,6 +262,21 @@ namespace NUnit.Framework.Assertions
                 "Spurious result left by Assert.Fail()");
         }
 
+        private async Task<Exception> CatchException(AsyncTestDelegate del)
+        {
+            using (new TestExecutionContext.IsolatedContext())
+            {
+                try
+                {
+                    await del();
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            }
+        }
         private Exception CatchException(TestDelegate del)
         {
             using (new TestExecutionContext.IsolatedContext())

--- a/src/NUnitFramework/tests/AsyncExecutionApiAdapter.Assert-based.cs
+++ b/src/NUnitFramework/tests/AsyncExecutionApiAdapter.Assert-based.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework
                 {
                     try
                     {
-                        ex = Assert.ThrowsAsync<Exception>(asyncUserCode);
+                        ex = Assert.ThrowsAsync<Exception>(asyncUserCode).GetAwaiter().GetResult();
                     }
                     catch { }
                 }
@@ -68,7 +68,7 @@ namespace NUnit.Framework
                 {
                     try
                     {
-                        ex = Assert.CatchAsync(asyncUserCode);
+                        ex = Assert.CatchAsync(asyncUserCode).GetAwaiter().GetResult();
                     }
                     catch { }
                 }


### PR DESCRIPTION
There seems to be quite a bit of legacy code around converting async to sync APIs. give nunit now supports tests returning a task, shouldnt most of that code be removed?