### PR TITLE
Make currentRuntime #if easier to parse

### DIFF
--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -29,10 +29,10 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class RuntimeFrameworkTests
     {
-        static readonly RuntimeType currentRuntime =
 #if NETCOREAPP
-            RuntimeType.NetCore;
+        static readonly RuntimeType currentRuntime = RuntimeType.NetCore;
 #else
+        static readonly RuntimeType currentRuntime =
             Type.GetType("Mono.Runtime", false) != null
                 ? RuntimeType.Mono
                 : RuntimeType.NetFramework;


### PR DESCRIPTION
Multi-line code structures built with `#if` like this can only really be parsed by Roslyn and Visual Studio.

Many lightweight editors and syntax highlighters (GitHub.com included) cannot parse this as they can not know the value of the preprocessor variables when simply browsing an individual file. This breaks syntax highlighting until the highlighter can recover somewhere further down the file (if at all).

Additionally even if they could it means one branch of the code is "dead" and does not get syntax highlighting or other semantic features down the line.

Simply rewriting the `#if` as per this PR means that the syntax highlighters and tools can parse each line without needing to know the value of preprocessor variables and can syntax highlight both lines.

Finally some humans (myself included) find this easier to read.

This is the only place in the NUnit source code that follows this pattern and the last parsing problem the forthcoming C# semantic code analysis on github.com has with this repo (you can see more information at https://github.com/tree-sitter/tree-sitter-c-sharp).

Here's before and after screenshots from VS Code for additional consideration:

**Before**
![image](https://user-images.githubusercontent.com/118951/94834697-a20de080-0408-11eb-87e9-fe89a7159240.png)

**After**
![image](https://user-images.githubusercontent.com/118951/94834766-b651dd80-0408-11eb-827f-15efac38127b.png)
