### PR TITLE
Avoid using a culture-sensitive EndsWith in common code

### DIFF
--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -365,7 +365,7 @@ namespace NUnit.Framework.Internal
         {
             string typeName = type.FullName;
 
-            if (typeName.EndsWith("[]"))
+            if (typeName.EndsWith("[]", StringComparison.Ordinal))
                 return false;
 
             string typeNameWithoutGenerics = GetTypeNameWithoutGenerics(typeName);


### PR DESCRIPTION
This was causing a similar issue to #1555, due to TupleComparer and
ValueTupleComparer (in the NUnitEqualityComparer chain) calling into
TypeHelper.

(The impact for NodaTime is that tests on Linux in en-GB take 5-6
times as long as they should. We perform a lot of equality
comparisons which get as far as EquatablesComparer in the chain.)

It would be good to take a complete audit of StartsWith and EndsWith
calls (and maybe even have a Roslyn-based unit test to make sure
that any culture-sensitive calls are deliberately so), but I don't
have the expertise to make the calls for other parts of the
codebase. I'm pretty confident about this one :)