### PR TITLE
Do not construct object for OneTimeSetUp in InstancePerTestCase lifecycle

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -199,7 +199,7 @@ namespace NUnit.Framework.Internal.Execution
                     command = new OneTimeSetUpCommand(command, item);
 
                 // Construct the fixture if necessary
-                if (!Test.TypeInfo.IsStaticClass)
+                if (!Test.TypeInfo.IsStaticClass && !Test.HasLifeCycle(LifeCycle.InstancePerTestCase))
                     command = new ConstructFixtureCommand(command);
             }
 

--- a/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 namespace NUnit.TestData.LifeCycleTests
-{
+{ 
     public static class AssemblyLevelFixtureLifeCycleTest
     {
         public const string Code = @"
@@ -10,7 +10,7 @@ namespace NUnit.TestData.LifeCycleTests
             [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 
             [TestFixture]
-            public class FixtureUnderTest
+            public class FixtureUnderTest : NUnit.TestData.LifeCycleTests.BaseLifeCycle
             {
                 private int _value;
 
@@ -24,6 +24,159 @@ namespace NUnit.TestData.LifeCycleTests
                 public void Test2()
                 {
                     Assert.AreEqual(0, _value++);
+                }
+            }
+            ";
+    }
+
+    public static class OverrideAssemblyLevelFixtureLifeCycleTest
+    {
+        public const string Code = @"
+            using NUnit.Framework;
+
+            [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+            [TestFixture]
+            [FixtureLifeCycle(LifeCycle.SingleInstance)]
+            public class FixtureUnderTest : NUnit.TestData.LifeCycleTests.BaseLifeCycle
+            {
+                private int _value;
+
+                [Test]
+                [Order(0)]
+                public void Test1()
+                {
+                    Assert.AreEqual(0, _value++);
+                }
+
+                [Test]
+                [Order(1)]
+                public void Test2()
+                {
+                    Assert.AreEqual(1, _value++);
+                }
+            }
+            ";
+    }
+
+    public static class NestedOverrideAssemblyLevelFixtureLifeCycleTest
+    {
+        public const string OuterClass = @"
+            using NUnit.Framework;
+
+            [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+            [TestFixture]
+            [FixtureLifeCycle(LifeCycle.SingleInstance)]
+            public class FixtureUnderTest
+            {
+                public class NestedFixture : NUnit.TestData.LifeCycleTests.BaseLifeCycle
+                {
+                    private int _value;
+
+                    [Test]
+                    [Order(0)]
+                    public void Test1()
+                    {
+                        Assert.AreEqual(0, _value++);
+                    }
+
+                    [Test]
+                    [Order(1)]
+                    public void Test2()
+                    {
+                        Assert.AreEqual(1, _value++);
+                    }
+                }
+            }
+            ";
+
+        public const string InnerClass = @"
+            using NUnit.Framework;
+
+            [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+            [TestFixture]
+            public class FixtureUnderTest
+            {
+                [FixtureLifeCycle(LifeCycle.SingleInstance)]
+                public class NestedFixture : NUnit.TestData.LifeCycleTests.BaseLifeCycle
+                {
+                    private int _value;
+
+                    [Test]
+                    [Order(0)]
+                    public void Test1()
+                    {
+                        Assert.AreEqual(0, _value++);
+                    }
+
+                    [Test]
+                    [Order(1)]
+                    public void Test2()
+                    {
+                        Assert.AreEqual(1, _value++);
+                    }
+                }
+            }
+            ";
+    }
+
+    public static class InheritedOverrideTest
+    {
+        public const string InheritClassWithOtherLifecycle = @"
+            using NUnit.Framework;
+
+            [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+            [FixtureLifeCycle(LifeCycle.SingleInstance)]
+            public class Base : NUnit.TestData.LifeCycleTests.BaseLifeCycle
+            {
+            }
+
+            [TestFixture]
+            public class FixtureUnderTest : Base
+            {
+                private int _value;
+
+                [Test]
+                [Order(0)]
+                public void Test1()
+                {
+                    Assert.AreEqual(0, _value++);
+                }
+
+                [Test]
+                [Order(1)]
+                public void Test2()
+                {
+                    Assert.AreEqual(1, _value++);
+                }
+            }
+            ";
+
+        public const string InheritClassWithOtherLifecycleFromOtherAssembly = @"
+            using NUnit.Framework;
+
+            [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+
+            [TestFixture]
+            public class FixtureUnderTest : NUnit.TestData.LifeCycleTests.LifeCycleInheritanceBaseSingleInstance
+            {
+                private int _value;
+
+                [Test]
+                [Order(0)]
+                public void Test1()
+                {
+                    Assert.AreEqual(0, _value++);
+                }
+
+                [Test]
+                [Order(1)]
+                public void Test2()
+                {
+                    Assert.AreEqual(1, _value++);
                 }
             }
             ";

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -264,7 +264,7 @@ namespace NUnit.TestData.LifeCycleTests
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class RepeatingLifeCycleFixtureInstancePerTestCase
+    public class RepeatingLifeCycleFixtureInstancePerTestCase : BaseLifeCycle
     {
         public int Counter { get; set; }
         public static int RepeatCounter { get; set; }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -2,6 +2,7 @@
 
 
 using System;
+using System.Threading;
 using NUnit.Framework;
 
 namespace NUnit.TestData.LifeCycleTests
@@ -55,38 +56,38 @@ namespace NUnit.TestData.LifeCycleTests
 
         public BaseLifeCycle()
         {
-            ConstructCount++;
+            Interlocked.Increment(ref ConstructCount);
         }
 
         public void Dispose()
         {
-            DisposeCount++;
+            Interlocked.Increment(ref DisposeCount);
         }
 
         [OneTimeSetUp]
-        public static void OneTimeSetup()
+        public static void BaseOneTimeSetup()
         {
-            OneTimeSetUpCount++;
+            Interlocked.Increment(ref OneTimeSetUpCount);
         }
 
         [OneTimeTearDown]
-        public static void OneTimeTearDown()
+        public static void BaseOneTimeTearDown()
         {
-            OneTimeTearDownCount++;
+            Interlocked.Increment(ref OneTimeTearDownCount);
         }
 
         [SetUp]
-        public void SetUp()
+        public void BaseSetUp()
         {
-            SetUpCountTotal++;
-            InstanceSetUpCount++;
+            Interlocked.Increment(ref SetUpCountTotal);
+            Interlocked.Increment(ref InstanceSetUpCount);
         }
 
         [TearDown]
-        public void TearDown()
+        public void BaseTearDown()
         {
-            TearDownCountTotal++;
-            InstanceTearDownCount++;
+            Interlocked.Increment(ref TearDownCountTotal);
+            Interlocked.Increment(ref InstanceTearDownCount);
         }
     }
 
@@ -282,7 +283,7 @@ namespace NUnit.TestData.LifeCycleTests
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     [Parallelizable(ParallelScope.All)]
-    public class ParallelLifeCycleFixtureInstancePerTestCase
+    public class ParallelLifeCycleFixtureInstancePerTestCase : BaseLifeCycle
     {
         int _setupCount = 0;
 

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -224,14 +224,12 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTestCaseSource : IDisposable
+    public class FixtureWithTestCaseSource : BaseLifeCycle
     {
         private int _counter;
 
-        public static int DisposeCalls { get; set; }
         public static int[] Args() => new[] { 1, 42 };
 
-        public void Dispose() => DisposeCalls++;
 
         [TestCaseSource(nameof(Args))]
         public void Test(int _)

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -251,13 +251,9 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTheoryTest : IDisposable
+    public class FixtureWithTheoryTest : BaseLifeCycle
     {
         private int _counter;
-
-        public static int DisposeCalls { get; set; }
-
-        public void Dispose() => DisposeCalls++;
 
         [Theory]
         public void Test(bool? _)

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -6,68 +6,161 @@ using NUnit.Framework;
 
 namespace NUnit.TestData.LifeCycleTests
 {
+    #region Basic Lifecycle
     [TestFixture]
-    public class DisposableFixture : IDisposable
+    public class CountingLifeCycleTestFixture
     {
-        public static int DisposeCount = 0;
+        public int Count { get; set; }
+
+        [Test]
+        public void CountIsAlwaysOne()
+        {
+            Count++;
+            Assert.AreEqual(1, Count);
+        }
+
+        [Test]
+        public void CountIsAlwaysOne_2()
+        {
+            Count++;
+            Assert.AreEqual(1, Count);
+        }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class SetupAndTearDownFixtureInstancePerTestCase
+    {
+        int _totalSetupCount = 0;
+        int _totalTearDownCount = 0;
+
+        [SetUp]
+        public void Setup()
+        {
+            _totalSetupCount++;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _totalTearDownCount++;
+        }
+
+        [Test]
+        public void DummyTest1()
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1));
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DummyTest2()
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1));
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DummyTest3()
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1));
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase
+    {
+        public static int TotalOneTimeSetupCount = 0;
+        public static int TotalOneTimeTearDownCount = 0;
+
+        [OneTimeSetUp]
+        public static void OneTimeSetup()
+        {
+            TotalOneTimeSetupCount++;
+        }
+
+        [OneTimeTearDown]
+        public static void OneTimeTearDown()
+        {
+            TotalOneTimeTearDownCount++;
+        }
 
         [Test]
         public void DummyTest1() { }
 
         [Test]
         public void DummyTest2() { }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class DisposableLifeCycleFixtureInstancePerTestCase : IDisposable
+    {
+        public static int DisposeCalls { get; set; }
+        public static int ConstructCalls { get; set; }
+
+        public DisposableLifeCycleFixtureInstancePerTestCase()
+        {
+            ConstructCalls++;
+        }
+
+        [Test]
+        [Order(1)]
+        public void TestCase1()
+        {
+            Assert.That(DisposeCalls, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Order(2)]
+        public void TestCase2()
+        {
+            Assert.That(DisposeCalls, Is.EqualTo(1));
+        }
+
+        [Test]
+        [Order(3)]
+        public void TestCase3()
+        {
+            Assert.That(DisposeCalls, Is.EqualTo(2));
+        }
 
         public void Dispose()
         {
-            DisposeCount++;
+            DisposeCalls++;
         }
     }
+    #endregion
 
+    #region Validation
+
+    [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class LifeCycleWithNestedFixture
+    public class InstanceOneTimeSetupAndTearDownFixtureInstancePerTestCase
     {
-        public class NestedFixture
+        public int TotalOneTimeSetupCount = 0;
+        public int TotalOneTimeTearDownCount = 0;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
         {
-            private int _value;
-
-            [Test]
-            public void Test1()
-            {
-                Assert.AreEqual(0, _value++);
-            }
-
-            [Test]
-            public void Test2()
-            {
-                Assert.AreEqual(0, _value++);
-            }
+            TotalOneTimeSetupCount++;
         }
-    }
 
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class LifeCycleWithNestedOverridingFixture
-    {
-        [FixtureLifeCycle(LifeCycle.SingleInstance)]
-        public class NestedFixture
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
         {
-            private int _value;
-
-            [Test]
-            [Order(0)]
-            public void Test1()
-            {
-                Assert.AreEqual(0, _value++);
-            }
-
-            [Test]
-            [Order(1)]
-            public void Test2()
-            {
-                Assert.AreEqual(1, _value++);
-            }
+            TotalOneTimeTearDownCount++;
         }
-    }
 
+        [Test]
+        public void DummyTest1() { }
+    }
+    #endregion
+
+    #region Test Annotations
     [TestFixtureSource(nameof(FixtureArgs))]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class LifeCycleWithTestFixtureSourceFixture : IDisposable
@@ -128,7 +221,7 @@ namespace NUnit.TestData.LifeCycleTests
         public static int[] Args() => new[] { 1, 42 };
 
         public void Dispose() => DisposeCalls++;
-        
+
         [TestCaseSource(nameof(Args))]
         public void Test(int _)
         {
@@ -170,155 +263,6 @@ namespace NUnit.TestData.LifeCycleTests
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class SetupAndTearDownFixtureInstancePerTestCase
-    {
-        int _totalSetupCount = 0;
-        int _totalTearDownCount = 0;
-
-        [SetUp]
-        public void Setup()
-        {
-            _totalSetupCount++;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            _totalTearDownCount++;
-        }
-
-        [Test]
-        public void DummyTest1() 
-        {
-            Assert.That(_totalSetupCount, Is.EqualTo(1)); 
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void DummyTest2()
-        {
-            Assert.That(_totalSetupCount, Is.EqualTo(1));
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void DummyTest3()
-        {
-            Assert.That(_totalSetupCount, Is.EqualTo(1));
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
-        }
-    }
-
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase
-    {
-        public static int TotalOneTimeSetupCount = 0;
-        public static int TotalOneTimeTearDownCount = 0;
-
-        [OneTimeSetUp]
-        public static void OneTimeSetup()
-        {
-            TotalOneTimeSetupCount++;
-        }
-
-        [OneTimeTearDown]
-        public static void OneTimeTearDown()
-        {
-            TotalOneTimeTearDownCount++;
-        }
-
-        [Test]
-        public void DummyTest1() {}
-
-        [Test]
-        public void DummyTest2() {}
-    }
-
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class InstanceOneTimeSetupAndTearDownFixtureInstancePerTestCase
-    {
-        public int TotalOneTimeSetupCount = 0;
-        public int TotalOneTimeTearDownCount = 0;
-
-        [OneTimeSetUp]
-        public void OneTimeSetup()
-        {
-            TotalOneTimeSetupCount++;
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            TotalOneTimeTearDownCount++;
-        }
-
-        [Test]
-        public void DummyTest1() {}
-    }
-
-    [TestFixture]
-    public class CountingLifeCycleTestFixture
-    {
-        public int Count { get; set; }
-
-        [Test]
-        public void CountIsAlwaysOne()
-        {
-            Count++;
-            Assert.AreEqual(1, Count);
-        }
-
-        [Test]
-        public void CountIsAlwaysOne_2()
-        {
-            Count++;
-            Assert.AreEqual(1, Count);
-        }
-    }
-
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class DisposableLifeCycleFixtureInstancePerTestCase : IDisposable
-    {
-        public static int DisposeCalls { get; set; }
-        public static int ConstructCalls { get; set; }
-        
-        public DisposableLifeCycleFixtureInstancePerTestCase()
-        {
-            ConstructCalls++;
-        }
-        
-        [Test]
-        [Order(1)]
-        public void TestCase1()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(0));
-        }
-
-        [Test]
-        [Order(2)]
-        public void TestCase2()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(1));
-        }
-
-        [Test]
-        [Order(3)]
-        public void TestCase3()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(2));
-        }
-
-        public void Dispose()
-        {
-            DisposeCalls++;
-        }
-    }
-    
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class RepeatingLifeCycleFixtureInstancePerTestCase
     {
         public int Counter { get; set; }
@@ -348,7 +292,7 @@ namespace NUnit.TestData.LifeCycleTests
         }
 
         [Test]
-        public void DummyTest1() 
+        public void DummyTest1()
         {
             Assert.That(_setupCount, Is.EqualTo(1));
         }
@@ -365,4 +309,61 @@ namespace NUnit.TestData.LifeCycleTests
             Assert.That(_setupCount, Is.EqualTo(1));
         }
     }
+    #endregion
+
+    #region Nesting and inheritance
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class LifeCycleWithNestedFixture
+    {
+        public class NestedFixture
+        {
+            private int _value;
+
+            [Test]
+            public void Test1()
+            {
+                Assert.AreEqual(0, _value++);
+            }
+
+            [Test]
+            public void Test2()
+            {
+                Assert.AreEqual(0, _value++);
+            }
+        }
+    }
+
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class LifeCycleWithNestedOverridingFixture
+    {
+        [FixtureLifeCycle(LifeCycle.SingleInstance)]
+        public class NestedFixture
+        {
+            private int _value;
+
+            [Test]
+            [Order(0)]
+            public void Test1()
+            {
+                Assert.AreEqual(0, _value++);
+            }
+
+            [Test]
+            [Order(1)]
+            public void Test2()
+            {
+                Assert.AreEqual(1, _value++);
+            }
+        }
+    }
+    #endregion
+
+
+
+
+
+
+
+    
+
 }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -360,12 +360,18 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class LifeCycleInheritanceBase
+    public class LifeCycleInheritanceBaseInstancePerTestCase : BaseLifeCycle
+    {
+    }
+
+    /// <remarks>Used implicitly in <see cref="AssemblyLevelFixtureLifeCycleTest"/></remarks>
+    [FixtureLifeCycle(LifeCycle.SingleInstance)]
+    public class LifeCycleInheritanceBaseSingleInstance : BaseLifeCycle
     {
     }
 
     [TestFixture]
-    public class LifeCycleInheritedFixture : LifeCycleInheritanceBase
+    public class LifeCycleInheritedFixture : LifeCycleInheritanceBaseInstancePerTestCase
     {
         private int _value;
 
@@ -384,7 +390,7 @@ namespace NUnit.TestData.LifeCycleTests
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.SingleInstance)]
-    public class LifeCycleInheritanceOverriddenFixture : LifeCycleInheritanceBase
+    public class LifeCycleInheritanceOverriddenFixture : LifeCycleInheritanceBaseInstancePerTestCase
     {
         private int _value;
 

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -317,7 +317,7 @@ namespace NUnit.TestData.LifeCycleTests
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class LifeCycleWithNestedFixture
     {
-        public class NestedFixture
+        public class NestedFixture : BaseLifeCycle
         {
             private int _value;
 
@@ -339,7 +339,7 @@ namespace NUnit.TestData.LifeCycleTests
     public class LifeCycleWithNestedOverridingFixture
     {
         [FixtureLifeCycle(LifeCycle.SingleInstance)]
-        public class NestedFixture
+        public class NestedFixture : BaseLifeCycle
         {
             private int _value;
 

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -28,110 +28,102 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class SetupAndTearDownFixtureInstancePerTestCase
+    public class FullLifecycleTestCase : IDisposable
     {
-        int _totalSetupCount = 0;
-        int _totalTearDownCount = 0;
+        public static int ConstructCount;
+        public static int DisposeCount;
+        public static int OneTimeSetUpCount;
+        public static int OneTimeTearDownCount;
 
-        [SetUp]
-        public void Setup()
+        public static int SetUpCountTotal;
+        public static int TearDownCountTotal;
+
+        public int InstanceSetUpCount;
+        public int InstanceTearDownCount;
+
+        public static void Reset()
         {
-            _totalSetupCount++;
+            ConstructCount = 0;
+            DisposeCount = 0;
+            OneTimeSetUpCount = 0;
+            OneTimeTearDownCount = 0;
+            SetUpCountTotal = 0;
+            TearDownCountTotal = 0;
         }
 
-        [TearDown]
-        public void TearDown()
+        public FullLifecycleTestCase()
         {
-            _totalTearDownCount++;
+            ConstructCount++;
         }
 
-        [Test]
-        public void DummyTest1()
+        public void Dispose()
         {
-            Assert.That(_totalSetupCount, Is.EqualTo(1));
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+            DisposeCount++;
         }
-
-        [Test]
-        public void DummyTest2()
-        {
-            Assert.That(_totalSetupCount, Is.EqualTo(1));
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void DummyTest3()
-        {
-            Assert.That(_totalSetupCount, Is.EqualTo(1));
-            Assert.That(_totalTearDownCount, Is.EqualTo(0));
-        }
-    }
-
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase
-    {
-        public static int TotalOneTimeSetupCount = 0;
-        public static int TotalOneTimeTearDownCount = 0;
 
         [OneTimeSetUp]
         public static void OneTimeSetup()
         {
-            TotalOneTimeSetupCount++;
+            OneTimeSetUpCount++;
         }
 
         [OneTimeTearDown]
         public static void OneTimeTearDown()
         {
-            TotalOneTimeTearDownCount++;
+            OneTimeTearDownCount++;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            SetUpCountTotal++;
+            InstanceSetUpCount++;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TearDownCountTotal++;
+            InstanceTearDownCount++;
         }
 
         [Test]
-        public void DummyTest1() { }
+        public void DummyTest1()
+        {
+            Assert.That(ConstructCount - DisposeCount, Is.EqualTo(1));
+
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(0));
+
+            Assert.That(InstanceSetUpCount, Is.EqualTo(1));
+            Assert.That(InstanceTearDownCount, Is.EqualTo(0));
+        }
 
         [Test]
-        public void DummyTest2() { }
+        public void DummyTest2()
+        {
+            Assert.That(ConstructCount - DisposeCount, Is.EqualTo(1));
+
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(0));
+
+            Assert.That(InstanceSetUpCount, Is.EqualTo(1));
+            Assert.That(InstanceTearDownCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DummyTest3()
+        {
+            Assert.That(ConstructCount - DisposeCount, Is.EqualTo(1));
+
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(0));
+
+            Assert.That(InstanceSetUpCount, Is.EqualTo(1));
+            Assert.That(InstanceTearDownCount, Is.EqualTo(0));
+        }
     }
 
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class DisposableLifeCycleFixtureInstancePerTestCase : IDisposable
-    {
-        public static int DisposeCalls { get; set; }
-        public static int ConstructCalls { get; set; }
-
-        public DisposableLifeCycleFixtureInstancePerTestCase()
-        {
-            ConstructCalls++;
-        }
-
-        [Test]
-        [Order(1)]
-        public void TestCase1()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(0));
-        }
-
-        [Test]
-        [Order(2)]
-        public void TestCase2()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(1));
-        }
-
-        [Test]
-        [Order(3)]
-        public void TestCase3()
-        {
-            Assert.That(DisposeCalls, Is.EqualTo(2));
-        }
-
-        public void Dispose()
-        {
-            DisposeCalls++;
-        }
-    }
     #endregion
 
     #region Validation

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -6,40 +6,22 @@ using NUnit.Framework;
 
 namespace NUnit.TestData.LifeCycleTests
 {
-    #region Basic Lifecycle
-    [TestFixture]
-    public class CountingLifeCycleTestFixture
+    /// <summary>
+    /// Base class for all LifeCycle tests: provides default implementation for counting 
+    /// the total number of calls to constructor and setup methods.
+    /// </summary>
+    public class BaseLifeCycle : IDisposable
     {
-        public int Count { get; set; }
+        protected static int ConstructCount;
+        protected static int DisposeCount;
+        protected static int OneTimeSetUpCount;
+        protected static int OneTimeTearDownCount;
 
-        [Test]
-        public void CountIsAlwaysOne()
-        {
-            Count++;
-            Assert.AreEqual(1, Count);
-        }
+        protected static int SetUpCountTotal;
+        protected static int TearDownCountTotal;
 
-        [Test]
-        public void CountIsAlwaysOne_2()
-        {
-            Count++;
-            Assert.AreEqual(1, Count);
-        }
-    }
-
-    [TestFixture]
-    public class FullLifecycleTestCase : IDisposable
-    {
-        public static int ConstructCount;
-        public static int DisposeCount;
-        public static int OneTimeSetUpCount;
-        public static int OneTimeTearDownCount;
-
-        public static int SetUpCountTotal;
-        public static int TearDownCountTotal;
-
-        public int InstanceSetUpCount;
-        public int InstanceTearDownCount;
+        protected int InstanceSetUpCount;
+        protected int InstanceTearDownCount;
 
         public static void Reset()
         {
@@ -51,7 +33,27 @@ namespace NUnit.TestData.LifeCycleTests
             TearDownCountTotal = 0;
         }
 
-        public FullLifecycleTestCase()
+        public static void VerifySingleInstance(int numberOfTests)
+        {
+            Assert.That(ConstructCount, Is.EqualTo(1));
+            Assert.That(DisposeCount, Is.EqualTo(1));
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(1));
+            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests));
+            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests));
+        }
+
+        public static void VerifyInstancePerTestCase(int numberOfTests)
+        {
+            Assert.That(ConstructCount, Is.EqualTo(numberOfTests));
+            Assert.That(DisposeCount, Is.EqualTo(numberOfTests));
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(1));
+            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests));
+            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests));
+        }
+
+        public BaseLifeCycle()
         {
             ConstructCount++;
         }
@@ -86,7 +88,32 @@ namespace NUnit.TestData.LifeCycleTests
             TearDownCountTotal++;
             InstanceTearDownCount++;
         }
+    }
 
+    #region Basic Lifecycle
+    [TestFixture]
+    public class CountingLifeCycleTestFixture
+    {
+        public int Count { get; set; }
+
+        [Test]
+        public void CountIsAlwaysOne()
+        {
+            Count++;
+            Assert.AreEqual(1, Count);
+        }
+
+        [Test]
+        public void CountIsAlwaysOne_2()
+        {
+            Count++;
+            Assert.AreEqual(1, Count);
+        }
+    }
+
+    [TestFixture]
+    public class FullLifecycleTestCase : BaseLifeCycle
+    {
         [Test]
         public void DummyTest1()
         {

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -348,6 +348,50 @@ namespace NUnit.TestData.LifeCycleTests
             }
         }
     }
+
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class LifeCycleInheritanceBase
+    {
+    }
+
+    [TestFixture]
+    public class LifeCycleInheritedFixture : LifeCycleInheritanceBase
+    {
+        private int _value;
+
+        [Test]
+        public void Test1()
+        {
+            Assert.AreEqual(0, _value++);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            Assert.AreEqual(0, _value++);
+        }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.SingleInstance)]
+    public class LifeCycleInheritanceOverriddenFixture : LifeCycleInheritanceBase
+    {
+        private int _value;
+
+        [Test]
+        [Order(0)]
+        public void Test1()
+        {
+            Assert.AreEqual(0, _value++);
+        }
+
+        [Test]
+        [Order(1)]
+        public void Test2()
+        {
+            Assert.AreEqual(1, _value++);
+        }
+    }
     #endregion
 
 
@@ -356,6 +400,6 @@ namespace NUnit.TestData.LifeCycleTests
 
 
 
-    
+
 
 }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -239,13 +239,9 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithValuesAttributeTest : IDisposable
+    public class FixtureWithValuesAttributeTest : BaseLifeCycle
     {
         private int _counter;
-
-        public static int DisposeCalls { get; set; }
-
-        public void Dispose() => DisposeCalls++;
 
         [Test]
         public void Test([Values] bool? _)

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -209,13 +209,9 @@ namespace NUnit.TestData.LifeCycleTests
     }
 
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class FixtureWithTestCases : IDisposable
+    public class FixtureWithTestCases : BaseLifeCycle
     {
         private int _counter;
-
-        public static int DisposeCalls { get; set; }
-
-        public void Dispose() => DisposeCalls++;
 
         [TestCase(0)]
         [TestCase(1)]

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -33,24 +33,24 @@ namespace NUnit.TestData.LifeCycleTests
             TearDownCountTotal = 0;
         }
 
-        public static void VerifySingleInstance(int numberOfTests)
+        public static void VerifySingleInstance(int numberOfTests, int numberOfOneTimeSetUps = 1)
         {
-            Assert.That(ConstructCount, Is.EqualTo(1));
-            Assert.That(DisposeCount, Is.EqualTo(1));
-            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
-            Assert.That(OneTimeTearDownCount, Is.EqualTo(1));
-            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests));
-            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests));
+            Assert.That(ConstructCount, Is.EqualTo(1), nameof(ConstructCount));
+            Assert.That(DisposeCount, Is.EqualTo(1), nameof(DisposeCount));
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(numberOfOneTimeSetUps), nameof(OneTimeSetUpCount));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(numberOfOneTimeSetUps), nameof(OneTimeTearDownCount));
+            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests), nameof(SetUpCountTotal));
+            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests), nameof(SetUpCountTotal));
         }
 
-        public static void VerifyInstancePerTestCase(int numberOfTests)
+        public static void VerifyInstancePerTestCase(int numberOfTests, int numberOfOneTimeSetUps = 1)
         {
-            Assert.That(ConstructCount, Is.EqualTo(numberOfTests));
-            Assert.That(DisposeCount, Is.EqualTo(numberOfTests));
-            Assert.That(OneTimeSetUpCount, Is.EqualTo(1));
-            Assert.That(OneTimeTearDownCount, Is.EqualTo(1));
-            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests));
-            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests));
+            Assert.That(ConstructCount, Is.EqualTo(numberOfTests), nameof(ConstructCount));
+            Assert.That(DisposeCount, Is.EqualTo(numberOfTests), nameof(DisposeCount));
+            Assert.That(OneTimeSetUpCount, Is.EqualTo(numberOfOneTimeSetUps), nameof(OneTimeSetUpCount));
+            Assert.That(OneTimeTearDownCount, Is.EqualTo(numberOfOneTimeSetUps), nameof(OneTimeTearDownCount));
+            Assert.That(SetUpCountTotal, Is.EqualTo(numberOfTests), nameof(SetUpCountTotal));
+            Assert.That(TearDownCountTotal, Is.EqualTo(numberOfTests), nameof(SetUpCountTotal));
         }
 
         public BaseLifeCycle()
@@ -182,12 +182,10 @@ namespace NUnit.TestData.LifeCycleTests
     #region Test Annotations
     [TestFixtureSource(nameof(FixtureArgs))]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class LifeCycleWithTestFixtureSourceFixture : IDisposable
+    public class LifeCycleWithTestFixtureSourceFixture : BaseLifeCycle
     {
         private readonly int _initialValue;
         private int _value;
-
-        public static int DisposeCalls { get; set; }
 
         public LifeCycleWithTestFixtureSourceFixture(int num)
         {
@@ -196,8 +194,6 @@ namespace NUnit.TestData.LifeCycleTests
         }
 
         public static int[] FixtureArgs() => new[] { 1, 42 };
-
-        public void Dispose() => DisposeCalls++;
 
         [Test]
         public void Test1()

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -283,7 +283,13 @@ namespace NUnit.TestData.LifeCycleTests
     public class DisposableLifeCycleFixtureInstancePerTestCase : IDisposable
     {
         public static int DisposeCalls { get; set; }
-
+        public static int ConstructCalls { get; set; }
+        
+        public DisposableLifeCycleFixtureInstancePerTestCase()
+        {
+            ConstructCalls++;
+        }
+        
         [Test]
         [Order(1)]
         public void TestCase1()

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -121,11 +121,11 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseShouldApplyToTestsWithValuesParameters()
         {
-            FixtureWithValuesAttributeTest.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithValuesAttributeTest));
             ITestResult result = TestBuilder.RunTest(fixture);
+
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.That(FixtureWithValuesAttributeTest.DisposeCalls, Is.EqualTo(3));
+            BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -72,14 +72,17 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void InstancePerTestCaseShouldDisposeForEachTestCase()
+        public void InstancePerTestCaseShouldDisposeForEachConstructorCall()
         {
             DisposableLifeCycleFixtureInstancePerTestCase.DisposeCalls = 0;
+            DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls = 0;
+            
             var fixture = TestBuilder.MakeFixture(typeof(DisposableLifeCycleFixtureInstancePerTestCase));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
             Assert.AreEqual(3, DisposableLifeCycleFixtureInstancePerTestCase.DisposeCalls);
+            Assert.AreEqual(3, DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -144,9 +144,10 @@ namespace NUnit.Framework.Attributes
             RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter = 0;
             var fixture = TestBuilder.MakeFixture(typeof(RepeatingLifeCycleFixtureInstancePerTestCase));
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
             Assert.AreEqual(3, RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter);
+            BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -205,13 +205,89 @@ namespace NUnit.Framework.Attributes
         public void AssemblyLevelInstancePerTestCaseShouldCreateInstanceForEachTestCase()
         {
             var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
-                AssemblyLevelFixtureLifeCycleTest.Code, new[] { typeof(Test).Assembly.Location });
+                AssemblyLevelFixtureLifeCycleTest.Code, new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
             var testType = asm.GetType("FixtureUnderTest");
             var fixture = TestBuilder.MakeFixture(testType);
 
             ITestResult result = TestBuilder.RunTest(fixture);
 
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifyInstancePerTestCase(2);
+        }
+
+        [Test]
+        public void FixtureLevelLifeCycleShouldOverrideAssemblyLevelLifeCycle()
+        {
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
+                OverrideAssemblyLevelFixtureLifeCycleTest.Code,
+                new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
+            var testType = asm.GetType("FixtureUnderTest");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
+        }
+
+        [Test]
+        public void OuterFixtureLevelLifeCycleShouldOverrideAssemblyLevelLifeCycleInNestedFixture()
+        {
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
+                NestedOverrideAssemblyLevelFixtureLifeCycleTest.OuterClass,
+                new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
+            var testType = asm.GetType("FixtureUnderTest+NestedFixture");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
+        }
+
+        [Test]
+        public void InnerFixtureLevelLifeCycleShouldOverrideAssemblyLevelLifeCycleInNestedFixture()
+        {
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
+                NestedOverrideAssemblyLevelFixtureLifeCycleTest.InnerClass,
+                new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
+            var testType = asm.GetType("FixtureUnderTest+NestedFixture");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
+        }
+
+        [Test]
+        public void BaseLifecycleShouldOverrideAssemblyLevelLifeCycle()
+        {
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
+                InheritedOverrideTest.InheritClassWithOtherLifecycle,
+                new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
+            var testType = asm.GetType("FixtureUnderTest");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
+        }
+
+        [Test]
+        public void BaseLifecycleFromOtherAssemblyShouldOverrideAssemblyLevelLifeCycle()
+        {
+            var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
+                InheritedOverrideTest.InheritClassWithOtherLifecycleFromOtherAssembly,
+                new[] { typeof(Test).Assembly.Location, typeof(BaseLifeCycle).Assembly.Location });
+            var testType = asm.GetType("FixtureUnderTest");
+            var fixture = TestBuilder.MakeFixture(testType);
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -11,6 +11,12 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class LifeCycleAttributeTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            BaseLifeCycle.Reset();
+        }
+
         #region Basic Lifecycle
         [Test]
         public void InstancePerTestCaseCreatesAnInstanceForEachTestCase()
@@ -40,7 +46,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseFullLifeCycleTest()
         {
-            FullLifecycleTestCase.Reset();
+            BaseLifeCycle.Reset();
             var fixture = TestBuilder.MakeFixture(typeof(FullLifecycleTestCase));
             var attr = new FixtureLifeCycleAttribute(LifeCycle.InstancePerTestCase);
             attr.ApplyToTest(fixture);
@@ -48,18 +54,13 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
 
-            Assert.That(FullLifecycleTestCase.ConstructCount, Is.EqualTo(3));
-            Assert.That(FullLifecycleTestCase.DisposeCount, Is.EqualTo(3));
-            Assert.That(FullLifecycleTestCase.OneTimeSetUpCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.OneTimeTearDownCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.SetUpCountTotal, Is.EqualTo(3));
-            Assert.That(FullLifecycleTestCase.TearDownCountTotal, Is.EqualTo(3));
+            BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
 
         [Test]
         public void SingleInstanceFullLifeCycleTest()
         {
-            FullLifecycleTestCase.Reset();
+            BaseLifeCycle.Reset();
             var fixture = TestBuilder.MakeFixture(typeof(FullLifecycleTestCase));
             var attr = new FixtureLifeCycleAttribute(LifeCycle.SingleInstance);
             attr.ApplyToTest(fixture);
@@ -69,12 +70,7 @@ namespace NUnit.Framework.Attributes
                 result.Children.Select(t => t.ResultState),
                 Is.EquivalentTo(new[] { ResultState.Success, ResultState.Failure, ResultState.Failure }));
 
-            Assert.That(FullLifecycleTestCase.ConstructCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.DisposeCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.OneTimeSetUpCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.OneTimeTearDownCount, Is.EqualTo(1));
-            Assert.That(FullLifecycleTestCase.SetUpCountTotal, Is.EqualTo(3));
-            Assert.That(FullLifecycleTestCase.TearDownCountTotal, Is.EqualTo(3));
+            BaseLifeCycle.VerifySingleInstance(3);
         }
         #endregion
 

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -178,6 +178,21 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
+
+        public void ChildClassWithoutLifeCycleShouldInheritLifeCycle()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleInheritedFixture));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+
+        [Test]
+        public void ChildClassWithLifeCycleShouldOverrideLifeCycle()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleInheritanceOverriddenFixture));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
         #endregion
 
         #region Assembly level InstancePerTestCase

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -187,6 +187,7 @@ namespace NUnit.Framework.Attributes
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleInheritedFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifyInstancePerTestCase(2);
         }
 
         [Test]
@@ -195,6 +196,7 @@ namespace NUnit.Framework.Attributes
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleInheritanceOverriddenFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
         }
         #endregion
 

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -167,17 +167,19 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NestedFeatureWithoutLifeCycleShouldInheritLifeCycle()
         {
-            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture));
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture.NestedFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifyInstancePerTestCase(2);
         }
 
         [Test]
         public void NestedFeatureWithLifeCycleShouldOverrideLifeCycle()
         {
-            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedOverridingFixture));
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedOverridingFixture.NestedFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifySingleInstance(2);
         }
 
         public void ChildClassWithoutLifeCycleShouldInheritLifeCycle()
@@ -280,5 +282,31 @@ namespace NUnit.Framework.Attributes
         #endregion
 
 
+    }
+
+    /// <summary>
+    /// To prove that <see cref="NestedFeatureWithoutLifeCycleShouldInheritLifeCycle"/> is indeed broken.
+    /// </summary>
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Nested
+    {
+        [TestFixture]
+        public class NestedAgain
+        {
+            int x;
+
+            [Test, Order(1)]
+            public void Test1()
+            {
+                Assert.That(x++, Is.EqualTo(0));
+            }
+
+            [Test, Order(2)]
+            public void Test2()
+            {
+                Assert.That(x++, Is.EqualTo(0));
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -90,11 +90,12 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseShouldApplyToTestFixtureSourceTests()
         {
-            LifeCycleWithTestFixtureSourceFixture.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithTestFixtureSourceFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.That(LifeCycleWithTestFixtureSourceFixture.DisposeCalls, Is.EqualTo(4));
+
+            // TODO: OneTimeSetUpCount is called twice. Expected? Does seem consistent w/ reusing the class; then there are also two calls.
+            BaseLifeCycle.VerifyInstancePerTestCase(4, 2);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Attributes
         }
         #endregion
 
-        #region Validation
+        #region Fixture Validation
         [Test]
         public void InstanceOneTimeSetupTearDownThrows()
         {
@@ -182,6 +182,7 @@ namespace NUnit.Framework.Attributes
             BaseLifeCycle.VerifySingleInstance(2);
         }
 
+        [Test]
         public void ChildClassWithoutLifeCycleShouldInheritLifeCycle()
         {
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleInheritedFixture));

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -101,11 +101,11 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseShouldApplyToTestCaseTests()
         {
-            FixtureWithTestCases.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestCases));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.That(FixtureWithTestCases.DisposeCalls, Is.EqualTo(4));
+
+            BaseLifeCycle.VerifyInstancePerTestCase(4);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -92,8 +92,8 @@ namespace NUnit.Framework.Attributes
         {
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithTestFixtureSourceFixture));
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
             // TODO: OneTimeSetUpCount is called twice. Expected? Does seem consistent w/ reusing the class; then there are also two calls.
             BaseLifeCycle.VerifyInstancePerTestCase(4, 2);
         }
@@ -103,19 +103,19 @@ namespace NUnit.Framework.Attributes
         {
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestCases));
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
             BaseLifeCycle.VerifyInstancePerTestCase(4);
         }
 
         [Test]
         public void InstancePerTestCaseShouldApplyToTestCaseSourceTests()
         {
-            FixtureWithTestCaseSource.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTestCaseSource));
             ITestResult result = TestBuilder.RunTest(fixture);
+
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.That(FixtureWithTestCaseSource.DisposeCalls, Is.EqualTo(2));
+            BaseLifeCycle.VerifyInstancePerTestCase(2);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -9,6 +9,7 @@ using NUnit.TestUtilities;
 namespace NUnit.Framework.Attributes
 {
     [TestFixture]
+    [NonParallelizable]
     public class LifeCycleAttributeTests
     {
         [SetUp]
@@ -156,7 +157,9 @@ namespace NUnit.Framework.Attributes
             var fixture = TestBuilder.MakeFixture(typeof(ParallelLifeCycleFixtureInstancePerTestCase));
 
             ITestResult result = TestBuilder.RunTest(fixture);
+
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
         #endregion
 

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -165,6 +165,7 @@ namespace NUnit.Framework.Attributes
 
         #region Nesting and inheritance
         [Test]
+        [Ignore("Bug #3888")]
         public void NestedFeatureWithoutLifeCycleShouldInheritLifeCycle()
         {
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture.NestedFixture));
@@ -234,6 +235,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        [Ignore("Bug #3888")]
         public void OuterFixtureLevelLifeCycleShouldOverrideAssemblyLevelLifeCycleInNestedFixture()
         {
             var asm = TestAssemblyHelper.GenerateInMemoryAssembly(
@@ -359,33 +361,5 @@ namespace NUnit.Framework.Attributes
         }
 #endif
         #endregion
-
-
-    }
-
-    /// <summary>
-    /// To prove that <see cref="NestedFeatureWithoutLifeCycleShouldInheritLifeCycle"/> is indeed broken.
-    /// </summary>
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class Nested
-    {
-        [TestFixture]
-        public class NestedAgain
-        {
-            int x;
-
-            [Test, Order(1)]
-            public void Test1()
-            {
-                Assert.That(x++, Is.EqualTo(0));
-            }
-
-            [Test, Order(2)]
-            public void Test2()
-            {
-                Assert.That(x++, Is.EqualTo(0));
-            }
-        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -11,41 +11,7 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class LifeCycleAttributeTests
     {
-        [Test]
-        public void SetupTearDownIsCalledOnce()
-        {
-            var fixture = TestBuilder.MakeFixture(typeof(SetupAndTearDownFixtureInstancePerTestCase));
-
-            ITestResult result = TestBuilder.RunTest(fixture);
-
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
-        }
-
-        [Test]
-        public void OneTimeSetupTearDownIsCalledOnce()
-        {
-            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount = 0;
-            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount = 0;
-
-            var fixture = TestBuilder.MakeFixture(typeof(StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase));
-
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-
-            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount);
-            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount);
-        }
-
-        [Test]
-        public void InstanceOneTimeSetupTearDownThrows()
-        {
-            var fixture = TestBuilder.MakeFixture(typeof(InstanceOneTimeSetupAndTearDownFixtureInstancePerTestCase));
-
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-            Assert.That(result.ResultState.Label, Is.EqualTo("Error"));
-        }
-
+        #region Basic Lifecycle
         [Test]
         public void InstancePerTestCaseCreatesAnInstanceForEachTestCase()
         {
@@ -72,11 +38,36 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
+        public void SetupTearDownIsCalledOnce()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(SetupAndTearDownFixtureInstancePerTestCase));
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
+        }
+
+        [Test]
+        public void OneTimeSetupTearDownIsCalledOnce()
+        {
+            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount = 0;
+            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount = 0;
+
+            var fixture = TestBuilder.MakeFixture(typeof(StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase));
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+
+            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount);
+            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount);
+        }
+
+        [Test]
         public void InstancePerTestCaseShouldDisposeForEachConstructorCall()
         {
             DisposableLifeCycleFixtureInstancePerTestCase.DisposeCalls = 0;
             DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls = 0;
-            
+
             var fixture = TestBuilder.MakeFixture(typeof(DisposableLifeCycleFixtureInstancePerTestCase));
             ITestResult result = TestBuilder.RunTest(fixture);
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
@@ -85,6 +76,21 @@ namespace NUnit.Framework.Attributes
             Assert.AreEqual(3, DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls);
         }
 
+        #endregion
+
+        #region Validation
+        [Test]
+        public void InstanceOneTimeSetupTearDownThrows()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(InstanceOneTimeSetupAndTearDownFixtureInstancePerTestCase));
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+            Assert.That(result.ResultState.Label, Is.EqualTo("Error"));
+        }
+        #endregion
+
+        #region Test Annotations
         [Test]
         public void InstancePerTestCaseShouldApplyToTestFixtureSourceTests()
         {
@@ -134,6 +140,47 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
             Assert.That(FixtureWithTheoryTest.DisposeCalls, Is.EqualTo(3));
         }
+
+        [Test]
+        public void InstancePerTestCaseShouldApplyToRepeat()
+        {
+            RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter = 0;
+            var fixture = TestBuilder.MakeFixture(typeof(RepeatingLifeCycleFixtureInstancePerTestCase));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+
+            Assert.AreEqual(3, RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter);
+        }
+
+        [Test]
+        public void InstancePerTestCaseShouldApplyToParralelTests()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(ParallelLifeCycleFixtureInstancePerTestCase));
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+        #endregion
+
+        #region Nesting and inheritance
+        [Test]
+        public void NestedFeatureWithoutLifeCycleShouldInheritLifeCycle()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+
+        [Test]
+        public void NestedFeatureWithLifeCycleShouldOverrideLifeCycle()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedOverridingFixture));
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+        #endregion
+
+        #region Assembly level InstancePerTestCase
 
 #if NETFRAMEWORK
         [Test]
@@ -214,41 +261,8 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
 #endif
+        #endregion
 
-        [Test]
-        public void InstancePerTestCaseWithRepeatShouldWorkAsExpected()
-        {
-            RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter = 0;
-            var fixture = TestBuilder.MakeFixture(typeof(RepeatingLifeCycleFixtureInstancePerTestCase));
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
-            Assert.AreEqual(3, RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter);
-        }
-
-        [Test]
-        public void ConstructorIsCalledOnceForEachTestInParallelTests()
-        {
-            var fixture = TestBuilder.MakeFixture(typeof(ParallelLifeCycleFixtureInstancePerTestCase)); 
-            
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-        }
-
-        [Test]
-        public void NestedFeatureWithoutLifeCycleShouldInheritLifeCycle()
-        {
-            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture));
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-        }
-
-        [Test]
-        public void NestedFeatureWithLifeCycleShouldOverrideLifeCycle()
-        {
-            var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedOverridingFixture));
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -38,44 +38,44 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        public void SetupTearDownIsCalledOnce()
+        public void InstancePerTestCaseFullLifeCycleTest()
         {
-            var fixture = TestBuilder.MakeFixture(typeof(SetupAndTearDownFixtureInstancePerTestCase));
+            FullLifecycleTestCase.Reset();
+            var fixture = TestBuilder.MakeFixture(typeof(FullLifecycleTestCase));
+            var attr = new FixtureLifeCycleAttribute(LifeCycle.InstancePerTestCase);
+            attr.ApplyToTest(fixture);
 
             ITestResult result = TestBuilder.RunTest(fixture);
-
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
+
+            Assert.That(FullLifecycleTestCase.ConstructCount, Is.EqualTo(3));
+            Assert.That(FullLifecycleTestCase.DisposeCount, Is.EqualTo(3));
+            Assert.That(FullLifecycleTestCase.OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.OneTimeTearDownCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.SetUpCountTotal, Is.EqualTo(3));
+            Assert.That(FullLifecycleTestCase.TearDownCountTotal, Is.EqualTo(3));
         }
 
         [Test]
-        public void OneTimeSetupTearDownIsCalledOnce()
+        public void SingleInstanceFullLifeCycleTest()
         {
-            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount = 0;
-            StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount = 0;
-
-            var fixture = TestBuilder.MakeFixture(typeof(StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase));
+            FullLifecycleTestCase.Reset();
+            var fixture = TestBuilder.MakeFixture(typeof(FullLifecycleTestCase));
+            var attr = new FixtureLifeCycleAttribute(LifeCycle.SingleInstance);
+            attr.ApplyToTest(fixture);
 
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            Assert.That(
+                result.Children.Select(t => t.ResultState),
+                Is.EquivalentTo(new[] { ResultState.Success, ResultState.Failure, ResultState.Failure }));
 
-            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeSetupCount);
-            Assert.AreEqual(1, StaticOneTimeSetupAndTearDownFixtureInstancePerTestCase.TotalOneTimeTearDownCount);
+            Assert.That(FullLifecycleTestCase.ConstructCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.DisposeCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.OneTimeSetUpCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.OneTimeTearDownCount, Is.EqualTo(1));
+            Assert.That(FullLifecycleTestCase.SetUpCountTotal, Is.EqualTo(3));
+            Assert.That(FullLifecycleTestCase.TearDownCountTotal, Is.EqualTo(3));
         }
-
-        [Test]
-        public void InstancePerTestCaseShouldDisposeForEachConstructorCall()
-        {
-            DisposableLifeCycleFixtureInstancePerTestCase.DisposeCalls = 0;
-            DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls = 0;
-
-            var fixture = TestBuilder.MakeFixture(typeof(DisposableLifeCycleFixtureInstancePerTestCase));
-            ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-
-            Assert.AreEqual(3, DisposableLifeCycleFixtureInstancePerTestCase.DisposeCalls);
-            Assert.AreEqual(3, DisposableLifeCycleFixtureInstancePerTestCase.ConstructCalls);
-        }
-
         #endregion
 
         #region Validation

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -131,11 +131,11 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void InstancePerTestCaseShouldApplyToTheories()
         {
-            FixtureWithTheoryTest.DisposeCalls = 0;
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithTheoryTest));
             ITestResult result = TestBuilder.RunTest(fixture);
+
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.That(FixtureWithTheoryTest.DisposeCalls, Is.EqualTo(3));
+            BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
 
         [Test]


### PR DESCRIPTION
Test + (hopefully to-the-point) solution for #3843 . May need some extra unit tests?