### PR TITLE
Unique Test ID for Repeated Tests

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -85,6 +85,7 @@ namespace NUnit.Framework
                         break;
 
                     context.CurrentRepeatCount++;
+                    context.CurrentTest.SetNextId();
                 }
 
                 return context.CurrentResult;

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -92,6 +92,7 @@ namespace NUnit.Framework
                     {
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
                         context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
+                        context.CurrentTest.SetNextId();
                     }
                 }
 

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -92,7 +92,6 @@ namespace NUnit.Framework
                     {
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
                         context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
-                        context.CurrentTest.SetNextId();
                     }
                 }
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
         {
             Guard.ArgumentNotNullOrEmpty(name, nameof(name));
 
-            Id = SetNextId();
+            Id = GetNextId();
             Name = name;
             FullName = !string.IsNullOrEmpty(pathName)
                 ? pathName + '.' + name
@@ -92,9 +92,14 @@ namespace NUnit.Framework.Internal
             TearDownMethods = new IMethodInfo[0];
         }
 
-        internal string SetNextId()
+        internal void SetNextId()
         {
-            return Id = IdPrefix + unchecked(_nextID++);
+            Id = GetNextId();
+        }
+
+        private static string GetNextId()
+        {
+            return IdPrefix + unchecked(_nextID++);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
         {
             Guard.ArgumentNotNullOrEmpty(name, nameof(name));
 
-            Id = GetNextId();
+            Id = SetNextId();
             Name = name;
             FullName = !string.IsNullOrEmpty(pathName)
                 ? pathName + '.' + name
@@ -92,9 +92,9 @@ namespace NUnit.Framework.Internal
             TearDownMethods = new IMethodInfo[0];
         }
 
-        private static string GetNextId()
+        internal string SetNextId()
         {
-            return IdPrefix + unchecked(_nextID++);
+            return Id = IdPrefix + unchecked(_nextID++);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
+++ b/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
@@ -37,21 +37,6 @@ namespace NUnit.Framework.Internal
             _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
-        private int _retried;
-        [Retry(5)]
-        [Test]
-        public void Retry()
-        {
-            Assert.That(_idHolder, Does.Not.ContainKey(ID));
-            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
-
-            if (_retried < 3)
-            {
-                _retried++;
-                Assert.Fail();
-            }
-        }
-            
         public static IEnumerable<string> SomeStrings => new List<string>
         {
             "1", "2", "3", "4"

--- a/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
+++ b/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -9,7 +8,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class UniqueTestIdTests
     {
-        private static ConcurrentDictionary<string, string> _idHolder = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> IdHolder = new ConcurrentDictionary<string, string>();
         private static string ID => TestContext.CurrentContext.Test.ID;
             
         [TestCase(1)]
@@ -18,23 +17,23 @@ namespace NUnit.Framework.Internal
         [TestCase(4)]
         public void TestCase(int testCase)
         {
-            Assert.That(_idHolder, Does.Not.ContainKey(ID));
-            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(IdHolder, Does.Not.ContainKey(ID));
+            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         [TestCaseSource(nameof(SomeStrings))]
         public void TestCaseSource(string testCaseSourceData)
         {
-            Assert.That(_idHolder, Does.Not.ContainKey(ID));
-            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(IdHolder, Does.Not.ContainKey(ID));
+            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         [Repeat(5)]
         [Test]
         public void Repeat()
         {
-            Assert.That(_idHolder, Does.Not.ContainKey(ID));
-            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(IdHolder, Does.Not.ContainKey(ID));
+            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         public static IEnumerable<string> SomeStrings => new List<string>

--- a/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
+++ b/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class UniqueTestIdTests
+    {
+        private static ConcurrentDictionary<string, string> _idHolder = new ConcurrentDictionary<string, string>();
+        private static string ID => TestContext.CurrentContext.Test.ID;
+            
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void TestCase(int testCase)
+        {
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+        }
+
+        [TestCaseSource(nameof(SomeStrings))]
+        public void TestCaseSource(string testCaseSourceData)
+        {
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+        }
+
+        [Repeat(5)]
+        [Test]
+        public void Repeat()
+        {
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+        }
+
+        private int retried;
+        [Retry(5)]
+        [Test]
+        public void Retry()
+        {
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+
+            if (retried < 3)
+            {
+                retried++;
+                throw new Exception();
+            }
+        }
+            
+        public static IEnumerable<string> SomeStrings => new List<string>
+        {
+            "1", "2", "3", "4"
+        };
+    }
+}

--- a/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
+++ b/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Internal
             _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
-        private int retried;
+        private int _retried;
         [Retry(5)]
         [Test]
         public void Retry()
@@ -45,10 +45,10 @@ namespace NUnit.Framework.Internal
             Assert.That(_idHolder, Does.Not.ContainKey(ID));
             _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
 
-            if (retried < 3)
+            if (_retried < 3)
             {
-                retried++;
-                throw new Exception();
+                _retried++;
+                Assert.Fail();
             }
         }
             


### PR DESCRIPTION
Unique Test ID for Repeated Tests.

Currently repeated tests, ID wise, are the same. So users who try to distinguish different tests based on their unique IDs, can't do this for repeated tests.