### PR TITLE
Fix date on Ignored and Explicit Tests

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -332,7 +332,7 @@ namespace NUnit.Framework.Internal.Execution
         {
             foreach (WorkItem child in workItem.Children)
             {
-                child.Result.SetResult(resultState, message);
+                SetChildWorkItemSkippedResult(child.Result, resultState, message);
                 _suiteResult.AddResult(child.Result);
 
                 // Some runners may depend on getting the TestFinished event
@@ -342,6 +342,14 @@ namespace NUnit.Framework.Internal.Execution
                 if (child is CompositeWorkItem)
                     SkipChildren((CompositeWorkItem)child, resultState, message);
             }
+        }
+
+        private void SetChildWorkItemSkippedResult(TestResult result, ResultState resultState, string message)
+        {
+            result.SetResult(resultState, message);
+            result.StartTime = Context.StartTime;
+            result.EndTime = DateTime.UtcNow;
+            result.Duration = Context.Duration;
         }
 
         private void PerformOneTimeTearDown()

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -336,10 +336,7 @@ namespace NUnit.Framework.Internal.Execution
 
             Result.StartTime = Context.StartTime;
             Result.EndTime = DateTime.UtcNow;
-
-            long tickCount = Stopwatch.GetTimestamp() - Context.StartTicks;
-            double seconds = (double)tickCount / Stopwatch.Frequency;
-            Result.Duration = seconds;
+            Result.Duration = Context.Duration;
 
             // We add in the assert count from the context. If
             // this item is for a test case, we are adding the

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -212,6 +213,18 @@ namespace NUnit.Framework.Internal
         /// The time the current test started in Ticks
         /// </summary>
         public long StartTicks { get; set; }
+
+        /// <summary>
+        /// The current duration of the test taken
+        /// </summary>
+        public double Duration
+        {
+            get
+            {
+                var tickCount = Stopwatch.GetTimestamp() - StartTicks;
+                return (double)tickCount / Stopwatch.Frequency;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the current test result

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -215,7 +215,7 @@ namespace NUnit.Framework.Internal
         public long StartTicks { get; set; }
 
         /// <summary>
-        /// The current duration of the test taken
+        /// Gets the elapsed time for running the test in seconds
         /// </summary>
         public double Duration
         {

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -114,7 +114,7 @@ namespace NUnit.Tests
         public class MockTestFixture
         {
             public const int Tests = 13;
-            public const int Suites = 1;
+            public const int Suites = 2;
 
             public const int Passed = 2;
 
@@ -155,10 +155,9 @@ namespace NUnit.Tests
             [Test, Ignore("Ignore Message")]
             public void IgnoreTest() { }
 
-            [Test, Ignore("Ignore testcase")]
-            [TestCase(1)]
-            [TestCase(2)]
-            [TestCase(3)]
+            [TestCase(1, Ignore = "Ignore testcase")]
+            [TestCase(2, Ignore = "Ignore testcase")]
+            [TestCase(3, Ignore = "Ignore testcase")]
             public void SkippedTest(int a)
             {
                 Assert.Pass();

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -155,13 +156,18 @@ namespace NUnit.Tests
             [Test, Ignore("Ignore Message")]
             public void IgnoreTest() { }
 
-            [TestCase(1, Ignore = "Ignore testcase")]
-            [TestCase(2, Ignore = "Ignore testcase")]
-            [TestCase(3, Ignore = "Ignore testcase")]
-            public void SkippedTest(int a)
+            [TestCaseSource(nameof(SkippedTestCaseData))]
+            public void SkippedTest(int _)
             {
                 Assert.Pass();
             }
+
+            public static IEnumerable<TestCaseData> SkippedTestCaseData => new[]
+            {
+                new TestCaseData(1).Ignore("Ignore testcase"),
+                new TestCaseData(2).Ignore("Ignore testcase"),
+                new TestCaseData(3).Ignore("Ignore testcase")
+            };
 
             [Test, Explicit]
             public void ExplicitTest() { }

--- a/src/NUnitFramework/mock-assembly/MockAssembly.cs
+++ b/src/NUnitFramework/mock-assembly/MockAssembly.cs
@@ -113,12 +113,12 @@ namespace NUnit.Tests
         [Category("FixtureCategory")]
         public class MockTestFixture
         {
-            public const int Tests = 10;
+            public const int Tests = 13;
             public const int Suites = 1;
 
             public const int Passed = 2;
 
-            public const int Skipped_Ignored = 1;
+            public const int Skipped_Ignored = 4;
             public const int Skipped_Explicit = 1;
             public const int Skipped = Skipped_Ignored + Skipped_Explicit;
 
@@ -154,6 +154,15 @@ namespace NUnit.Tests
 
             [Test, Ignore("Ignore Message")]
             public void IgnoreTest() { }
+
+            [Test, Ignore("Ignore testcase")]
+            [TestCase(1)]
+            [TestCase(2)]
+            [TestCase(3)]
+            public void SkippedTest(int a)
+            {
+                Assert.Pass();
+            }
 
             [Test, Explicit]
             public void ExplicitTest() { }

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -113,7 +113,7 @@ namespace NUnitLite.Tests
         [TestCase("errors", MockTestFixture.Failed_Error)]
         [TestCase("failures", MockTestFixture.Failed_Other)]
         [TestCase("inconclusive", MockTestFixture.Inconclusive)]
-        [TestCase("not-run", MockTestFixture.Skipped+MockTestFixture.Failed_NotRunnable-MockTestFixture.Skipped_Explicit)]
+        [TestCase("not-run", MockTestFixture.Skipped+MockTestFixture.Failed_NotRunnable)]
         [TestCase("ignored", MockTestFixture.Skipped_Ignored)]
         [TestCase("skipped", MockTestFixture.Skipped-MockTestFixture.Skipped_Ignored-MockTestFixture.Skipped_Explicit)]
         [TestCase("invalid", MockTestFixture.Failed_NotRunnable)]

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -209,7 +209,7 @@ namespace NUnitLite.Tests
         }
 
         [Test]
-        public void IgnoredTestCases_HaveValidEndTimeAttribute()
+        public void IgnoredTestCases_HaveValidStartAndEndTimeAttributes()
         {
             DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
             DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
@@ -234,7 +234,7 @@ namespace NUnitLite.Tests
         }
 
         [Test]
-        public void ExplicitTest_HasValidEndTimeAttribute()
+        public void ExplicitTest_HasValidStartAndEndTimeAttributes()
         {
             DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
             DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
@@ -254,7 +254,7 @@ namespace NUnitLite.Tests
             Assert.IsTrue(DateTime.TryParse(endTimeStr, out var endTime));
 
             Assert.That(startTime, Is.InRange(testRunStartTime, testRunEndTime), "Explicit test cases should be set to approximately the start time of test suite");
-            Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Explicit test cases should be set to approximately the start time of test suite");
+            Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Explicit test cases should be set to approximately the end time of test suite");
         }
 
         #region Helper Methods

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -214,7 +214,6 @@ namespace NUnitLite.Tests
             DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
             DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
 
-            string startTimeString = RequiredAttribute(topNode, "start-time");
             var testCaseNodes = suiteNode.SelectNodes("test-suite[@name='SkippedTest']/test-case");
             Assert.That(testCaseNodes, Is.Not.Null);
 

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -209,7 +209,7 @@ namespace NUnitLite.Tests
         }
 
         [Test]
-        public void IgnoredTestCase_HasValidEndTimeAttribute()
+        public void IgnoredTestCases_HaveValidEndTimeAttribute()
         {
             DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
             DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
@@ -219,12 +219,42 @@ namespace NUnitLite.Tests
 
             foreach (XmlNode testCase in testCaseNodes)
             {
-                DateTime.TryParse(RequiredAttribute(testCase, "start-time"), out var startTime);
-                DateTime.TryParse(RequiredAttribute(testCase, "end-time"), out var endTime);
+                string startTimeStr = RequiredAttribute(testCase, "start-time");
+                string endTimeStr = RequiredAttribute(testCase, "end-time");
+
+                Assert.That(startTimeStr, Does.EndWith("Z"), "Ignored start-time is not UTC");
+                Assert.That(endTimeStr, Does.EndWith("Z"), "Ignored end-time is not UTC");
+
+                Assert.IsTrue(DateTime.TryParse(startTimeStr, out var startTime));
+                Assert.IsTrue(DateTime.TryParse(endTimeStr, out var endTime));
 
                 Assert.That(startTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
                 Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
             }
+        }
+
+        [Test]
+        public void ExplicitTest_HasValidEndTimeAttribute()
+        {
+            DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
+            DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
+
+            var testCaseNodes = suiteNode.SelectNodes("test-case[@name='ExplicitTest']");
+            Assert.That(testCaseNodes, Is.Not.Null.And.Count.EqualTo(1));
+
+            XmlNode testCase = testCaseNodes[0];
+
+            string startTimeStr = RequiredAttribute(testCase, "start-time");
+            string endTimeStr = RequiredAttribute(testCase, "end-time");
+
+            Assert.That(startTimeStr, Does.EndWith("Z"), "Explicit start-time is not UTC");
+            Assert.That(endTimeStr, Does.EndWith("Z"), "Explicit end-time is not UTC");
+
+            Assert.IsTrue(DateTime.TryParse(startTimeStr, out var startTime));
+            Assert.IsTrue(DateTime.TryParse(endTimeStr, out var endTime));
+
+            Assert.That(startTime, Is.InRange(testRunStartTime, testRunEndTime), "Explicit test cases should be set to approximately the start time of test suite");
+            Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Explicit test cases should be set to approximately the start time of test suite");
         }
 
         #region Helper Methods

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -208,6 +208,26 @@ namespace NUnitLite.Tests
             Assert.That(success, "{0} is an invalid value for end time", endTimeString);
         }
 
+        [Test]
+        public void IgnoredTestCase_HasValidEndTimeAttribute()
+        {
+            DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
+            DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
+
+            string startTimeString = RequiredAttribute(topNode, "start-time");
+            var testCaseNodes = suiteNode.SelectNodes("test-suite[@name='SkippedTest']/test-case");
+            Assert.That(testCaseNodes, Is.Not.Null);
+
+            foreach (XmlNode testCase in testCaseNodes)
+            {
+                DateTime.TryParse(RequiredAttribute(testCase, "start-time"), out var startTime);
+                DateTime.TryParse(RequiredAttribute(testCase, "end-time"), out var endTime);
+
+                Assert.That(startTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
+                Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
+            }
+        }
+
         #region Helper Methods
 
         private string RequiredAttribute(XmlNode node, string name)

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -215,7 +215,7 @@ namespace NUnitLite.Tests
             DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
 
             var testCaseNodes = suiteNode.SelectNodes("test-suite[@name='SkippedTest']/test-case");
-            Assert.That(testCaseNodes, Is.Not.Null);
+            Assert.That(testCaseNodes, Is.Not.Null.And.Count.EqualTo(3));
 
             foreach (XmlNode testCase in testCaseNodes)
             {
@@ -229,7 +229,7 @@ namespace NUnitLite.Tests
                 Assert.IsTrue(DateTime.TryParse(endTimeStr, out var endTime));
 
                 Assert.That(startTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
-                Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the start time of test suite");
+                Assert.That(endTime, Is.InRange(testRunStartTime, testRunEndTime), "Ignored test cases should be set to approximately the end time of test suite");
             }
         }
 

--- a/src/NUnitFramework/nunitlite.tests/TextUIReportTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUIReportTests.cs
@@ -101,7 +101,13 @@ namespace NUnitLite.Tests
                 "Tests Not Run\n\n" +
                 "1) Ignored : NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest\n" +
                 "Ignore Message\n\n" +
-                "2) Explicit : NUnit.Tests.Assemblies.MockTestFixture.ExplicitTest\n\n"));
+                "2) Ignored : NUnit.Tests.Assemblies.MockTestFixture.SkippedTest(1)\n"+
+                "Ignore testcase\n\n"+
+                "3) Ignored : NUnit.Tests.Assemblies.MockTestFixture.SkippedTest(2)\n"+
+                "Ignore testcase\n\n"+
+                "4) Ignored : NUnit.Tests.Assemblies.MockTestFixture.SkippedTest(3)\n"+
+                "Ignore testcase\n\n"+
+                "5) Explicit : NUnit.Tests.Assemblies.MockTestFixture.ExplicitTest\n\n"));
         }
 
         [Test]
@@ -112,9 +118,9 @@ namespace NUnitLite.Tests
             Assert.That(Report, Is.EqualTo(
                 "Test Run Summary\n" +
                 "  Overall result: Failed\n" +
-                "  Test Count: 10, Passed: 2, Failed: 4, Warnings: 1, Inconclusive: 1, Skipped: 2\n" +
+                "  Test Count: 13, Passed: 2, Failed: 4, Warnings: 1, Inconclusive: 1, Skipped: 5\n" +
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 2\n" +
-                "    Skipped Tests - Ignored: 1, Explicit: 1, Other: 0\n" +
+                "    Skipped Tests - Ignored: 4, Explicit: 1, Other: 0\n" +
                 "  Start time: 2014-12-02 12:34:56Z\n" +
                 "    End time: 2014-12-02 12:34:56Z\n" +
                 "    Duration: 0.123 seconds\n\n"));

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -89,7 +89,7 @@ namespace NUnitLite
             xmlWriter.WriteAttributeString("total", summary.TestCount.ToString());
             xmlWriter.WriteAttributeString("errors", summary.ErrorCount.ToString());
             xmlWriter.WriteAttributeString("failures", summary.FailureCount.ToString());
-            var notRunTotal = summary.SkipCount + summary.FailureCount + summary.InvalidCount;
+            var notRunTotal = summary.IgnoreCount + summary.ExplicitCount + summary.SkipCount + summary.InvalidCount;
             xmlWriter.WriteAttributeString("not-run", notRunTotal.ToString());
             xmlWriter.WriteAttributeString("inconclusive", summary.InconclusiveCount.ToString());
             xmlWriter.WriteAttributeString("ignored", summary.IgnoreCount.ToString());

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -89,8 +89,7 @@ namespace NUnitLite
             xmlWriter.WriteAttributeString("total", summary.TestCount.ToString());
             xmlWriter.WriteAttributeString("errors", summary.ErrorCount.ToString());
             xmlWriter.WriteAttributeString("failures", summary.FailureCount.ToString());
-            var notRunTotal = summary.IgnoreCount + summary.ExplicitCount + summary.SkipCount + summary.InvalidCount;
-            xmlWriter.WriteAttributeString("not-run", notRunTotal.ToString());
+            xmlWriter.WriteAttributeString("not-run", summary.NotRunCount.ToString());
             xmlWriter.WriteAttributeString("inconclusive", summary.InconclusiveCount.ToString());
             xmlWriter.WriteAttributeString("ignored", summary.IgnoreCount.ToString());
             xmlWriter.WriteAttributeString("skipped", summary.SkipCount.ToString());


### PR DESCRIPTION
Continues the work started by @Poimen in ##3706 superseding that PR.

Fixes #2339
Fixes #3724

This fixes the Unit Tests for the fix completed by @Poimen, adds additional tests and fixes a bug in the NUnit2 result writer that these changes exposed.

The unit tests cover the changes but I've also tested by examining the test results and manually verifying the start/end/duration of ignored and explicit tests.