### PR TITLE
Collection Superset/Subset/Equivalent works with Tuple+ValueTuple for all cases

### DIFF
--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -92,6 +92,35 @@ namespace NUnit.Framework.Constraints
 
 #if !NET35
         [Test]
+        public void WorksOnTuples()
+        {
+            var actual = new[] { Tuple.Create('a', 1), Tuple.Create('b', 2), Tuple.Create('c', 3), Tuple.Create('d', 4) };
+            var expected = new[] { Tuple.Create('b', 2), Tuple.Create('c', 3) };
+
+            var constraint = new CollectionSupersetConstraint(expected);
+            var constraintResult = constraint.ApplyTo(actual);
+
+            Assert.That(constraintResult.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public void WorksOnTuples_OneTypeIsntIComparer()
+        {
+            var a = new S { C = 'a' };
+            var b = new S { C = 'b' };
+            var c = new S { C = 'c' };
+            var d = new S { C = 'd' };
+
+            var actual = new[] { Tuple.Create(a, 1), Tuple.Create(b, 2), Tuple.Create(c, 3), Tuple.Create(d, 4) };
+            var expected = new[] { Tuple.Create(b, 2), Tuple.Create(c, 3) };
+
+            var constraint = new CollectionSupersetConstraint(expected);
+            var constraintResult = constraint.ApplyTo(actual);
+
+            Assert.That(constraintResult.IsSuccess, Is.True);
+        }
+
+        [Test]
         public void WorksOnValueTuples()
         {
             var actual = new[] { ('a', 1), ('b', 2), ('c', 3), ('d', 4) };

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -90,6 +90,42 @@ namespace NUnit.Framework.Constraints
             }
         }
 
+#if !NET35
+        [Test]
+        public void WorksOnValueTuples()
+        {
+            var actual = new[] { ('a', 1), ('b', 2), ('c', 3), ('d', 4) };
+            var expected = new[] { ('b', 2), ('c', 3) };
+
+            var constraint = new CollectionSupersetConstraint(expected);
+            var constraintResult = constraint.ApplyTo(actual);
+
+            Assert.That(constraintResult.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public void WorksOnValueTuples_OneTypeIsntIComparer()
+        {
+            var a = new S { C = 'a' };
+            var b = new S { C = 'b' };
+            var c = new S { C = 'c' };
+            var d = new S { C = 'd' };
+
+            var actual = new[] { (a, 1), (b, 2), (c, 3), (d, 4) };
+            var expected = new[] { (b, 2), (c, 3) };
+
+            var constraint = new CollectionSupersetConstraint(expected);
+            var constraintResult = constraint.ApplyTo(actual);
+
+            Assert.That(constraintResult.IsSuccess, Is.True);
+        }
+        
+        private class S
+        {
+            public char C;
+        }
+#endif
+
         public class IgnoreCaseDataProvider
         {
             public static IEnumerable TestCases


### PR DESCRIPTION
Fixes #3841 

CollectionTally could fail if a ValueTuple  is passed where one of the contained item's types doesn't implement IComparable. This PR provides an exception-based fallback for cases like this which can't easily be identified upfront.

This is branched from/to 3.13.x, but should likely later be cherry-picked onto the main development branch