### PR TITLE
Cherry-pick Fix IDisposable call for InstancePerTestCase with parametrized test cases to 3.13.x branch

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,7 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
@@ -42,7 +41,7 @@ namespace NUnit.Framework.Internal.Commands
             : base(innerCommand)
         {
             Guard.OperationValid(
-                Test is IDisposableFixture || Test?.Parent is IDisposableFixture, 
+                HasDisposableFixture(Test),
                 $"DisposeFixtureCommand does not apply neither to {Test.GetType().Name}, nor to {Test.Parent?.GetType().Name ?? "it's parent (null)"}");
 
             AfterTest = (context) =>
@@ -58,6 +57,19 @@ namespace NUnit.Framework.Internal.Commands
                     context.CurrentResult.RecordTearDownException(ex);
                 }
             };
+        }
+
+        private static bool HasDisposableFixture(ITest test)
+        {
+            while (test != null)
+            {
+                if (test is IDisposableFixture)
+                    return true;
+
+                test = test.Parent;
+            }
+
+            return false;
         }
     }
 }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -91,10 +91,12 @@ namespace NUnit.TestData.LifeCycleTests
 
     [TestFixtureSource(nameof(FixtureArgs))]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class LifeCycleWithTestFixtureSourceFixture
+    public class LifeCycleWithTestFixtureSourceFixture : IDisposable
     {
         private readonly int _initialValue;
         private int _value;
+
+        public static int DisposeCalls { get; set; }
 
         public LifeCycleWithTestFixtureSourceFixture(int num)
         {
@@ -103,6 +105,8 @@ namespace NUnit.TestData.LifeCycleTests
         }
 
         public static int[] FixtureArgs() => new[] { 1, 42 };
+
+        public void Dispose() => DisposeCalls++;
 
         [Test]
         public void Test1()
@@ -118,9 +122,13 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTestCases
+    public class FixtureWithTestCases : IDisposable
     {
         private int _counter;
+
+        public static int DisposeCalls { get; set; }
+
+        public void Dispose() => DisposeCalls++;
 
         [TestCase(0)]
         [TestCase(1)]
@@ -133,12 +141,15 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTestCaseSource
+    public class FixtureWithTestCaseSource : IDisposable
     {
         private int _counter;
 
+        public static int DisposeCalls { get; set; }
         public static int[] Args() => new[] { 1, 42 };
 
+        public void Dispose() => DisposeCalls++;
+        
         [TestCaseSource(nameof(Args))]
         public void Test(int _)
         {
@@ -147,9 +158,13 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithValuesAttributeTest
+    public class FixtureWithValuesAttributeTest : IDisposable
     {
         private int _counter;
+
+        public static int DisposeCalls { get; set; }
+
+        public void Dispose() => DisposeCalls++;
 
         [Test]
         public void Test([Values] bool? _)
@@ -159,9 +174,13 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTheoryTest
+    public class FixtureWithTheoryTest : IDisposable
     {
         private int _counter;
+
+        public static int DisposeCalls { get; set; }
+
+        public void Dispose() => DisposeCalls++;
 
         [Theory]
         public void Test(bool? _)

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -106,41 +106,51 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseShouldApplyToTestFixtureSourceTests()
         {
+            LifeCycleWithTestFixtureSourceFixture.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithTestFixtureSourceFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(LifeCycleWithTestFixtureSourceFixture.DisposeCalls, Is.EqualTo(4));
         }
 
         [Test]
         public void InstancePerTestCaseShouldApplyToTestCaseTests()
         {
+            FixtureWithTestCases.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestCases));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(FixtureWithTestCases.DisposeCalls, Is.EqualTo(4));
         }
 
         [Test]
         public void InstancePerTestCaseShouldApplyToTestCaseSourceTests()
         {
+            FixtureWithTestCaseSource.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestCaseSource));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(FixtureWithTestCaseSource.DisposeCalls, Is.EqualTo(2));
         }
 
         [Test]
         public void InstancePerTestCaseShouldApplyToTestsWithValuesParameters()
         {
+            FixtureWithValuesAttributeTest.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithValuesAttributeTest));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(FixtureWithValuesAttributeTest.DisposeCalls, Is.EqualTo(3));
         }
 
         [Test]
         public void InstancePerTestCaseShouldApplyToTheories()
         {
+            FixtureWithTheoryTest.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTheoryTest));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(FixtureWithTheoryTest.DisposeCalls, Is.EqualTo(3));
         }
 
 #if NETFRAMEWORK


### PR DESCRIPTION
Fixes #3773 on the 3.13.x branch.

See #3804