### PR TITLE
Add the framework version to Assembly start-suite events

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -209,7 +209,8 @@ namespace NUnit.Framework.Api
         /// <returns>The XML result of exploring the tests</returns>
         public string ExploreTests(string filter)
         {
-            return Runner.ExploreTests(TestFilter.FromXml(filter)).ToXml(true).OuterXml;
+            TNode result = Runner.ExploreTests(TestFilter.FromXml(filter)).ToXml(true);
+            return InsertChildElements(result).OuterXml;
         }
 
         /// <summary>
@@ -220,13 +221,7 @@ namespace NUnit.Framework.Api
         public string RunTests(string filter)
         {
             TNode result = Runner.Run(new TestProgressReporter(null), TestFilter.FromXml(filter)).ToXml(true);
-
-            // Insert elements as first child in reverse order
-            if (Settings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, Settings);
-            InsertEnvironmentElement(result);
-
-            return result.OuterXml;
+            return InsertChildElements(result).OuterXml;
         }
 
         class ActionCallback : ICallbackEventHandler
@@ -260,15 +255,8 @@ namespace NUnit.Framework.Api
         public string RunTests(Action<string> callback, string filter)
         {
             var handler = new ActionCallback(callback);
-
             TNode result = Runner.Run(new TestProgressReporter(handler), TestFilter.FromXml(filter)).ToXml(true);
-
-            // Insert elements as first child in reverse order
-            if (Settings != null) // Some platforms don't have settings
-                InsertSettingsElement(result, Settings);
-            InsertEnvironmentElement(result);
-
-            return result.OuterXml;
+            return InsertChildElements(result).OuterXml;
         }
 
         /// <summary>
@@ -341,6 +329,21 @@ namespace NUnit.Framework.Api
         private void CountTests(ICallbackEventHandler handler, string filter)
         {
             handler.RaiseCallbackEvent(CountTests(filter).ToString());
+        }
+
+        /// <summary>
+        /// Inserts the environment and settings elements
+        /// </summary>
+        /// <param name="targetNode">Target node</param>
+        /// <returns>The updated target node</returns>
+        private TNode InsertChildElements(TNode targetNode)
+        {
+            // Insert elements as first child in reverse order
+            if (Settings != null) // Some platforms don't have settings
+                InsertSettingsElement(targetNode, Settings);
+            InsertEnvironmentElement(targetNode);
+
+            return targetNode;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -24,7 +24,9 @@
 #nullable enable
 
 using System;
+using System.Reflection;
 using System.Web.UI;
+using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
@@ -57,16 +59,20 @@ namespace NUnit.Framework.Internal
         /// <param name="test">The test that is starting</param>
         public void TestStarted(ITest test)
         {
-            string startElement = test is TestSuite
-                ? "start-suite"
-                : "start-test";
-
             var parent = GetParent(test);
             try
             {
-                string report = test is TestSuite 
-                    ? $"<start-suite id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\"/>"
-                    : $"<start-test id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" classname=\"{FormatAttributeValue(test.ClassName ?? "")}\" methodname=\"{FormatAttributeValue(test.MethodName ?? "")}\"/>";
+                string report;
+                if (test is TestSuite)
+                {
+                    // Only add framework-version for the Assemlby start-suite
+                    string version = test.TestType == "Assembly" ? $"framework-version=\"{typeof(TestProgressReporter).GetTypeInfo().Assembly.GetName().Version}\" " : "";
+                    report = $"<start-suite id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" {version}/>";
+                }
+                else
+                {
+                    report = $"<start-test id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" classname=\"{FormatAttributeValue(test.ClassName ?? "")}\" methodname=\"{FormatAttributeValue(test.MethodName ?? "")}\"/>";
+                }
 
                 handler.RaiseCallbackEvent(report);
             }

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Internal
                 string report;
                 if (test is TestSuite)
                 {
-                    // Only add framework-version for the Assemlby start-suite
+                    // Only add framework-version for the Assembly start-suite
                     string version = test.TestType == "Assembly" ? $"framework-version=\"{typeof(TestProgressReporter).GetTypeInfo().Assembly.GetName().Version}\" " : "";
                     report = $"<start-suite id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" {version}/>";
                 }

--- a/src/NUnitFramework/framework/Schemas/TestDefinitions.xsd
+++ b/src/NUnitFramework/framework/Schemas/TestDefinitions.xsd
@@ -50,11 +50,50 @@
   <xs:attributeGroup name="TestCaseAttributeGroup">
     <xs:attributeGroup ref="TestBaseAttributeGroup" />
     <xs:attribute name="seed" type="xs:string" use="required" />
-  </xs:attributeGroup>
+  </xs:attributeGroup> 
 
   <!-- NUnit.Framework.Internal.TestSuite.AddToXml -->
   <xs:complexType name="TestSuiteElementType">
     <xs:sequence>
+      <!-- NUnit.Framework.Api.FrameworkController.InsertEnvironmentElement -->
+      <xs:element name="environment" minOccurs="0">
+        <xs:complexType>
+          <xs:attribute name="framework-version" type="xs:string" use="required" />
+          <xs:attribute name="clr-version" type="xs:string" use="required" />
+          <xs:attribute name="os-version" type="xs:string" use="required" />
+          <xs:attribute name="platform" type="xs:string" />
+          <xs:attribute name="cwd" type="xs:string" use="required" />
+          <xs:attribute name="machine-name" type="xs:string" />
+          <xs:attribute name="user" type="xs:string" />
+          <xs:attribute name="user-domain" type="xs:string" />
+          <xs:attribute name="culture" type="xs:string" use="required" />
+          <xs:attribute name="uiculture" type="xs:string" use="required" />
+          <xs:attribute name="os-architecture" type="xs:string" use="required" />
+        </xs:complexType>
+      </xs:element>
+      <!-- NUnit.Framework.Api.FrameworkController.InsertSettingsElement -->
+      <xs:element name="settings" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <!-- NUnit.Framework.Api.FrameworkController.AddSetting -->
+            <xs:element name="setting" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <!-- NUnit.Framework.Api.FrameworkController.AddDictionaryEntries -->
+                  <xs:element name="item" minOccurs="0" maxOccurs ="unbounded">
+                    <xs:complexType>
+                      <xs:attribute name="key" type="xs:string" use="required" />
+                      <xs:attribute name="value" type="xs:string" use="required" />
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required" />
+                <xs:attribute name="value" type="xs:string" />
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:group ref="TestBaseElementGroup" />
       <xs:group ref="ContainedTestGroup" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>

--- a/src/NUnitFramework/framework/Schemas/TestResult.xsd
+++ b/src/NUnitFramework/framework/Schemas/TestResult.xsd
@@ -36,7 +36,6 @@
   </xs:redefine>
   <xs:group name="TestResultBaseElementGroup">
     <xs:sequence>
-      <xs:group ref="RootResultElementGroup" minOccurs="0" />
       <xs:group ref="TestBaseElementGroup" />
       <!-- NUnit.Framework.Internal.TestResult.AddFailureElement -->
       <xs:element name="failure" minOccurs="0">
@@ -132,51 +131,6 @@
     <xs:attribute name="duration" type="TestDurationType" />
     <xs:attribute name="asserts" type="NonnegativeInt32" use="required" />
   </xs:attributeGroup>
-
-  <!-- NUnit.Framework.Api.FrameworkController.RunTests -->
-  <xs:group name="RootResultElementGroup">
-    <xs:sequence>
-      <!-- NUnit.Framework.Api.FrameworkController.InsertEnvironmentElement -->
-      <xs:element name="environment">
-        <xs:complexType>
-          <xs:attribute name="framework-version" type="xs:string" use="required" />
-          <xs:attribute name="clr-version" type="xs:string" use="required" />
-          <xs:attribute name="os-version" type="xs:string" use="required" />
-          <xs:attribute name="platform" type="xs:string" />
-          <xs:attribute name="cwd" type="xs:string" use="required" />
-          <xs:attribute name="machine-name" type="xs:string" />
-          <xs:attribute name="user" type="xs:string" />
-          <xs:attribute name="user-domain" type="xs:string" />
-          <xs:attribute name="culture" type="xs:string" use="required" />
-          <xs:attribute name="uiculture" type="xs:string" use="required" />
-          <xs:attribute name="os-architecture" type="xs:string" use="required" />
-        </xs:complexType>
-      </xs:element>
-      <!-- NUnit.Framework.Api.FrameworkController.InsertSettingsElement -->
-      <xs:element name="settings" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <!-- NUnit.Framework.Api.FrameworkController.AddSetting -->
-            <xs:element name="setting" minOccurs="0" maxOccurs="unbounded">
-              <xs:complexType>
-                <xs:sequence>
-                  <!-- NUnit.Framework.Api.FrameworkController.AddDictionaryEntries -->
-                  <xs:element name="item" minOccurs="0" maxOccurs ="unbounded">
-                    <xs:complexType>
-                      <xs:attribute name="key" type="xs:string" use="required" />
-                      <xs:attribute name="value" type="xs:string" use="required" />
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string" use="required" />
-                <xs:attribute name="value" type="xs:string" />
-              </xs:complexType>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
 
   <!-- NUnitLite.NUnit3XmlOutputWriter.WriteXmlResultOutput -->
   <!-- NUnitLite.NUnit3XmlOutputWriter.MakeTestRunElement -->

--- a/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
@@ -22,10 +22,12 @@
 // ***********************************************************************
 
 using System;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.TestUtilities;
 using NUnit.TestData.TestFixtureTests;
+using NUnit.Compatibility;
 
 namespace NUnit.Framework.Internal
 {
@@ -61,6 +63,20 @@ namespace NUnit.Framework.Internal
             Assert.That(startReport, Contains.Substring("type=\"Assembly\""));
 
             Assert.That(_listener.Reports.Count(x => x.StartsWith("<start-suite") && x.Contains("type=\"Assembly\"")), Is.EqualTo(1), "More than one Assembly event");
+        }
+
+        [Test]
+        public void TestStarted_AssemblyIncludesFrameworkVersion()
+        {
+            var work = TestBuilder.CreateWorkItem(new TestAssembly("mytest.dll"));
+            work.Context.Listener = _reporter;
+
+            TestBuilder.ExecuteWorkItem(work);
+
+            var startReport = _listener.Reports.FirstOrDefault();
+            Assert.NotNull(startReport);
+            Assert.That(startReport, Does.StartWith("<start-suite"));
+            Assert.That(startReport, Contains.Substring($"framework-version=\"{typeof(TestProgressReporter).GetTypeInfo().Assembly.GetName().Version}\""));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3657

As requested by the adapter team, this allows them to know which version of NUnit is running so that they can treat newer versions more efficiently.
