### PR TITLE
Add missing license in file. Add missing "readonly" modifiers on immutable structs

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
@@ -1,14 +1,36 @@
-using System;
+// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints.Comparers
 {
-    internal struct ComparisonState
+    internal readonly ref struct ComparisonState
     {
         /// <summary>
         /// Flag indicating whether or not this is the top level comparison.
         /// </summary>
-        public bool TopLevelComparison { get; }
+        public readonly bool TopLevelComparison { get; }
 
         /// <summary>
         /// A list of tracked comparisons
@@ -43,10 +65,10 @@ namespace NUnit.Framework.Constraints.Comparers
             return false;
         }
 
-        private struct Comparison
+        private readonly struct Comparison
         {
-            public object X { get; }
-            public object Y { get; }
+            public readonly object X { get; }
+            public readonly object Y { get; }
 
             public Comparison(object x, object y)
             {


### PR DESCRIPTION
A few things I noticed that I missed in a previous PR (#3406 , which addressed #52 )
A new file was added (ComparisonState.cs) but I had forgotten to add the license header at the top of the file. This PR adds it with the copyright date of that changeset (2019).

Additionally, a common theme in the recommended approach to that PR was to make the structs immutable, however the `readonly` keyword on the struct itself was omitted. This PR adds that in to ensure that the types _remain_ immutable by default, even if new members are added.

NOTE: I ran into some issues when trying to make the `ImmutableStruct` from that PR `readonly`: https://github.com/nunit/nunit/issues/3604