### PR TITLE
Equal constraint using comparer

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -49,13 +49,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public virtual bool CanCompare(object x, object y)
         {
-            if (x is string && y is string)
-                return true;
-
-            if (x is IEnumerable || y is IEnumerable)
-                return false;
-
-            return true;
+            return (x is string || !(x is IEnumerable)) &&
+                   (y is string || !(y is IEnumerable));
         }
 
         #region Nested IComparer Adapter

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -558,6 +558,38 @@ namespace NUnit.Framework.Constraints
             }
 
             [Test]
+            public void UsesProvidedEqualityComparerForExpectedIsString()
+            {
+                var comparer = new ObjectToStringEqualityComparer();
+                Assert.That(4, Is.EqualTo("4").Using(comparer));
+                Assert.That(comparer.WasCalled, "Comparer was not called");
+            }
+
+            [Test]
+            public void UsesProvidedEqualityComparerForActualIsString()
+            {
+                var comparer = new ObjectToStringEqualityComparer();
+                Assert.That("4", Is.EqualTo(4).Using(comparer));
+                Assert.That(comparer.WasCalled, "Comparer was not called");
+            }
+
+            [Test]
+            public void UsesProvidedComparerForExpectedIsString()
+            {
+                var comparer = new ObjectToStringComparer();
+                Assert.That(4, Is.EqualTo("4").Using(comparer));
+                Assert.That(comparer.WasCalled, "Comparer was not called");
+            }
+
+            [Test]
+            public void UsesProvidedComparerForActualIsString()
+            {
+                var comparer = new ObjectToStringComparer();
+                Assert.That("4", Is.EqualTo(4).Using(comparer));
+                Assert.That(comparer.WasCalled, "Comparer was not called");
+            }
+
+            [Test]
             public void UsesProvidedGenericEqualityComparer()
             {
                 var comparer = new GenericEqualityComparer<int>();

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectToStringComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectToStringComparer.cs
@@ -23,28 +23,47 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace NUnit.TestUtilities.Comparers
 {
     /// <summary>
-    /// ObjectToStringComparer is used in testing the <see cref="NUnit.Framework.Constraints.RangeConstraint"/> when the object does not implement the <see cref="IComparer"/>  interface.
+    /// ObjectToStringComparer is used in testing the <see cref="Framework.Constraints.RangeConstraint"/> when the object does not implement the <see cref="IComparer"/>  interface.
     /// Compares them as numbers when both arguments are <see cref="int"/>, else it uses <seealso cref="string.CompareTo(string)"/>.
     /// </summary>
-    public class ObjectToStringComparer : System.Collections.IComparer
+    public class ObjectToStringComparer : IComparer
     {
-        public bool WasCalled = false;
-        int System.Collections.IComparer.Compare(object x, object y)
+        public bool WasCalled { get; private set; }
+
+        int IComparer.Compare(object x, object y)
         {
             WasCalled = true;
 
-            if (int.TryParse(x.ToString(), out var intX) && int.TryParse(y.ToString(), out var intY))
+            string xAsString = x.ToString();
+            string yAsString = y.ToString();
+            if (int.TryParse(xAsString, out int intX) && int.TryParse(yAsString, out int intY))
             {
                 return intX.CompareTo(intY);
             }
 
-            return x.ToString().CompareTo(y.ToString());
+            return xAsString.CompareTo(yAsString);
+        }
+    }
 
+    public class ObjectToStringEqualityComparer : IEqualityComparer
+    {
+        private readonly IComparer _comparer = new ObjectToStringComparer();
+
+        public bool WasCalled { get; private set; }
+
+        public new bool Equals(object x, object y)
+        {
+            WasCalled = true;
+            return _comparer.Compare(x, y) == 0;
+        }
+
+        public int GetHashCode(object obj)
+        {
+            return obj.ToString().GetHashCode();
         }
     }
 
@@ -54,7 +73,7 @@ namespace NUnit.TestUtilities.Comparers
     /// </summary>
     public class NoComparer
     {
-        public readonly object _value;
+        private readonly object _value;
         public NoComparer(object value)
         {
             _value = value;


### PR DESCRIPTION
Fixes #1897

Changes EqualityAdapter.CanCompare if one of the arguments is `string` and the other is not `IEnumerable`.