### PR TITLE
TestFixtureSource arguments usage in the TestCaseSource method

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -35,15 +35,6 @@ using NUnit.Framework.Internal.Builders;
 
 namespace NUnit.Framework
 {
-    public enum TestFixtureArgumentPlaceholder
-    {
-        Arg0,
-        Arg1,
-        Arg2,
-        Arg3
-    }
-
-
     /// <summary>
     /// Indicates the source to be used to provide test fixture instances for a test class.
     /// </summary>
@@ -283,7 +274,10 @@ namespace NUnit.Framework
             return null;
         }
 
-
+        /// <summary>
+        /// Ensures that the test case source generator method is called with correct arguments
+        /// and that exceptions are converted appropriately.
+        /// </summary>
         private IEnumerable InvokeTestCaseSourceMethod(MethodInfo method, object?[]? suiteArguments)
         {
             try
@@ -304,7 +298,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="methodParams">Method parameters specified.</param>
         /// <param name="suiteArguments">Arguments specified in the test fixture source.</param>
-        /// <exception cref="ArgumentException">Indicates incorrect configuration. </exception>
+        /// <exception cref="ArgumentException">Indicates parameters mismatch.</exception>
         private static object?[]? UpdateTestCaseSourceParameters(object?[]? methodParams, object?[]? suiteArguments)
         {
             // Case #1 : No parameters to call with.
@@ -324,25 +318,33 @@ namespace NUnit.Framework
             return result;
         }
 
+        /// <summary>
+        /// Attempts to replace specific parameter with respective fixture
+        /// argument if necessary.
+        /// </summary>
+        /// <param name="methodParam">Parameter to be replaced.</param>
+        /// <param name="suiteArguments">Arguments of the fixture.</param>
+        /// <exception cref="ArgumentException">If reference to fixture argument cannot be resolved.</exception>
+        /// <returns>Actual value to be passed to the test case source.</returns>
         private static object? SubstituteFixtureParameterIfNeeded(object? methodParam, object?[]? suiteArguments)
         {
-            if (!(methodParam is TestFixtureArgumentPlaceholder))
+            if (!(methodParam is TestFixtureArgumentRef))
             {
+                // Not a reference... return original value.
                 return methodParam;
             }
 
-            // Not a reference... return original value.
-
+            // It is a reference to an argument passed to the fixture.
+            // Find its index based on the value.
             int index = (int)methodParam;
 
-            // It is a reference to an argument passed to the fixture.
 
             if (index < 0 || null == suiteArguments || suiteArguments.Length <= index)
             {
                 throw new ArgumentException($"Unable to get a reference to fixture attribute at index {index}");
             }
 
-            // Substitute the parameter.
+            // And return corresponding fixture argument.
             return suiteArguments[index];
         }
 

--- a/src/NUnitFramework/framework/Attributes/TestFixtureArgumentRef.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureArgumentRef.cs
@@ -1,0 +1,79 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Represents reference to an argument
+    /// from the test fixture in form of 0-based
+    /// index. Used for forwarding values
+    /// to the test case sources.
+    ///
+    /// If your fixture contains more than 10 arguments
+    /// you can always cast any higher index
+    /// to <see cref="TestFixtureArgumentRef"/>
+    /// </summary>
+    public enum TestFixtureArgumentRef
+    {
+        /// <summary>
+        /// Argument at index 0
+        /// </summary>
+        Arg0 = 0,
+        /// <summary>
+        /// Argument at index 1
+        /// </summary>
+        Arg1 = 1,
+        /// <summary>
+        /// Argument at index 2
+        /// </summary>
+        Arg2 = 2,
+        /// <summary>
+        /// Argument at index 3
+        /// </summary>
+        Arg3 = 3,
+        /// <summary>
+        /// Argument at index 4
+        /// </summary>
+        Arg4 = 4,
+        /// <summary>
+        /// Argument at index 5
+        /// </summary>
+        Arg5 = 5,
+        /// <summary>
+        /// Argument at index 6
+        /// </summary>
+        Arg6 = 6,
+        /// <summary>
+        /// Argument at index 7
+        /// </summary>
+        Arg7 = 7,
+        /// <summary>
+        /// Argument at index 8
+        /// </summary>
+        Arg8 = 8,
+        /// <summary>
+        /// Argument at index 9
+        /// </summary>
+        Arg9 = 9
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceWithTestFixtureArgumentsTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceWithTestFixtureArgumentsTests.cs
@@ -1,0 +1,97 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Lukasz Skomial
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Attributes
+{
+    [TestFixtureSource(nameof(Fixtures))]
+    public class TestCaseSourceWithTestFixtureArgumentsTests
+    {
+        private const string FIXTURE_ARG1 = "fixture_arg_1";
+        private const string FIXTURE_ARG2 = "fixture_arg_2";
+        private const string FIXTURE_ARG3 = "fixture_arg_3";
+
+        private string[] FixtureArgs { get; } 
+        
+        public TestCaseSourceWithTestFixtureArgumentsTests(params string[] args)
+        {
+            FixtureArgs = args;
+        }
+
+        
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext), 
+            new object?[]{ FIXTURE_ARG1, TestFixtureArgumentPlaceholder.Arg0 })]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
+            new object?[] { FIXTURE_ARG3, TestFixtureArgumentPlaceholder.Arg2 })]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
+            new object?[] { "11", (TestFixtureArgumentPlaceholder) 10 })]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
+            new object?[] { "failure...", (TestFixtureArgumentPlaceholder) 1000})]
+        public void TestFixtureArgument(string expectedValue, string actualValue)
+        {
+
+        }
+
+
+
+        
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContextNumeric),
+            new object?[] { 0, 0 })]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContextNumeric),
+            new object?[] { 10, 10 })]
+        public void TestFixtureArgument2(int expectedValue, int actualValue)
+        {
+
+        }
+
+        [Test]
+        public void DummyTest()
+        {
+
+        }
+
+
+        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContextNumeric(int expectedValue, int actualValue)
+        {
+            yield return new TestCaseData(expectedValue, actualValue);
+        }
+
+        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContext(string expectedValue, string actualValue)
+        {
+            yield return new TestCaseData(expectedValue, actualValue);
+        }
+
+
+        public static IEnumerable<TestFixtureData> Fixtures
+        {
+            get
+            {
+                //yield return new TestFixtureData(FIXTURE_ARG1, FIXTURE_ARG2, FIXTURE_ARG3);
+                yield return new TestFixtureData(FIXTURE_ARG1, FIXTURE_ARG2, FIXTURE_ARG3, "4", "5", "6", "7", "8", "9", "10", "11");
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceWithTestFixtureArgumentsTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceWithTestFixtureArgumentsTests.cs
@@ -24,74 +24,118 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NUnit.Framework.Attributes
 {
-    [TestFixtureSource(nameof(Fixtures))]
+    [TestFixtureSource(nameof(TestFixturesSource))]
     public class TestCaseSourceWithTestFixtureArgumentsTests
     {
-        private const string FIXTURE_ARG1 = "fixture_arg_1";
-        private const string FIXTURE_ARG2 = "fixture_arg_2";
-        private const string FIXTURE_ARG3 = "fixture_arg_3";
+        private static string[] FixtureArgumentsSource { get; }
+        private const int NUMBER_OF_ARGS = 3;
 
-        private string[] FixtureArgs { get; } 
-        
-        public TestCaseSourceWithTestFixtureArgumentsTests(params string[] args)
+        static TestCaseSourceWithTestFixtureArgumentsTests()
         {
-            FixtureArgs = args;
+            string uniqueIdentifier = Guid.NewGuid().ToString("N");
+
+            FixtureArgumentsSource = new string[NUMBER_OF_ARGS];
+
+            for (int i = 0; i < NUMBER_OF_ARGS; i++)
+            {
+                FixtureArgumentsSource[i] = $"ARG_{i}_{uniqueIdentifier}";
+            }
         }
 
-        
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContext), 
-            new object?[]{ FIXTURE_ARG1, TestFixtureArgumentPlaceholder.Arg0 })]
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
-            new object?[] { FIXTURE_ARG3, TestFixtureArgumentPlaceholder.Arg2 })]
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
-            new object?[] { "11", (TestFixtureArgumentPlaceholder) 10 })]
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContext),
-            new object?[] { "failure...", (TestFixtureArgumentPlaceholder) 1000})]
-        public void TestFixtureArgument(string expectedValue, string actualValue)
-        {
-
-        }
-
-
-
-        
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContextNumeric),
-            new object?[] { 0, 0 })]
-        [TestCaseSource(nameof(TestCaseDataWithFixtureContextNumeric),
-            new object?[] { 10, 10 })]
-        public void TestFixtureArgument2(int expectedValue, int actualValue)
-        {
-
-        }
-
-        [Test]
-        public void DummyTest()
-        {
-
-        }
-
-
-        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContextNumeric(int expectedValue, int actualValue)
-        {
-            yield return new TestCaseData(expectedValue, actualValue);
-        }
-
-        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContext(string expectedValue, string actualValue)
-        {
-            yield return new TestCaseData(expectedValue, actualValue);
-        }
-
-
-        public static IEnumerable<TestFixtureData> Fixtures
+        public static IEnumerable<TestFixtureData> TestFixturesSource
         {
             get
             {
-                //yield return new TestFixtureData(FIXTURE_ARG1, FIXTURE_ARG2, FIXTURE_ARG3);
-                yield return new TestFixtureData(FIXTURE_ARG1, FIXTURE_ARG2, FIXTURE_ARG3, "4", "5", "6", "7", "8", "9", "10", "11");
+                for (int maxArgs = 0; maxArgs <= NUMBER_OF_ARGS; maxArgs++)
+                {
+                    string[] args = FixtureArgumentsSource.Take(maxArgs).ToArray();
+
+                    yield return new TestFixtureData(maxArgs, args).SetArgDisplayNames($"{maxArgs}_arguments_test");
+
+                }
             }
         }
+
+        /// <summary>
+        /// The actual arguments used to create the fixture.
+        /// </summary>
+        private string[] FixtureArgs { get; } 
+        private int FixtureNumberOfArgs { get; }
+
+        public TestCaseSourceWithTestFixtureArgumentsTests(int numberOfArgs, string[] args)
+        {
+            FixtureNumberOfArgs = numberOfArgs;
+            FixtureArgs = args;
+        }
+
+
+
+        /// <summary>
+        /// Checks that argument from fixture can
+        /// be passed to 
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext), new object[]{ TestFixtureArgumentRef.Arg0 })]
+        public void FixtureArgumentTest(int argumentIndex, int numberOfArguments)
+        {
+            Assert.AreEqual(FixtureNumberOfArgs, numberOfArguments);
+            Assert.AreEqual(FixtureArgs[argumentIndex], FixtureArgumentsSource[argumentIndex]);
+        }
+
+        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContext(int numberOfArgsFixtureWasCreatedWith)
+        {
+            for (int i = 0; i < numberOfArgsFixtureWasCreatedWith; i++)
+            {
+                yield return new TestCaseData(i, numberOfArgsFixtureWasCreatedWith)
+                    .SetArgDisplayNames($"Number of args : {i + 1} of {numberOfArgsFixtureWasCreatedWith} ");
+            }
+        }
+
+
+
+        /// <summary>
+        /// Checks that you can specify index as integer
+        /// and cast it to the enum and the correct
+        /// argument will be passed to the test case source method.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(TestCaseDataWithFixtureContext2), new object[] { (TestFixtureArgumentRef) 1 })]
+        public void FixtureArgumentAsIntegerTest(string argument, int index)
+        {
+            Assert.AreEqual(FixtureArgs[index], argument);
+        }
+
+        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContext2(string[] data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                yield return new TestCaseData(data[i], i)
+                    .SetArgDisplayNames($"Argument {i + 1} of {data.Length} validation.");
+            }
+        }
+
+
+        /// <summary>
+        /// Checks that integers are not
+        /// treated as parameters index.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(PassThroughMethod), new object[]{ 1, 0 })]
+        public void IntegerSourceArgumentsStillWorkAsExpected(int a, int b)
+        {
+            Assert.AreEqual(1, a);
+            Assert.AreEqual(0, b);
+        }
+
+
+        public static IEnumerable<TestCaseData> PassThroughMethod(int a, int b)
+        {
+            yield return new TestCaseData(a, b);
+        }
+
     }
 }


### PR DESCRIPTION
Hi,

I have found a need to use some information specific to `TestFixture` I'm in during `TestCaseSource` generation code.
It might be something that is being discussed in #2950 

The solution presented here allows to reference arguments passed to TestFixtureData in the TestCaseSource attribute. 

Please see sample usage in `TestCaseSourceWithTestFixtureArgumentsTests`.

The fixtures are created with data as follows 

```c#
        public static IEnumerable<TestFixtureData> TestFixturesSource
        {
            get
            {
                for (int maxArgs = 0; maxArgs <= NUMBER_OF_ARGS; maxArgs++)
                {
                    string[] args = FixtureArgumentsSource.Take(maxArgs).ToArray();

                    yield return new TestFixtureData(maxArgs, args).SetArgDisplayNames($"{maxArgs}_arguments_test");

                }
            }
        }
```

So that each fixture contains different number of arguments. In order to make test case source aware one can ask for the `maxArgs` value by referencing `TestFixtureArgumentRef.Arg0`.

```c#
        [Test]
        [TestCaseSource(nameof(TestCaseDataWithFixtureContext), new object[]{ TestFixtureArgumentRef.Arg0 })]
        public void FixtureArgumentTest(int argumentIndex, int numberOfArguments)
        {
            Assert.AreEqual(FixtureNumberOfArgs, numberOfArguments);
            Assert.AreEqual(FixtureArgs[argumentIndex], FixtureArgumentsSource[argumentIndex]);
        }

        public static IEnumerable<TestCaseData> TestCaseDataWithFixtureContext(int numberOfArgsFixtureWasCreatedWith)
        {
            for (int i = 0; i < numberOfArgsFixtureWasCreatedWith; i++)
            {
                yield return new TestCaseData(i, numberOfArgsFixtureWasCreatedWith)
                    .SetArgDisplayNames($"Number of args : {i + 1} of {numberOfArgsFixtureWasCreatedWith} ");
            }
        }

```

In this case the `TextFixtureArgumentRef.Arg0` gets replaced with respective test fixture argument before the `TestCaseDataWithFixtureContext` method is called, which allows to generate test cases specific for given fixture.

The `TextFixtureArgumentRef` enumeration allows addressing up to 10 parameters (0-9). IF there is a need for more one can cast any integer value like `(TextFixtureArgumentRef) 22`  which will simply get replaced by value of fixture argument at index 22.
