### PR TITLE
Add FrameworkPackageSettings for default thread Culture and UICulture

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkPackageSettings.cs
@@ -64,6 +64,20 @@ namespace NUnit
         public const string DefaultTimeout = "DefaultTimeout";
 
         /// <summary>
+        /// A string representing the default thread culture to be used for
+        /// running tests. String should be a valid BCP-47 culture name. If
+        /// culture is unset, tests run on the machine's default culture.
+        /// </summary>
+        public const string DefaultCulture = "DefaultCulture";
+
+        /// <summary>
+        /// A string representing the default thread UI culture to be used for
+        /// running tests. String should be a valid BCP-47 culture name. If
+        /// culture is unset, tests run on the machine's default culture.
+        /// </summary>
+        public const string DefaultUICulture = "DefaultUICulture";
+
+        /// <summary>
         /// A TextWriter to which the internal trace will be sent.
         /// </summary>
         public const string InternalTraceWriter = "InternalTraceWriter";

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -30,6 +30,7 @@ using NUnit.Framework.Internal.Execution;
 using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
+using System.Globalization;
 using System.Security;
 using NUnit.Framework.Internal.Abstractions;
 
@@ -332,6 +333,10 @@ namespace NUnit.Framework.Api
             // Apply package settings to the context
             if (Settings.ContainsKey(FrameworkPackageSettings.DefaultTimeout))
                 Context.TestCaseTimeout = (int)Settings[FrameworkPackageSettings.DefaultTimeout];
+            if (Settings.ContainsKey(FrameworkPackageSettings.DefaultCulture))
+                Context.CurrentCulture = new CultureInfo((string)Settings[FrameworkPackageSettings.DefaultCulture], false);
+            if (Settings.ContainsKey(FrameworkPackageSettings.DefaultUICulture))
+                Context.CurrentUICulture = new CultureInfo((string)Settings[FrameworkPackageSettings.DefaultUICulture], false);
             if (Settings.ContainsKey(FrameworkPackageSettings.StopOnError))
                 Context.StopOnError = (bool)Settings[FrameworkPackageSettings.StopOnError];
 


### PR DESCRIPTION
Fixes #3667 

As per other framework package settings - this leaves validation to the engine. There's also no testing of this functionality (as per other settings used in the same way).