### PR TITLE
Reduce memory overhead of TestNameGenerator

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal
             var result = new StringBuilder();
 
             foreach (var fragment in _fragments)
-                result.Append(fragment.GetText(testMethod, args));
+                fragment.AppendTextTo(result, testMethod, args);
 
             return result.ToString();
         }
@@ -199,12 +199,12 @@ namespace NUnit.Framework.Internal
         {
             private const string THREE_DOTS = "...";
 
-            public virtual string GetText(TestMethod testMethod, object[] args)
+            public virtual void AppendTextTo(StringBuilder sb, TestMethod testMethod, object[] args)
             {
-                return GetText(testMethod.Method.MethodInfo, args);
+                AppendTextTo(sb, testMethod.Method.MethodInfo, args);
             }
 
-            public abstract string GetText(MethodInfo method, object[] args);
+            public abstract void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args);
 
             protected static void AppendGenericTypeNames(StringBuilder sb, MethodInfo method)
             {
@@ -264,19 +264,17 @@ namespace NUnit.Framework.Internal
                         display = builder.ToString();
                     }
                 }
-                else if (arg is double)
+                else if (arg is double dbl)
                 {
-                    double d = (double)arg;
-
-                    if (double.IsNaN(d))
+                    if (double.IsNaN(dbl))
                         display = "double.NaN";
-                    else if (double.IsPositiveInfinity(d))
+                    else if (double.IsPositiveInfinity(dbl))
                         display = "double.PositiveInfinity";
-                    else if (double.IsNegativeInfinity(d))
+                    else if (double.IsNegativeInfinity(dbl))
                         display = "double.NegativeInfinity";
-                    else if (d == double.MaxValue)
+                    else if (dbl == double.MaxValue)
                         display = "double.MaxValue";
-                    else if (d == double.MinValue)
+                    else if (dbl == double.MinValue)
                         display = "double.MinValue";
                     else
                     {
@@ -285,10 +283,8 @@ namespace NUnit.Framework.Internal
                         display += "d";
                     }
                 }
-                else if (arg is float)
+                else if (arg is float f)
                 {
-                    float f = (float)arg;
-
                     if (float.IsNaN(f))
                         display = "float.NaN";
                     else if (float.IsPositiveInfinity(f))
@@ -306,28 +302,26 @@ namespace NUnit.Framework.Internal
                         display += "f";
                     }
                 }
-                else if (arg is decimal)
+                else if (arg is decimal dec)
                 {
-                    decimal d = (decimal)arg;
-                    if (d == decimal.MinValue)
+                    if (dec == decimal.MinValue)
                         display = "decimal.MinValue";
-                    else if (d == decimal.MaxValue)
+                    else if (dec == decimal.MaxValue)
                         display = "decimal.MaxValue";
                     else
                         display += "m";
                 }
-                else if (arg is long)
+                else if (arg is long l)
                 {
-                    if (arg.Equals(long.MinValue))
+                    if (l.Equals(long.MinValue))
                         display = "long.MinValue";
-                    else if (arg.Equals(long.MaxValue))
+                    else if (l.Equals(long.MaxValue))
                         display = "long.MaxValue";
                     else
                         display += "L";
                 }
-                else if (arg is ulong)
+                else if (arg is ulong ul)
                 {
-                    ulong ul = (ulong)arg;
                     if (ul == ulong.MinValue)
                         display = "ulong.MinValue";
                     else if (ul == ulong.MaxValue)
@@ -335,9 +329,8 @@ namespace NUnit.Framework.Internal
                     else
                         display += "UL";
                 }
-                else if (arg is string)
+                else if (arg is string str)
                 {
-                    var str = (string)arg;
                     bool tooLong = stringMax > 0 && str.Length > stringMax;
                     int limit = tooLong ? stringMax - THREE_DOTS.Length : 0;
 
@@ -355,50 +348,50 @@ namespace NUnit.Framework.Internal
                     sb.Append("\"");
                     display = sb.ToString();
                 }
-                else if (arg is char)
+                else if (arg is char c)
                 {
-                    display = "\'" + EscapeSingleChar((char)arg) + "\'";
+                    display = "\'" + EscapeSingleChar(c) + "\'";
                 }
-                else if (arg is int)
+                else if (arg is int i)
                 {
-                    if (arg.Equals(int.MaxValue))
+                    if (i.Equals(int.MaxValue))
                         display = "int.MaxValue";
-                    else if (arg.Equals(int.MinValue))
+                    else if (i.Equals(int.MinValue))
                         display = "int.MinValue";
                 }
-                else if (arg is uint)
+                else if (arg is uint ui)
                 {
-                    if (arg.Equals(uint.MaxValue))
+                    if (ui.Equals(uint.MaxValue))
                         display = "uint.MaxValue";
-                    else if (arg.Equals(uint.MinValue))
+                    else if (ui.Equals(uint.MinValue))
                         display = "uint.MinValue";
                 }
-                else if (arg is short)
+                else if (arg is short s)
                 {
-                    if (arg.Equals(short.MaxValue))
+                    if (s.Equals(short.MaxValue))
                         display = "short.MaxValue";
-                    else if (arg.Equals(short.MinValue))
+                    else if (s.Equals(short.MinValue))
                         display = "short.MinValue";
                 }
-                else if (arg is ushort)
+                else if (arg is ushort us)
                 {
-                    if (arg.Equals(ushort.MaxValue))
+                    if (us.Equals(ushort.MaxValue))
                         display = "ushort.MaxValue";
-                    else if (arg.Equals(ushort.MinValue))
+                    else if (us.Equals(ushort.MinValue))
                         display = "ushort.MinValue";
                 }
-                else if (arg is byte)
+                else if (arg is byte b)
                 {
-                    if (arg.Equals(byte.MaxValue))
+                    if (b.Equals(byte.MaxValue))
                         display = "byte.MaxValue";
-                    else if (arg.Equals(byte.MinValue))
+                    else if (b.Equals(byte.MinValue))
                         display = "byte.MinValue";
                 }
-                else if (arg is sbyte)
+                else if (arg is sbyte sb)
                 {
-                    if (arg.Equals(sbyte.MaxValue))
+                    if (sb.Equals(sbyte.MaxValue))
                         display = "sbyte.MaxValue";
-                    else if (arg.Equals(sbyte.MinValue))
+                    else if (sb.Equals(sbyte.MinValue))
                         display = "sbyte.MinValue";
                 }
 
@@ -455,20 +448,20 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        private class TestIDFragment : NameFragment
+        private sealed class TestIDFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return "{i}"; // No id available using MethodInfo
+                sb.Append("{i}"); // No id available using MethodInfo
             }
 
-            public override string GetText(TestMethod testMethod, object[] args)
+            public override void AppendTextTo(StringBuilder sb, TestMethod testMethod, object[] args)
             {
-                return testMethod.Id;
+                sb.Append(testMethod.Id);
             }
         }
 
-        private class FixedTextFragment : NameFragment
+        private sealed class FixedTextFragment : NameFragment
         {
             private readonly string _text;
 
@@ -477,69 +470,61 @@ namespace NUnit.Framework.Internal
                 _text = text;
             }
 
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return _text;
+                sb.Append(_text);
             }
         }
 
-        private class MethodNameFragment : NameFragment
+        private sealed class MethodNameFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                var sb = new StringBuilder();
-
                 sb.Append(method.Name);
 
                 if (method.IsGenericMethod)
                     AppendGenericTypeNames(sb, method);
-
-                return sb.ToString();
             }
         }
 
-        private class NamespaceFragment : NameFragment
+        private sealed class NamespaceFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return method.DeclaringType.Namespace;
+                sb.Append(method.DeclaringType.Namespace);
             }
         }
 
-        private class MethodFullNameFragment : NameFragment
+        private sealed class MethodFullNameFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                var sb = new StringBuilder();
-
                 sb.Append(method.DeclaringType.FullName);
                 sb.Append('.');
                 sb.Append(method.Name);
 
                 if (method.IsGenericMethod)
                     AppendGenericTypeNames(sb, method);
-
-                return sb.ToString();
             }
         }
 
-        private class ClassNameFragment : NameFragment
+        private sealed class ClassNameFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return method.DeclaringType.Name;
+                sb.Append(method.DeclaringType.Name);
             }
         }
 
-        private class ClassFullNameFragment : NameFragment
+        private sealed class ClassFullNameFragment : NameFragment
         {
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return method.DeclaringType.FullName;
+                sb.Append(method.DeclaringType.FullName);
             }
         }
 
-        private class ArgListFragment : NameFragment
+        private sealed class ArgListFragment : NameFragment
         {
             private readonly int _maxStringLength;
 
@@ -548,10 +533,8 @@ namespace NUnit.Framework.Internal
                 _maxStringLength = maxStringLength;
             }
 
-            public override string GetText(MethodInfo method, object[] arglist)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] arglist)
             {
-                var sb = new StringBuilder();
-
                 if (arglist != null)
                 {
                     sb.Append('(');
@@ -564,12 +547,10 @@ namespace NUnit.Framework.Internal
 
                     sb.Append(')');
                 }
-
-                return sb.ToString();
             }
         }
 
-        private class ArgumentFragment : NameFragment
+        private sealed class ArgumentFragment : NameFragment
         {
             private readonly int _index;
             private readonly int _maxStringLength;
@@ -580,15 +561,14 @@ namespace NUnit.Framework.Internal
                 _maxStringLength = maxStringLength;
             }
 
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                return _index < args.Length
-                    ? GetDisplayString(args[_index], _maxStringLength)
-                    : string.Empty;
+                if (_index < args.Length)
+                    sb.Append(GetDisplayString(args[_index], _maxStringLength));
             }
         }
 
-        private class ParamArgListFragment : NameFragment
+        private sealed class ParamArgListFragment : NameFragment
         {
             private readonly int _maxStringLength;
 
@@ -597,10 +577,8 @@ namespace NUnit.Framework.Internal
                 _maxStringLength = maxStringLength;
             }
 
-            public override string GetText(MethodInfo method, object[] args)
+            public override void AppendTextTo(StringBuilder sb, MethodInfo method, object[] args)
             {
-                var sb = new StringBuilder();
-
                 if (args != null)
                 {
                     sb.Append('(');
@@ -622,7 +600,6 @@ namespace NUnit.Framework.Internal
 
                     sb.Append(')');
                 }
-                return sb.ToString();
             }
         }
 


### PR DESCRIPTION
This PR reduces memory overhead through two main improvements:
- Reduce the number of string allocations or instances of `StringBuilder` by passing the top-level `StringBuilder` instance in `TestNameGenerator` down into the different `NameFragment`s
- Eliminate a few boxing operations inside of `NameFragment.GetDisplayString` by converting `object arg` into a primitive type (when possible) before comparing it to another primitive

This is a bit of an implementation of the approach suggested in #3498 , though these changes happen to be fully encapsulated within this particular class with no public/internal method signature changes.

### Benchmarks
<details>
  <summary>View Results</summary>
  
  <pre>
|             Method |        Mean |      Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |------------:|-----------:|----------:|-------:|------:|------:|----------:|
| Original_SingleArg |    389.7 ns |   85.82 ns |   4.70 ns | 0.1626 |     - |     - |     680 B |
|      New_SingleArg |   383.29 ns | 324.930 ns | 17.811 ns | 0.0801 |     - |     - |     336 B |
|   Original_ManyArg |  1,886.9 ns |  468.58 ns |  25.68 ns | 0.7553 |     - |     - |    3161 B |
|        New_ManyArg | 1,841.49 ns | 254.842 ns | 13.969 ns | 0.5074 |     - |     - |    2129 B |
|     Original_NoArg |    144.8 ns |   81.61 ns |   4.47 ns | 0.0937 |     - |     - |     392 B |
|          New_NoArg |    90.09 ns |   7.174 ns |  0.393 ns | 0.0343 |     - |     - |     144 B |
  </pre>
</details>

<details>
  <summary>View Code</summary>

  ```csharp
    [ShortRunJob]
    [MemoryDiagnoser]
    public class TestNameGenerator_GetDisplayName
    {
        private static void NoArgs() { }
        private static T Generic1Arg<T>(T t) => t;
        private static T1 GenericManyArg<T1, T2, T3, T4, T5, T6, T7>(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => t1;


        private static readonly TestMethod NoArgMethod = GenerateFromMethodInfo(nameof(NoArgs));
        private static readonly TestMethod SingleArgMethod = GenerateFromMethodInfo(nameof(Generic1Arg));
        private static readonly TestMethod ManyArgMethod = GenerateFromMethodInfo(nameof(GenericManyArg));

        private static readonly object[] SingleArg = new object[] { 42 };
        private static readonly object[] ManyArgs = new object[] { 42, double.PositiveInfinity, null, "yabba dabba doo", (byte)65, new CustomType(), -76205367f };

        private class CustomType { }

        private static TestMethod GenerateFromMethodInfo(string localMethodName)
        {
            var type = typeof(TestNameGenerator_GetDisplayName);
            var method = type.GetMethod(localMethodName, BindingFlags.NonPublic | BindingFlags.Static);

            var testMethod = new TestMethod(new MethodWrapper(type, method));

            return testMethod;
        }

        private static readonly TestNameGenerator _newImpl = new TestNameGenerator();
        private static readonly OriginalTestNameGenerator _originalImpl = new OriginalTestNameGenerator();

        [Benchmark]
        public string Original_SingleArg() => _originalImpl.GetDisplayName(SingleArgMethod, SingleArg);

        [Benchmark]
        public string New_SingleArg() => _newImpl.GetDisplayName(SingleArgMethod, SingleArg);


        [Benchmark]
        public string Original_ManyArg() => _originalImpl.GetDisplayName(ManyArgMethod, ManyArgs);

        [Benchmark]
        public string New_ManyArg() => _newImpl.GetDisplayName(ManyArgMethod, ManyArgs);


        [Benchmark]
        public string Original_NoArg() => _originalImpl.GetDisplayName(NoArgMethod);

        [Benchmark]
        public string New_NoArg() => _newImpl.GetDisplayName(NoArgMethod);
    }
  ```
</details>