### PR TITLE
Apply attributes recursively for nested classes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -38,7 +38,7 @@ namespace NUnit.Framework
                     fixture.MakeInvalid(reason);
             }
 
-            fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
+            fixture.ApplyAttributesToTest(typeInfo.Type);
 
             return new TestSuite[] { fixture };
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -247,7 +247,7 @@ namespace NUnit.Framework
         {
             var fixture = _builder.BuildFrom(typeInfo, filter, this);
             fixture.ApplyAttributesToTest(new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly));
-            fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
+            fixture.ApplyAttributesToTest(typeInfo.Type);
 
             yield return fixture;
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework
             Type sourceType = SourceType ?? typeInfo.Type;
 
             var fixtureSuite = new ParameterizedFixtureSuite(typeInfo);
-            fixtureSuite.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
+            fixtureSuite.ApplyAttributesToTest(typeInfo.Type);
             var assemblyLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly);
             var typeLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo());
 

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Internal.Builders
                 CheckTestFixtureIsValid(fixture);
 
             fixture.ApplyAttributesToTest(new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.GetTypeInfo().Assembly));
-            fixture.ApplyAttributesToTest(typeInfo.Type.GetTypeInfo());
+            fixture.ApplyAttributesToTest(typeInfo.Type);
 
             AddTestCasesToFixture(fixture, filter);
 

--- a/src/NUnitFramework/framework/Internal/Extensions/TestExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/TestExtensions.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+using System.IO;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Extensions
@@ -10,11 +12,12 @@ namespace NUnit.Framework.Internal.Extensions
         {
             while (test != null)
             {
-                if (test is TestFixture fixture && fixture.LifeCycle == LifeCycle.InstancePerTestCase)
-                    return lifeCycle == LifeCycle.InstancePerTestCase;
+                if (test is TestFixture fixture)
+                    return fixture.LifeCycle == lifeCycle;
 
                 test = test.Parent;
             }
+
             return lifeCycle != LifeCycle.InstancePerTestCase;
         }
     }

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -315,6 +316,30 @@ namespace NUnit.Framework.Internal
         public void ApplyAttributesToTest(ICustomAttributeProvider provider)
         {
             ApplyAttributesToTest(provider.GetAttributes<IApplyToTest>(inherit: true));
+        }
+
+        /// <summary>
+        /// Recursively apply the attributes on <paramref name="type"/> to this test,
+        /// including attributes on nesting types.
+        /// </summary>
+        /// <param name="type">The </param>
+        public void ApplyAttributesToTest(Type type)
+        {
+            foreach (var t in GetNestedTypes(type).Reverse()) 
+                ApplyAttributesToTest((ICustomAttributeProvider) t.GetTypeInfo());
+        }
+        
+        /// <summary>
+        /// Returns all nested types, inner first.
+        /// </summary>
+        private IEnumerable<Type> GetNestedTypes(Type inner)
+        {
+            var current = inner;
+            while (current != null)
+            {
+                yield return current;
+                current = current.DeclaringType;
+            }
         }
 
         private void ApplyAttributesToTest(IEnumerable<IApplyToTest> attributes)

--- a/src/NUnitFramework/testdata/TestFixtureData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureData.cs
@@ -184,6 +184,14 @@ namespace NUnit.TestData.TestFixtureTests
         public void Success()
         {
         }
+
+        public class SubFixture
+        {
+            [Test]
+            public void Success()
+            {
+            }
+        }
     }
 
     [TestFixture(Ignore = "testing ignore a fixture")]

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -165,7 +165,6 @@ namespace NUnit.Framework.Attributes
 
         #region Nesting and inheritance
         [Test]
-        [Ignore("Bug #3888")]
         public void NestedFeatureWithoutLifeCycleShouldInheritLifeCycle()
         {
             var fixture = TestBuilder.MakeFixture(typeof(LifeCycleWithNestedFixture.NestedFixture));
@@ -235,7 +234,6 @@ namespace NUnit.Framework.Attributes
         }
 
         [Test]
-        [Ignore("Bug #3888")]
         public void OuterFixtureLevelLifeCycleShouldOverrideAssemblyLevelLifeCycleInNestedFixture()
         {
             var asm = TestAssemblyHelper.GenerateInMemoryAssembly(

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -146,6 +146,13 @@ namespace NUnit.Framework.Internal
             Assert.AreEqual(RunState.Ignored, suite.RunState);
             Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
         }
+        
+        [Test]
+        public void FixtureWithNestedIgnoreAttributeIsIgnored() {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreAttribute.SubFixture));
+            Assert.AreEqual(RunState.Ignored, suite.RunState);
+            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+        }
 
         [Test]
         public void FixtureUsingIgnorePropertyIsIgnored()


### PR DESCRIPTION
This resolves #3888 by applying _all_ attributes recursively for nested classes.

Although this is a nice solution in terms of consistency, it also has a somewhat higher risk of breaking backwards compatibility (in all test cases in the world there is probably _someone_ depending on the non-inheritance of attributes). So maybe this is an OK solution for 4.0+ but not for backporting to 3.x. An interesting example of this is the `Ignore` attribute:

```C#
    [TestFixture]
    [Ignore("testing ignore a fixture")]
    public class FixtureUsingIgnoreAttribute
    {
        [Test]
        public void Success()
        {
        }

        public class SubFixture
        {
            [Test]
            public void Success()
            {
                // this is currently a test that runs, but gets ignored with this change
            }
        }
    }
```

A safer (but less consistent) solution would filter the recursive application for specific attributes (maybe based on an explicit interface?)

Note that branch is 'on top of' #3843 as it depends (somewhat) on the new test system added there. The framework changes should apply to master without any changes.