### PR TITLE
Copy test suite properties when exploring with a filter

### DIFF
--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -108,6 +108,10 @@ namespace NUnit.Framework.Internal
             this.RunState = suite.RunState;
             this.Fixture  = suite.Fixture;
 
+            foreach (string key in suite.Properties.Keys)
+            foreach (object val in suite.Properties[key])
+                this.Properties.Add(key, val);
+
             foreach (var child in suite.tests)
             {
                 if(filter.Pass(child))

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -245,6 +245,24 @@ namespace NUnit.Framework.Api
             var explorer = _runner.ExploreTests(filter);
             Assert.That(explorer.TestCaseCount, Is.EqualTo(_runner.CountTestCases(filter)));
         }
+
+        [Test]
+        public void ExploreTests_AfterLoad_WithFilter_TestSuitesRetainProperties()
+        {
+            LoadMockAssembly();
+            ITestFilter filter = new CategoryFilter("FixtureCategory");
+
+            var explorer = _runner.ExploreTests(filter);
+
+            var runnerFixture = _runner.LoadedTest.Tests[0].Tests[0].Tests[0].Tests[0];
+            var explorerFixture = explorer.Tests[0].Tests[0].Tests[0].Tests[0];
+
+            Assert.That(explorerFixture.Properties.Keys.Count, Is.EqualTo(runnerFixture.Properties.Keys.Count));
+            Assert.That(explorerFixture.Properties.Get(PropertyNames.Category),
+                Is.EqualTo(explorerFixture.Properties.Get(PropertyNames.Category)));
+            Assert.That(explorerFixture.Properties.Get(PropertyNames.Description),
+                Is.EqualTo(explorerFixture.Properties.Get(PropertyNames.Description)));
+        }
         #endregion
 
         #region Run


### PR DESCRIPTION
Fixes #3611 

I've added a test that compares properties between a TestFixture from an ITestAssemblyRunner to the same fixture retrieved via ExploreTests, but would appreciate any feedback around the right way to cover this. 

I've manually tested this against a test assembly I have from another project. Ran explore with `--where 'cat=AppFamilyUtilitiesTests`.

Before changes, result was:
```xml
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<test-run id="0" runstate="Runnable" testcasecount="10">
  <test-suite type="Assembly" id="0-1163" name="Foreman.Tests.dll" fullname="C:\dev\stash\devops\jobbuilder\JobBuilder\Foreman.Tests\bin\Debug\Foreman.Tests.dll" runstate="Runnable" testcasecount="10">
    <test-suite type="TestSuite" id="0-1164" name="Foreman" fullname="Foreman" runstate="Runnable" testcasecount="10">
      <test-suite type="TestSuite" id="0-1165" name="Tests" fullname="Foreman.Tests" runstate="Runnable" testcasecount="10">
        <test-suite type="TestSuite" id="0-1166" name="HelpersTest" fullname="Foreman.Tests.HelpersTest" runstate="Runnable" testcasecount="10">
          <test-suite type="TestFixture" id="0-1167" name="AppFamilyUtilitiesTests" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" testcasecount="10">
            <test-suite type="ParameterizedMethod" id="0-1169" name="GetRoleIdToAppFamilyToADGroupCNTests" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" testcasecount="2">
              <test-case id="0-1090" name="Empty AppFamilyGroupModel list" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.Empty AppFamilyGroupModel list" methodname="GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" seed="1242564091">
                <properties />
              </test-case>
              <test-case id="0-1091" name="Three roles and with multiple app families per role" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.Three roles and with multiple app families per role" methodname="GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" seed="1740957023">
                <properties />
              </test-case>
            </test-suite>
          </test-suite>
        </test-suite>
      </test-suite>
    </test-suite>
  </test-suite>
</test-run>
```

After changes:
```xml
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<test-run id="0" runstate="Runnable" testcasecount="10">
  <test-suite type="Assembly" id="0-1163" name="Foreman.Tests.dll" fullname="C:\dev\stash\devops\jobbuilder\JobBuilder\Foreman.Tests\bin\Debug\Foreman.Tests.dll" runstate="Runnable" testcasecount="10">
    <properties>
      <property name="_PID" value="4100" />
      <property name="_APPDOMAIN" value="domain-" />
    </properties>
    <test-suite type="TestSuite" id="0-1164" name="Foreman" fullname="Foreman" runstate="Runnable" testcasecount="10">
      <test-suite type="TestSuite" id="0-1165" name="Tests" fullname="Foreman.Tests" runstate="Runnable" testcasecount="10">
        <test-suite type="TestSuite" id="0-1166" name="HelpersTest" fullname="Foreman.Tests.HelpersTest" runstate="Runnable" testcasecount="10">
          <test-suite type="TestFixture" id="0-1167" name="AppFamilyUtilitiesTests" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" testcasecount="10">
            <test-suite type="ParameterizedMethod" id="0-1169" name="GetRoleIdToAppFamilyToADGroupCNTests" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" testcasecount="2">
              <properties>
                <property name="Category" value="AppFamilyUtilitiesTests" />
              </properties>
              <test-case id="0-1090" name="Empty AppFamilyGroupModel list" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.Empty AppFamilyGroupModel list" methodname="GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" seed="195536145">
                <properties />
              </test-case>
              <test-case id="0-1091" name="Three roles and with multiple app families per role" fullname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests.Three roles and with multiple app families per role" methodname="GetRoleIdToAppFamilyToADGroupCNTests" classname="Foreman.Tests.HelpersTest.AppFamilyUtilitiesTests" runstate="Runnable" seed="700917615">
                <properties />
              </test-case>
            </test-suite>
          </test-suite>
        </test-suite>
      </test-suite>
    </test-suite>
  </test-suite>
</test-run>
```