### PR TITLE
Backport performance improvements

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Constraints
                     missingItems.Add(o);
 
                 List<object> extraItems = new List<object>();
-                if(_sorted)
+                if (_sorted)
                 {
                     for (int index = _extraItems.Count - 1; index >= 0; index--)
                         extraItems.Add(_extraItems[index]);

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -23,6 +23,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework.Internal.Extensions;
 
 namespace NUnit.Framework.Constraints
 {
@@ -49,18 +50,33 @@ namespace NUnit.Framework.Constraints
 
         private readonly NUnitEqualityComparer comparer;
 
+        private bool _sorted = false;
+
         /// <summary>The result of the comparison between the two collections.</summary>
         public CollectionTallyResult Result
         {
             get
             {
-                return new CollectionTallyResult(
-                    new List<object>(_missingItems),
-                    new List<object>(_extraItems));
+                var missingItems = new List<object>(_missingItems.Count);
+                foreach (var o in _missingItems)
+                    missingItems.Add(o);
+
+                List<object> extraItems = new List<object>();
+                if(_sorted)
+                {
+                    for (int index = _extraItems.Count - 1; index >= 0; index--)
+                        extraItems.Add(_extraItems[index]);
+                }
+                else
+                {
+                    extraItems.AddRange(_extraItems);
+                }
+
+                return new CollectionTallyResult(missingItems, extraItems);
             }
         }
 
-        private readonly List<object> _missingItems = new List<object>();
+        private readonly ArrayList _missingItems = new ArrayList();
 
         private readonly List<object> _extraItems = new List<object>();
 
@@ -73,6 +89,9 @@ namespace NUnit.Framework.Constraints
 
             foreach (object o in c)
                 _missingItems.Add(o);
+
+            if (c.IsSortable())
+                _missingItems.Sort();
         }
 
         private bool ItemsEqual(object expected, object actual)
@@ -101,8 +120,25 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The objects to remove.</param>
         public void TryRemove(IEnumerable c)
         {
-            foreach (object o in c)
-                TryRemove(o);
+            if (c.IsSortable())
+            {
+                var remove = new ArrayList();
+                foreach (object o in c)
+                    remove.Add(o);
+
+                remove.Sort();
+                _sorted = true;
+
+                // Reverse so that we match removing from the end,
+                // see issue #2598 - Is.Not.EquivalentTo is extremely slow
+                for (int index = remove.Count - 1; index >= 0; index--)
+                    TryRemove(remove[index]);
+            }
+            else
+            {
+                foreach (object o in c)
+                    TryRemove(o);
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Constraints
                 foreach (var o in _missingItems)
                     missingItems.Add(o);
 
-                List<object> extraItems = new List<object>();
+                List<object> extraItems = new List<object>(_extraItems.Count);
                 if (_sorted)
                 {
                     for (int index = _extraItems.Count - 1; index >= 0; index--)

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -60,6 +60,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (obj is System.Double) return true;
                 if (obj is System.Single) return true;
+                if (obj is System.Decimal) return true;
             }
             return false;
         }
@@ -70,6 +71,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (type == typeof(double)) return true;
                 if (type == typeof(float)) return true;
+                if (type == typeof(decimal)) return true;
             }
             return false;
         }

--- a/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Collections;
+using System.Linq;
+
+namespace NUnit.Framework.Internal.Extensions
+{
+    internal static class IEnumerableExtensions
+    {
+        public static bool IsSortable(this IEnumerable collection)
+        {
+            if (collection is null)
+                return false;
+
+            var collectionType = collection.GetType();
+
+            var @interface = collectionType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && (
+                    (i.Namespace == "System.Collections.Generic" && i.Name == "IEnumerable`1") ||
+                    (i.Namespace == "System.Linq" && i.Name == "IIListProvider`1")));
+
+            if (@interface is null)
+                return false;
+
+            var itemType = @interface
+                .GetGenericArguments()
+                .FirstOrDefault();
+
+            if (itemType is null)
+                return false;
+
+            return itemType.ImplementsIComparable();
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Collections;
+using System.Collections.Specialized;
 using System.Linq;
 
 namespace NUnit.Framework.Internal.Extensions
@@ -12,13 +13,16 @@ namespace NUnit.Framework.Internal.Extensions
             if (collection is null)
                 return false;
 
+            if (collection is StringCollection)
+                return true;
+
             var collectionType = collection.GetType();
 
             var @interface = collectionType
                 .GetInterfaces()
-                .FirstOrDefault(i => i.IsGenericType && (
-                    (i.Namespace == "System.Collections.Generic" && i.Name == "IEnumerable`1") ||
-                    (i.Namespace == "System.Linq" && i.Name == "IIListProvider`1")));
+                .FirstOrDefault(i => i.IsGenericType && 
+                    i.Namespace == "System.Collections.Generic" && 
+                    i.Name == "IEnumerable`1");
 
             if (@interface is null)
                 return false;

--- a/src/NUnitFramework/framework/Internal/Extensions/TypeExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/TypeExtensions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Internal.Extensions
+{
+    internal static class TypeExtensions
+    {
+        public static bool ImplementsIComparable(this Type type) =>
+            type?.GetInterface("System.IComparable") != null;
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -65,6 +65,15 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void CollectionsInDifferentOrderArNotEqual()
+        {
+            IList expected = new List<int> { 1, 2, 3 };
+            IList actual = new List<int> { 3, 2, 1 };
+
+            Assert.That(actual, Is.Not.EqualTo(expected));
+        }
+
+        [Test]
         public void FailureForEnumerablesWithDifferentSizes()
         {
             IEnumerable<int> expected = new int[] { 1, 2, 3 }.Select(i => i);

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework.Internal;
@@ -344,6 +345,29 @@ namespace NUnit.Framework.Constraints
         {
             var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
             var expected = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(actual);
+            var constraintResult = constraint.ApplyTo(expected);
+            Assert.That(constraintResult.IsSuccess, Is.True);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeStringCollection()
+        {
+            var actual = new StringCollection();
+            var expected = new StringCollection();
+            foreach(var i in Enumerable.Range(0, SIZE))
+            {
+                actual.Add(i.ToString());
+                expected.Add(i.ToString());
+            }
 
             var watch = Stopwatch.StartNew();
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -344,7 +344,7 @@ namespace NUnit.Framework.Constraints
         public void LargeStringCollectionsInReversedOrder()
         {
             var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
-            var expected = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+            var expected = Enumerable.Range(0, SIZE).Select(i => (SIZE - i - 1).ToString()).ToList();
 
             var watch = Stopwatch.StartNew();
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -24,6 +24,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
@@ -32,6 +34,8 @@ namespace NUnit.Framework.Constraints
 {
     public class CollectionEquivalentConstraintTests
     {
+        const int SIZE = 10000; // For large collection tests
+
         [Test]
         public void EqualCollectionsAreEquivalent()
         {
@@ -274,5 +278,122 @@ namespace NUnit.Framework.Constraints
             Assert.That(writer.ToString(), Is.EqualTo(expectedMessage));
         }
 #endif
+
+        // The following tests are each running in 14ms to 46ms on my machine. Based on that,
+        // warn at 100ms and fail at 500ms
+        const int LARGE_COLLECTION_WARN_TIME = 100;
+        const int LARGE_COLLECTION_FAIL_TIME = 500;
+
+        [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeIntCollectionsInSameOrder()
+        {
+            var actual = Enumerable.Range(0, SIZE);
+            var expected = Enumerable.Range(0, SIZE);
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(actual);
+            var constraintResult = constraint.ApplyTo(expected);
+            Assert.That(constraintResult.IsSuccess, Is.True);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeIntCollectionsInReversedOrder()
+        {
+            var actual = Enumerable.Range(0, SIZE);
+            var expected = Enumerable.Range(0, SIZE).Select(i => SIZE - i - 1);
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(actual);
+            var constraintResult = constraint.ApplyTo(expected);
+            Assert.That(constraintResult.IsSuccess, Is.True);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeStringCollectionsInSameOrder()
+        {
+            var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+            var expected = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(actual);
+            var constraintResult = constraint.ApplyTo(expected);
+            Assert.That(constraintResult.IsSuccess, Is.True);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeStringCollectionsInReversedOrder()
+        {
+            var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+            var expected = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(actual);
+            var constraintResult = constraint.ApplyTo(expected);
+            Assert.That(constraintResult.IsSuccess, Is.True);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2598 - Is.Not.EquivalentTo is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeByteCollectionsNotEquivalent()
+        {
+            byte[] data = new byte[SIZE];
+            byte[] encrypted = new byte[SIZE];
+            encrypted[0] = 2;
+            encrypted[1] = 3;
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(data);
+            var constraintResult = constraint.ApplyTo(encrypted);
+            Assert.That(constraintResult.IsSuccess, Is.False);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
+
+        [Test(Description = "Issue #2598 - Is.Not.EquivalentTo is extremely slow")]
+        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
+        public void LargeByteCollectionsNotEquivalentAtEnd()
+        {
+            byte[] data = new byte[SIZE];
+            byte[] encrypted = new byte[SIZE];
+            encrypted[SIZE - 2] = 2;
+            encrypted[SIZE - 1] = 3;
+
+            var watch = Stopwatch.StartNew();
+
+            var constraint = new CollectionEquivalentConstraint(data);
+            var constraintResult = constraint.ApplyTo(encrypted);
+            Assert.That(constraintResult.IsSuccess, Is.False);
+
+            watch.Stop();
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
+                Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Extensions/IEnumerableExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/IEnumerableExtensionTests.cs
@@ -32,6 +32,7 @@ namespace NUnit.Framework.Internal.Extensions
             new TestCaseData(new List<string> { "1" }).SetArgDisplayNames("List<string>"),
             new TestCaseData(new HashSet<int> { 1 }).SetArgDisplayNames("HashSet<int>"),
             new TestCaseData(new HashSet<string> { "1" }).SetArgDisplayNames("HashSet<string>"),
+            new TestCaseData(new StringCollection { "1" }).SetArgDisplayNames("StringCollection"),
         };
 
         public static IEnumerable<TestCaseData> UnsortableCollections => new[]
@@ -41,7 +42,6 @@ namespace NUnit.Framework.Internal.Extensions
             new TestCaseData(new Hashtable()).SetArgDisplayNames("Hashtable"),
             new TestCaseData(new Queue()).SetArgDisplayNames("Queue"),
             new TestCaseData(new ListDictionary()).SetArgDisplayNames("ListDictionary"),
-            new TestCaseData(new StringCollection()).SetArgDisplayNames("StringCollection"),
             new TestCaseData(new SimpleObjectCollection()).SetArgDisplayNames("SimpleObjectCollection (ICollection)"),
         };
     }

--- a/src/NUnitFramework/tests/Internal/Extensions/IEnumerableExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/IEnumerableExtensionTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using NUnit.TestUtilities.Collections;
+
+namespace NUnit.Framework.Internal.Extensions
+{
+    public class IEnumerableExtensionTests
+    {
+        [TestCaseSource(nameof(SortableCollections))]
+        public void SortableCollectionsAreSortable(IEnumerable collection)
+        {
+            Assert.That(collection.IsSortable(), Is.True);
+        }
+
+        [TestCaseSource(nameof(UnsortableCollections))]
+        public void UnsortableCollectionsAreNotSortable(IEnumerable collection)
+        {
+            Assert.That(collection.IsSortable(), Is.False);
+        }
+
+        public static IEnumerable<TestCaseData> SortableCollections => new[]
+        {
+            new TestCaseData(new int[] { 1 }).SetArgDisplayNames("int[]"),
+            new TestCaseData(new string[] { "1" }).SetArgDisplayNames("string[]"),
+            new TestCaseData(Enumerable.Range(0, 10)).SetArgDisplayNames("IEnumerable<int>"),
+            new TestCaseData(Enumerable.Range(0, 10).Select(n => n.ToString())).SetArgDisplayNames("IEnumerable<string>"),
+            new TestCaseData(new List<int> { 1 }).SetArgDisplayNames("List<int>"),
+            new TestCaseData(new List<string> { "1" }).SetArgDisplayNames("List<string>"),
+            new TestCaseData(new HashSet<int> { 1 }).SetArgDisplayNames("HashSet<int>"),
+            new TestCaseData(new HashSet<string> { "1" }).SetArgDisplayNames("HashSet<string>"),
+        };
+
+        public static IEnumerable<TestCaseData> UnsortableCollections => new[]
+        {
+            new TestCaseData(null).SetArgDisplayNames("null"),
+            new TestCaseData(new ArrayList()).SetArgDisplayNames("ArrayList"),
+            new TestCaseData(new Hashtable()).SetArgDisplayNames("Hashtable"),
+            new TestCaseData(new Queue()).SetArgDisplayNames("Queue"),
+            new TestCaseData(new ListDictionary()).SetArgDisplayNames("ListDictionary"),
+            new TestCaseData(new StringCollection()).SetArgDisplayNames("StringCollection"),
+            new TestCaseData(new SimpleObjectCollection()).SetArgDisplayNames("SimpleObjectCollection (ICollection)"),
+        };
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+
+namespace NUnit.Framework.Internal.Extensions
+{
+    public class TypeExtensionTests
+    {
+        [TestCaseSource(nameof(TypesThatImplementIComparable))]
+        public void TypesThatImplementIComparable_ReturnTrue(Type type)
+        {
+            Assert.That(type.ImplementsIComparable(), Is.True);
+        }
+
+        [TestCaseSource(nameof(TypesThatDontImplementIComparable))]
+        public void TypesThatDontImplementIComparable_ReturnFalse(Type type)
+        {
+            Assert.That(type.ImplementsIComparable(), Is.False);
+        }
+
+        public static IEnumerable<Type> TypesThatImplementIComparable => new[]
+        {
+            typeof(byte),
+            typeof(sbyte),
+            typeof(int),
+            typeof(uint),
+            typeof(long),
+            typeof(ulong),
+            typeof(short),
+            typeof(ushort),
+            typeof(char),
+            typeof(float),
+            typeof(double),
+            typeof(decimal),
+            typeof(string),
+            typeof(bool),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan),
+            typeof(Guid),
+            typeof(BigInteger),
+            typeof(ValueTuple),
+            typeof(Version),
+        };
+
+        public static IEnumerable<Type> TypesThatDontImplementIComparable => new[]
+        {
+            null,
+            typeof(object),
+            typeof(Exception),
+            typeof(ValueType),
+            typeof(Stream)
+        };
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Numerics;
 
 namespace NUnit.Framework.Internal.Extensions
 {
@@ -41,8 +40,6 @@ namespace NUnit.Framework.Internal.Extensions
             typeof(DateTimeOffset),
             typeof(TimeSpan),
             typeof(Guid),
-            typeof(BigInteger),
-            typeof(ValueTuple),
             typeof(Version),
         };
 


### PR DESCRIPTION
Backporting #3834 to the `v3.13-dev` branch fixing #2799 on that branch.

The `v3.13-dev` branch tests are failing on my local machine. It looks like an update to .NET 5.0 broke the 5.0 NUnitlite tests? I am pushing anyway. I would prefer to fix that in a separate PR. If the builds/tests pass, I will merge this and fix separately. If not, then we'll see...

- Performance improvements comparing equivalence of large collections
- Add support for StringCollection
- Update src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
- Update src/NUnitFramework/framework/Constraints/CollectionTally.cs
- Update src/NUnitFramework/framework/Constraints/CollectionTally.cs
- Remove types from test that are not supported in .NET 3.5
