### PR TITLE
Backport race condition fix (PR 3883)

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -153,12 +153,13 @@ namespace NUnit.Framework.Internal.Execution
             IsActive = true;
 
             if (_firstStart)
+            {
+                _firstStart = false;
                 StartWorkers();
+            }
 
             foreach (var q in Queues)
                 q.Start();
-
-            _firstStart = false;
         }
 
         private void StartWorkers()


### PR DESCRIPTION
Backporting #3883 to the v3.13-dev branch.
Fixes #3273 

This fixes a race condition which can unexpectedly spawn additional worker threads