### PR TITLE
Fix comparisons of high precision decimals

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -60,7 +60,6 @@ namespace NUnit.Framework.Constraints
             {
                 if (obj is System.Double) return true;
                 if (obj is System.Single) return true;
-                if (obj is System.Decimal) return true;
             }
             return false;
         }
@@ -71,7 +70,6 @@ namespace NUnit.Framework.Constraints
             {
                 if (type == typeof(double)) return true;
                 if (type == typeof(float)) return true;
-                if (type == typeof(decimal)) return true;
             }
             return false;
         }

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -105,6 +105,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (type == typeof(byte)) return true;
                 if (type == typeof(sbyte)) return true;
+                if (type == typeof(decimal)) return true;
                 if (type == typeof(int)) return true;
                 if (type == typeof(uint)) return true;
                 if (type == typeof(long)) return true;

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -69,6 +69,47 @@ namespace NUnit.Framework.Constraints
             Assert.That(result, Is.EqualTo(0.00000000000000079M));
         }
 
+        [Test]
+        public void TreatFloatingPointsSameForInstanceOrType()
+        {
+            var values = new object[] {
+                (double)1.1,
+                (float)1.1
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var value in values)
+                {
+                    Assert.That(Numerics.IsFloatingPointNumeric(value), Is.True);
+                    Assert.That(Numerics.IsFloatingPointNumeric(value.GetType()), Is.True);
+                }
+            });
+        }
+
+        [Test]
+        public void TreatFixedPointsSameForInstanceOrType()
+        {
+            var values = new object[] {
+                (byte)1,
+                (sbyte)1,
+                (decimal)1,
+                (int)1,
+                (uint)1,
+                (long)1,
+                (ulong)1,
+                (short)1,
+                (ushort)1,
+                (char)1
+            };
+
+            foreach (var value in values)
+            {
+                Assert.That(Numerics.IsFixedPointNumeric(value), Is.True);
+                Assert.That(Numerics.IsFixedPointNumeric(value.GetType()), Is.True);
+            }
+        }
+
         [TestCase((int)9500)]
         [TestCase((int)10000)]
         [TestCase((int)10500)]

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -58,6 +58,17 @@ namespace NUnit.Framework.Constraints
             Assert.IsTrue(Numerics.AreEqual(123m, 123m, ref zeroTolerance));
         }
 
+        [Test]
+        public void CanCompareDecimalsWithHighPrecision()
+        {
+            var expected = 95217168582.206969750145956m;
+            var actual   = 95217168582.20696975014595521m;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(0.00000000000000079M));
+        }
+
         [TestCase((int)9500)]
         [TestCase((int)10000)]
         [TestCase((int)10500)]


### PR DESCRIPTION
Fixes #3898 

NOTE: I'm unsure the history behind treating `decimal` separate from `IsFloatingPointNumeric`, but recently adding it to `IsFloatingPointNumeric` broke high-precision comparisons. I've removed it again to try and preserve previous behaviour.
I also noticed that `IsFixedPointNumeric` would return true when given decimal as a boxed value (the `object` overload) but `false` when given decimal in the `Type` overload. This PR changes this to now return `true` for both cases