### PR TITLE
add ClearOutput method to TestResult

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -656,6 +656,18 @@ namespace NUnit.Framework.Internal
             return writer.ToString();
         }
 
+
+        /// <summary>
+        /// Clears any text output written to this result.
+        /// </summary>
+        public void ClearOutput()
+        {
+            lock (OutWriter)
+            {
+                _output.Clear();
+            }
+        }
+
         #endregion
 
         #region Helper Methods

--- a/src/NUnitFramework/tests/Internal/Results/TestResultOutputTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultOutputTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2014 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -67,6 +67,24 @@ namespace NUnit.Framework.Internal.Results
         }
 
         [Test]
+        public void ClearOutput()
+        {
+            _result.OutWriter.WriteLine(SOME_TEXT);
+            _result.ClearOutput();
+
+            Assert.That(_result.Output, Does.Not.Contain(SOME_TEXT));
+        }
+        [Test]
+        public void CanWriteOutputToResult_AfterClearOutput()
+        {
+            _result.OutWriter.WriteLine("Deleted text ");
+            _result.ClearOutput();
+            _result.OutWriter.WriteLine(SOME_TEXT);
+
+            Assert.That(_result.Output, Is.EqualTo(SOME_TEXT + NL));
+        }
+
+        [Test]
         public void IfNothingIsWritten_XmlOutputIsEmpty()
         {
             Assert.That(_result.ToXml(false).SelectSingleNode("output"), Is.Null);
@@ -96,6 +114,26 @@ namespace NUnit.Framework.Internal.Results
             Assert.NotNull(outputNode, "No output node found in XML");
             Assert.That(outputNode.Value, Is.EqualTo(SOME_TEXT + NL +
                 "More text written in segments." + NL + "Last line!" + NL));
+        }
+
+        [Test]
+        public void ClearOutput_XmlOutput()
+        {
+            _result.OutWriter.WriteLine(SOME_TEXT);
+            _result.ClearOutput();
+
+            Assert.That(_result.ToXml(false).SelectSingleNode("output"), Is.Null);
+        }
+        [Test]
+        public void CanWriteOutputToResult_AfterClearOutput_XmlOutput()
+        {
+            _result.OutWriter.WriteLine("Deleted text ");
+            _result.ClearOutput();
+            _result.OutWriter.WriteLine(SOME_TEXT);
+
+            var outputNode = _result.ToXml(false).SelectSingleNode("output");
+            Assert.NotNull(outputNode, "No output node found in XML");
+            Assert.That(outputNode.Value, Is.EqualTo(SOME_TEXT + NL));
         }
 
         [Test]


### PR DESCRIPTION
Adds the option to be able to clear testresult output.


**Use case:** 
The idea is based off of how Azure devops infers test results and only attaches logs for failed tests. 

So my use case would be in some teardown, clear output if test passes:
        [TearDown]
        public void BaseTearDown()
        {
            var result = TestExecutionContext.CurrentContext.CurrentResult;
            if (Equals(result.ResultState, ResultState.Success))
                result.ClearOutput();
        }

When working with very large (100s of MB!) reports, or tests with large outputs (up to 10MB, 400 lines, per test) , any sort of processing of the results can be very slow and often leads to memory issues.
So this would allow you to suppress/clear output for a test/fixture at any point _before_ it gets written to the results.
Saving a lot of MB in space and a lot of time in processing reports

Other use cases could be suppressing output from third party libraries, repeated test setups etc.

These changes don't affect any existing functionality and its completely up to the user to decide what logging is (or not) important to them.





