### PR TITLE
Adds obsolete comment to debug writer class issue #2680

### DIFF
--- a/src/NUnitFramework/nunitlite/DebugWriter.cs
+++ b/src/NUnitFramework/nunitlite/DebugWriter.cs
@@ -32,6 +32,7 @@ namespace NUnitLite
     /// output to Debug. We don't use Trace because
     /// writing to it is not supported in CF.
     /// </summary>
+    [Obsolete("No longer used", true)]
     public class DebugWriter : TextWriter
     {
         private static TextWriter writer;

--- a/src/NUnitFramework/nunitlite/DebugWriter.cs
+++ b/src/NUnitFramework/nunitlite/DebugWriter.cs
@@ -32,7 +32,7 @@ namespace NUnitLite
     /// output to Debug. We don't use Trace because
     /// writing to it is not supported in CF.
     /// </summary>
-    [Obsolete("No longer used", true)]
+    [Obsolete("No longer used")]
     public class DebugWriter : TextWriter
     {
         private static TextWriter writer;


### PR DESCRIPTION
There are still a few references that popped up when the code loaded so I just left the methods and properties alone and depreciated the class itself.