### PR TITLE
Prevent partial updates to collectiontally's _missingItems

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -89,8 +89,7 @@ namespace NUnit.Framework.Constraints
         {
             this.comparer = comparer;
 
-            foreach (object o in c)
-                _missingItems.Add(o);
+            _missingItems = ToArrayList(c);
 
             if (c.IsSortable())
             {
@@ -141,9 +140,7 @@ namespace NUnit.Framework.Constraints
         {
             if (_isSortable && c.IsSortable())
             {
-                var remove = new ArrayList();
-                foreach (object o in c)
-                    remove.Add(o);
+                var remove = ToArrayList(c);
 
                 if (TrySort(ref remove))
                 {
@@ -169,6 +166,18 @@ namespace NUnit.Framework.Constraints
                 foreach (object o in c)
                     TryRemove(o);
             }
+        }
+
+        private static ArrayList ToArrayList(IEnumerable items)
+        {
+            if (items is ICollection ic)
+                return new ArrayList(ic);
+
+            var list = new ArrayList();
+            foreach (object o in items)
+                list.Add(o);
+
+            return list;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Constraints
 
             if (c.IsSortable())
             {
-                _isSortable = TrySort(_missingItems);
+                _isSortable = TrySort(ref _missingItems);
             }
         }
 
@@ -104,8 +104,9 @@ namespace NUnit.Framework.Constraints
             return comparer.AreEqual(expected, actual, ref tolerance);
         }
 
-        private static bool TrySort(ArrayList items)
+        private static bool TrySort(ref ArrayList items)
         {
+            var original = (ArrayList)items.Clone();
             try
             {
                 items.Sort();
@@ -113,6 +114,7 @@ namespace NUnit.Framework.Constraints
             }
             catch (InvalidOperationException e) when (e.InnerException is ArgumentException ae && ae.Message.Contains(nameof(IComparable)))
             {
+                items = original;
                 return false;
             }
         }
@@ -143,7 +145,7 @@ namespace NUnit.Framework.Constraints
                 foreach (object o in c)
                     remove.Add(o);
 
-                if (TrySort(remove))
+                if (TrySort(ref remove))
                 {
                     _sorted = true;
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
@@ -277,6 +278,33 @@ namespace NUnit.Framework.Constraints
                 "  Extra (1): < \"hocusfocus\" >" + Environment.NewLine;
 
             Assert.That(writer.ToString(), Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void WorksWithNonIComparableTuples()
+        {
+            var message3 = new object();
+            var message4 = new object();
+            var actual = new[]
+            {
+                new Tuple<int, object, CancellationToken>(1, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(1, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message4, CancellationToken.None)
+            };
+
+            var expected = new[]
+            {
+                new Tuple<int, object, CancellationToken>(1, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(1, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message3, CancellationToken.None)
+            };
+
+            var constraint = new CollectionEquivalentConstraint(expected);
+            var result = constraint.ApplyTo(actual);
+
+            Assert.That(result.IsSuccess);
         }
 #endif
 


### PR DESCRIPTION
Fixes #3976 

This fixes an error which can come up when `ArrayList.Sort()` throws an exception when trying to sort Tuples which contain non-IComparable members, preventing comparison of equivalent collections. The exception was thrown mid-swap of items, leaving the ArrayList in a corrupt state.
