### PR TITLE
Comparer: Preference IComparable<T> over IComparable

### DIFF
--- a/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
+++ b/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Constraints
         }
     }
 
-    class ClassWithIComparableOfT : IComparable<ClassWithIComparableOfT>
+    class ClassWithIComparableOfT : IComparable<ClassWithIComparableOfT>, IComparable<int>
     {
         private readonly int val;
 
@@ -108,6 +108,11 @@ namespace NUnit.Framework.Constraints
         public int CompareTo(ClassWithIComparableOfT other)
         {
             return val.CompareTo(other.val);
+        }
+
+        public int CompareTo(int other)
+        {
+            return val.CompareTo(other);
         }
     }
 

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -58,6 +58,14 @@ namespace NUnit.Framework.Constraints
             Assert.That(actual, Is.GreaterThan(expected));
         }
 
+        [Test]
+        public void CanCompareIComparablesOfInt()
+        {
+            int expected = 0;
+            ClassWithIComparableOfT actual = new ClassWithIComparableOfT(42);
+            Assert.That(actual, Is.GreaterThan(expected));
+        }
+
         [TestCase(6.0, 5.0, 0.05)]
         [TestCase(5.05, 5.0, 0.05)] // upper range bound
         [TestCase(5.0001, 5.0, 0.05)]

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -58,6 +58,14 @@ namespace NUnit.Framework.Constraints
             Assert.That(actual, Is.GreaterThanOrEqualTo(expected));
         }
 
+        [Test]
+        public void CanCompareIComparablesOfInt()
+        {
+            int expected = 0;
+            ClassWithIComparableOfT actual = new ClassWithIComparableOfT(42);
+            Assert.That(actual, Is.GreaterThanOrEqualTo(expected));
+        }
+
         [TestCase(6.0, 5.0, 0.05)]
         [TestCase(5.05, 5.0, 0.05)] // upper range bound
         [TestCase(5.0001, 5.0, 0.05)]

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -58,6 +58,14 @@ namespace NUnit.Framework.Constraints
             Assert.That(actual, Is.LessThan(expected));
         }
 
+        [Test]
+        public void CanCompareIComparablesOfInt()
+        {
+            int expected = 42;
+            ClassWithIComparableOfT actual = new ClassWithIComparableOfT(0);
+            Assert.That(actual, Is.LessThan(expected));
+        }
+
         [TestCase(4.0, 5.0, 0.05)]
         [TestCase(4.95, 5.0, 0.05)] // lower range bound
         [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -58,6 +58,14 @@ namespace NUnit.Framework.Constraints
             Assert.That(actual, Is.LessThanOrEqualTo(expected));
         }
 
+        [Test]
+        public void CanCompareIComparablesOfInt()
+        {
+            int expected = 42;
+            ClassWithIComparableOfT actual = new ClassWithIComparableOfT(0);
+            Assert.That(actual, Is.LessThanOrEqualTo(expected));
+        }
+
         [TestCase(4.0, 5.0, 0.05)]
         [TestCase(4.95, 5.0, 0.05)] // lower range bound
         [TestCase(4.9501, 5.0, 0.05)] // lower range bound + .01

--- a/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
@@ -72,5 +72,98 @@ namespace NUnit.Framework.Constraints
             Assert.That(comparer.Compare(greater, lesser) > 0);
             Assert.That(comparer.Compare(lesser, greater) < 0);
         }
+
+        [Test]
+        public void Comparables()
+        {
+            var greater = new ClassWithIComparable(42);
+            var lesser = new ClassWithIComparable(-42);
+
+            Assert.That(comparer.Compare(greater, lesser) > 0);
+            Assert.That(comparer.Compare(lesser, greater) < 0);
+        }
+
+        [Test]
+        public void ComparablesOfT()
+        {
+            var greater = new ClassWithIComparableOfT(42);
+            var lesser = new ClassWithIComparableOfT(-42);
+
+            Assert.That(comparer.Compare(greater, lesser) > 0);
+            Assert.That(comparer.Compare(lesser, greater) < 0);
+        }
+
+        [Test]
+        public void ComparablesOfInt1()
+        {
+            int greater = 42;
+            var lesser = new ClassWithIComparableOfT(-42);
+
+            Assert.That(comparer.Compare(greater, lesser) > 0);
+            Assert.That(comparer.Compare(lesser, greater) < 0);
+        }
+
+        [Test]
+        public void ComparablesOfInt2()
+        {
+            var greater = new ClassWithIComparableOfT(42);
+            int lesser = -42;
+
+            Assert.That(comparer.Compare(greater, lesser) > 0);
+            Assert.That(comparer.Compare(lesser, greater) < 0);
+        }
+
+        [Test]
+        public void ComparablesOfInt3()
+        {
+            short greater = 42;
+            var lesser = new ClassWithIComparableOfT(-42);
+
+            Assert.That(comparer.Compare(greater, lesser) > 0);
+            Assert.That(comparer.Compare(lesser, greater) < 0);
+        }
+
+        #region Comparison Test Classes
+
+        private class ClassWithIComparable : IComparable
+        {
+            private readonly int val;
+
+            public ClassWithIComparable(int val)
+            {
+                this.val = val;
+            }
+
+            public int CompareTo(object x)
+            {
+                ClassWithIComparable other = x as ClassWithIComparable;
+                if (x is ClassWithIComparable)
+                    return val.CompareTo(other.val);
+
+                throw new ArgumentException();
+            }
+        }
+
+        private class ClassWithIComparableOfT : IComparable<ClassWithIComparableOfT>, IComparable<int>
+        {
+            private readonly int val;
+
+            public ClassWithIComparableOfT(int val)
+            {
+                this.val = val;
+            }
+
+            public int CompareTo(ClassWithIComparableOfT other)
+            {
+                return val.CompareTo(other.val);
+            }
+
+            public int CompareTo(int other)
+            {
+                return val.CompareTo(other);
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #3641 
