### PR TITLE
IStructuralEquatable support

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -48,6 +48,9 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
+            if (DoesUseStructuralEquality(xType) && DoesUseStructuralEquality(yType))
+                return null;
+
             MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
             if (equals != null)
                 return InvokeFirstIEquatableEqualsSecond(x, y, equals);
@@ -57,6 +60,15 @@ namespace NUnit.Framework.Constraints.Comparers
                 return InvokeFirstIEquatableEqualsSecond(y, x, equals);
 
             return null;
+        }
+
+        private static bool DoesUseStructuralEquality(Type type)
+        {
+            foreach(var @interface in type.GetInterfaces())
+                if (@interface.FullName == "System.Collections.IStructuralComparable" || @interface.FullName == "System.Collections.IStructuralEquatable")
+                    return true;
+
+            return false;
         }
 
         private static MethodInfo FirstImplementsIEquatableOfSecond(Type first, Type second)

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -22,10 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Reflection;
-using NUnit.Compatibility;
 
 namespace NUnit.Framework.Constraints.Comparers
 {
@@ -49,10 +46,6 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (x is IEnumerable && DoesUseStructuralEquality(xType)
-                && y is IEnumerable && DoesUseStructuralEquality(yType))
-                return null;
-
             MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
             if (equals != null)
                 return InvokeFirstIEquatableEqualsSecond(x, y, equals);
@@ -62,18 +55,6 @@ namespace NUnit.Framework.Constraints.Comparers
                 return InvokeFirstIEquatableEqualsSecond(y, x, equals);
 
             return null;
-        }
-
-        private static bool DoesUseStructuralEquality(Type type)
-        {
-            if (!type.IsValueType)
-                return false;
-
-            foreach(var @interface in type.GetInterfaces())
-                if (@interface.FullName == "System.Collections.IStructuralComparable" || @interface.FullName == "System.Collections.IStructuralEquatable")
-                    return true;
-
-            return false;
         }
 
         private static MethodInfo FirstImplementsIEquatableOfSecond(Type first, Type second)

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Constraints.Comparers
             return pair.Value;
         }
 
-        private static IList<KeyValuePair<Type, MethodInfo>> GetEquatableGenericArguments(Type type)
+        private static List<KeyValuePair<Type, MethodInfo>> GetEquatableGenericArguments(Type type)
         {
             var genericArgs = new List<KeyValuePair<Type, MethodInfo>>();
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;
@@ -48,7 +49,8 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (DoesUseStructuralEquality(xType) && DoesUseStructuralEquality(yType))
+            if (x is IEnumerable && DoesUseStructuralEquality(xType)
+                && y is IEnumerable && DoesUseStructuralEquality(yType))
                 return null;
 
             MethodInfo equals = FirstImplementsIEquatableOfSecond(xType, yType);
@@ -64,6 +66,9 @@ namespace NUnit.Framework.Constraints.Comparers
 
         private static bool DoesUseStructuralEquality(Type type)
         {
+            if (!type.IsValueType)
+                return false;
+
             foreach(var @interface in type.GetInterfaces())
                 if (@interface.FullName == "System.Collections.IStructuralComparable" || @interface.FullName == "System.Collections.IStructuralEquatable")
                     return true;

--- a/src/NUnitFramework/framework/Constraints/Comparers/StructuralComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StructuralComparer.cs
@@ -1,0 +1,93 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if !NET35
+using System.Collections;
+
+namespace NUnit.Framework.Constraints.Comparers
+{
+    /// <summary>
+    /// Comparator for two types related by <see cref="IStructuralEquatable"/>.
+    /// </summary>
+    class StructuralComparer : IChainComparer
+    {
+        private readonly NUnitEqualityComparer _equalityComparer;
+
+        internal StructuralComparer(NUnitEqualityComparer equalityComparer)
+        {
+            _equalityComparer = equalityComparer;
+        }
+
+        public bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state)
+        {
+            if (_equalityComparer.CompareAsCollection && state.TopLevelComparison)
+                return null;
+
+            if (x is IStructuralEquatable xEquatable && y is IStructuralEquatable yEquatable)
+            {
+                // We can't pass tolerance as a ref so we pass by value and reassign later
+                var equalityComparison = new NUnitEqualityComparison(_equalityComparer, tolerance);
+
+                // Check both directions in case they are different implementations, and only one is aware of the other.
+                // Like how ImmutableArray<int> is structurally equatable to int[]
+                // but int[] is NOT structurally equatable to ImmutableArray<int>
+                var xResult = xEquatable.Equals(y, equalityComparison);
+                var yResult = yEquatable.Equals(x, equalityComparison);
+
+                // Keep all the refs up to date
+                tolerance = equalityComparison.Tolerance;
+
+                return xResult || yResult;
+            }
+
+            return null;
+        }
+
+        private sealed class NUnitEqualityComparison : IEqualityComparer
+        {
+            private readonly NUnitEqualityComparer _comparer;
+
+            private Tolerance _tolerance;
+            public Tolerance Tolerance { get { return _tolerance; } }
+
+            public NUnitEqualityComparison(NUnitEqualityComparer comparer, Tolerance tolerance)
+            {
+                _comparer = comparer;
+                _tolerance = tolerance;
+            }
+
+            public new bool Equals(object x, object y)
+            {
+                return _comparer.AreEqual(x, y, ref _tolerance);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                // TODO: Better hashcode generation, likely based on the corresponding comparer to ensure types which can be
+                // compared with each other end up in the same bucket
+                return 0;
+            }
+        }
+    }
+}
+#endif

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -83,6 +83,9 @@ namespace NUnit.Framework.Constraints
                 new TimeSpanToleranceComparer(),
                 new TupleComparer(this),
                 new ValueTupleComparer(this),
+#if !NET35
+                new StructuralComparer(this),
+#endif
                 new EquatablesComparer(this),
                 enumerablesComparer
             };

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net35' and '$(TargetFramework)' != 'net40'">
+    <PackageReference Include="System.Runtime" version="4.3.1" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -123,7 +123,9 @@ namespace NUnit.Framework.Constraints
                 () => ImmutableArray.Create(data),
                 () => ImmutableList.Create(data),
                 () => ImmutableQueue.Create(data),
-                () => ImmutableStack.Create(data.Reverse().ToArray())
+                () => ImmutableStack.Create(data.Reverse().ToArray()),
+                () => new List<int>(data),
+                () => data
             };
 
             for (var i = 0; i < immutableDataGenerators.Length; i++)

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -24,12 +24,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
 #if !(NET35 || NET40)
 using System.Collections.Immutable;
 #endif
 using System.Linq;
-using System.Reflection;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -138,16 +136,6 @@ namespace NUnit.Framework.Constraints
                     yield return new object[] { x, y };
                 }
             }
-        }
-
-        [Test]
-        public void ImmutableArrayEquals_UsingStructuralEquality()
-        {
-            var x = ImmutableArray.Create(1, 2, 3);
-            var y = ImmutableArray.Create(1, 2, 3);
-
-            Assert.That(x, Is.EqualTo(y).Using(StructuralComparisons.StructuralComparer));
-            Assert.That(x, Is.EqualTo(y).Using(StructuralComparisons.StructuralEqualityComparer));
         }
 #endif
     }

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -109,6 +109,42 @@ namespace NUnit.Framework.Constraints
         };
 
 #if !(NET35 || NET40)
+        [Test]
+        [DefaultFloatingPointTolerance(0.5)]
+        public void StructuralComparerOnSameCollection_RespectsAndSetsToleranceByRef()
+        {
+            var integerTypes = ImmutableArray.Create<int>(1);
+            var floatingTypes = ImmutableArray.Create<double>(1.1);
+
+            var equalsConstraint = Is.EqualTo(floatingTypes);
+            var originalTolerance = equalsConstraint.Tolerance;
+
+            Assert.That(integerTypes, equalsConstraint);
+
+            Assert.That(equalsConstraint.Tolerance, Is.Not.EqualTo(originalTolerance));
+            Assert.That(equalsConstraint.Tolerance.Mode, Is.Not.EqualTo(originalTolerance.Mode));
+        }
+
+        [Test]
+        public void StructuralComparerOnSameCollection_OfDifferentUnderlyingType_UsesNUnitComparer()
+        {
+            var integerTypes = ImmutableArray.Create<int>(1);
+            var floatingTypes = ImmutableArray.Create<double>(1.1);
+
+            Assert.That(integerTypes, Is.Not.EqualTo(floatingTypes));
+            Assert.That(integerTypes, Is.EqualTo(floatingTypes).Within(0.5));
+        }
+
+        [Test]
+        public void StructuralComparerOnDifferentCollection_OfDifferentUnderlyingType_UsesNUnitComparer()
+        {
+            var integerTypes = ImmutableArray.Create<int>(1);
+            var floatingTypes = new double[] { 1.1 };
+
+            Assert.That(integerTypes, Is.Not.EqualTo(floatingTypes));
+            Assert.That(integerTypes, Is.EqualTo(floatingTypes).Within(0.5));
+        }
+
         [TestCaseSource(nameof(GetImmutableCollectionsData))]
         public void ImmutableCollectionsEquals(object x, object y)
         {

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -32,7 +32,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -32,6 +32,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">


### PR DESCRIPTION
Fixes #3447 

It looks like the reason for the failures here was that, as an implementer of IEquatable<>, ImmutableArray was not deferring comparisons down to the enumerable-level. IEquatable<> in turn attempted reference equality on the boxed objects of ImmutableArray (a struct).

I'd welcome some feedback on the implementation here, as I'm not entirely sure the best solution.