### PR TITLE
Add attributes to Assert.NotNull method to tell compiler input is checked for null.

### DIFF
--- a/src/NUnitFramework/framework/Assert.Conditions.cs
+++ b/src/NUnitFramework/framework/Assert.Conditions.cs
@@ -26,6 +26,7 @@
 using System.Collections;
 using NUnit.Framework.Constraints;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NUnit.Framework
 {
@@ -41,7 +42,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void True(bool? condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.True ,message, args);
+            Assert.That(condition, Is.True, message, args);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void True(bool? condition)
         {
-            Assert.That(condition, Is.True ,null, null);
+            Assert.That(condition, Is.True, null, null);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void True(bool condition)
         {
-            Assert.That(condition, Is.True ,null, null);
+            Assert.That(condition, Is.True, null, null);
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsTrue(bool? condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.True ,message, args);
+            Assert.That(condition, Is.True, message, args);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsTrue(bool condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.True ,message, args);
+            Assert.That(condition, Is.True, message, args);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void IsTrue(bool? condition)
         {
-            Assert.That(condition, Is.True ,null, null);
+            Assert.That(condition, Is.True, null, null);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void IsTrue(bool condition)
         {
-            Assert.That(condition, Is.True ,null, null);
+            Assert.That(condition, Is.True, null, null);
         }
 
         #endregion
@@ -126,7 +127,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void False(bool? condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.False ,message, args);
+            Assert.That(condition, Is.False, message, args);
         }
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void False(bool condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.False ,message, args);
+            Assert.That(condition, Is.False, message, args);
         }
 
         /// <summary>
@@ -147,7 +148,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void False(bool? condition)
         {
-            Assert.That(condition, Is.False ,null, null);
+            Assert.That(condition, Is.False, null, null);
         }
 
         /// <summary>
@@ -157,7 +158,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void False(bool condition)
         {
-            Assert.That(condition, Is.False ,null, null);
+            Assert.That(condition, Is.False, null, null);
         }
 
         /// <summary>
@@ -169,7 +170,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsFalse(bool? condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.False ,message, args);
+            Assert.That(condition, Is.False, message, args);
         }
 
         /// <summary>
@@ -181,7 +182,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsFalse(bool condition, string? message, params object?[]? args)
         {
-            Assert.That(condition, Is.False ,message, args);
+            Assert.That(condition, Is.False, message, args);
         }
 
         /// <summary>
@@ -191,7 +192,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void IsFalse(bool? condition)
         {
-            Assert.That(condition, Is.False ,null, null);
+            Assert.That(condition, Is.False, null, null);
         }
 
         /// <summary>
@@ -201,34 +202,14 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         public static void IsFalse(bool condition)
         {
-            Assert.That(condition, Is.False ,null, null);
+            Assert.That(condition, Is.False, null, null);
         }
 
         #endregion
 
         #region NotNull
 
-        /// <summary>
-        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="anObject">The object that is to be tested</param>
-        /// <param name="message">The message to display in case of failure</param>
-        /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotNull(object? anObject, string? message, params object?[]? args)
-        {
-            Assert.That(anObject, Is.Not.Null ,message, args);
-        }
-
-        /// <summary>
-        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
-        /// exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="anObject">The object that is to be tested</param>
-        public static void NotNull(object? anObject)
-        {
-            Assert.That(anObject, Is.Not.Null ,null, null);
-        }
+#pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
 
         /// <summary>
         /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
@@ -237,9 +218,9 @@ namespace NUnit.Framework
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotNull(object? anObject, string? message, params object?[]? args)
+        public static void NotNull([NotNull] object? anObject, string? message, params object?[]? args)
         {
-            Assert.That(anObject, Is.Not.Null ,message, args);
+            Assert.That(anObject, Is.Not.Null, message, args);
         }
 
         /// <summary>
@@ -247,10 +228,34 @@ namespace NUnit.Framework
         /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void IsNotNull(object? anObject)
+        public static void NotNull([NotNull] object? anObject)
         {
-            Assert.That(anObject, Is.Not.Null ,null, null);
+            Assert.That(anObject, Is.Not.Null, null, null);
         }
+
+        /// <summary>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="anObject">The object that is to be tested</param>
+        /// <param name="message">The message to display in case of failure</param>
+        /// <param name="args">Array of objects to be used in formatting the message</param>
+        public static void IsNotNull([NotNull] object? anObject, string? message, params object?[]? args)
+        {
+            Assert.That(anObject, Is.Not.Null, message, args);
+        }
+
+        /// <summary>
+        /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
+        /// exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="anObject">The object that is to be tested</param>
+        public static void IsNotNull([NotNull] object? anObject)
+        {
+            Assert.That(anObject, Is.Not.Null, null, null);
+        }
+
+#pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
         #endregion
 
@@ -265,7 +270,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void Null(object? anObject, string? message, params object?[]? args)
         {
-            Assert.That(anObject, Is.Null ,message, args);
+            Assert.That(anObject, Is.Null, message, args);
         }
 
         /// <summary>
@@ -275,7 +280,7 @@ namespace NUnit.Framework
         /// <param name="anObject">The object that is to be tested</param>
         public static void Null(object? anObject)
         {
-            Assert.That(anObject, Is.Null ,null, null);
+            Assert.That(anObject, Is.Null, null, null);
         }
 
         /// <summary>
@@ -287,7 +292,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsNull(object? anObject, string? message, params object?[]? args)
         {
-            Assert.That(anObject, Is.Null ,message, args);
+            Assert.That(anObject, Is.Null, message, args);
         }
 
         /// <summary>
@@ -297,7 +302,7 @@ namespace NUnit.Framework
         /// <param name="anObject">The object that is to be tested</param>
         public static void IsNull(object? anObject)
         {
-            Assert.That(anObject, Is.Null ,null, null);
+            Assert.That(anObject, Is.Null, null, null);
         }
 
         #endregion
@@ -313,7 +318,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsNaN(double aDouble, string? message, params object?[]? args)
         {
-            Assert.That(aDouble, Is.NaN ,message, args);
+            Assert.That(aDouble, Is.NaN, message, args);
         }
 
         /// <summary>
@@ -323,7 +328,7 @@ namespace NUnit.Framework
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double aDouble)
         {
-            Assert.That(aDouble, Is.NaN ,null, null);
+            Assert.That(aDouble, Is.NaN, null, null);
         }
 
         /// <summary>
@@ -335,7 +340,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsNaN(double? aDouble, string? message, params object?[]? args)
         {
-            Assert.That(aDouble, Is.NaN ,message, args);
+            Assert.That(aDouble, Is.NaN, message, args);
         }
 
         /// <summary>
@@ -345,7 +350,7 @@ namespace NUnit.Framework
         /// <param name="aDouble">The value that is to be tested</param>
         public static void IsNaN(double? aDouble)
         {
-            Assert.That(aDouble, Is.NaN ,null, null);
+            Assert.That(aDouble, Is.NaN, null, null);
         }
 
         #endregion
@@ -362,7 +367,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsEmpty(string? aString, string? message, params object?[]? args)
         {
-            Assert.That(aString, new EmptyStringConstraint() ,message, args);
+            Assert.That(aString, new EmptyStringConstraint(), message, args);
         }
 
         /// <summary>
@@ -371,7 +376,7 @@ namespace NUnit.Framework
         /// <param name="aString">The string to be tested</param>
         public static void IsEmpty(string? aString)
         {
-            Assert.That(aString, new EmptyStringConstraint() ,null, null);
+            Assert.That(aString, new EmptyStringConstraint(), null, null);
         }
 
         #endregion
@@ -387,7 +392,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsEmpty(IEnumerable collection, string? message, params object?[]? args)
         {
-            Assert.That(collection, new EmptyCollectionConstraint() ,message, args);
+            Assert.That(collection, new EmptyCollectionConstraint(), message, args);
         }
 
         /// <summary>
@@ -397,7 +402,7 @@ namespace NUnit.Framework
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         public static void IsEmpty(IEnumerable collection)
         {
-            Assert.That(collection, new EmptyCollectionConstraint() ,null, null);
+            Assert.That(collection, new EmptyCollectionConstraint(), null, null);
         }
 
         #endregion
@@ -417,7 +422,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsNotEmpty(string? aString, string? message, params object?[]? args)
         {
-            Assert.That(aString, Is.Not.Empty ,message, args);
+            Assert.That(aString, Is.Not.Empty, message, args);
         }
 
         /// <summary>
@@ -427,7 +432,7 @@ namespace NUnit.Framework
         /// <param name="aString">The string to be tested</param>
         public static void IsNotEmpty(string? aString)
         {
-            Assert.That(aString, Is.Not.Empty ,null, null);
+            Assert.That(aString, Is.Not.Empty, null, null);
         }
 
         #endregion
@@ -443,7 +448,7 @@ namespace NUnit.Framework
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsNotEmpty(IEnumerable collection, string? message, params object?[]? args)
         {
-            Assert.That(collection, Is.Not.Empty ,message, args);
+            Assert.That(collection, Is.Not.Empty, message, args);
         }
 
         /// <summary>
@@ -453,7 +458,7 @@ namespace NUnit.Framework
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         public static void IsNotEmpty(IEnumerable collection)
         {
-            Assert.That(collection, Is.Not.Empty ,null, null);
+            Assert.That(collection, Is.Not.Empty, null, null);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -24,6 +24,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework
@@ -198,6 +199,8 @@ namespace NUnit.Framework
 
         #region Assert.That<TActual>
 
+#pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
+
         /// <summary>
         /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
         /// block.
@@ -205,7 +208,7 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression)
+        public static void That<TActual>([NotNull] TActual actual, IResolveConstraint expression)
         {
             Assert.That(actual, expression, null, null);
         }
@@ -219,7 +222,7 @@ namespace NUnit.Framework
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message, params object?[]? args)
+        public static void That<TActual>([NotNull] TActual actual, IResolveConstraint expression, string? message, params object?[]? args)
         {
             var constraint = expression.Resolve();
 
@@ -238,7 +241,7 @@ namespace NUnit.Framework
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That<TActual>(
-            TActual actual,
+            [NotNull] TActual actual,
             IResolveConstraint expression,
             Func<string?> getExceptionMessage)
         {
@@ -249,6 +252,8 @@ namespace NUnit.Framework
             if (!result.IsSuccess)
                 ReportFailure(result, getExceptionMessage());
         }
+
+#pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
         #endregion
 
@@ -261,7 +266,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void ByVal(object? actual, IResolveConstraint expression)
+        public static void ByVal([NotNull] object? actual, IResolveConstraint expression)
         {
             Assert.That(actual, expression, null, null);
         }
@@ -279,7 +284,7 @@ namespace NUnit.Framework
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void ByVal(object? actual, IResolveConstraint expression, string? message, params object?[]? args)
+        public static void ByVal([NotNull] object? actual, IResolveConstraint expression, string? message, params object?[]? args)
         {
             Assert.That(actual, expression, message, args);
         }

--- a/src/NUnitFramework/framework/AssertionExtensions.cs
+++ b/src/NUnitFramework/framework/AssertionExtensions.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Extension methods to help with Assert and nullability.
+    /// </summary>
+    public static class AssertionExtensions
+    {
+        /// <summary>
+        /// Assert that this source is not null.
+        /// </summary>
+        /// <typeparam name="T">The type of instance being handled.</typeparam>
+        /// <param name="source">The source instance to check for null.</param>
+        /// <returns>The source instance, or throws when null.</returns>
+        public static T AssertNotNull<T>(this T? source)
+            where T : class
+        {
+            Assert.NotNull(source);
+
+            return source;
+        }
+
+        /// <summary>
+        /// Assert that this source is not null.
+        /// </summary>
+        /// <typeparam name="T">The type of instance being handled.</typeparam>
+        /// <param name="source">The source instance to check for null.</param>
+        /// <param name="name">The name of the source instance.</param>
+        /// <returns>The source instance, or throws when null.</returns>
+        public static T AssertNotNull<T>(this T? source, string name)
+            where T : class
+        {
+            Assert.NotNull(source, name);
+
+            return source;
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
@@ -109,5 +109,25 @@ namespace NUnit.Framework.Internal.Results
             TNode suiteNode = _suiteResult.ToXml(true);
             Assert.Null(suiteNode.SelectSingleNode("assertions"));
         }
+
+#nullable enable
+
+        [TestCase("")]
+        public void ValidatedNotNull(string? possiblyNull)
+        {
+            Assert.NotNull(possiblyNull);
+            Assert.That(possiblyNull.Length, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [TestCase("")]
+        public void ValidatedNotNullExtension(string? possiblyNull)
+        {
+            string notNull = possiblyNull.AssertNotNull(nameof(possiblyNull));
+            Assert.That(notNull.Length, Is.GreaterThanOrEqualTo(0));
+            string reallyNotNull = possiblyNull.AssertNotNull();
+            Assert.That(reallyNotNull.Length, Is.GreaterThanOrEqualTo(0));
+        }
+
+#nullable restore
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
@@ -120,6 +120,13 @@ namespace NUnit.Framework.Internal.Results
         }
 
         [TestCase("")]
+        public void ValidatedNotNullUsingThat(string? possiblyNull)
+        {
+            Assert.That(possiblyNull, Is.Not.Null);
+            Assert.That(possiblyNull.Length, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [TestCase("")]
         public void ValidatedNotNullExtension(string? possiblyNull)
         {
             string notNull = possiblyNull.AssertNotNull(nameof(possiblyNull));


### PR DESCRIPTION
Partially fixes #3376 