### PR TITLE
Removed 'NUnitEqualityComparer.AreEqual(object, object, Tolerance, bool)'

### DIFF
--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -128,15 +128,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public bool AreEqual(object x, object y, ref Tolerance tolerance)
         {
-            return AreEqual(x, y, ref tolerance, true);
-        }
-
-        /// <summary>
-        /// Compares two objects for equality within a tolerance.
-        /// </summary>
-        public bool AreEqual(object x, object y, ref Tolerance tolerance, bool topLevelComparison)
-        {
-            return AreEqual(x, y, ref tolerance, new ComparisonState(topLevelComparison));
+            return AreEqual(x, y, ref tolerance, new ComparisonState(true));
         }
 
         internal bool AreEqual(object x, object y, ref Tolerance tolerance, ComparisonState state)


### PR DESCRIPTION
This is PR 2/2 that solves issue #3410.

Changes:
* Removed method `NUnitEqualityComparer.AreEqual(object, object, Tolerance, bool)` that was marked obsolete by PR #3959.
* Changed `AreEqual(object, object, Tolerance)` to use another overload.

@stevenaw: While working on this I started wondering if the changes are sufficient. When this PR is merged, there is no possibility to access the behavior that was accessible by setting `topLevelComparison = false` in the past. Shouldn't be the visibility of `AreEqual(object, object, Tolerance, ComparisonState)` raised to `public`?
