### PR TITLE
Fixed a race condition that could cause NUnit to launch unsanctioned background test execution threads destabilising the test environment.

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -132,12 +132,13 @@ namespace NUnit.Framework.Internal.Execution
             IsActive = true;
 
             if (_firstStart)
+            {
+                _firstStart = false;
                 StartWorkers();
+            }
 
             foreach (var q in Queues)
                 q.Start();
-
-            _firstStart = false;
         }
 
         private void StartWorkers()


### PR DESCRIPTION
In our repeated hammering of NCrunch/NUnit in our CI, we've picked up on an intermittent issue that has probably been in the NUnit code base for a while now.

When the WorkShift starts up worker threads in a first-start situation, the worker threads can end the shift before the _firstStart flag is set in the WorkShift.Start() method.  This causes the first-start code to repeat more than once in the WorkShift, spawning background threads that destabilise the test environment.

The simple solution is to make sure the flag is set to false prior to kicking off background threads.