### PR TITLE
Issue/3984: Add NET6.0 support

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -19,6 +19,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET Core SDK 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup .NET Core SDK 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - name: Setup .NET Core SDK 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Install dotnet tools
       run: dotnet tool restore
 
@@ -58,6 +73,11 @@ jobs:
       with:
         dotnet-version: '5.0.x'
 
+    - name: Setup .NET Core SDK 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Install F#
       run: sudo apt-get install fsharp
 
@@ -90,6 +110,11 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
+
+    - name: Setup .NET Core SDK 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
 
     - name: Install dotnet tools
       run: dotnet tool restore

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -48,11 +48,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup .NET Core SDK 2.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.x'
-
     - name: Setup .NET Core SDK 3.1.x
       uses: actions/setup-dotnet@v1
       with:
@@ -85,11 +80,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Setup .NET Core SDK 2.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.x'
 
     - name: Setup .NET Core SDK 3.1.x
       uses: actions/setup-dotnet@v1

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -35,6 +35,7 @@ As the NUnit solution targets multiple frameworks, a single build will generate 
  (directory with nunit.sln)
     bin\
        Debug\
+          net6.0
           net5.0
           net45
           net46

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,7 +38,6 @@ As the NUnit solution targets multiple frameworks, a single build will generate 
           net5.0
           net45
           net46
-          netcoreapp2.1
           netcoreapp3.1
           netstandard2.0
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 build_script:
   - ps: .\build.ps1 --target=Appveyor --configuration=Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,12 @@ jobs:
     vmImage: windows-latest
   steps:
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK'
+    inputs:
+      version: 6.0.100
+      performMultiLevelLookup: true
+
   - powershell: |
      dotnet tool restore
      dotnet cake --target=Test --test-run-name=Windows --configuration=Release
@@ -39,10 +45,16 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
+    displayName: 'Install .NET SDK'
     inputs:
-      version: 5.0.202
+      version: 6.0.100
       performMultiLevelLookup: true
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET runtime 5.0'
+    inputs:
+      packageType: runtime
+      version: 5.0.x
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 3.1'
@@ -71,10 +83,16 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
+    displayName: 'Install .NET SDK'
     inputs:
-      version: 5.0.202
+      version: 6.0.100
       performMultiLevelLookup: true
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET runtime 5.0'
+    inputs:
+      packageType: runtime
+      version: 5.0.x
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 3.1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,6 @@ jobs:
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core runtime 2.1'
-    inputs:
-      packageType: runtime
-      version: 2.1.x
-
-  - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 3.1'
     inputs:
       packageType: runtime
@@ -81,12 +75,6 @@ jobs:
     inputs:
       version: 5.0.202
       performMultiLevelLookup: true
-
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core runtime 2.1'
-    inputs:
-      packageType: runtime
-      version: 2.1.x
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 3.1'

--- a/build.cake
+++ b/build.cake
@@ -143,10 +143,7 @@ Task("Build")
     .IsDependentOn("NuGetRestore")
     .Does(() =>
     {
-        if(IsRunningOnWindows())
-            MSBuild(SOLUTION_FILE, CreateMsBuildSettings());
-        else
-            DotNetCoreBuild(SOLUTION_FILE, CreateDotNetCoreBuildSettings());
+        DotNetCoreBuild(SOLUTION_FILE, CreateDotNetCoreBuildSettings());
     });
 
 DotNetCoreBuildSettings CreateDotNetCoreBuildSettings() =>
@@ -156,41 +153,6 @@ DotNetCoreBuildSettings CreateDotNetCoreBuildSettings() =>
         NoRestore = true,
         Verbosity = DotNetCoreVerbosity.Minimal
     };
-
-MSBuildSettings CreateMsBuildSettings()
-{
-    var settings = new MSBuildSettings { Verbosity = Verbosity.Minimal, Configuration = configuration };
-
-    if (!BuildSystem.IsLocalBuild)
-    {
-        // Extra arguments for NuGet package creation: EmbedUntrackedSources and ContinuousIntegrationBuild for deterministic build
-        settings.ArgumentCustomization = args => args.Append("-p:EmbedUntrackedSources=true -p:ContinuousIntegrationBuild=true");
-    }
-
-    if (IsRunningOnWindows())
-    {
-        // Find MSBuild for Visual Studio 2019 and newer
-        DirectoryPath vsLatest = VSWhereLatest();
-        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
-
-        // Find MSBuild for Visual Studio 2017
-        if (msBuildPath != null && !FileExists(msBuildPath))
-            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
-
-        // Have we found MSBuild yet?
-        if (!FileExists(msBuildPath))
-        {
-            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
-        }
-
-        Information("Building using MSBuild at " + msBuildPath);
-        settings.ToolPath = msBuildPath;
-    }
-    else
-        settings.ToolPath = Context.Tools.Resolve("msbuild");
-
-    return settings;
-}
 
 //////////////////////////////////////////////////////////////////////
 // TEST

--- a/build.cake
+++ b/build.cake
@@ -27,12 +27,14 @@ var packageVersion = version + modifier + dbgSuffix;
 // SUPPORTED FRAMEWORKS
 //////////////////////////////////////////////////////////////////////
 
-var AllFrameworks = new string[]
+// Equivalent of NUnitLibraryFrameworks in Directory.Build.props
+var LibraryFrameworks = new string[]
 {
     "net45",
     "netstandard2.0"
 };
 
+// Subset of NUnitRuntimeFrameworks in Directory.Build.props
 var NetCoreTests = new String[]
 {
     "netcoreapp3.1",
@@ -179,7 +181,7 @@ Task("Test45")
 var testNetStandard20 = Task("TestNetStandard20")
     .Description("Tests the .NET Standard 2.0 version of the framework");
 
-foreach (var runtime in new[] { "netcoreapp3.1", "net5.0", "net6.0" })
+foreach (var runtime in NetCoreTests)
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
@@ -251,7 +253,7 @@ Task("CreateImage")
         CreateDirectory(imageBinDir);
         Information("Created directory " + imageBinDir);
 
-        foreach (var runtime in AllFrameworks)
+        foreach (var runtime in LibraryFrameworks)
         {
             var targetDir = imageBinDir + Directory(runtime);
             var sourceDir = BIN_DIR + Directory(runtime);
@@ -303,10 +305,9 @@ Task("PackageZip")
     {
         CreateDirectory(PACKAGE_DIR);
 
-        var zipFiles =
-            GetFiles(CurrentImageDir + "*.*") +
-            GetFiles(CurrentImageDir + "bin/net45/**/*.*") +
-            GetFiles(CurrentImageDir + "bin/netstandard2.0/**/*.*");
+        var zipFiles = GetFiles(CurrentImageDir + "*.*");
+        foreach (var framework in LibraryFrameworks)
+            zipFiles += GetFiles(CurrentImageDir + "bin/"+ framework + "/**/*.*");
         Zip(CurrentImageDir, File(ZIP_PACKAGE), zipFiles);
     });
 

--- a/build.cake
+++ b/build.cake
@@ -35,7 +35,9 @@ var AllFrameworks = new string[]
 
 var NetCoreTests = new String[]
 {
-    "netcoreapp3.1"
+    "netcoreapp3.1",
+    "net5.0",
+    "net6.0"
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -215,11 +217,11 @@ Task("Test45")
 var testNetStandard20 = Task("TestNetStandard20")
     .Description("Tests the .NET Standard 2.0 version of the framework");
 
-foreach (var runtime in new[] { "netcoreapp3.1", "net5.0" })
+foreach (var runtime in new[] { "netcoreapp3.1", "net5.0", "net6.0" })
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
-        .WithCriteria(IsRunningOnWindows() || runtime != "net5.0-windows")
+        .WithCriteria(IsRunningOnWindows() || !runtime.EndsWith("windows"))
         .IsDependentOn("Build")
         .OnError(exception => { ErrorDetail.Add(exception.Message); })
         .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -35,7 +35,6 @@ var AllFrameworks = new string[]
 
 var NetCoreTests = new String[]
 {
-    "netcoreapp2.1",
     "netcoreapp3.1"
 };
 
@@ -216,7 +215,7 @@ Task("Test45")
 var testNetStandard20 = Task("TestNetStandard20")
     .Description("Tests the .NET Standard 2.0 version of the framework");
 
-foreach (var runtime in new[] { "netcoreapp2.1", "netcoreapp3.1", "net5.0" })
+foreach (var runtime in new[] { "netcoreapp3.1", "net5.0" })
 {
     var task = Task("TestNetStandard20 on " + runtime)
         .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
@@ -343,8 +342,7 @@ Task("PackageZip")
         var zipFiles =
             GetFiles(CurrentImageDir + "*.*") +
             GetFiles(CurrentImageDir + "bin/net45/**/*.*") +
-            GetFiles(CurrentImageDir + "bin/netstandard2.0/**/*.*") +
-            GetFiles(CurrentImageDir + "bin/netcoreapp2.0/**/*.*");
+            GetFiles(CurrentImageDir + "bin/netstandard2.0/**/*.*");
         Zip(CurrentImageDir, File(ZIP_PACKAGE), zipFiles);
     });
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.202",
+    "version": "6.0.100",
     "allowPrerelease": false,
     "rollForward": "major"
   }

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -49,8 +49,6 @@ How to use this package:
     <file src="bin/netstandard2.0/nunitlite.pdb" target="lib\netstandard2.0" />
     <file src="bin/net45/nunitlite-runner.exe" target="tools\net45" />
     <file src="bin/net45/nunitlite-runner.pdb" target="tools\net45" />
-    <file src="bin/netcoreapp2.1/nunitlite-runner.dll" target="tools\netcoreapp2.1" />
-    <file src="bin/netcoreapp2.1/nunitlite-runner.pdb" target="tools\netcoreapp2.1" />
     <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="tools\netcoreapp3.1" />
     <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="tools\netcoreapp3.1" />
   </files>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -19,6 +19,7 @@ Supported platforms:
 - .NET Framework 4.5+
 - .NET Standard 2.0+
 - .NET Core 2.1+
+- .NET 5.0+
 
 How to use this package:
 
@@ -36,6 +37,12 @@ How to use this package:
         <dependency id="NUnit" version="[$version$]" />
         <dependency id="NETStandard.Library" version="2.0.0" />
       </group>
+      <group targetFramework="net5.0">
+        <dependency id="NUnit" version="[$version$]" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="NUnit" version="[$version$]" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -51,5 +58,9 @@ How to use this package:
     <file src="bin/net45/nunitlite-runner.pdb" target="tools\net45" />
     <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="tools\netcoreapp3.1" />
     <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="tools\netcoreapp3.1" />
+    <file src="bin/net5.0/nunitlite.dll" target="lib\net5.0" />
+    <file src="bin/net5.0/nunitlite.pdb" target="lib\net5.0" />
+    <file src="bin/net6.0/nunitlite.dll" target="lib\net6.0" />
+    <file src="bin/net6.0/nunitlite.pdb" target="lib\net6.0" />
   </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -18,7 +18,7 @@
 Supported platforms:
 - .NET Framework 4.5+
 - .NET Standard 2.0+
-- .NET Core 2.1+
+- .NET Core 3.1+
 - .NET 5.0+
 
 How to use this package:
@@ -36,6 +36,9 @@ How to use this package:
       <group targetFramework="netstandard2.0">
         <dependency id="NUnit" version="[$version$]" />
         <dependency id="NETStandard.Library" version="2.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="NUnit" version="[$version$]" />
       </group>
       <group targetFramework="net5.0">
         <dependency id="NUnit" version="[$version$]" />
@@ -56,8 +59,8 @@ How to use this package:
     <file src="bin/netstandard2.0/nunitlite.pdb" target="lib\netstandard2.0" />
     <file src="bin/net45/nunitlite-runner.exe" target="tools\net45" />
     <file src="bin/net45/nunitlite-runner.pdb" target="tools\net45" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="tools\netcoreapp3.1" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="tools\netcoreapp3.1" />
+    <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="lib\netcoreapp3.1" />
+    <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="lib\netcoreapp3.1" />
     <file src="bin/net5.0/nunitlite.dll" target="lib\net5.0" />
     <file src="bin/net5.0/nunitlite.pdb" target="lib\net5.0" />
     <file src="bin/net6.0/nunitlite.dll" target="lib\net6.0" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -21,6 +21,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
 #elif NET5_0
 [assembly: AssemblyConfiguration(".NET 5.0 Debug")]
+#elif NET6_0
+[assembly: AssemblyConfiguration(".NET 6.0 Debug")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.
 #endif
@@ -35,6 +37,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Core 3.1")]
 #elif NET5_0
 [assembly: AssemblyConfiguration(".NET 5.0")]
+#elif NET6_0
+[assembly: AssemblyConfiguration(".NET 6.0")]
 #else
 #error Missing AssemblyConfiguration attribute for this target.
 #endif

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -17,11 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard2.0'
-                            and '$(TargetFramework)' != 'netcoreapp2.1'
-                            and '$(TargetFramework)' != 'netcoreapp3.1'
-                            and '$(TargetFramework)' != 'net5.0'
-                            and '$(TargetFramework)' != 'net5.0-windows'">$(DefineConstants);THREAD_ABORT</DefineConstants>
+    <DefineConstants Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">$(DefineConstants);THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 
   <!-- We always want a good debugging experience in tests -->

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -6,7 +6,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-
+    <NUnitLibraryFrameworks>net45;netstandard2.0</NUnitLibraryFrameworks>
+    <NUnitRuntimeFrameworks>net45;netcoreapp3.1;net5.0;net6.0</NUnitRuntimeFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite.Tests</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnitLite</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
+    <NoWarn>$(NoWarn);NU1604</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.7.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>
 

--- a/src/NUnitFramework/testdata/TestFixtureData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureData.cs
@@ -517,7 +517,7 @@ namespace NUnit.TestData.TestFixtureTests
         [Test]
         public void ChangeCurrentPrincipal()
         {
-            WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            IIdentity identity = new GenericIdentity("NUnit");
             GenericPrincipal principal = new GenericPrincipal( identity, new string[] { } );
             System.Threading.Thread.CurrentPrincipal = principal;
         }

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.TestData</RootNamespace>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.TestData</RootNamespace>
-    <TargetFrameworks>net45;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.TestData</RootNamespace>
-    <TargetFrameworks>net45;net46;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -286,10 +286,12 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     this.Consumer();
                 }
+#if THREAD_ABORT
                 catch (System.Threading.ThreadAbortException)
                 {
                     Thread.ResetAbort();
                 }
+#endif
                 catch (Exception ex)
                 {
                     this.myConsumerException = ex;

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -179,7 +179,9 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#pragma warning disable SYSLIB0032
         [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
+#pragma warning restore SYSLIB0032
         private static Exception RecordPossiblyDangerousException(Action action)
         {
             try

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
 
     <!-- Either NUnit or NUnitLite is not loading assemblies in a way that properly respects the

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
 
     <!-- Either NUnit or NUnitLite is not loading assemblies in a way that properly respects the

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
 
     <!-- Either NUnit or NUnitLite is not loading assemblies in a way that properly respects the


### PR DESCRIPTION
Fixes #3984 
Fixes #3980 by suppressing warning.

Changing the SDK in global.json to 6.0.100 causes restore error with fsharp.

> D:\3rd\nUnit\nunit\src\NUnitFramework\testdata.fsharp\nunit.testdata.fsharp.fsproj : error NU1604: Project dependency System.ValueTuple does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.

This only occurs on the net45 build.

The obj/project.assets.json contains:
```
"System.ValueTuple": {
  "target": "Package",
   "version": "(, )",
   "generatePathProperty": true
}
```

While previously the version was listed as `"version": "[4.4.0, )"`

`dotnet restore` only succeeds once I set the target to `net471` or greater.
Before that it thinks it needs `System.ValueTuple` version `4.3.0` 

For now I worked around it by ignoring the error.

Other changes:
* Most non-runtime test libraries only need to be compiled for netstandard2.0 as they are only executed in the context of the project that references them.
* Not sure what runtimes (.dll/.exe) need including in nunitlite. Previously net5.0 wasn't added.
* The cake script tries to explicitly run `msbuild` on windows. This fails on my machine as it can't find VS2022 preview and hence uses the wrong version of `msbuild`. As `dotnet build` works on all platforms, I added a separate commit to drop it. The build already uses `dotnet` for restore.
