### PR TITLE
Force the OneTimeTearDown to be executed on the current thread if STA

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -191,24 +191,32 @@ namespace NUnit.Framework.Internal.Execution
                     composite.Completed += OnWorkItemCompletion;
                 }
 
-            switch (strategy)
+            // The attribute SingleThreaded may not be applied to the content in time, so here as a workaround, check for the flag again
+            if (work.Context.IsSingleThreaded)
             {
-                default:
-                case ParallelExecutionStrategy.Direct:
-                    work.Execute();
-                    break;
-                case ParallelExecutionStrategy.Parallel:
-                    if (work.TargetApartment == ApartmentState.STA)
-                        ParallelSTAQueue.Enqueue(work);
-                    else
-                        ParallelQueue.Enqueue(work);
-                    break;
-                case ParallelExecutionStrategy.NonParallel:
-                    if (work.TargetApartment == ApartmentState.STA)
-                        NonParallelSTAQueue.Enqueue(work);
-                    else
-                        NonParallelQueue.Enqueue(work);
-                    break;
+                work.Execute();
+            }
+            else
+            {
+                switch (strategy)
+                {
+                    default:
+                    case ParallelExecutionStrategy.Direct:
+                        work.Execute();
+                        break;
+                    case ParallelExecutionStrategy.Parallel:
+                        if (work.TargetApartment == ApartmentState.STA)
+                            ParallelSTAQueue.Enqueue(work);
+                        else
+                            ParallelQueue.Enqueue(work);
+                        break;
+                    case ParallelExecutionStrategy.NonParallel:
+                        if (work.TargetApartment == ApartmentState.STA)
+                            NonParallelSTAQueue.Enqueue(work);
+                        else
+                            NonParallelQueue.Enqueue(work);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
This aims to be a workaround for #3961 

When both `SingleThreaded` and `Parallizable` attributes are attached to the test fixture, `SingleThreadedAttribute.ApplyToContext` may be executed later than expected (even after all test methods in the test fixtures are executed), so it leads to the following result:

1. The parent context still has `IsSingleThreaded` false, and all the test methods are executed on this context: (`targetApartment` and `currentApartment` are both `Unknown`, in `WorkItem.Execute`), so `WorkItem.RunOnCurrentThread` is always called.

2. Then, when the `OneTimeTearDown` of test fixture is executed, a new `OneTimeTearDownWorkItem` is created based on the current work item (see `CompositeWorkItem.OnAllChildItemsCompleted`), which *inherits* the parent `ExecutionStrategy`. At that time, since the `Context.IsSingleThreaded` may still haven't been set to true, the `ExecutionStrategy` will be `Parallel`.

3. At this time, not sure about the call stack, `SingleThreadedAttribute.ApplyToContext` is called and `IsSingleThreaded` set to true.

4. When the one time tear down work item is actually executed, though `Context.IsSingleThreaded` is now true, but the `ParallelExecutionStrategy` is already set in step 2, so it will still fall into the `ParallelExecutionStrategy.Parallel` branch and executed by a parallel queue, which may happen on another thread (see `ParallelWorkItemDispatcher.Dispatch`).

6. The PR adds a workaround, when it's going to execute the work item, double-check if `Context.IsSingleThreaded` is set to true, and if so, force it to run on the current thread.

The clean fix should be investiage why step 3 is delayed but that's beyond my ability. Thanks.