### PR TITLE
fix: Correct builds on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.103
+      version: 5.0.202
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
@@ -77,7 +77,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: 5.0.103
+      version: 5.0.202
       performMultiLevelLookup: true
 
   - task: UseDotNet@2

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.101",
+    "version": "5.0.202",
     "allowPrerelease": false,
     "rollForward": "major"
   }


### PR DESCRIPTION
According to NuGet/Announcements#56 .NET SDK 5.0.202 will have NuGet package verification disabled on Linux and macOS.