### PR TITLE
fix: Fix CI build on MacOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.103
+      version: 5.0.202
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
@@ -79,7 +79,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.103
+      version: 5.0.202
       performMultiLevelLookup: true
 
   - task: UseDotNet@2

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.101",
+    "version": "5.0.202",
     "allowPrerelease": false,
     "rollForward": "major"
   }


### PR DESCRIPTION
According to https://github.com/NuGet/Announcements/issues/56
.NET SDK 5.0.202 will have NuGet package verification disabled on Linux and macOS.

Before this PR the macOS builds would fail in NuGet restore with 
```
========================================
NuGetRestore
========================================
  Determining projects to restore...
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3028: Package 'Microsoft.NETCore.Platforms 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3037: Package 'Microsoft.NETCore.Platforms 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3028: Package 'Microsoft.NETCore.Platforms 1.1.1' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3037: Package 'Microsoft.NETCore.Platforms 1.1.1' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3028: Package 'Microsoft.NETCore.Platforms 1.1.1' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3037: Package 'Microsoft.NETCore.Platforms 1.1.1' from source 'https://api.nuget.org/v3/index.json': The repository countersignature validity period has expired. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3028: Package 'System.Security.Principal.Windows 4.5.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3037: Package 'System.Security.Principal.Windows 4.5.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired. [/Users/runner/work/1/s/nunit.sln]
/Users/runner/work/1/s/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj : error NU3028: Package 'System.Security.Principal.Windows 4.5.0' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny. [/Users/runner/work/1/s/nunit.sln]
....
```