### PR TITLE
Fix FixtureLifeCycle application

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -267,6 +267,7 @@ namespace NUnit.Framework
         public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo, IPreFilter filter)
         {
             var fixture = _builder.BuildFrom(typeInfo, filter, this);
+            fixture.ApplyAttributesToTest(new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly));
             fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
 
             yield return fixture;

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -126,10 +126,14 @@ namespace NUnit.Framework
 
             var fixtureSuite = new ParameterizedFixtureSuite(typeInfo);
             fixtureSuite.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
+            var assemblyLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly);
+            var typeLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo());
 
             foreach (ITestFixtureData parms in GetParametersFor(sourceType))
             {
                 TestSuite fixture = _builder.BuildFrom(typeInfo, filter, parms);
+                fixture.ApplyAttributesToTest(assemblyLifeCycleAttributeProvider);
+                fixture.ApplyAttributesToTest(typeLifeCycleAttributeProvider);
                 fixtureSuite.Add(fixture);
             }
 

--- a/src/NUnitFramework/framework/Internal/AttributeProviderWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/AttributeProviderWrapper.cs
@@ -1,0 +1,65 @@
+// ***********************************************************************
+// Copyright (c) 2008-2021 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
+{
+    internal class AttributeProviderWrapper<T> : ICustomAttributeProvider
+        where T : Attribute
+    {
+        private readonly ICustomAttributeProvider _innerProvider;
+
+        public AttributeProviderWrapper(ICustomAttributeProvider innerProvider)
+        {
+            _innerProvider = innerProvider;
+        }
+
+        public object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            var attributes = _innerProvider.GetCustomAttributes(attributeType, inherit);
+            return GetFiltered(attributes);
+        }
+
+        public object[] GetCustomAttributes(bool inherit)
+        {
+            var attributes = _innerProvider.GetCustomAttributes(inherit);
+            return GetFiltered(attributes);
+        }
+
+        public bool IsDefined(Type attributeType, bool inherit)
+        {
+            return GetCustomAttributes(attributeType, inherit).Any();
+        }
+
+        private static T[] GetFiltered(IEnumerable<object> attributes)
+        {
+            return attributes
+                   .OfType<T>()
+                   .ToArray();
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -76,6 +76,7 @@ namespace NUnit.Framework.Internal.Builders
             if (fixture.RunState != RunState.NotRunnable)
                 CheckTestFixtureIsValid(fixture);
 
+            fixture.ApplyAttributesToTest(new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly));
             fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
 
             AddTestCasesToFixture(fixture, filter);

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 namespace NUnit.TestData.LifeCycleTests
 {
     [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class DisposableFixture : IDisposable
     {
         public static int DisposeCount = 0;
@@ -42,6 +41,34 @@ namespace NUnit.TestData.LifeCycleTests
         public void Dispose()
         {
             DisposeCount++;
+        }
+    }
+
+    [TestFixtureSource(nameof(FixtureArgs))]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class LifeCycleWithTestFixtureSourceFixture
+    {
+        private readonly int _initialValue;
+        private int _value;
+
+        public LifeCycleWithTestFixtureSourceFixture(int num)
+        {
+            _initialValue = num;
+            _value = num;
+        }
+
+        public static int[] FixtureArgs() => new[] { 1, 42 };
+
+        [Test]
+        public void Test1()
+        {
+            Assert.AreEqual(_initialValue, _value++);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            Assert.AreEqual(_initialValue, _value++);
         }
     }
 

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -104,6 +104,52 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void InstancePerTestCaseShouldApplyToTestFixtureSourceTests()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithTestFixtureSourceFixture));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+
+#if NETFRAMEWORK
+        [Test]
+        public void AssemblyLevelInstancePerTestCaseShouldCreateInstanceForEachTestCase()
+        {
+            var code = @"
+                using NUnit.Framework;
+
+                [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+                [TestFixture]
+                public class AssemblyLevelFixtureLifeCycleTest
+                {
+                    private int _value;
+
+                    [Test]
+                    public void Test1()
+                    {
+                        Assert.AreEqual(0, _value++);
+                    }
+
+                    [Test]
+                    public void Test2()
+                    {
+                        Assert.AreEqual(0, _value++);
+                    }
+                }
+                ";
+
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(code, new[] { typeof(Test).Assembly.Location });
+            var testType = asm.GetType("AssemblyLevelFixtureLifeCycleTest");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+#endif
+
+        [Test]
         public void InstancePerTestCaseWithRepeatShouldWorkAsExpected()
         {
             RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter = 0;

--- a/src/NUnitFramework/tests/TestUtilities/TestAssemblyHelper.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestAssemblyHelper.cs
@@ -1,0 +1,54 @@
+// ***********************************************************************
+// Copyright (c) 2021 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if NETFRAMEWORK
+
+using System;
+using System.CodeDom.Compiler;
+using System.Linq;
+using System.Reflection;
+
+namespace NUnit.TestUtilities
+{
+    public static class TestAssemblyHelper
+    {
+        public static Assembly GenerateInMemoryAssembly(string code, string[] referencedAssemblies)
+        {
+            var options = new CompilerParameters() { GenerateInMemory = true };
+            options.ReferencedAssemblies.AddRange(referencedAssemblies);
+
+            var codeProvider = CodeDomProvider.CreateProvider("CSharp");
+            var result = codeProvider.CompileAssemblyFromSource(options, code);
+
+            if (!result.Errors.HasErrors)
+                return result.CompiledAssembly;
+
+            var errors = string.Join(", ", result.Errors
+                                                 .Cast<CompilerError>()
+                                                 .Select(err => err.ToString()).ToArray());
+
+            throw new InvalidOperationException($"Failed to create assembly: {errors}");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #3716 and #3715 

I was not sure how to better test the assembly-level attribute without creating a dedicated project - current test only checks full .NET Framework (although the fix itself should work everywhere). I tried to use Roslyn for .NET Standard, but there were some dependencies conflicts, unfortunately, which I am not ready to resolve at the moment.