### PR TITLE
Update internal string comparisons to use Ordinal when safe

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -148,7 +148,7 @@ namespace NUnit.Framework.Api
                         if (!string.IsNullOrEmpty(parameters))
                             foreach (string param in parameters.Split(new[] { ';' }))
                             {
-                                int eq = param.IndexOf("=");
+                                int eq = param.IndexOf('=');
 
                                 if (eq > 0 && eq < param.Length - 1)
                                 {

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework
         protected CategoryAttribute()
         {
             this.categoryName = this.GetType().Name;
-            if ( categoryName.EndsWith( "Attribute" ) )
+            if ( categoryName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 categoryName = categoryName.Substring( 0, categoryName.Length - 9 );
         }
 

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -119,7 +119,7 @@ namespace NUnit.Framework
         public void ApplyToTest(Test test)
         {
             var joinType = _strategy.GetType().Name;
-            if (joinType.EndsWith("Strategy"))
+            if (joinType.EndsWith("Strategy", StringComparison.Ordinal))
                 joinType = joinType.Substring(0, joinType.Length - 8);
 
             test.Properties.Set(PropertyNames.JoinType, joinType);

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework
         protected PropertyAttribute( object propertyValue )
         {
             string propertyName = this.GetType().Name;
-            if ( propertyName.EndsWith( "Attribute" ) )
+            if ( propertyName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 propertyName = propertyName.Substring( 0, propertyName.Length - 9 );
             this.properties.Add(propertyName, propertyValue);
         }

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
             get
             {
                 var name = predicate.GetMethodInfo().Name;
-                return name.StartsWith("<")
+                return name.StartsWith("<", StringComparison.Ordinal)
                     ? "value matching lambda expression"
                     : "value matching " + name;
             }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Constraints
         private static bool IsSpecialComparisonType(Type type)
         {
             if (type.IsGenericType)
-                return type.FullName.StartsWith("System.Collections.Generic.KeyValuePair`2");
+                return type.FullName.StartsWith("System.Collections.Generic.KeyValuePair`2", StringComparison.Ordinal);
             else if (Numerics.IsNumericType(type))
                 return true;
             else
@@ -255,7 +255,7 @@ namespace NUnit.Framework.Constraints
         {
             foreach (var type in actual.GetType().GetInterfaces())
             {
-                if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable`1"))
+                if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable`1", StringComparison.Ordinal))
                 {
                     return type.GenericTypeArguments[0];
                 }

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -274,7 +274,7 @@ namespace NUnit.Framework.Interfaces
             Guard.ArgumentNotNullOrEmpty(xpath, nameof(xpath));
             if (xpath[0] == '/')
                 throw new ArgumentException("XPath expressions starting with '/' are not supported", nameof(xpath));
-            if (xpath.IndexOf("//") >= 0)
+            if (xpath.IndexOf("//", StringComparison.Ordinal) >= 0)
                 throw new ArgumentException("XPath expressions with '//' are not supported", nameof(xpath));
 
             string head = xpath;
@@ -378,7 +378,7 @@ namespace NUnit.Framework.Interfaces
 
             while (true)
             {
-                int illegal = text.IndexOf("]]>", start);
+                int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
                 if (illegal < 0)
                     break;
                 writer.WriteCData(text.Substring(start, illegal - start + 2));
@@ -410,7 +410,7 @@ namespace NUnit.Framework.Interfaces
                 int lbrack = xpath.IndexOf('[');
                 if (lbrack >= 0)
                 {
-                    if (!xpath.EndsWith("]"))
+                    if (!xpath.EndsWith("]", StringComparison.Ordinal))
                         throw new ArgumentException("Invalid property expression", nameof(xpath));
 
                     _nodeName = xpath.Substring(0, lbrack);

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -23,6 +23,7 @@
 
 #nullable enable
 
+using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Builders
@@ -82,7 +83,7 @@ namespace NUnit.Framework.Internal.Builders
                 if (parms.TestName != null)
                 {
                     // The test is simply for efficiency
-                    testMethod.Name = parms.TestName.Contains("{")
+                    testMethod.Name = parms.TestName.IndexOf('{') >= 0
                         ? new TestNameGenerator(parms.TestName).GetDisplayName(testMethod, parms.OriginalArguments)
                         : parms.TestName;
                 }

--- a/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Internal.Builders
                 return _namespaceIndex[ns];
 
             TestSuite suite;
-            int index = ns.LastIndexOf(".");
+            int index = ns.LastIndexOf('.');
 
             if( index == -1 )
             {

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Internal
             if (from == null)
             {
                 // Look for the marker that indicates from was null
-                return to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable");
+                return to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable", StringComparison.Ordinal);
             }
 
             if (convertibleValueTypes.ContainsKey(to) && convertibleValueTypes[to].Contains(from))

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -367,7 +367,7 @@ namespace NUnit.Common
                     // This can be changed without breaking backwards compatibility with frameworks.
                     foreach (string param in parameters.Split(new[] { ';' }))
                     {
-                        int eq = param.IndexOf("=");
+                        int eq = param.IndexOf('=');
                         if (eq == -1 || eq == param.Length - 1)
                         {
                             ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
@@ -459,7 +459,8 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/';
+            return v.StartsWith("-", StringComparison.Ordinal)
+                || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -459,7 +459,7 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith('-') || (v.StartsWith('/') && Path.DirectorySeparatorChar != '/');
+            return v.StartsWith("-", StringComparison.Ordinal) || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -459,8 +459,7 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith("-", StringComparison.Ordinal)
-                || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
+            return v.StartsWith('-') || (v.StartsWith('/') && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -366,7 +366,7 @@ namespace NUnitLite
             int start = 0;
             while (true)
             {
-                int illegal = text.IndexOf("]]>", start);
+                int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
                 if (illegal < 0)
                     break;
                 xmlWriter.WriteCData(text.Substring(start, illegal - start + 2));

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -266,7 +266,7 @@ namespace NUnitLite
 
                 WriteOutput(result.Output);
 
-                if (!result.Output.EndsWith("\n"))
+                if (!result.Output.EndsWith("\n", StringComparison.Ordinal))
                     Writer.WriteLine();
             }
 
@@ -689,7 +689,7 @@ namespace NUnitLite
             Writer.Write(color, text);
 
             _testCreatedOutput = true;
-            _needsNewLine = !text.EndsWith("\n");
+            _needsNewLine = !text.EndsWith("\n", StringComparison.Ordinal);
         }
 
          private static ColorStyle GetColorForResultStatus(string status)


### PR DESCRIPTION
Contributes to #3588 

This PR tackles the low-hanging fruit of StartsWith/EndsWith/Contains of string comparisons within the framework. It focuses on cases where the argument is a string literal with all characters lying within the standard ASCII range.

The majority of the cases deal with either:
- Inspection of type/member names
- Detection of line breaks