### PR TITLE
RepeatAttribute increments CurrentRepeatCount on each repeat iteration

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -104,6 +104,8 @@ namespace NUnit.Framework
                     // TODO: We may want to change this so that all iterations are run
                     if (context.CurrentResult.ResultState != ResultState.Success)
                         break;
+
+                    context.CurrentRepeatCount++;
                 }
 
                 return context.CurrentResult;

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -171,9 +171,8 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Get the number of times the current Test has been repeated. This is currently only
-        /// set when using the <see cref="RetryAttribute"/>.
-        /// TODO: add this to the RepeatAttribute as well
+        /// Get the number of times the current Test has been repeated 
+        /// when using the <see cref="RetryAttribute"/> or <see cref="RepeatAttribute"/>.
         /// </summary>
         public int CurrentRepeatCount
         {

--- a/src/NUnitFramework/testdata/RepeatedTestFixture.cs
+++ b/src/NUnitFramework/testdata/RepeatedTestFixture.cs
@@ -163,4 +163,24 @@ namespace NUnit.TestData.RepeatingTests
             Assert.IsTrue(true);
         }
     }
+
+    public class RepeatedTestVerifyAttempt : RepeatingTestsFixtureBase
+    {
+        [Test, Repeat(3)]
+        public void AlwaysPasses()
+        {
+            Count = TestContext.CurrentContext.CurrentRepeatCount;
+        }
+
+        [Test, Repeat(3)]
+        public void PassesTwoTimes()
+        {
+            Assert.That(Count, Is.EqualTo(TestContext.CurrentContext.CurrentRepeatCount), "expected CurrentRepeatCount to be incremented only after first two attempts");
+            Count++;
+            if (Count > 2)
+            {
+                Assert.Fail("forced failure on 3rd repetition");
+            }
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/RepeatedTestFixture.cs
+++ b/src/NUnitFramework/testdata/RepeatedTestFixture.cs
@@ -176,11 +176,11 @@ namespace NUnit.TestData.RepeatingTests
         public void PassesTwoTimes()
         {
             Assert.That(Count, Is.EqualTo(TestContext.CurrentContext.CurrentRepeatCount), "expected CurrentRepeatCount to be incremented only after first two attempts");
-            Count++;
-            if (Count > 2)
+            if (Count > 1)
             {
                 Assert.Fail("forced failure on 3rd repetition");
             }
+            Count++;
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -68,6 +68,26 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void RepeatUpdatesCurrentRepeatCountPropertyOnEachAttempt()
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
+            ITestResult result = TestBuilder.RunTestCase(fixture, "PassesTwoTimes");
+
+            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.AreEqual(result.FailCount, 1, "expected that the test failed the last repetition");
+        }
+
+        [Test]
+        public void RepeatUpdatesCurrentRepeatCountPropertyOnGreenTest()
+        {
+            RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
+            ITestResult result = TestBuilder.RunTestCase(fixture, "AlwaysPasses");
+
+            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.AreEqual(result.FailCount, 0, "expected that the test passes all repetitions without a failure");
+        }
+
+        [Test]
         public void CategoryWorksWithRepeatedTest()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(RepeatedTestWithCategory));
@@ -108,7 +128,7 @@ namespace NUnit.Framework.Attributes
             var fixtureInstance = new FixtureWithMultipleRepeatAttributesOnSameMethod();
             fixtureSuite.Fixture = fixtureInstance;
             TestBuilder.RunTest(fixtureSuite, fixtureInstance);
-
+            
             Assert.That(fixtureInstance.MethodRepeatCount, Is.EqualTo(2));
         }
 

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Attributes
             var fixtureInstance = new FixtureWithMultipleRepeatAttributesOnSameMethod();
             fixtureSuite.Fixture = fixtureInstance;
             TestBuilder.RunTest(fixtureSuite, fixtureInstance);
-            
+
             Assert.That(fixtureInstance.MethodRepeatCount, Is.EqualTo(2));
         }
 

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Attributes
         public void RepeatUpdatesCurrentRepeatCountPropertyOnEachAttempt()
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
-            ITestResult result = TestBuilder.RunTestCase(fixture, "PassesTwoTimes");
+            ITestResult result = TestBuilder.RunTestCase(fixture, nameof(RepeatedTestVerifyAttempt.PassesTwoTimes));
 
             Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
             Assert.AreEqual(result.FailCount, 1, "expected that the test failed the last repetition");
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Attributes
         public void RepeatUpdatesCurrentRepeatCountPropertyOnGreenTest()
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
-            ITestResult result = TestBuilder.RunTestCase(fixture, "AlwaysPasses");
+            ITestResult result = TestBuilder.RunTestCase(fixture, nameof(RepeatedTestVerifyAttempt.AlwaysPasses));
 
             Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
             Assert.AreEqual(result.FailCount, 0, "expected that the test passes all repetitions without a failure");


### PR DESCRIPTION
Closes #3662 
RepeatAttribute should be incrementing the test context CurrentRepeatCount property for the sake of consistency.