### PR TITLE
Only use decimal comparison if one of the operands is decimal

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -385,22 +385,22 @@ namespace NUnit.Framework.Constraints
             if (!IsNumericType(expected) || !IsNumericType(actual))
                 throw new ArgumentException("Both arguments must be numeric");
 
-            // Treat as decimal if one is decimal and other can be treated as decimal
-            if (expected is decimal eDec && IsWithinDecimalRange(Convert.ToDouble(actual)))
-                return eDec.CompareTo(Convert.ToDecimal(actual));
-            else if (actual is decimal aDec && IsWithinDecimalRange(Convert.ToDouble(expected)))
-                return Convert.ToDecimal(expected).CompareTo(aDec);
-
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
+            if (expected is decimal || actual is decimal)
             {
-                var expectedAsDouble = Convert.ToDouble(expected);
-                var actualAsDouble = Convert.ToDouble(actual);
-
-                if (IsWithinDecimalRange(expectedAsDouble) && IsWithinDecimalRange(actualAsDouble))
-                    return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
-                
-                return expectedAsDouble.CompareTo(actualAsDouble);
+                // Treat as decimal if one is decimal and other can be treated as decimal
+                if (expected is decimal eDec && IsWithinDecimalRange(Convert.ToDouble(actual)))
+                    return eDec.CompareTo(Convert.ToDecimal(actual));
+                else if (actual is decimal aDec && IsWithinDecimalRange(Convert.ToDouble(expected)))
+                    return Convert.ToDecimal(expected).CompareTo(aDec);
+                else
+                    return Convert.ToDouble(expected).CompareTo(Convert.ToDouble(actual));
             }
+
+            if (expected is double || actual is double)
+                return Convert.ToDouble(expected).CompareTo(Convert.ToDouble(actual));
+
+            if (expected is float || actual is float)
+                return Convert.ToSingle(expected).CompareTo(Convert.ToSingle(actual));
 
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Constraints
 {
@@ -136,6 +135,14 @@ namespace NUnit.Framework.Constraints
             const double value = 0.0099999999999988987;
 
             Assert.That(value, Is.LessThan(maximum));
+        }
+
+        [Test]
+        public void CanCompareHighResDouble()
+        {
+            const double value = 1.0000000000000038d;
+
+            Assert.That(value, Is.GreaterThan(1.0));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3999 in master

Corresponding PR #4002 for 3.13 is already merged.