### PR TITLE
Allow randomizing 'Guid' test arguments with [Random]

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -166,6 +166,8 @@ namespace NUnit.Framework
                     _source = new SByteDataSource(_count);
                 else if (parmType == typeof(decimal))
                     _source = new DecimalDataSource(_count);
+                else if (parmType == typeof(Guid))
+                    _source = new GuidDataSource(_count);
                 else if (parmType.GetTypeInfo().IsEnum)
                     _source = new EnumDataSource(_count);
                 else // Default
@@ -244,6 +246,7 @@ namespace NUnit.Framework
 
                 var randomizer = Randomizer.GetRandomizer(parameter.ParameterInfo);
 
+                Guard.OperationValid(CanUseRange() || !_inRange, $"The value type {parameter.ParameterType} does not support range of values.");
                 Guard.OperationValid(!(Distinct && _inRange && !CanBeDistinct(_min!, _max!, _count)), $"The range of values is [{_min}, {_max}[ and the random value count is {_count} so the values cannot be distinct.");
 
 
@@ -271,9 +274,15 @@ namespace NUnit.Framework
                 }
             }
 
+            protected virtual bool CanUseRange()
+            {
+                return true;
+            }
+
             protected abstract T GetNext(Randomizer randomizer);
             protected abstract T GetNext(Randomizer randomizer, T min, T max);
             protected abstract bool CanBeDistinct(T min, T max, int count);
+
         }
 
         #endregion
@@ -647,6 +656,35 @@ namespace NUnit.Framework
             protected override bool CanBeDistinct(decimal min, decimal max, int count)
             {
                 return true;
+            }
+        }
+
+        #endregion
+
+        #region GuidDataSource
+
+        class GuidDataSource : RandomDataSource<Guid>
+        {
+            public GuidDataSource(int count) : base(count) { }
+
+            protected override Guid GetNext(Randomizer randomizer)
+            {
+                return randomizer.NextGuid();
+            }
+
+            protected override Guid GetNext(Randomizer randomizer, Guid min, Guid max)
+            {
+                throw new NotSupportedException($"{typeof(Guid)} does not support range of parameters being specified.");
+            }
+
+            protected override bool CanBeDistinct(Guid min, Guid max, int count)
+            {
+                throw new NotSupportedException($"{typeof(Guid)} does not support range of parameters being specified.");
+            }
+
+            protected override bool CanUseRange()
+            {
+                return false;
             }
         }
 

--- a/src/NUnitFramework/testdata/RandomAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/RandomAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
 using System.Collections.Generic;
@@ -335,6 +335,25 @@ namespace NUnit.TestData.RandomAttributeTests
         {
             Assert.That(previousSByteValues, Does.Not.Contain(x));
             previousSByteValues.Add(x);
+        }
+
+        #endregion
+
+        #region Guid
+
+        private readonly List<Guid> previousGuidValues = new List<Guid>();
+
+        [Test]
+        public void RandomGuid([Random(COUNT)] Guid x)
+        {
+            Assert.Pass();
+        }
+
+        [Test]
+        public void RandomGuid_Distinct([Random(COUNT, Distinct = true)] Guid x)
+        {
+            Assert.That(previousGuidValues, Does.Not.Contain(x));
+            previousGuidValues.Add(x);
         }
 
         #endregion


### PR DESCRIPTION
Hi,

This PR should solve #3899.

I am not particularly satisfied about 
1. having to throw `NotSupportedException`s, but I chose to stay the closest possible to the current design. Very open to suggestion on a better design (interface for range support ?)
2. not having a test for checking that using `min` and/or `max` with `Guid` parameters would actually be refused through the `Guard`, but I did not find a test for the other one checking about having enough different values in the range when using `Distinct`. If I missed something, again, would be very happy to enhance the proposal.

If this PR is accepted, the [documentation for random attribute](https://docs.nunit.org/articles/nunit/writing-tests/attributes/random.html) will need to be updated for , though a PR on [nunit/docs, random.md](https://github.com/nunit/docs/blob/master/docs/articles/nunit/writing-tests/attributes/random.md)

For the sake of completeness, and even if this is outside the responsibility of nunit, I'm also getting a warning in Visual Studio, coming from a [Jetbrains rule](https://www.jetbrains.com/help/rider/NUnit.ParameterTypeIsNotCompatibleWithAttribute.html), which would require an update.
![image](https://user-images.githubusercontent.com/8553578/135714912-587381f7-3fc5-48f0-9d98-6e85b2e37347.png)


 