### PR TITLE
Add GitHub Actions to build on Windows, Linux and Mac

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,10 +1,6 @@
 name: Continuous Integration
 
-on:
-  push:
-    branches: [ master, release, v3.13-dev ]
-  pull_request:
-    branches: [ master, release, v3.13-dev ]
+on: [push, pull_request]
 
 jobs:
   build-windows:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:
-        name: Test results (Linux)
+        name: Test results (macOS)
         path: test-results
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,107 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master, release, v3.13-dev ]
+  pull_request:
+    branches: [ master, release, v3.13-dev ]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build and Test
+      run: .\build.ps1 --target=Test --test-run-name=Windows
+
+    - name: Package
+      run: .\build.ps1 --target=Package
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Package
+        path: package
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test results (Windows)
+        path: test-results
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK 2.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Setup .NET Core SDK 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup .NET Core SDK 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - name: Install F#
+      run: sudo apt-get install fsharp
+
+    - name: Install Cake.Tool
+      run: dotnet tool install --global Cake.Tool
+
+    - name: Build and Test
+      run: dotnet cake --target=Test --test-run-name=Linux --configuration=Release
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test results (Linux)
+        path: test-results
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK 2.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Setup .NET Core SDK 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup .NET Core SDK 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - name: Install Cake.Tool
+      run: dotnet tool install --global Cake.Tool
+
+    - name: Build and Test
+      run: dotnet cake --target=Test --test-run-name=Linux --configuration=Release
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test results (Linux)
+        path: test-results
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,16 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - release
+      - 'v3.13-dev'
+  pull_request:
+    branches:
+      - master
+      - release
+      - 'v3.13-dev'
 
 jobs:
   build-windows:

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ project.lock.json
 .config/dotnet-tools.json
 *.err
 *.out
+.ionide


### PR DESCRIPTION
Fixes #3812

Currently just builds on all three platforms and saves the packages from Windows. It does not publish the packages to any NuGet package feed. In the future, we may do that.