### PR TITLE
Use reflection wrappers for Setup/Teardown methods (#3700)

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/IMethodInfo.cs
@@ -60,6 +60,11 @@ namespace NUnit.Framework.Interfaces
         /// Gets a value indicating whether the method is public.
         /// </summary>
         bool IsPublic { get; }
+        
+        /// <summary>
+        /// Gets a value indicating whether the method is static.
+        /// </summary>
+        bool IsStatic { get; }
 
         /// <summary>
         /// Gets a value indicating whether the method contains unassigned generic type parameters.

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -152,5 +152,13 @@ namespace NUnit.Framework.Interfaces
         object Construct(object?[]? args);
 
         #endregion
+
+        /// <summary>
+        /// Returns all methods declared by this type that have the specified attribute, optionally
+        /// including base classes. Methods from a base class are always returned before methods from a class that
+        /// inherits from it.
+        /// </summary>
+        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
+        MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class;
     }
 }

--- a/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITypeInfo.cs
@@ -159,6 +159,6 @@ namespace NUnit.Framework.Interfaces
         /// inherits from it.
         /// </summary>
         /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class;
+        IMethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -114,14 +114,14 @@ namespace NUnit.Framework.Internal.Commands
             _methodValidator?.Validate(method.MethodInfo);
 
             if (AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo))
-                AsyncToSyncAdapter.Await(() => InvokeMethod(method.MethodInfo, context));
+                AsyncToSyncAdapter.Await(() => InvokeMethod(method, context));
             else
-                InvokeMethod(method.MethodInfo, context);
+                InvokeMethod(method, context);
         }
 
-        private static object InvokeMethod(MethodInfo method, TestExecutionContext context)
+        private static object InvokeMethod(IMethodInfo method, TestExecutionContext context)
         {
-            return Reflect.InvokeMethod(method, method.IsStatic ? null : context.TestObject);
+            return method.Invoke(method.IsStatic ? null : context.TestObject, null);
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
 
 namespace NUnit.Framework.Internal.Commands
@@ -35,8 +36,8 @@ namespace NUnit.Framework.Internal.Commands
     public class SetUpTearDownItem
     {
         private readonly IMethodValidator _methodValidator;
-        private readonly IList<MethodInfo> _setUpMethods;
-        private readonly IList<MethodInfo> _tearDownMethods;
+        private readonly IList<IMethodInfo> _setUpMethods;
+        private readonly IList<IMethodInfo> _tearDownMethods;
         private bool _setUpWasRun;
 
         /// <summary>
@@ -46,8 +47,8 @@ namespace NUnit.Framework.Internal.Commands
         /// <param name="tearDownMethods">A list teardown methods for this level</param>
         /// <param name="methodValidator">A method validator to validate each method before calling.</param>
         public SetUpTearDownItem(
-            IList<MethodInfo> setUpMethods, 
-            IList<MethodInfo> tearDownMethods, 
+            IList<IMethodInfo> setUpMethods, 
+            IList<IMethodInfo> tearDownMethods, 
             IMethodValidator methodValidator = null)
         {
             _setUpMethods = setUpMethods;
@@ -72,7 +73,7 @@ namespace NUnit.Framework.Internal.Commands
         {
             _setUpWasRun = true;
 
-            foreach (MethodInfo setUpMethod in _setUpMethods)
+            foreach (IMethodInfo setUpMethod in _setUpMethods)
                 RunSetUpOrTearDownMethod(context, setUpMethod);
         }
 
@@ -107,15 +108,15 @@ namespace NUnit.Framework.Internal.Commands
                 }
         }
 
-        private void RunSetUpOrTearDownMethod(TestExecutionContext context, MethodInfo method)
+        private void RunSetUpOrTearDownMethod(TestExecutionContext context, IMethodInfo method)
         {
-            Guard.ArgumentNotAsyncVoid(method, nameof(method));
-            _methodValidator?.Validate(method);
+            Guard.ArgumentNotAsyncVoid(method.MethodInfo, nameof(method));
+            _methodValidator?.Validate(method.MethodInfo);
 
-            if (AsyncToSyncAdapter.IsAsyncOperation(method))
-                AsyncToSyncAdapter.Await(() => InvokeMethod(method, context));
+            if (AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo))
+                AsyncToSyncAdapter.Await(() => InvokeMethod(method.MethodInfo, context));
             else
-                InvokeMethod(method, context);
+                InvokeMethod(method.MethodInfo, context);
         }
 
         private static object InvokeMethod(MethodInfo method, TestExecutionContext context)

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -129,8 +129,8 @@ namespace NUnit.Framework.Internal.Execution
                 // In normal operation we should always get the methods from the parent fixture.
                 // However, some of NUnit's own tests can create a TestMethod without a parent
                 // fixture. Most likely, we should stop doing this, but it affects 100s of cases.
-                var setUpMethods = parentFixture?.SetUpMethods ?? Reflect.GetMethodsWithAttribute<SetUpAttribute>(Test.TypeInfo, true);
-                var tearDownMethods = parentFixture?.TearDownMethods ?? Reflect.GetMethodsWithAttribute<TearDownAttribute>(Test.TypeInfo, true);
+                var setUpMethods = parentFixture?.SetUpMethods ?? Test.TypeInfo.GetMethodsWithAttribute<SetUpAttribute>(true);
+                var tearDownMethods = parentFixture?.TearDownMethods ?? Test.TypeInfo.GetMethodsWithAttribute<TearDownAttribute>(true);
 
                 // Wrap in SetUpTearDownCommands
                 var setUpTearDownList = BuildSetUpTearDownList(setUpMethods, tearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -129,8 +129,8 @@ namespace NUnit.Framework.Internal.Execution
                 // In normal operation we should always get the methods from the parent fixture.
                 // However, some of NUnit's own tests can create a TestMethod without a parent
                 // fixture. Most likely, we should stop doing this, but it affects 100s of cases.
-                var setUpMethods = parentFixture?.SetUpMethods ?? Reflect.GetMethodsWithAttribute(Test.TypeInfo.Type, typeof(SetUpAttribute), true);
-                var tearDownMethods = parentFixture?.TearDownMethods ?? Reflect.GetMethodsWithAttribute(Test.TypeInfo.Type, typeof(TearDownAttribute), true);
+                var setUpMethods = parentFixture?.SetUpMethods ?? Reflect.GetMethodsWithAttribute<SetUpAttribute>(Test.TypeInfo.Type, true);
+                var tearDownMethods = parentFixture?.TearDownMethods ?? Reflect.GetMethodsWithAttribute<TearDownAttribute>(Test.TypeInfo.Type, true);
 
                 // Wrap in SetUpTearDownCommands
                 var setUpTearDownList = BuildSetUpTearDownList(setUpMethods, tearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -129,8 +129,8 @@ namespace NUnit.Framework.Internal.Execution
                 // In normal operation we should always get the methods from the parent fixture.
                 // However, some of NUnit's own tests can create a TestMethod without a parent
                 // fixture. Most likely, we should stop doing this, but it affects 100s of cases.
-                var setUpMethods = parentFixture?.SetUpMethods ?? Reflect.GetMethodsWithAttribute<SetUpAttribute>(Test.TypeInfo.Type, true);
-                var tearDownMethods = parentFixture?.TearDownMethods ?? Reflect.GetMethodsWithAttribute<TearDownAttribute>(Test.TypeInfo.Type, true);
+                var setUpMethods = parentFixture?.SetUpMethods ?? Reflect.GetMethodsWithAttribute<SetUpAttribute>(Test.TypeInfo, true);
+                var tearDownMethods = parentFixture?.TearDownMethods ?? Reflect.GetMethodsWithAttribute<TearDownAttribute>(Test.TypeInfo, true);
 
                 // Wrap in SetUpTearDownCommands
                 var setUpTearDownList = BuildSetUpTearDownList(setUpMethods, tearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -369,8 +369,8 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="methodValidator">Method validator used before each method execution.</param>
         /// <returns>A list of SetUpTearDownItems</returns>
         protected List<SetUpTearDownItem> BuildSetUpTearDownList(
-            MethodInfo[] setUpMethods, 
-            MethodInfo[] tearDownMethods,
+            IMethodInfo[] setUpMethods, 
+            IMethodInfo[] tearDownMethods,
             IMethodValidator methodValidator = null)
         {
             Guard.ArgumentNotNull(setUpMethods, nameof(setUpMethods));
@@ -408,8 +408,8 @@ namespace NUnit.Framework.Internal.Execution
         // adding each method to the appropriate level as we go.
         private static SetUpTearDownItem BuildNode(
             Type fixtureType, 
-            IList<MethodInfo> setUpMethods, 
-            IList<MethodInfo> tearDownMethods,
+            IList<IMethodInfo> setUpMethods, 
+            IList<IMethodInfo> tearDownMethods,
             IMethodValidator methodValidator)
         {
             // Create lists of methods for this level only.
@@ -421,13 +421,13 @@ namespace NUnit.Framework.Internal.Execution
             return new SetUpTearDownItem(mySetUpMethods, myTearDownMethods, methodValidator);
         }
 
-        private static List<MethodInfo> SelectMethodsByDeclaringType(Type type, IList<MethodInfo> methods)
+        private static List<MethodInfo> SelectMethodsByDeclaringType(Type type, IList<IMethodInfo> methods)
         {
             var list = new List<MethodInfo>();
 
             foreach (var method in methods)
-                if (method.DeclaringType == type)
-                    list.Add(method);
+                if (method.TypeInfo.Type == type)
+                    list.Add(method.MethodInfo);
 
             return list;
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -421,13 +421,13 @@ namespace NUnit.Framework.Internal.Execution
             return new SetUpTearDownItem(mySetUpMethods, myTearDownMethods, methodValidator);
         }
 
-        private static List<MethodInfo> SelectMethodsByDeclaringType(Type type, IList<IMethodInfo> methods)
+        private static List<IMethodInfo> SelectMethodsByDeclaringType(Type type, IList<IMethodInfo> methods)
         {
-            var list = new List<MethodInfo>();
+            var list = new List<IMethodInfo>();
 
             foreach (var method in methods)
                 if (method.TypeInfo.Type == type)
-                    list.Add(method.MethodInfo);
+                    list.Add(method);
 
             return list;
         }

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -93,10 +93,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets a value indicating whether the method is static.
         /// </summary>
-        public bool IsStatic
-        {
-            get { return MethodInfo.IsStatic; }
-        }
+        public bool IsStatic => MethodInfo.IsStatic;
 
         /// <summary>
         /// Gets a value indicating whether the method contains unassigned generic type parameters.

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -91,6 +91,14 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Gets a value indicating whether the method is static.
+        /// </summary>
+        public bool IsStatic
+        {
+            get { return MethodInfo.IsStatic; }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the method contains unassigned generic type parameters.
         /// </summary>
         public bool ContainsGenericParameters

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -53,40 +53,12 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class Reflect
     {
-        private static readonly BindingFlags AllMembers = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        internal static readonly BindingFlags AllMembers = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
         // A zero-length Type array - not provided by System.Type for all CLR versions we support.
         private static readonly Type[] EmptyTypes = new Type[0];
 
         #region Get Methods of a type
-
-        /// <summary>
-        /// Returns all methods declared by the specified fixture type that have the specified attribute, optionally
-        /// including base classes. Methods from a base class are always returned before methods from a class that
-        /// inherits from it.
-        /// </summary>
-        /// <param name="fixtureType">The type to examine.</param>
-        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        public static MethodInfo[] GetMethodsWithAttribute<T>(this ITypeInfo fixtureType, bool inherit) where T : class
-        {
-            if (!inherit)
-            {
-                return fixtureType.Type
-                   .GetMethods(AllMembers | BindingFlags.DeclaredOnly)
-                   .Where(method => method.IsDefined(typeof(T), inherit: false))
-                   .ToArray();
-            }
-
-            var methodsByDeclaringType = fixtureType.Type
-                .GetMethods(AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
-                .Where(method => method.IsDefined(typeof(T), inherit: true))
-                .ToLookup(method => method.DeclaringType);
-
-            return fixtureType.Type.TypeAndBaseTypes()
-                .Reverse()
-                .SelectMany(declaringType => methodsByDeclaringType[declaringType])
-                .ToArray();
-        }
 
         /// <summary>
         /// Examine a fixture type and return true if it has a method with

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -67,22 +67,22 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="fixtureType">The type to examine.</param>
         /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        public static MethodInfo[] GetMethodsWithAttribute<T>(Type fixtureType, bool inherit) where T : class
+        public static MethodInfo[] GetMethodsWithAttribute<T>(ITypeInfo fixtureType, bool inherit) where T : class
         {
             if (!inherit)
             {
-                return fixtureType
+                return fixtureType.Type
                    .GetMethods(AllMembers | BindingFlags.DeclaredOnly)
                    .Where(method => method.IsDefined(typeof(T), inherit: false))
                    .ToArray();
             }
 
-            var methodsByDeclaringType = fixtureType
+            var methodsByDeclaringType = fixtureType.Type
                 .GetMethods(AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
                 .Where(method => method.IsDefined(typeof(T), inherit: true))
                 .ToLookup(method => method.DeclaringType);
 
-            return fixtureType.TypeAndBaseTypes()
+            return fixtureType.Type.TypeAndBaseTypes()
                 .Reverse()
                 .SelectMany(declaringType => methodsByDeclaringType[declaringType])
                 .ToArray();

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -66,21 +66,20 @@ namespace NUnit.Framework.Internal
         /// inherits from it.
         /// </summary>
         /// <param name="fixtureType">The type to examine.</param>
-        /// <param name="attributeType">Only methods to which this attribute is applied will be returned.</param>
         /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        public static MethodInfo[] GetMethodsWithAttribute(Type fixtureType, Type attributeType, bool inherit)
+        public static MethodInfo[] GetMethodsWithAttribute<T>(Type fixtureType, bool inherit) where T : class
         {
             if (!inherit)
             {
                 return fixtureType
                    .GetMethods(AllMembers | BindingFlags.DeclaredOnly)
-                   .Where(method => method.IsDefined(attributeType, inherit: false))
+                   .Where(method => method.IsDefined(typeof(T), inherit: false))
                    .ToArray();
             }
 
             var methodsByDeclaringType = fixtureType
                 .GetMethods(AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
-                .Where(method => method.IsDefined(attributeType, inherit: true))
+                .Where(method => method.IsDefined(typeof(T), inherit: true))
                 .ToLookup(method => method.DeclaringType);
 
             return fixtureType.TypeAndBaseTypes()

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="fixtureType">The type to examine.</param>
         /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        public static MethodInfo[] GetMethodsWithAttribute<T>(ITypeInfo fixtureType, bool inherit) where T : class
+        public static MethodInfo[] GetMethodsWithAttribute<T>(this ITypeInfo fixtureType, bool inherit) where T : class
         {
             if (!inherit)
             {

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal
             if (index > 0)
                 this.Name = this.Name.Substring(index + 1);
 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo.Type, true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo.Type, true);
+            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo, true);
+            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo, true);
 
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal
             if (index > 0)
                 this.Name = this.Name.Substring(index + 1);
 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(OneTimeSetUpAttribute), true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(OneTimeTearDownAttribute), true);
+            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo.Type, true);
+            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo.Type, true);
 
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/SetUpFixture.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal
             if (index > 0)
                 this.Name = this.Name.Substring(index + 1);
 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo, true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo, true);
+            OneTimeSetUpMethods = TypeInfo.GetMethodsWithAttribute<OneTimeSetUpAttribute>(true);
+            OneTimeTearDownMethods = TypeInfo.GetMethodsWithAttribute<OneTimeTearDownAttribute>(true);
 
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -108,8 +108,8 @@ namespace NUnit.Framework.Internal
             Method = method;
             Properties = new PropertyBag();
             RunState = RunState.Runnable;
-            SetUpMethods = new MethodInfo[0];
-            TearDownMethods = new MethodInfo[0];
+            SetUpMethods = new IMethodInfo[0];
+            TearDownMethods = new IMethodInfo[0];
         }
 
         private static string GetNextId()
@@ -284,12 +284,12 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The SetUp methods.
         /// </summary>
-        public MethodInfo[] SetUpMethods { get; protected set; }
+        public IMethodInfo[] SetUpMethods { get; protected set; }
 
         /// <summary>
         /// The teardown methods
         /// </summary>
-        public MethodInfo[] TearDownMethods { get; protected set; }
+        public IMethodInfo[] TearDownMethods { get; protected set; }
 
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -47,10 +47,10 @@ namespace NUnit.Framework.Internal
         /// <param name="arguments">Arguments used to instantiate the test fixture, or null if none used</param>
         public TestFixture(ITypeInfo fixtureType, object?[]? arguments = null) : base(fixtureType, arguments)
         {
-            SetUpMethods = Reflect.GetMethodsWithAttribute<SetUpAttribute>(TypeInfo, true);
-            TearDownMethods = Reflect.GetMethodsWithAttribute<TearDownAttribute>(TypeInfo, true); 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo, true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo, true);
+            SetUpMethods = TypeInfo.GetMethodsWithAttribute<SetUpAttribute>(true);
+            TearDownMethods = TypeInfo.GetMethodsWithAttribute<TearDownAttribute>(true); 
+            OneTimeSetUpMethods = TypeInfo.GetMethodsWithAttribute<OneTimeSetUpAttribute>(true);
+            OneTimeTearDownMethods = TypeInfo.GetMethodsWithAttribute<OneTimeTearDownAttribute>(true);
             
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -47,10 +47,10 @@ namespace NUnit.Framework.Internal
         /// <param name="arguments">Arguments used to instantiate the test fixture, or null if none used</param>
         public TestFixture(ITypeInfo fixtureType, object?[]? arguments = null) : base(fixtureType, arguments)
         {
-            SetUpMethods = Reflect.GetMethodsWithAttribute<SetUpAttribute>(TypeInfo.Type, true);
-            TearDownMethods = Reflect.GetMethodsWithAttribute<TearDownAttribute>(TypeInfo.Type, true); 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo.Type, true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo.Type, true);
+            SetUpMethods = Reflect.GetMethodsWithAttribute<SetUpAttribute>(TypeInfo, true);
+            TearDownMethods = Reflect.GetMethodsWithAttribute<TearDownAttribute>(TypeInfo, true); 
+            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo, true);
+            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo, true);
             
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -47,10 +47,10 @@ namespace NUnit.Framework.Internal
         /// <param name="arguments">Arguments used to instantiate the test fixture, or null if none used</param>
         public TestFixture(ITypeInfo fixtureType, object?[]? arguments = null) : base(fixtureType, arguments)
         {
-            SetUpMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(SetUpAttribute), true);
-            TearDownMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(TearDownAttribute), true); 
-            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(OneTimeSetUpAttribute), true);
-            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute(TypeInfo.Type, typeof(OneTimeTearDownAttribute), true);
+            SetUpMethods = Reflect.GetMethodsWithAttribute<SetUpAttribute>(TypeInfo.Type, true);
+            TearDownMethods = Reflect.GetMethodsWithAttribute<TearDownAttribute>(TypeInfo.Type, true); 
+            OneTimeSetUpMethods = Reflect.GetMethodsWithAttribute<OneTimeSetUpAttribute>(TypeInfo.Type, true);
+            OneTimeTearDownMethods = Reflect.GetMethodsWithAttribute<OneTimeTearDownAttribute>(TypeInfo.Type, true);
             
             CheckSetUpTearDownMethods(OneTimeSetUpMethods);
             CheckSetUpTearDownMethods(OneTimeTearDownMethods);

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -53,8 +53,8 @@ namespace NUnit.Framework.Internal
         public TestSuite(string name) : base(name)
         {
             Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new MethodInfo[0];
-            OneTimeTearDownMethods = new MethodInfo[0];
+            OneTimeSetUpMethods = new IMethodInfo[0];
+            OneTimeTearDownMethods = new IMethodInfo[0];
         }
 
         /// <summary>
@@ -66,8 +66,8 @@ namespace NUnit.Framework.Internal
             : base(parentSuiteName, name)
         {
             Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new MethodInfo[0];
-            OneTimeTearDownMethods = new MethodInfo[0];
+            OneTimeSetUpMethods = new IMethodInfo[0];
+            OneTimeTearDownMethods = new IMethodInfo[0];
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace NUnit.Framework.Internal
             : base(fixtureType)
         {
             Arguments = arguments ?? TestParameters.NoArguments;
-            OneTimeSetUpMethods = new MethodInfo[0];
-            OneTimeTearDownMethods = new MethodInfo[0];
+            OneTimeSetUpMethods = new IMethodInfo[0];
+            OneTimeTearDownMethods = new IMethodInfo[0];
         }
 
         /// <summary>
@@ -91,8 +91,8 @@ namespace NUnit.Framework.Internal
             : base(new TypeWrapper(fixtureType))
         {
             Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new MethodInfo[0];
-            OneTimeTearDownMethods = new MethodInfo[0];
+            OneTimeSetUpMethods = new IMethodInfo[0];
+            OneTimeTearDownMethods = new IMethodInfo[0];
         }
 
         /// <summary>
@@ -234,12 +234,12 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// OneTimeSetUp methods for this suite
         /// </summary>
-        public MethodInfo[] OneTimeSetUpMethods { get; protected set; }
+        public IMethodInfo[] OneTimeSetUpMethods { get; protected set; }
 
         /// <summary>
         /// OneTimeTearDown methods for this suite
         /// </summary>
-        public MethodInfo[] OneTimeTearDownMethods { get; protected set; }
+        public IMethodInfo[] OneTimeTearDownMethods { get; protected set; }
 
         #endregion
 
@@ -306,15 +306,15 @@ namespace NUnit.Framework.Internal
         /// Check that setup and teardown methods marked by certain attributes
         /// meet NUnit's requirements and mark the tests not runnable otherwise.
         /// </summary>
-        protected void CheckSetUpTearDownMethods(MethodInfo[] methods)
+        protected void CheckSetUpTearDownMethods(IMethodInfo[] methods)
         {
-            foreach (MethodInfo method in methods)
+            foreach (IMethodInfo method in methods)
             {
                 if (method.IsAbstract)
                 {
                     MakeInvalid("An abstract SetUp and TearDown methods cannot be run: " + method.Name);
                 }
-                else if (!(method.IsPublic || method.IsFamily))
+                else if (!(method.IsPublic || method.MethodInfo.IsFamily))
                 {
                     MakeInvalid("SetUp and TearDown methods must be public or protected: " + method.Name);
                 }
@@ -322,16 +322,16 @@ namespace NUnit.Framework.Internal
                 {
                     MakeInvalid("SetUp and TearDown methods must not have parameters: " + method.Name);
                 }
-                else if (AsyncToSyncAdapter.IsAsyncOperation(method))
+                else if (AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo))
                 {
-                    if (method.ReturnType == typeof(void))
+                    if (method.ReturnType.Type == typeof(void))
                         MakeInvalid("SetUp and TearDown methods must not be async void: " + method.Name);
-                    else if (!Reflect.IsVoidOrUnit(AwaitAdapter.GetResultType(method.ReturnType)))
+                    else if (!Reflect.IsVoidOrUnit(AwaitAdapter.GetResultType(method.ReturnType.Type)))
                         MakeInvalid("SetUp and TearDown methods must return void or an awaitable type with a void result: " + method.Name);
                 }
                 else
                 {
-                    if (!Reflect.IsVoidOrUnit(method.ReturnType))
+                    if (!Reflect.IsVoidOrUnit(method.ReturnType.Type))
                         MakeInvalid("SetUp and TearDown methods must return void or an awaitable type with a void result: " + method.Name);
                 }
             }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -266,13 +266,14 @@ namespace NUnit.Framework.Internal
         /// inherits from it.
         /// </summary>
         /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
-        public MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
+        public IMethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
         {
             if (!inherit)
             {
                 return Type
                                   .GetMethods(Reflect.AllMembers | BindingFlags.DeclaredOnly)
                                   .Where(method => method.IsDefined(typeof(T), inherit: false))
+                                  .Select(method => new MethodWrapper(Type, method))
                                   .ToArray();
             }
 
@@ -283,7 +284,7 @@ namespace NUnit.Framework.Internal
 
             return Type.TypeAndBaseTypes()
                               .Reverse()
-                              .SelectMany(declaringType => methodsByDeclaringType[declaringType])
+                              .SelectMany(declaringType => methodsByDeclaringType[declaringType].Select(method => new MethodWrapper(declaringType, method)))
                               .ToArray();
         }
     }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -24,6 +24,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -257,6 +258,33 @@ namespace NUnit.Framework.Internal
         public override string ToString()
         {
             return Type.ToString();
+        }
+
+        /// <summary>
+        /// Returns all methods declared by this type that have the specified attribute, optionally
+        /// including base classes. Methods from a base class are always returned before methods from a class that
+        /// inherits from it.
+        /// </summary>
+        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
+        public MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
+        {
+            if (!inherit)
+            {
+                return Type
+                                  .GetMethods(Reflect.AllMembers | BindingFlags.DeclaredOnly)
+                                  .Where(method => method.IsDefined(typeof(T), inherit: false))
+                                  .ToArray();
+            }
+
+            var methodsByDeclaringType = Type
+                                                    .GetMethods(Reflect.AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
+                                                    .Where(method => method.IsDefined(typeof(T), inherit: true))
+                                                    .ToLookup(method => method.DeclaringType);
+
+            return Type.TypeAndBaseTypes()
+                              .Reverse()
+                              .SelectMany(declaringType => methodsByDeclaringType[declaringType])
+                              .ToArray();
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/TypeWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeWrapper.cs
@@ -271,21 +271,21 @@ namespace NUnit.Framework.Internal
             if (!inherit)
             {
                 return Type
-                                  .GetMethods(Reflect.AllMembers | BindingFlags.DeclaredOnly)
-                                  .Where(method => method.IsDefined(typeof(T), inherit: false))
-                                  .Select(method => new MethodWrapper(Type, method))
-                                  .ToArray();
+                    .GetMethods(Reflect.AllMembers | BindingFlags.DeclaredOnly)
+                    .Where(method => method.IsDefined(typeof(T), inherit: false))
+                    .Select(method => new MethodWrapper(Type, method))
+                    .ToArray();
             }
 
             var methodsByDeclaringType = Type
-                                                    .GetMethods(Reflect.AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
-                                                    .Where(method => method.IsDefined(typeof(T), inherit: true))
-                                                    .ToLookup(method => method.DeclaringType);
+                .GetMethods(Reflect.AllMembers | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
+                .Where(method => method.IsDefined(typeof(T), inherit: true))
+                .ToLookup(method => method.DeclaringType);
 
             return Type.TypeAndBaseTypes()
-                              .Reverse()
-                              .SelectMany(declaringType => methodsByDeclaringType[declaringType].Select(method => new MethodWrapper(declaringType, method)))
-                              .ToArray();
+                .Reverse()
+                .SelectMany(declaringType => methodsByDeclaringType[declaringType].Select(method => new MethodWrapper(declaringType, method)))
+                .ToArray();
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomMethodWrapper.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomMethodWrapper.cs
@@ -58,6 +58,8 @@ namespace NUnit.Framework.Attributes
 
             public bool IsPublic => _baseInfo.IsPublic;
 
+            public bool IsStatic => _baseInfo.IsStatic;
+
             public bool ContainsGenericParameters => _baseInfo.ContainsGenericParameters;
 
             public bool IsGenericMethod => _baseInfo.IsGenericMethod;

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomTypeWrapper.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomTypeWrapper.cs
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Attributes
                 return _baseInfo.MakeGenericType(typeArgs);
             }
 
-            public MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
+            public IMethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
             {
                 return _baseInfo.GetMethodsWithAttribute<T>(inherit);
             }

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomTypeWrapper.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.CustomTypeWrapper.cs
@@ -126,6 +126,11 @@ namespace NUnit.Framework.Attributes
             {
                 return _baseInfo.MakeGenericType(typeArgs);
             }
+
+            public MethodInfo[] GetMethodsWithAttribute<T>(bool inherit) where T : class
+            {
+                return _baseInfo.GetMethodsWithAttribute<T>(inherit);
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -36,13 +36,13 @@ namespace NUnit.Framework.Internal
     {
         private AsyncSetupTearDownFixture _testObject;
         private TestExecutionContext _context;
-        private static readonly IList<MethodInfo> Empty = new MethodInfo[0];
+        private static readonly IList<IMethodInfo> Empty = new IMethodInfo[0];
 
         [SetUp]
         public void Setup()
         {
             _testObject = new AsyncSetupTearDownFixture();
-            var method = new MethodWrapper(typeof(AsyncSetupTearDownFixture), Success.ElementAt(0));
+            var method = Success.ElementAt(0);
             _context = new TestExecutionContext { TestObject = _testObject, CurrentResult = new TestCaseResult(new TestMethod(method)) };
         }
 
@@ -94,18 +94,18 @@ namespace NUnit.Framework.Internal
             Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.Error));
         }
 
-        private IEnumerable<MethodInfo> Success
+        private IEnumerable<IMethodInfo> Success
         {
             get { yield return Method("SuccessfulAsyncMethod"); }
         }
-        private IEnumerable<MethodInfo> Failure
+        private IEnumerable<IMethodInfo> Failure
         {
             get { yield return Method("FailingAsyncMethod"); }
         }
 
-        private MethodInfo Method(string methodName)
+        private IMethodInfo Method(string methodName)
         {
-            return _testObject.GetType().GetMethod(methodName);
+            return new MethodWrapper(_testObject.GetType(), _testObject.GetType().GetMethod(methodName));
         }
     }
 }


### PR DESCRIPTION
Use the reflection wrapper types (ITypeInfo/TypeWrapper and IMethodInfo/MethodWrapper) for locating and invoking setup and teardown methods.

This allows users who are supplying their own ITypeInfo/IMethodInfo implementations to have their code be correctly invoked for setup/teardown methods, in the same way that they already are for actual TestMethods.

There is still enough direct usage of `ITypeInfo.Type` and `IMethodInfo.MethodInfo` that any implementation would still need to have _some_ kind of real CLR type backing it, but at least this makes it possible to do some interesting things at the point of invocation itself. We might want to change the remaining usages to go via the interfaces as well, at which point it would be possible to execute against a completely faked type hierarchy.

Fixes #3700