### PR TITLE
Don't install .NET Core 5.x SDK on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,12 +12,6 @@ jobs:
     vmImage: windows-latest
   steps:
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      version: 5.0.101
-      performMultiLevelLookup: true
-
   - powershell: .\build.ps1 --target=Test --test-run-name=Windows
     displayName: Build, test, and publish results
 
@@ -41,11 +35,6 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
-
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      version: 5.0.101
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
@@ -78,11 +67,6 @@ jobs:
   pool:
     vmImage: macOS-latest
   steps:
-
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      version: 5.0.101
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'


### PR DESCRIPTION
Fixes #3724

Removes the install of .NET Core 5.0.101 which is already installed for each OS. This will prevent errors installing an older version if they get updated in the future.

I left the 2.1 and 3.1 runtime installs on Linux and MacOS because the docs do not specify that they are installed.