### PR TITLE
Don't manually install .NET 5.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,6 @@ branches:
   except:
     - /travis-.*/
 
-install:
-  - ps: Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-  - ps: .\dotnet-install.ps1 -Version 5.0.101
-
 build_script:
   - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"
 
@@ -22,6 +18,6 @@ deploy:
     skip_symbols: true
     on:
       branch: master
-      
+
 # For PRs, skip the branch run and only run against the virtual PR merge.
 skip_branch_with_pr: true


### PR DESCRIPTION
Fixes #3729

A newer version of .NET 5.0 is installed on the latest AppVeyor build images so attempting to install an older version causes the build to fail.