### PR TITLE
Obsolete AreEqual methods with nullable numeric arguments for 3.13

### DIFF
--- a/src/NUnitFramework/framework/Assert.Equality.cs
+++ b/src/NUnitFramework/framework/Assert.Equality.cs
@@ -66,10 +66,9 @@ namespace NUnit.Framework
         /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
+        [System.Obsolete("This method will be removed in NUnit 4.0.")]
         public static void AreEqual(double expected, double? actual, double delta, string? message, params object?[]? args)
         {
-            // TODO: https://github.com/nunit/nunit/issues/3449
-            //                                    ↓↓↓↓↓↓↓
             AssertDoublesAreEqual(expected, actual!.Value, delta, message, args);
         }
 
@@ -80,10 +79,9 @@ namespace NUnit.Framework
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The actual value</param>
         /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
+        [System.Obsolete("This method will be removed in NUnit 4.0.")]
         public static void AreEqual(double expected, double? actual, double delta)
         {
-            // TODO: https://github.com/nunit/nunit/issues/3449
-            //                                    ↓↓↓↓↓↓↓
             AssertDoublesAreEqual(expected, actual!.Value, delta, null, null);
         }
 

--- a/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
+++ b/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
@@ -126,8 +126,8 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void CanCompareWithTolerance()
         {
+#pragma warning disable 0618
             double? five = 5.0;
-
             Assert.AreEqual(5.0000001, five, .0001); 
             Assert.That( five, Is.EqualTo(5.0000001).Within(.0001));
 
@@ -135,6 +135,7 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreEqual(3.00001f, three, .001);
             Assert.That( three, Is.EqualTo(3.00001f).Within(.001));
+#pragma warning restore 0618
         }
 
         private enum Colors


### PR DESCRIPTION
Closes #3449