### PR TITLE
Fix high precision decimal calculations in v3.13 (#3898)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -402,18 +402,11 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 throw new ArgumentException("Both arguments must be numeric");
 
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-            {
-                var expectedDbl = Convert.ToDouble(expected);
-                var actualDbl = Convert.ToDouble(expected);
-
-                // Use double only if it is outside of valid decimal range
-                if (Math.Min(expectedDbl, actualDbl) < (double)decimal.MinValue
-                    || Math.Max(expectedDbl, actualDbl) > (double)decimal.MaxValue)
-                    return expectedDbl.CompareTo(actualDbl);
-
+            if (expected is decimal || actual is decimal)
                 return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
-            }
+
+            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
+                return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
 
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));
@@ -427,6 +420,11 @@ namespace NUnit.Framework.Constraints
             return Convert.ToInt32(expected).CompareTo(Convert.ToInt32(actual));
         }
         #endregion
+
+        private static bool IsWithinDecimalRange(double value)
+        {
+            return value >= (double)decimal.MinValue && value <= (double)decimal.MaxValue;
+        }
 
         #region Numeric Difference
 
@@ -456,16 +454,16 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 return double.NaN;
 
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-            {
-                var difference = Convert.ToDouble(expected) - Convert.ToDouble(actual);
-                return isAbsolute ? difference : difference / Convert.ToDouble(expected) * 100;
-            }
-
             if (expected is decimal || actual is decimal)
             {
                 var difference = Convert.ToDecimal(expected) - Convert.ToDecimal(actual);
                 return isAbsolute ? difference : difference / Convert.ToDecimal(expected) * 100;
+            }
+
+            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
+            {
+                var difference = Convert.ToDouble(expected) - Convert.ToDouble(actual);
+                return isAbsolute ? difference : difference / Convert.ToDouble(expected) * 100;
             }
 
             if (expected is ulong || actual is ulong)

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -403,10 +403,17 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("Both arguments must be numeric");
 
             if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-                return Convert.ToDouble(expected).CompareTo(Convert.ToDouble(actual));
+            {
+                var expectedDbl = Convert.ToDouble(expected);
+                var actualDbl = Convert.ToDouble(expected);
 
-            if (expected is decimal || actual is decimal)
+                // Use double only if it is outside of valid decimal range
+                if (Math.Min(expectedDbl, actualDbl) < (double)decimal.MinValue
+                    || Math.Max(expectedDbl, actualDbl) > (double)decimal.MaxValue)
+                    return expectedDbl.CompareTo(actualDbl);
+
                 return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
+            }
 
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -105,6 +105,39 @@ namespace NUnit.Framework.Constraints
             Assert.That(Numerics.Difference(new object(), new object(), tenPercent.Mode), Is.EqualTo(double.NaN));
         }
 
+        [Test]
+        public void CanCompareDecimalsWithHighPrecision()
+        {
+            var expected = 95217168582.206969750145956m;
+            var actual = 95217168582.20696975014595521m;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(0.00000000000000079M));
+        }
+
+        [Test]
+        public void CanCompareDoublesWithHighMantissa()
+        {
+            var expected = Convert.ToDouble(decimal.MaxValue) * 1.1;
+            var actual = Convert.ToDouble(decimal.MaxValue);
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(7.9228162514264408E+27));
+        }
+
+        [Test]
+        public void CanCompareMidRangeDecimalAndDouble()
+        {
+            var expected = 3.14159m;
+            var actual = 2.718281d;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.TypeOf<double>().And.EqualTo(0.42330899999999971));
+        }
+
         [TestCase((int)8500)]
         [TestCase((int)11500)]
         [TestCase((uint)8500)]

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -143,11 +143,11 @@ namespace NUnit.Framework.Constraints
         public void CanCompareMidRangeDecimalAndDouble()
         {
             var expected = 3.14159m;
-            var actual = 2.718281d;
+            var actual =   2.718281d;
 
             var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
 
-            Assert.That(result, Is.TypeOf<double>().And.EqualTo(0.42330899999999971));
+            Assert.That(result, Is.EqualTo(0.423309));
         }
 
         [TestCase((int)8500)]

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -140,6 +140,17 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void CanCompareDecimalAndHighDouble()
+        {
+            var expected = Convert.ToDouble(decimal.MaxValue) * 1.1;
+            var actual = decimal.MaxValue;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(7.9228162514264408E+27));
+        }
+
+        [Test]
         public void CanCompareMidRangeDecimalAndDouble()
         {
             var expected = 3.14159m;

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -109,6 +109,18 @@ namespace NUnit.Framework.Constraints
         public void CanCompareDecimalsWithHighPrecision()
         {
             var expected = 95217168582.206969750145956m;
+            var actual =   95217168582.20696975014595521m;
+
+            var result = Numerics.Compare(expected, actual);
+
+            Assert.That(expected, Is.GreaterThan(actual));
+        }
+
+
+        [Test]
+        public void CanCalculateDifferenceDecimalsWithHighPrecision()
+        {
+            var expected = 95217168582.206969750145956m;
             var actual = 95217168582.20696975014595521m;
 
             var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);


### PR DESCRIPTION
Fixes #3898 
Fixes high-precision decimal calculations by internally using `decimal` when appropriate.

I tried a few approaches here, and the one I found worked best while maintaining full backwards compatibility is to compare `expected` and `actual` as decimals when at least one of the values is decimal and BOTH are within the valid values for decimals (between `decimal.MinValue` and `decimal.MaxValue`).

I also tried to treat all floating point operations as `decimal` internally when expected and actual are within valid range, however this caused some a change in failure messages when comparing two `double` or `float` values (or a double to an int, etc) with a tolerance since the number of decimal places in the "+/-" portion of the error message changed. This approach broke some existing tests in nunit, and likely would've broken others as well.

NOTE: After merging, this should also be ported to the main development branch too