### PR TITLE
Add missing [DoesNotReturn] annotations for Assert.Pass, Ignore, and Inconclusive

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -69,6 +70,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
+        [DoesNotReturn]
         static public void Pass(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
@@ -88,6 +90,7 @@ namespace NUnit.Framework
         /// of success returned to NUnit.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
+        [DoesNotReturn]
         static public void Pass(string? message)
         {
             Assert.Pass(message, null);
@@ -98,6 +101,7 @@ namespace NUnit.Framework
         /// that are passed in. This allows a test to be cut short, with a result
         /// of success returned to NUnit.
         /// </summary>
+        [DoesNotReturn]
         static public void Pass()
         {
             Assert.Pass(string.Empty, null);
@@ -177,6 +181,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
+        [DoesNotReturn]
         static public void Ignore(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
@@ -195,6 +200,7 @@ namespace NUnit.Framework
         /// passed in. This causes the test to be reported as ignored.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
+        [DoesNotReturn]
         static public void Ignore(string? message)
         {
             Assert.Ignore(message, null);
@@ -204,6 +210,7 @@ namespace NUnit.Framework
         /// Throws an <see cref="IgnoreException"/>.
         /// This causes the test to be reported as ignored.
         /// </summary>
+        [DoesNotReturn]
         static public void Ignore()
         {
             Assert.Ignore(string.Empty, null);
@@ -219,6 +226,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="InconclusiveException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
+        [DoesNotReturn]
         static public void Inconclusive(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;
@@ -237,6 +245,7 @@ namespace NUnit.Framework
         /// passed in. This causes the test to be reported as inconclusive.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="InconclusiveException"/> with.</param>
+        [DoesNotReturn]
         static public void Inconclusive(string? message)
         {
             Assert.Inconclusive(message, null);
@@ -246,6 +255,7 @@ namespace NUnit.Framework
         /// Throws an <see cref="InconclusiveException"/>.
         /// This causes the test to be reported as Inconclusive.
         /// </summary>
+        [DoesNotReturn]
         static public void Inconclusive()
         {
             Assert.Inconclusive(string.Empty, null);


### PR DESCRIPTION
These methods always throw an exception. I noticed these were missing when `if (x is null) Assert.Inconclusive(...);` did not cause the compiler to understand that `x` was not null after that line.

Looks like I'd already figured this out for `Assume.That`:
https://github.com/nunit/nunit/blob/45cc9cd8bf48fedd4aadac4c8dc72b8001c9fa3e/src/NUnitFramework/framework/Assume.cs#L134-L142