### PR TITLE
fix #3636: allow spaces in -test and -testlist filter format "{m} (unique attribute)"

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
@@ -38,6 +38,7 @@ namespace NUnitLite.Tests
             new TestCaseData("--prefilter=A.B.C", "LOAD", new string[] { "A.B.C" }),
             new TestCaseData("--test=A.B.C", "LOAD", new string[] { "A.B.C" }),
             new TestCaseData("--test=A.B.C(arg)", "LOAD", new string[] { "A.B.C" }),
+            new TestCaseData("--test=A.B.C (arg)", "LOAD", new string[] { "A.B.C" }),
             new TestCaseData("--test=A.B<type>.C(arg)", "LOAD", new string[] { "A.B" })
        };
 

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -331,7 +331,7 @@ namespace NUnitLite
                 {
                     int end = testName.IndexOfAny(new char[] { '(', '<' });
                     if (end > 0)
-                        prefilters.Add(testName.Substring(0, end));
+                        prefilters.Add(testName.Substring(0, end).Trim());
                     else
                         prefilters.Add(testName);
                 }


### PR DESCRIPTION
Fixes #3636 