### PR TITLE
Add test verifying equality works for Complex on all platforms

### DIFF
--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -52,6 +52,14 @@ namespace NUnit.Framework.Constraints
                 new TestCaseData(double.PositiveInfinity, double.PositiveInfinity.ToString())
             };
 
+#if !NET35
+        [Test]
+        public void Complex_PassesEquality()
+        {
+            Assert.AreEqual(new System.Numerics.Complex(1, 100), new System.Numerics.Complex(1, 100));
+        }
+#endif
+
         #region DateTimeEquality
 
         public class DateTimeEquality
@@ -741,12 +749,12 @@ namespace NUnit.Framework.Constraints
             get
             {
                 var ptr = new System.IntPtr(0);
-                var ExampleTestA = new ExampleTest.ClassA(0);
-                var ExampleTestB = new ExampleTest.ClassB(0);
+                var exampleTestA = new ExampleTest.ClassA(0);
+                var exampleTestB = new ExampleTest.ClassB(0);
                 var clipTestA = new ExampleTest.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Clip.ReallyLongClassNameShouldBeHere();
                 var clipTestB = new ExampleTest.Clip.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Clip.ReallyLongClassNameShouldBeHere();
                 yield return new object[] { 0, ptr };
-                yield return new object[] { ExampleTestA, ExampleTestB };
+                yield return new object[] { exampleTestA, exampleTestB };
                 yield return new object[] { clipTestA, clipTestB };
             }
         }


### PR DESCRIPTION
Fixes #1809

Draft PR + new test verifying that equality of `Complex` types works on Linux (filed ticket was against .NET Core 1 preview).
`Complex` doesn't exist on NET35, so test is enclosed in `#if !NET35` directive

Based on @mikkelbu 's comment in the issue, it's likely this is a runtime bug in `1.0` which was fixed in `1.1.0` and backported to `1.0`. The original issue: https://github.com/dotnet/runtime/issues/6834