### PR TITLE
Support .Net 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ project.lock.json
 *.project.lock.json
 .dotnet
 .config/dotnet-tools.json
+*.err
+*.out

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,9 +6,9 @@ There are two ways to build NUnit: using the solution file in an IDE or through 
 
 ## Solution Build
 
-The framework is built using a single Visual Studio solution, `nunit.sln`, which may be built with [Visual Studio 2019](https://www.visualstudio.com/vs/) on Windows and [Visual Studio for Mac](https://www.visualstudio.com/vs/) on macOS. Currently, MonoDevelop does not support the new multi-targeted `csproj` project format. Once MonoDevelop is updated, it should start working again. Until then, we recommend [Visual Studio Code](https://code.visualstudio.com/) and compiling using the build scripts on non-Windows platforms.
+The framework is built using a single Visual Studio solution, `nunit.sln`, which may be built with [Visual Studio 2019 16.8](https://www.visualstudio.com/vs/) or newer on Windows and [Visual Studio for Mac](https://www.visualstudio.com/vs/) on macOS. Currently, MonoDevelop does not support the new multi-targeted `csproj` project format. Once MonoDevelop is updated, it should start working again. Until then, we recommend [Visual Studio Code](https://code.visualstudio.com/) and compiling using the build scripts on non-Windows platforms.
 
-On all platforms, you will need to install [.NET Core 2.0.3 SDK](https://www.microsoft.com/net/download/windows) or newer. On Mac or Linux, you will need to install [Mono 5.2.0](https://www.mono-project.com/download/). Currently (as of 5.4.1), newer versions of Mono are broken and crash during the compile.
+On all platforms, you will need to install [.NET 5.0 SDK](https://www.microsoft.com/net/download/windows) or newer. On Mac or Linux, you will need to install [Mono 5.2.0](https://www.mono-project.com/download/). Currently (as of 5.4.1), newer versions of Mono are broken and crash during the compile.
 
 The solutions all place their output in a common bin directory under the solution root.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 install:
   - ps: Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-  - ps: .\dotnet-install.ps1 -Version 5.0.100-preview.6.20318.15
+  - ps: .\dotnet-install.ps1 -Version 5.0.100
 
 build_script:
   - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100-preview.6.20318.15
+      version: 5.0.100
       performMultiLevelLookup: true
 
   - powershell: .\build.ps1 --target=Test --test-run-name=Windows
@@ -45,7 +45,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100-preview.6.20318.15
+      version: 5.0.100
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
@@ -82,7 +82,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100-preview.6.20318.15
+      version: 5.0.100
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'

--- a/build.cake
+++ b/build.cake
@@ -138,42 +138,49 @@ Task("NuGetRestore")
 // BUILD FRAMEWORKS
 //////////////////////////////////////////////////////////////////////
 
+var buildSettings = new DotNetCoreBuildSettings
+{
+    Configuration = configuration,
+    NoRestore = false,
+    Verbosity = DotNetCoreVerbosity.Minimal,
+};
+
 Task("Build")
     .Description("Builds the Solution")
     .IsDependentOn("NuGetRestore")
     .Does(() =>
     {
-        MSBuild(SOLUTION_FILE, CreateSettings());
+        DotNetCoreBuild(SOLUTION_FILE, buildSettings);
     });
 
-MSBuildSettings CreateSettings()
-{
-    var settings = new MSBuildSettings { Verbosity = Verbosity.Minimal, Configuration = configuration };
+// MSBuildSettings CreateSettings()
+// {
+//     var settings = new MSBuildSettings { Verbosity = Verbosity.Minimal, Configuration = configuration };
 
-    if (IsRunningOnWindows())
-    {
-        // Find MSBuild for Visual Studio 2019 and newer
-        DirectoryPath vsLatest = VSWhereLatest();
-        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
+//     if (IsRunningOnWindows())
+//     {
+//         // Find MSBuild for Visual Studio 2019 and newer
+//         DirectoryPath vsLatest = VSWhereLatest();
+//         FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
-        // Find MSBuild for Visual Studio 2017
-        if (msBuildPath != null && !FileExists(msBuildPath))
-            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+//         // Find MSBuild for Visual Studio 2017
+//         if (msBuildPath != null && !FileExists(msBuildPath))
+//             msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
-        // Have we found MSBuild yet?
-        if (!FileExists(msBuildPath))
-        {
-            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
-        }
+//         // Have we found MSBuild yet?
+//         if (!FileExists(msBuildPath))
+//         {
+//             throw new Exception($"Failed to find MSBuild: {msBuildPath}");
+//         }
 
-        Information("Building using MSBuild at " + msBuildPath);
-        settings.ToolPath = msBuildPath;
-    }
-    else
-        settings.ToolPath = Context.Tools.Resolve("msbuild");
+//         Information("Building using MSBuild at " + msBuildPath);
+//         settings.ToolPath = msBuildPath;
+//     }
+//     else
+//         settings.ToolPath = Context.Tools.Resolve("msbuild");
 
-    return settings;
-}
+//     return settings;
+// }
 
 //////////////////////////////////////////////////////////////////////
 // TEST

--- a/build.cake
+++ b/build.cake
@@ -241,6 +241,7 @@ foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
+        .WithCriteria(IsRunningOnWindows() || runtime != "net5.0-windows")
         .IsDependentOn("Build")
         .OnError(exception => { ErrorDetail.Add(exception.Message); })
         .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -225,7 +225,7 @@ Task("Test35")
 var testNetStandard20 = Task("TestNetStandard20")
     .Description("Tests the .NET Standard 2.0 version of the framework");
 
-foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp3.1", "net5.0" })
+foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net5.0-windows" })
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
@@ -523,6 +523,9 @@ void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string frame
 
 void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string framework, FilePath resultFile, ref List<string> errorDetail)
 {
+    if (!FileExists(exePath))
+        return;
+
     int rc = StartProcess(
         "dotnet",
         new ProcessSettings

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6",
-    "allowPrerelease": true,
+    "version": "5.0.100",
+    "allowPrerelease": false,
     "rollForward": "major"
   }
 }

--- a/nunit.sln
+++ b/nunit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30709.132
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.framework", "src\NUnitFramework\framework\nunit.framework.csproj", "{B7753E96-F76B-4E9B-9071-47B16DB90FD6}"
 EndProject
@@ -10,13 +10,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
+		azure-pipelines.yml = azure-pipelines.yml
 		build.cake = build.cake
 		BUILDING.md = BUILDING.md
 		CHANGES.md = CHANGES.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		src\NUnitFramework\Directory.Build.props = src\NUnitFramework\Directory.Build.props
+		global.json = global.json
 		LICENSE.txt = LICENSE.txt
 		NOTICES.txt = NOTICES.txt
 		NuGet.config = NuGet.config

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -44,7 +44,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Core 2.1 Debug")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
-#elif NETCOREAPP5_0
+#elif NET5_0
 [assembly: AssemblyConfiguration(".NET 5.0 Debug")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.
@@ -62,7 +62,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Core 2.1")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1")]
-#elif NETCOREAPP5_0
+#elif NET5_0
 [assembly: AssemblyConfiguration(".NET 5.0")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -22,7 +22,8 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard2.0'
                             and '$(TargetFramework)' != 'netcoreapp2.1'
                             and '$(TargetFramework)' != 'netcoreapp3.1'
-                            and '$(TargetFramework)' != 'net5.0'">$(DefineConstants);THREAD_ABORT</DefineConstants>
+                            and '$(TargetFramework)' != 'net5.0'
+                            and '$(TargetFramework)' != 'net5.0-windows'">$(DefineConstants);THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
   <!-- We always want a good debugging experience in tests -->

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -198,7 +198,7 @@ namespace NUnit.Framework.Internal
             if (type1.IsAssignableFrom(type2)) { bestCommonType = type1; return true; }
             if (type2.IsAssignableFrom(type1)) { bestCommonType = type2; return true; }
 
-            bestCommonType = null;
+            bestCommonType = typeof(object);
             return false;
         }
 

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -6,6 +6,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -14,4 +14,9 @@
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -8,8 +8,15 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="'$(UseWindowsFormsAndWPF)' != 'true'" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(UseWindowsFormsAndWPF)' == 'true'" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
@@ -24,6 +24,11 @@
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
     <Compile Include="..\FrameworkVersion.cs" Link="Properties\FrameworkVersion.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net35;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Fakes.cs" Link="TestUtilities\Fakes.cs" />
     <Compile Include="..\SchemaTestUtils.cs" Link="TestUtilities\SchemaTestUtils.cs" />
     <Compile Include="..\TestBuilder.cs" Link="TestUtilities\TestBuilder.cs" />

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -1,9 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net35;net40;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFrameworks>net35;net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -19,4 +19,9 @@
     <None Update="Schemas\*.xsd" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -13,4 +13,9 @@
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
     <Deterministic>false</Deterministic>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.7.2" />
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>
 

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -8,6 +8,14 @@
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net35;net40;net46;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFrameworks>net35;net46;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -8,6 +8,11 @@
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="Microsoft.Bcl" version="1.1.10" />
     <PackageReference Include="Microsoft.Bcl.Async" version="1.0.168" />

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFrameworks>net35;net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net35;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -28,6 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
     <ProjectReference Include="..\slow-tests\slow-nunit-tests.csproj" />
     <ProjectReference Include="..\testdata\nunit.testdata.csproj" />

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -8,8 +8,15 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="'$(UseWindowsFormsAndWPF)' != 'true'" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(UseWindowsFormsAndWPF)' == 'true'" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <RootNamespace>NUnit.Framework</RootNamespace>
 
     <!-- Either NUnit or NUnitLite is not loading assemblies in a way that properly respects the

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net35;net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #3650

Fixes for building on the final version of .NET 5.0

- Global.json updated
- Target FSharp.Core 4.7.2 and disable automatically targeting 5.0.0.
- The framework define `NETCOREAPP5_0` was switched to `NET5_0`
- Our WPF test code needs to target `net5.0-windows`
- There are some changes in nullability
- Updates Cake build to use the new bin directories
- Updates the CI build definitions
- Update build requirements in `BUILDING.md`
