### PR TITLE
Marked 'NUnitEqualityComparer.AreEqual(object, object, Tolerance, bool)' as obsolete

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -159,12 +159,13 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public bool AreEqual(object x, object y, ref Tolerance tolerance)
         {
-            return AreEqual(x, y, ref tolerance, true);
+            return AreEqual(x, y, ref tolerance, new ComparisonState(true));
         }
 
         /// <summary>
         /// Compares two objects for equality within a tolerance.
         /// </summary>
+        [Obsolete("Will be removed in next major release. Use another overload instead.")]
         public bool AreEqual(object x, object y, ref Tolerance tolerance, bool topLevelComparison)
         {
             return AreEqual(x, y, ref tolerance, new ComparisonState(topLevelComparison));


### PR DESCRIPTION
This is PR 1/2 that solves issue #3410.

Changes:
* Marked the method `NUnitEqualityComparer.AreEqual(object, object, Tolerance, bool)` as obsolete.
* Changed the only (internal) caller of that method `AreEqual(object, object, Tolerance)`, so there are no internal references to the deprecated method.