### PR TITLE
Fix high precision decimal calculations in v4 (#3898)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -96,6 +96,11 @@ namespace NUnit.Framework.Constraints
             }
             return false;
         }
+
+        private static bool IsWithinDecimalRange(double value)
+        {
+            return value >= (double)decimal.MinValue && value <= (double)decimal.MaxValue;
+        }
         #endregion
 
         #region Numeric Equality
@@ -381,8 +386,11 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 throw new ArgumentException("Both arguments must be numeric");
 
-            if (expected is decimal || actual is decimal)
-                return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
+            // Treat as decimal if one is decimal and other can be treated as decimal
+            if (expected is decimal eDec && IsWithinDecimalRange(Convert.ToDouble(actual)))
+                return eDec.CompareTo(Convert.ToDecimal(actual));
+            else if (actual is decimal aDec && IsWithinDecimalRange(Convert.ToDouble(expected)))
+                return Convert.ToDecimal(expected).CompareTo(aDec);
 
             if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
                 return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
@@ -399,11 +407,6 @@ namespace NUnit.Framework.Constraints
             return Convert.ToInt32(expected).CompareTo(Convert.ToInt32(actual));
         }
         #endregion
-
-        private static bool IsWithinDecimalRange(double value)
-        {
-            return value >= (double)decimal.MinValue && value <= (double)decimal.MaxValue;
-        }
 
         #region Numeric Difference
 
@@ -433,9 +436,15 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 return double.NaN;
 
-            if (expected is decimal || actual is decimal)
+            // Treat as decimal if one is decimal and other can be treated as decimal
+            if (expected is decimal eDec && IsWithinDecimalRange(Convert.ToDouble(actual)))
             {
-                var difference = Convert.ToDecimal(expected) - Convert.ToDecimal(actual);
+                var difference = eDec - Convert.ToDecimal(actual);
+                return isAbsolute ? difference : difference / eDec * 100;
+            }
+            else if (actual is decimal aDec && IsWithinDecimalRange(Convert.ToDouble(expected)))
+            {
+                var difference = Convert.ToDecimal(expected) - aDec;
                 return isAbsolute ? difference : difference / Convert.ToDecimal(expected) * 100;
             }
 

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -381,18 +381,11 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 throw new ArgumentException("Both arguments must be numeric");
 
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-            {
-                var expectedDbl = Convert.ToDouble(expected);
-                var actualDbl = Convert.ToDouble(expected);
-
-                // Use double only if it is outside of valid decimal range
-                if (Math.Min(expectedDbl, actualDbl) < (double)decimal.MinValue
-                    || Math.Max(expectedDbl, actualDbl) > (double)decimal.MaxValue)
-                    return expectedDbl.CompareTo(actualDbl);
-
+            if (expected is decimal || actual is decimal)
                 return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
-            }
+
+            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
+                return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
 
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));
@@ -406,6 +399,11 @@ namespace NUnit.Framework.Constraints
             return Convert.ToInt32(expected).CompareTo(Convert.ToInt32(actual));
         }
         #endregion
+
+        private static bool IsWithinDecimalRange(double value)
+        {
+            return value >= (double)decimal.MinValue && value <= (double)decimal.MaxValue;
+        }
 
         #region Numeric Difference
 
@@ -435,16 +433,16 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 return double.NaN;
 
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-            {
-                var difference = Convert.ToDouble(expected) - Convert.ToDouble(actual);
-                return isAbsolute ? difference : difference / Convert.ToDouble(expected) * 100;
-            }
-
             if (expected is decimal || actual is decimal)
             {
                 var difference = Convert.ToDecimal(expected) - Convert.ToDecimal(actual);
                 return isAbsolute ? difference : difference / Convert.ToDecimal(expected) * 100;
+            }
+
+            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
+            {
+                var difference = Convert.ToDouble(expected) - Convert.ToDouble(actual);
+                return isAbsolute ? difference : difference / Convert.ToDouble(expected) * 100;
             }
 
             if (expected is ulong || actual is ulong)

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -382,10 +382,17 @@ namespace NUnit.Framework.Constraints
                 throw new ArgumentException("Both arguments must be numeric");
 
             if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-                return Convert.ToDouble(expected).CompareTo(Convert.ToDouble(actual));
+            {
+                var expectedDbl = Convert.ToDouble(expected);
+                var actualDbl = Convert.ToDouble(expected);
 
-            if (expected is decimal || actual is decimal)
+                // Use double only if it is outside of valid decimal range
+                if (Math.Min(expectedDbl, actualDbl) < (double)decimal.MinValue
+                    || Math.Max(expectedDbl, actualDbl) > (double)decimal.MaxValue)
+                    return expectedDbl.CompareTo(actualDbl);
+
                 return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
+            }
 
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -88,6 +88,18 @@ namespace NUnit.Framework.Constraints
         public void CanCompareDecimalsWithHighPrecision()
         {
             var expected = 95217168582.206969750145956m;
+            var actual =   95217168582.20696975014595521m;
+
+            var result = Numerics.Compare(expected, actual);
+
+            Assert.That(expected, Is.GreaterThan(actual));
+        }
+
+
+        [Test]
+        public void CanCalculateDifferenceDecimalsWithHighPrecision()
+        {
+            var expected = 95217168582.206969750145956m;
             var actual = 95217168582.20696975014595521m;
 
             var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -122,11 +122,11 @@ namespace NUnit.Framework.Constraints
         public void CanCompareMidRangeDecimalAndDouble()
         {
             var expected = 3.14159m;
-            var actual = 2.718281d;
+            var actual =   2.718281d;
 
             var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
 
-            Assert.That(result, Is.TypeOf<double>().And.EqualTo(0.42330899999999971));
+            Assert.That(result, Is.EqualTo(0.423309));
         }
 
         [TestCase((int)8500)]

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -119,6 +119,17 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void CanCompareDecimalAndHighDouble()
+        {
+            var expected = Convert.ToDouble(decimal.MaxValue) * 1.1;
+            var actual = decimal.MaxValue;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(7.9228162514264408E+27));
+        }
+
+        [Test]
         public void CanCompareMidRangeDecimalAndDouble()
         {
             var expected = 3.14159m;

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -84,6 +84,39 @@ namespace NUnit.Framework.Constraints
             Assert.That(Numerics.Difference(new object(), new object(), tenPercent.Mode), Is.EqualTo(double.NaN));
         }
 
+        [Test]
+        public void CanCompareDecimalsWithHighPrecision()
+        {
+            var expected = 95217168582.206969750145956m;
+            var actual = 95217168582.20696975014595521m;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(0.00000000000000079M));
+        }
+
+        [Test]
+        public void CanCompareDoublesWithHighMantissa()
+        {
+            var expected = Convert.ToDouble(decimal.MaxValue) * 1.1;
+            var actual = Convert.ToDouble(decimal.MaxValue);
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.EqualTo(7.9228162514264408E+27));
+        }
+
+        [Test]
+        public void CanCompareMidRangeDecimalAndDouble()
+        {
+            var expected = 3.14159m;
+            var actual = 2.718281d;
+
+            var result = Numerics.Difference(expected, actual, ToleranceMode.Linear);
+
+            Assert.That(result, Is.TypeOf<double>().And.EqualTo(0.42330899999999971));
+        }
+
         [TestCase((int)8500)]
         [TestCase((int)11500)]
         [TestCase((uint)8500)]


### PR DESCRIPTION
Fixes #3898 
Backport of #3929

Allows high-precision decimal comparisons to be treated internally as `decimal`