### PR TITLE
fix: Make CI work again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 install:
   - ps: Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-  - ps: .\dotnet-install.ps1 -Version 5.0.100
+  - ps: .\dotnet-install.ps1 -Version 5.0.101
 
 build_script:
   - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100
+      version: 5.0.101
       performMultiLevelLookup: true
 
   - powershell: .\build.ps1 --target=Test --test-run-name=Windows
@@ -45,7 +45,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100
+      version: 5.0.101
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
@@ -82,7 +82,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.100
+      version: 5.0.101
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.101",
     "allowPrerelease": false,
     "rollForward": "major"
   }


### PR DESCRIPTION
Fixes #3699 

EDIT: I don't understand why, but bumping the .NET 5 SDK from 5.0.100 to 5.0.101 solves the problem. (Is it already installed in the CI, so side-by-side installation provokes the failure ?)