### PR TITLE
Feature/4021 cancellationtoken

### DIFF
--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -43,6 +43,24 @@ namespace NUnit.Framework.Internal
             return IsAsyncOperation(@delegate.GetMethodInfo());
         }
 
+#if !THREAD_ABORT
+        public static bool AcceptsCancellationToken(MethodInfo method)
+        {
+            ParameterInfo[] parameters = method.GetParameters();
+            return parameters.Length > 0 && parameters[parameters.Length - 1].ParameterType == typeof(CancellationToken);
+        }
+
+        public static bool LastArgumentIsCancellationToken(object[] argumentList)
+        {
+            if (argumentList == null || argumentList.Length == 0)
+                return false;
+
+            object lastArgument = argumentList[argumentList.Length - 1];
+
+            return lastArgument != null && lastArgument.GetType() == typeof(CancellationToken);
+        }
+#endif
+
         public static object Await(Func<object> invoke)
         {
             Guard.ArgumentNotNull(invoke, nameof(invoke));

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -214,6 +214,15 @@ namespace NUnit.Framework.Internal.Builders
             else if (parms == null || !parms.HasExpectedResult)
                 return MarkAsNotRunnable(testMethod, "Method has non-void return value, but no result is expected");
 
+#if !THREAD_ABORT
+            if (AsyncToSyncAdapter.AcceptsCancellationToken(testMethod.Method.MethodInfo) &&
+                !AsyncToSyncAdapter.LastArgumentIsCancellationToken(arglist))
+            {
+                // Implict CancellationToken argument
+                argsProvided++;
+            }
+#endif
+
             if (argsProvided > 0 && maxArgsNeeded == 0)
                 return MarkAsNotRunnable(testMethod, "Arguments provided for method with no parameters");
 

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -345,6 +345,13 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public int TestCaseTimeout { get; set; }
 
+#if !THREAD_ABORT
+        /// <summary>
+        /// Gets or sets the <see cref="CancellationToken"/> for the test case.
+        /// </summary>
+        public CancellationToken CancellationToken { get; internal set; } = CancellationToken.None;
+#endif
+
         /// <summary>
         /// Gets a list of ITestActions set by upstream tests
         /// </summary>
@@ -452,9 +459,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public void IncrementAssertCount(int count)
         {
-            // TODO: Temporary implementation
-            while (count-- > 0)
-                Interlocked.Increment(ref _assertCount);
+            Interlocked.Add(ref _assertCount, count);
         }
 
         /// <summary>
@@ -488,9 +493,9 @@ namespace NUnit.Framework.Internal
             Listener?.SendMessage(new TestMessage(destination, message, CurrentTest.Id));
         }
 
-        #endregion
+#endregion
 
-        #region InitializeLifetimeService
+#region InitializeLifetimeService
 
         /// <summary>
         /// Obtain lifetime service object
@@ -544,9 +549,9 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        #endregion
+#endregion
 
-        #region Nested AdhocTestExecutionContext
+#region Nested AdhocTestExecutionContext
 
         /// <summary>
         /// An AdhocTestExecutionContext is created whenever a context is needed

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -27,6 +27,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+#if !THREAD_ABORT
+using System.Threading;
+#endif
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -45,7 +48,7 @@ namespace NUnit.Framework
         private TestAdapter? _test;
         private ResultAdapter? _result;
 
-        #region Constructor
+#region Constructor
 
         /// <summary>
         /// Construct a TestContext for an ExecutionContext
@@ -56,9 +59,9 @@ namespace NUnit.Framework
             _testExecutionContext = testExecutionContext;
         }
 
-        #endregion
+#endregion
 
-        #region Properties
+#region Properties
 
         /// <summary>
         /// Get the current test context. This is created
@@ -179,9 +182,19 @@ namespace NUnit.Framework
             get { return _testExecutionContext.CurrentRepeatCount; }
         }
 
-        #endregion
+#if !THREAD_ABORT
+        /// <summary>
+        /// Gets the <see cref="CancellationToken"/> for the test case.
+        /// </summary>
+        public CancellationToken CancellationToken
+        {
+            get { return _testExecutionContext.CancellationToken; }
+        }
+#endif
 
-        #region Static Methods
+#endregion
+
+#region Static Methods
 
         /// <summary>Write the string representation of a boolean value to the current result</summary>
         public static void Write(bool value) { Out.Write(value); }
@@ -416,7 +429,7 @@ namespace NUnit.Framework
                 get { return _test.Arguments; }
             }
 
-            #endregion
+#endregion
         }
 
 #endregion
@@ -530,9 +543,9 @@ namespace NUnit.Framework
 #endregion
         }
 
-        #endregion
+#endregion
 
-        #region Nested PropertyBagAdapter Class
+#region Nested PropertyBagAdapter Class
 
         /// <summary>
         /// <see cref="PropertyBagAdapter"/> adapts an <see cref="IPropertyBag"/>
@@ -607,6 +620,6 @@ namespace NUnit.Framework
             }
         }
 
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Fixes #3859 by setting both _message_ and _label_. 
Fixes #4021

It doesn't fix the current behaviour of `TimeoutAttribute` but allows for a _modern_ alternative.

Two commits:
1. Add CancellationToken to Test(Execution)Context which will be cancelled on Timeout.
2. Allow CancellationToken to be injected into Test methods