### PR TITLE
Eagerly detect sortable types for equivalency tests in 3.13.x

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -93,7 +93,8 @@ namespace NUnit.Framework.Constraints
 
             if (c.IsSortable())
             {
-                _isSortable = TrySort(ref _missingItems);
+                _missingItems.Sort();
+                _isSortable = true;
             }
         }
 
@@ -101,21 +102,6 @@ namespace NUnit.Framework.Constraints
         {
             Tolerance tolerance = Tolerance.Default;
             return comparer.AreEqual(expected, actual, ref tolerance);
-        }
-
-        private static bool TrySort(ref ArrayList items)
-        {
-            var original = (ArrayList)items.Clone();
-            try
-            {
-                items.Sort();
-                return true;
-            }
-            catch (InvalidOperationException e) when (e.InnerException is ArgumentException ae && ae.Message.Contains(nameof(IComparable)))
-            {
-                items = original;
-                return false;
-            }
         }
 
         /// <summary>Try to remove an object from the tally.</summary>
@@ -141,20 +127,14 @@ namespace NUnit.Framework.Constraints
             if (_isSortable && c.IsSortable())
             {
                 var remove = ToArrayList(c);
+                remove.Sort();
 
-                if (TrySort(ref remove))
-                {
-                    _sorted = true;
+                _sorted = true;
 
-                    // Reverse so that we match removing from the end,
-                    // see issue #2598 - Is.Not.EquivalentTo is extremely slow
-                    for (int index = remove.Count - 1; index >= 0; index--)
-                        TryRemove(remove[index]);
-                }
-                else
-                {
-                    TryRemoveSlow(c);
-                }
+                // Reverse so that we match removing from the end,
+                // see issue #2598 - Is.Not.EquivalentTo is extremely slow
+                for (int index = remove.Count - 1; index >= 0; index--)
+                    TryRemove(remove[index]);
             }
             else
             {

--- a/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/IEnumerableExtensions.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Internal.Extensions
             if (itemType is null)
                 return false;
 
-            return itemType.ImplementsIComparable();
+            return itemType.IsSortable();
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Extensions/TypeExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/TypeExtensions.cs
@@ -8,5 +8,20 @@ namespace NUnit.Framework.Internal.Extensions
     {
         public static bool ImplementsIComparable(this Type type) =>
             type?.GetInterface("System.IComparable") != null;
+
+        public static bool IsSortable(this Type type)
+        {
+            if (!type.ImplementsIComparable())
+                return false;
+
+            if (TypeHelper.IsTuple(type) || TypeHelper.IsValueTuple(type))
+            {
+                foreach (var typeArg in type.GetGenericArguments())
+                    if (!typeArg.IsSortable())
+                        return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Internal.Extensions
             typeof(Tuple<int, Tuple<int, Stream>>),
             typeof(ValueTuple<int, Stream>),
             typeof(ValueTuple<int, long, Stream>),
-            typeof(ValueTuple<int, Tuple<int, Stream>>),
+            typeof(ValueTuple<int, ValueTuple<int, Stream>>),
 #endif
         });
 
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Internal.Extensions
             typeof(Tuple<int, Tuple<int, long>>),
             typeof(ValueTuple<int, long>),
             typeof(ValueTuple<int, long, double>),
-            typeof(ValueTuple<int, Tuple<int, long>>),
+            typeof(ValueTuple<int, ValueTuple<int, long>>),
 #endif
         });
 

--- a/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/TypeExtensionTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace NUnit.Framework.Internal.Extensions
 {
@@ -19,6 +20,42 @@ namespace NUnit.Framework.Internal.Extensions
         {
             Assert.That(type.ImplementsIComparable(), Is.False);
         }
+
+        [TestCaseSource(nameof(TypesThatAreSortable))]
+        public void TypesThatAreSortable_ReturnTrue(Type type)
+        {
+            Assert.That(type.IsSortable(), Is.True);
+        }
+
+        [TestCaseSource(nameof(TypesThatAreNotSortable))]
+        public void TypesThatAreNotSortable_ReturnFalse(Type type)
+        {
+            Assert.That(type.IsSortable(), Is.False);
+        }
+
+        public static IEnumerable<Type> TypesThatAreNotSortable => TypesThatDontImplementIComparable.Union(new Type[]
+        {
+#if NET40_OR_GREATER
+            typeof(Tuple<int, Stream>),
+            typeof(Tuple<int, long, Stream>),
+            typeof(Tuple<int, Tuple<int, Stream>>),
+            typeof(ValueTuple<int, Stream>),
+            typeof(ValueTuple<int, long, Stream>),
+            typeof(ValueTuple<int, Tuple<int, Stream>>),
+#endif
+        });
+
+        public static IEnumerable<Type> TypesThatAreSortable => TypesThatImplementIComparable.Union(new Type[]
+        {
+#if NET40_OR_GREATER
+            typeof(Tuple<int, long>),
+            typeof(Tuple<int, long, double>),
+            typeof(Tuple<int, Tuple<int, long>>),
+            typeof(ValueTuple<int, long>),
+            typeof(ValueTuple<int, long, double>),
+            typeof(ValueTuple<int, Tuple<int, long>>),
+#endif
+        });
 
         public static IEnumerable<Type> TypesThatImplementIComparable => new[]
         {


### PR DESCRIPTION
Fixes #3998

This turned out much simpler than I expected. This PR will eagerly determine if an array can be sorted without issue for equivalency tests. This PR targets 3.13, but I'll cherry-pick the commits to 4.0 once the implementation is finalized.