### PR TITLE
Port PR 3978 to v4

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Constraints
 
             if (c.IsSortable())
             {
-                _isSortable = TrySort(_missingItems);
+                _isSortable = TrySort(ref _missingItems);
             }
         }
 
@@ -83,8 +83,9 @@ namespace NUnit.Framework.Constraints
             return comparer.AreEqual(expected, actual, ref tolerance);
         }
 
-        private static bool TrySort(ArrayList items)
+        private static bool TrySort(ref ArrayList items)
         {
+            var original = (ArrayList)items.Clone();
             try
             {
                 items.Sort();
@@ -92,6 +93,7 @@ namespace NUnit.Framework.Constraints
             }
             catch (InvalidOperationException e) when (e.InnerException is ArgumentException ae && ae.Message.Contains(nameof(IComparable)))
             {
+                items = original;
                 return false;
             }
         }
@@ -122,7 +124,7 @@ namespace NUnit.Framework.Constraints
                 foreach (object o in c)
                     remove.Add(o);
 
-                if (TrySort(remove))
+                if (TrySort(ref remove))
                 {
                     _sorted = true;
 

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -68,8 +68,7 @@ namespace NUnit.Framework.Constraints
         {
             this.comparer = comparer;
 
-            foreach (object o in c)
-                _missingItems.Add(o);
+            _missingItems = ToArrayList(c);
 
             if (c.IsSortable())
             {
@@ -120,9 +119,7 @@ namespace NUnit.Framework.Constraints
         {
             if (_isSortable && c.IsSortable())
             {
-                var remove = new ArrayList();
-                foreach (object o in c)
-                    remove.Add(o);
+                var remove = ToArrayList(c);
 
                 if (TrySort(ref remove))
                 {
@@ -148,6 +145,18 @@ namespace NUnit.Framework.Constraints
                 foreach (object o in c)
                     TryRemove(o);
             }
+        }
+
+        private static ArrayList ToArrayList(IEnumerable items)
+        {
+            if (items is ICollection ic)
+                return new ArrayList(ic);
+
+            var list = new ArrayList();
+            foreach (object o in items)
+                list.Add(o);
+
+            return list;
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -284,7 +284,6 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(result.IsSuccess);
         }
-#endif
 
         // The following tests are each running in 14ms to 46ms on my machine. Based on that,
         // warn at 100ms and fail at 500ms

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
@@ -256,6 +257,34 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(writer.ToString(), Is.EqualTo(expectedMessage));
         }
+
+        [Test]
+        public void WorksWithNonIComparableTuples()
+        {
+            var message3 = new object();
+            var message4 = new object();
+            var actual = new[]
+            {
+                new Tuple<int, object, CancellationToken>(1, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(1, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message4, CancellationToken.None)
+            };
+
+            var expected = new[]
+            {
+                new Tuple<int, object, CancellationToken>(1, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message4, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(1, message3, CancellationToken.None),
+                new Tuple<int, object, CancellationToken>(2, message3, CancellationToken.None)
+            };
+
+            var constraint = new CollectionEquivalentConstraint(expected);
+            var result = constraint.ApplyTo(actual);
+
+            Assert.That(result.IsSuccess);
+        }
+#endif
 
         // The following tests are each running in 14ms to 46ms on my machine. Based on that,
         // warn at 100ms and fail at 500ms


### PR DESCRIPTION
This PR syncs the bugfix from https://github.com/nunit/nunit/pull/3978 onto the main v4 branch
It originally fixed https://github.com/nunit/nunit/issues/3976

Some concerns were raised in the above PR about having to clone the source array prior to sorting. ~~A follow-up ticket will be created shortly~~. https://github.com/nunit/nunit/issues/3998 has been filed to avoid the in-memory copy of the arraylist