### PR TITLE
Add protection for the 0 == -0 floating point math case when comparing floats

### DIFF
--- a/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
+++ b/src/NUnitFramework/framework/Constraints/FloatingPointNumerics.cs
@@ -132,6 +132,13 @@ namespace NUnit.Framework.Constraints
 
             if (leftSignMask != rightSignMask) // Overflow possible, check each against zero
             {
+                // This check is specifically used to trap the case of 0 == -0
+                // In IEEE floating point maths, -0 is converted to Float.MinValue, which cannot be used with
+                // Math.Abs(...) below due to overflow issues. This should only match the 0 == -0 condition.
+                if (left == right)
+                {
+                    return true;
+                }
                 if (Math.Abs(leftUnion.Int) > maxUlps || Math.Abs(rightUnion.Int) > maxUlps)
                     return false;
             }
@@ -184,6 +191,13 @@ namespace NUnit.Framework.Constraints
 
             if (leftSignMask != rightSignMask) // Overflow possible, check each against zero
             {
+                // This check is specifically used to trap the case of 0 == -0
+                // In IEEE floating point maths, -0 is converted to Double.MinValue, which cannot be used with
+                // Math.Abs(...) below due to overflow issues. This should only match the 0 == -0 condition.
+                if (left == right)
+                {
+                    return true;
+                }
                 if (Math.Abs(leftUnion.Long) > maxUlps || Math.Abs(rightUnion.Long) > maxUlps)
                     return false;
             }

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -511,6 +511,20 @@ namespace NUnit.Framework.Constraints
             {
                 Assert.Throws<InvalidOperationException>(() => Assert.That(100m, Is.EqualTo(100m).Within(2).Ulps));
             }
+
+            [Test]
+            public void CanMatchNegativeZeroToZeroForDoubles()
+            {
+                Assert.That(0d, Is.EqualTo(-0d).Within(1).Ulps);
+                Assert.That(-0d, Is.EqualTo(0d).Within(1).Ulps);
+            }
+
+            [Test]
+            public void CanMatchNegativeZeroToZeroForFloats()
+            {
+                Assert.That(0f, Is.EqualTo(-0f).Within(1).Ulps);
+                Assert.That(-0f, Is.EqualTo(0f).Within(1).Ulps);
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes #3596 

This fixes the UPLS comparison to pickup the`0 == -0` special case.