### PR TITLE
Improve method discovery and filtering performance

### DIFF
--- a/src/NUnitFramework/framework/Internal/AttributeProviderWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/AttributeProviderWrapper.cs
@@ -23,12 +23,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace NUnit.Framework.Internal
 {
-    internal class AttributeProviderWrapper<T> : ICustomAttributeProvider
+    internal sealed class AttributeProviderWrapper<T> : ICustomAttributeProvider
         where T : Attribute
     {
         private readonly ICustomAttributeProvider _innerProvider;
@@ -52,14 +51,27 @@ namespace NUnit.Framework.Internal
 
         public bool IsDefined(Type attributeType, bool inherit)
         {
-            return GetCustomAttributes(attributeType, inherit).Any();
+            return GetCustomAttributes(attributeType, inherit).Length > 0;
         }
 
-        private static T[] GetFiltered(IEnumerable<object> attributes)
+        private static T[] GetFiltered(object[] attributes)
         {
-            return attributes
-                   .OfType<T>()
-                   .ToArray();
+            List<T> filtered = null;
+            foreach (var attribute in attributes)
+            {
+                if (attribute is T t)
+                {
+                    filtered ??= new List<T>();
+                    filtered.Add(t);
+                }
+            }
+
+            return filtered?.ToArray() ??
+#if NETSTANDARD2_0_OR_GREATER
+                Array.Empty<T>();
+#else
+                new T[0];
+#endif
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -105,8 +105,9 @@ namespace NUnit.Framework.Internal.Builders
         {
             var tests = new List<TestMethod>();
 
-            List<ITestBuilder> builders = new List<ITestBuilder>(
-                method.GetCustomAttributes<ITestBuilder>(false));
+            var metadata = MethodInfoCache.Get(method);
+
+            List<ITestBuilder> builders = new List<ITestBuilder>(metadata.TestBuilderAttributes);
 
             // See if we need to add a CombinatorialAttribute for parameterized data
             if (method.MethodInfo.GetParameters().Any(param => param.HasAttribute<IParameterDataSource>(false))

--- a/src/NUnitFramework/framework/Internal/Builders/MethodInfoCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/MethodInfoCache.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Builders
+{
+    /// <summary>
+    /// Caches static information for IMethodInfo to reduce re-calculations and memory allocations from reflection.
+    /// </summary>
+    internal static class MethodInfoCache
+    {
+        // we would otherwise do a lot of attribute allocations when repeatedly checking the same method for example
+        // in case of building TestCaseAttribute-based tests
+#if NET35
+        private static readonly Dictionary<IMethodInfo, TestMethodMetadata> MethodMetadataCache = new Dictionary<IMethodInfo, TestMethodMetadata>();
+#else
+        private static readonly ConcurrentDictionary<IMethodInfo, TestMethodMetadata> MethodMetadataCache = new ConcurrentDictionary<IMethodInfo, TestMethodMetadata>();
+#endif
+
+        /// <summary>
+        /// Returns cached metadata for method instance.
+        /// </summary>
+        internal static TestMethodMetadata Get(IMethodInfo method)
+        {
+#if NET35
+            lock (MethodMetadataCache)
+            {
+                if (!MethodMetadataCache.TryGetValue(method, out var metadata))
+                    MethodMetadataCache.Add(method, metadata = new TestMethodMetadata(method));
+
+                return metadata;
+            }
+#else
+            return MethodMetadataCache.GetOrAdd(method, m => new TestMethodMetadata(m));
+#endif
+        }
+
+        /// <summary>
+        /// Memoization of TestMethod information to reduce subsequent allocations from parameter and attribute information.
+        /// </summary>
+        internal sealed class TestMethodMetadata
+        {
+            public TestMethodMetadata(IMethodInfo method)
+            {
+                Parameters = method.GetParameters();
+                IsAsyncOperation = AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo);
+                IsVoidOrUnit = Reflect.IsVoidOrUnit(method.ReturnType.Type);
+
+                RepeatTestAttributes = method.GetCustomAttributes<IRepeatTest>(true);
+                TestBuilderAttributes = method.GetCustomAttributes<ITestBuilder>(false);
+            }
+
+            public IParameterInfo[] Parameters { get; }
+            public IRepeatTest[] RepeatTestAttributes { get; }
+            public bool IsAsyncOperation { get; }
+            public bool IsVoidOrUnit { get; }
+            public ITestBuilder[] TestBuilderAttributes { get; }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Builders/MethodInfoCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/MethodInfoCache.cs
@@ -48,15 +48,29 @@ namespace NUnit.Framework.Internal.Builders
                 IsAsyncOperation = AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo);
                 IsVoidOrUnit = Reflect.IsVoidOrUnit(method.ReturnType.Type);
 
+                // TODO could probably go trough inherited and non inherited in two passes instead of multiple
+
+                // inherited
                 RepeatTestAttributes = method.GetCustomAttributes<IRepeatTest>(true);
+                WrapTestMethodAttributes = method.GetCustomAttributes<IWrapTestMethod>(true);
+                WrapSetupTearDownAttributes = method.GetCustomAttributes<IWrapSetUpTearDown>(true);
+                ApplyToContextAttributes = method.GetCustomAttributes<IApplyToContext>(true);
+
+                // non-inherited
                 TestBuilderAttributes = method.GetCustomAttributes<ITestBuilder>(false);
+                TestActionAttributes = method.GetCustomAttributes<ITestAction>(false);
             }
 
             public IParameterInfo[] Parameters { get; }
-            public IRepeatTest[] RepeatTestAttributes { get; }
             public bool IsAsyncOperation { get; }
             public bool IsVoidOrUnit { get; }
+
+            public IRepeatTest[] RepeatTestAttributes { get; }
             public ITestBuilder[] TestBuilderAttributes { get; }
+            public IWrapTestMethod[] WrapTestMethodAttributes { get; }
+            public ITestAction[] TestActionAttributes { get; }
+            public IWrapSetUpTearDown[] WrapSetupTearDownAttributes { get; }
+            public IApplyToContext[] ApplyToContextAttributes { get; }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Builders;
 using NUnit.Framework.Internal.Execution;
 
 namespace NUnit.Framework.Internal.Commands
@@ -47,8 +48,8 @@ namespace NUnit.Framework.Internal.Commands
         /// <param name="tearDownMethods">A list teardown methods for this level</param>
         /// <param name="methodValidator">A method validator to validate each method before calling.</param>
         public SetUpTearDownItem(
-            IList<IMethodInfo> setUpMethods, 
-            IList<IMethodInfo> tearDownMethods, 
+            IList<IMethodInfo> setUpMethods,
+            IList<IMethodInfo> tearDownMethods,
             IMethodValidator methodValidator = null)
         {
             _setUpMethods = setUpMethods;
@@ -113,7 +114,9 @@ namespace NUnit.Framework.Internal.Commands
             Guard.ArgumentNotAsyncVoid(method.MethodInfo, nameof(method));
             _methodValidator?.Validate(method.MethodInfo);
 
-            if (AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo))
+            var methodInfo = MethodInfoCache.Get(method);
+
+            if (methodInfo.IsAsyncOperation)
                 AsyncToSyncAdapter.Await(() => InvokeMethod(method, context));
             else
                 InvokeMethod(method, context);

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -23,6 +23,7 @@
 
 using System;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Builders;
 
 namespace NUnit.Framework.Internal.Commands
 {
@@ -76,7 +77,9 @@ namespace NUnit.Framework.Internal.Commands
 
         private object RunTestMethod(TestExecutionContext context)
         {
-            if (AsyncToSyncAdapter.IsAsyncOperation(testMethod.Method.MethodInfo))
+            var methodInfo = MethodInfoCache.Get(testMethod.Method);
+
+            if (methodInfo.IsAsyncOperation)
             {
                 return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context));
             }

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -25,6 +25,7 @@ using System;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Abstractions;
+using NUnit.Framework.Internal.Builders;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Internal.Extensions;
 
@@ -111,10 +112,10 @@ namespace NUnit.Framework.Internal.Execution
                 // Command to execute test
                 TestCommand command = new TestMethodCommand(_testMethod);
 
-                var method = _testMethod.Method;
+                var method = MethodInfoCache.Get(_testMethod.Method);
 
                 // Add any wrappers to the TestMethodCommand
-                foreach (IWrapTestMethod wrapper in method.GetCustomAttributes<IWrapTestMethod>(true))
+                foreach (IWrapTestMethod wrapper in method.WrapTestMethodAttributes)
                     command = wrapper.Wrap(command);
 
                 // Create TestActionCommands using attributes of the method
@@ -158,11 +159,11 @@ namespace NUnit.Framework.Internal.Execution
                 }
 
                 // Add wrappers that apply before setup and after teardown
-                foreach (ICommandWrapper decorator in method.GetCustomAttributes<IWrapSetUpTearDown>(true))
+                foreach (ICommandWrapper decorator in method.WrapSetupTearDownAttributes)
                     command = decorator.Wrap(command);
 
                 // Add command to set up context using attributes that implement IApplyToContext
-                foreach (var attr in method.GetCustomAttributes<IApplyToContext>(true))
+                foreach (var attr in method.ApplyToContextAttributes)
                     command = new ApplyChangesToContextCommand(command, attr);
 
                 // Add a construct command and optionally a dispose command in case of instance per test case.
@@ -182,7 +183,7 @@ namespace NUnit.Framework.Internal.Execution
                     command = new TimeoutCommand(command, timeout, _debugger);
 
                 // Add wrappers for repeatable tests after timeout so the timeout is reset on each repeat
-                foreach (var repeatableAttribute in method.GetCustomAttributes<IRepeatTest>(true))
+                foreach (var repeatableAttribute in method.RepeatTestAttributes)
                     command = repeatableAttribute.Wrap(command);
 
                 return command;

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -21,18 +21,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
 {
     /// <summary>
-    /// Combines multiple filters so that a test must pass all 
+    /// Combines multiple filters so that a test must pass all
     /// of them in order to pass this filter.
     /// </summary>
-    internal class AndFilter : CompositeFilter
+    internal sealed class AndFilter : CompositeFilter
     {
         /// <summary>
         /// Constructs an empty AndFilter

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -21,10 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -33,7 +30,7 @@ namespace NUnit.Framework.Internal.Filters
     /// CategoryFilter is able to select or exclude tests
     /// based on their categories.
     /// </summary>
-    internal class CategoryFilter : ValueMatchFilter
+    internal sealed class CategoryFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a CategoryFilter using a single category name

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -29,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// ClassName filter selects tests based on the class FullName
     /// </summary>
-    internal class ClassNameFilter : ValueMatchFilter
+    internal sealed class ClassNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a FullNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ClassNameFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class ClassNameFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "class";
+
         /// <summary>
         /// Construct a FullNameFilter for a single name
         /// </summary>
@@ -53,9 +55,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "class"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using NUnit.Framework.Interfaces;

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -29,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-    internal class FullNameFilter : ValueMatchFilter
+    internal sealed class FullNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a FullNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/FullNameFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class FullNameFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "test";
+
         /// <summary>
         /// Construct a FullNameFilter for a single name
         /// </summary>
@@ -48,9 +50,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "test"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -30,13 +28,13 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// IdFilter selects tests based on their id
     /// </summary>
-    internal class IdFilter : ValueMatchFilter
+    internal sealed class IdFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct an IdFilter for a single value
         /// </summary>
         /// <param name="id">The id the filter will recognize.</param>
-        public IdFilter(string id) : base (id) { }
+        public IdFilter(string id) : base(id) { }
 
         /// <summary>
         /// Match a test against a single value.
@@ -45,7 +43,12 @@ namespace NUnit.Framework.Internal.Filters
         {
             // We make a direct test here rather than calling ValueMatchFilter.Match
             // because regular expressions are not supported for ID.
-            return test.Id == ExpectedValue;
+            var testId = test.Id;
+
+            // ids usually differ from the end as we have fixed prefix like 0-
+            return testId.Length == ExpectedValue.Length
+                   && testId[testId.Length - 1] == ExpectedValue[testId.Length - 1]
+                   && testId == ExpectedValue;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/IdFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class IdFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "id";
+
         /// <summary>
         /// Construct an IdFilter for a single value
         /// </summary>
@@ -55,9 +57,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "id"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    /// <summary>
+    /// Optimized filter to check in condition using HashSet.
+    /// </summary>
+    internal sealed class InFilter : TestFilter
+    {
+        private readonly Func<ITest, string> _selector;
+        private readonly HashSet<string> _values;
+
+        /// <summary>
+        /// Constructs new InFilter.
+        /// </summary>
+        /// <param name="selector">Selector to get value to check.</param>
+        /// <param name="values">Valid values for the filter.</param>
+        public InFilter(Func<ITest,string> selector, IEnumerable<string> values)
+        {
+            _selector = selector;
+            _values = new HashSet<string>(values);
+        }
+
+        public override bool Match(ITest test)
+        {
+            return _values.Contains(_selector(test));
+        }
+
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -13,18 +14,77 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class InFilter : TestFilter
     {
-        private readonly Func<ITest, string> _selector;
-        private readonly HashSet<string> _values;
+        private readonly Func<ITest, string?> _selector;
+        private readonly HashSet<string?> _values;
 
         /// <summary>
         /// Constructs new InFilter.
         /// </summary>
         /// <param name="selector">Selector to get value to check.</param>
         /// <param name="values">Valid values for the filter.</param>
-        public InFilter(Func<ITest,string> selector, IEnumerable<string> values)
+        public InFilter(Func<ITest, string?> selector, IEnumerable<string?> values)
         {
             _selector = selector;
-            _values = new HashSet<string>(values);
+            _values = new HashSet<string?>(values);
+        }
+
+        /// <summary>
+        /// Tries to optimize OrFilter into InFilter if contained filters are all same and non-regex.
+        /// </summary>
+        public static bool TryOptimize(OrFilter orFilter, [NotNullWhen(true)] out InFilter? optimized)
+        {
+            // check if we have all filters accessing same field in OR fashion without regex
+            var hashCommonTypeAndNonRegex = orFilter.Filters.Count > 0;
+            Type? commonType = null;
+
+            // eagerly build expected value collection
+            var expectedValues = new List<string?>(orFilter.Filters.Count);
+
+            // use for for faster traversal without boxed enumerator
+            for (var i = 0; i < orFilter.Filters.Count; i++)
+            {
+                var filter = orFilter.Filters[i];
+
+                // make sure invariants are valid
+                commonType ??= filter.GetType();
+                hashCommonTypeAndNonRegex &= commonType == filter.GetType();
+
+                // our supported filter types
+                hashCommonTypeAndNonRegex &=
+                    filter is ClassNameFilter { IsRegex: false }
+                    || filter is FullNameFilter { IsRegex: false }
+                    || filter is IdFilter { IsRegex: false }
+                    || filter is MethodNameFilter { IsRegex: false }
+                    || filter is NamespaceFilter { IsRegex: false }
+                    || filter is TestNameFilter { IsRegex: false };
+
+                if (!hashCommonTypeAndNonRegex)
+                {
+                    break;
+                }
+
+                expectedValues.Add(((ValueMatchFilter) filter).ExpectedValue);
+            }
+
+            if (hashCommonTypeAndNonRegex)
+            {
+                // we can transform, all filters in non-empty collection are of same type
+                Func<ITest, string?> selector = orFilter.Filters[0] switch
+                {
+                    ClassNameFilter _ => test => test.ClassName,
+                    FullNameFilter _ => test => test.FullName,
+                    IdFilter _ => test => test.Id,
+                    MethodNameFilter _ => test => test.MethodName,
+                    NamespaceFilter _ => test => test.TypeInfo?.Namespace,
+                    TestNameFilter _ => test => test.Name,
+                    _ => throw new InvalidOperationException("Invalid filter, logic wrong")
+                };
+                optimized = new InFilter(selector, expectedValues);
+                return true;
+            }
+
+            optimized = default;
+            return false;
         }
 
         public override bool Match(ITest test)

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class MethodNameFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "method";
+
         /// <summary>
         /// Construct a MethodNameFilter for a single name
         /// </summary>
@@ -48,9 +50,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "method"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/MethodNameFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -29,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// FullName filter selects tests based on their FullName
     /// </summary>
-    internal class MethodNameFilter : ValueMatchFilter
+    internal sealed class MethodNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a MethodNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// ClassName filter selects tests based on the class FullName
     /// </summary>
-    internal class NamespaceFilter : ValueMatchFilter
+    internal sealed class NamespaceFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a NamespaceFilter for a single namespace

--- a/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NamespaceFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class NamespaceFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "namespace";
+
         /// <summary>
         /// Construct a NamespaceFilter for a single namespace
         /// </summary>
@@ -55,9 +57,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "namespace"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/NotFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -29,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// NotFilter negates the operation of another filter
     /// </summary>
-    internal class NotFilter : TestFilter
+    internal sealed class NotFilter : TestFilter
     {
         /// <summary>
         /// Construct a not filter on another filter
@@ -94,7 +93,7 @@ namespace NUnit.Framework.Internal.Filters
         //    }
 
         //    return false;
-        //}	
+        //}
 
         /// <summary>
         /// Adds an XML node

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -31,6 +31,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class OrFilter : CompositeFilter
     {
+        internal const string XmlElementName = "or";
+
         /// <summary>
         /// Constructs an empty OrFilter
         /// </summary>
@@ -108,9 +110,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "or"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -21,10 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -33,7 +30,7 @@ namespace NUnit.Framework.Internal.Filters
     /// PropertyFilter is able to select or exclude tests
     /// based on their properties.
     /// </summary>
-    internal class PropertyFilter : ValueMatchFilter
+    internal sealed class PropertyFilter : ValueMatchFilter
     {
         private readonly string _propertyName;
 
@@ -42,7 +39,7 @@ namespace NUnit.Framework.Internal.Filters
         /// </summary>
         /// <param name="propertyName">A property name</param>
         /// <param name="expectedValue">The expected value of the property</param>
-        public PropertyFilter(string propertyName, string expectedValue) : base(expectedValue) 
+        public PropertyFilter(string propertyName, string expectedValue) : base(expectedValue)
         {
             _propertyName = propertyName;
         }

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
     /// </summary>
     internal sealed class TestNameFilter : ValueMatchFilter
     {
+        internal const string XmlElementName = "name";
+
         /// <summary>
         /// Construct a TestNameFilter for a single name
         /// </summary>
@@ -48,9 +50,6 @@ namespace NUnit.Framework.Internal.Filters
         /// Gets the element name
         /// </summary>
         /// <value>Element name</value>
-        protected override string ElementName
-        {
-            get { return "name"; }
-        }
+        protected override string ElementName => XmlElementName;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/TestNameFilter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -29,7 +28,7 @@ namespace NUnit.Framework.Internal.Filters
     /// <summary>
     /// TestName filter selects tests based on their Name
     /// </summary>
-    internal class TestNameFilter : ValueMatchFilter
+    internal sealed class TestNameFilter : ValueMatchFilter
     {
         /// <summary>
         /// Construct a TestNameFilter for a single name

--- a/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/ValueMatchFilter.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NUnit.Framework.Interfaces;
 

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -25,7 +25,6 @@
 
 using System;
 using System.Reflection;
-using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
@@ -34,7 +33,7 @@ namespace NUnit.Framework.Internal
     /// The MethodWrapper class wraps a MethodInfo so that it may
     /// be used in a platform-independent manner.
     /// </summary>
-    public class MethodWrapper : IMethodInfo
+    public class MethodWrapper : IMethodInfo, IEquatable<MethodWrapper>
     {
         /// <summary>
         /// Construct a MethodWrapper for a Type and a MethodInfo.
@@ -59,12 +58,12 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets the Type from which this method was reflected.
         /// </summary>
-        public ITypeInfo TypeInfo { get; private set; }
+        public ITypeInfo TypeInfo { get; }
 
         /// <summary>
         /// Gets the MethodInfo for this method.
         /// </summary>
-        public MethodInfo MethodInfo { get; private set; }
+        public MethodInfo MethodInfo { get; }
 
         /// <summary>
         /// Gets the name of the method.
@@ -196,5 +195,48 @@ namespace NUnit.Framework.Internal
         }
 
         #endregion
+
+        /// <inheritdoc />
+        public bool Equals(MethodWrapper? other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return MethodInfo.Equals(other.MethodInfo);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((MethodWrapper)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return MethodInfo.GetHashCode();
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Filters;
 
@@ -187,47 +186,18 @@ namespace NUnit.Framework.Internal
                 case "or":
                     List<TestFilter> orChildFilters = new List<TestFilter>();
 
-                    // check if we have all filters accessing same field in OR fashion without regex
-                    var hashCommonTypeAndNonRegex = node.ChildNodes.Count > 0;
-                    Type commonType = null;
-
                     foreach (var childNode in node.ChildNodes)
                     {
                         var filter = FromXml(childNode);
-
-                        // make sure invariants are valid
-                        commonType ??= filter.GetType();
-                        hashCommonTypeAndNonRegex &= commonType == filter.GetType();
-
-                        // our supported filter types
-                        hashCommonTypeAndNonRegex &=
-                            filter is ClassNameFilter { IsRegex: false }
-                            || filter is FullNameFilter { IsRegex: false }
-                            || filter is IdFilter { IsRegex: false }
-                            || filter is MethodNameFilter { IsRegex: false }
-                            || filter is NamespaceFilter { IsRegex: false }
-                            || filter is TestNameFilter { IsRegex: false };
-
                         orChildFilters.Add(filter);
                     }
 
-                    if (hashCommonTypeAndNonRegex)
+                    var orFilter = new OrFilter(orChildFilters.ToArray());
+                    if (InFilter.TryOptimize(orFilter, out InFilter optimized))
                     {
-                        // we can transform
-                        Func<ITest, string> selector = orChildFilters[0] switch
-                        {
-                            ClassNameFilter _ => test => test.ClassName,
-                            FullNameFilter _ => test => test.FullName,
-                            IdFilter _ => test => test.Id,
-                            MethodNameFilter _ => test => test.MethodName,
-                            NamespaceFilter _ => test => test.TypeInfo?.Namespace,
-                            TestNameFilter _ => test => test.Name,
-                            _ => throw new InvalidOperationException("Invalid filter, logic wrong")
-                        };
-                        return new InFilter(selector, orChildFilters.Select(x => ((ValueMatchFilter) x).ExpectedValue));
+                        return optimized;
                     }
-
-                    return new OrFilter(orChildFilters.ToArray());
+                    return orFilter;
 
                 case "not":
                     return new NotFilter(FromXml(node.FirstChild));

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -23,7 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Xml;
+using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Filters;
 
@@ -187,8 +187,45 @@ namespace NUnit.Framework.Internal
                 case "or":
                     List<TestFilter> orChildFilters = new List<TestFilter>();
 
+                    // check if we have all filters accessing same field in OR fashion without regex
+                    var hashCommonTypeAndNonRegex = node.ChildNodes.Count > 0;
+                    Type commonType = null;
+
                     foreach (var childNode in node.ChildNodes)
-                        orChildFilters.Add(FromXml(childNode));
+                    {
+                        var filter = FromXml(childNode);
+
+                        // make sure invariants are valid
+                        commonType ??= filter.GetType();
+                        hashCommonTypeAndNonRegex &= commonType == filter.GetType();
+
+                        // our supported filter types
+                        hashCommonTypeAndNonRegex &=
+                            filter is ClassNameFilter { IsRegex: false }
+                            || filter is FullNameFilter { IsRegex: false }
+                            || filter is IdFilter { IsRegex: false }
+                            || filter is MethodNameFilter { IsRegex: false }
+                            || filter is NamespaceFilter { IsRegex: false }
+                            || filter is TestNameFilter { IsRegex: false };
+
+                        orChildFilters.Add(filter);
+                    }
+
+                    if (hashCommonTypeAndNonRegex)
+                    {
+                        // we can transform
+                        Func<ITest, string> selector = orChildFilters[0] switch
+                        {
+                            ClassNameFilter _ => test => test.ClassName,
+                            FullNameFilter _ => test => test.FullName,
+                            IdFilter _ => test => test.Id,
+                            MethodNameFilter _ => test => test.MethodName,
+                            NamespaceFilter _ => test => test.TypeInfo?.Namespace,
+                            TestNameFilter _ => test => test.Name,
+                            _ => throw new InvalidOperationException("Invalid filter, logic wrong")
+                        };
+                        return new InFilter(selector, orChildFilters.Select(x => ((ValueMatchFilter) x).ExpectedValue));
+                    }
 
                     return new OrFilter(orChildFilters.ToArray());
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Builders;
 
 namespace NUnit.Framework.Internal
 {
@@ -307,9 +308,18 @@ namespace NUnit.Framework.Internal
                 {
                     // For fixtures, we use special rules to get actions
                     // Otherwise we just get the attributes
-                    _actions = Method == null && TypeInfo != null
-                        ? GetActionsForType(TypeInfo.Type)
-                        : GetCustomAttributes<ITestAction>(false);
+                    if (Method == null && TypeInfo != null)
+                    {
+                        _actions = GetActionsForType(TypeInfo.Type);
+                    }
+                    else if (Method != null)
+                    {
+                        _actions = MethodInfoCache.Get(Method).TestActionAttributes;
+                    }
+                    else
+                    {
+                        _actions = GetCustomAttributes<ITestAction>(false);
+                    }
                 }
 
                 return _actions;

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -25,8 +25,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Builders;
 
 namespace NUnit.Framework.Internal
 {
@@ -310,6 +310,8 @@ namespace NUnit.Framework.Internal
         {
             foreach (IMethodInfo method in methods)
             {
+                var methodInfo = MethodInfoCache.Get(method);
+
                 if (method.IsAbstract)
                 {
                     MakeInvalid("An abstract SetUp and TearDown methods cannot be run: " + method.Name);
@@ -318,11 +320,11 @@ namespace NUnit.Framework.Internal
                 {
                     MakeInvalid("SetUp and TearDown methods must be public or protected: " + method.Name);
                 }
-                else if (method.GetParameters().Length != 0)
+                else if (methodInfo.Parameters.Length != 0)
                 {
                     MakeInvalid("SetUp and TearDown methods must not have parameters: " + method.Name);
                 }
-                else if (AsyncToSyncAdapter.IsAsyncOperation(method.MethodInfo))
+                else if (methodInfo.IsAsyncOperation)
                 {
                     if (method.ReturnType.Type == typeof(void))
                         MakeInvalid("SetUp and TearDown methods must not be async void: " + method.Name);
@@ -331,7 +333,7 @@ namespace NUnit.Framework.Internal
                 }
                 else
                 {
-                    if (!Reflect.IsVoidOrUnit(method.ReturnType.Type))
+                    if (!methodInfo.IsVoidOrUnit)
                         MakeInvalid("SetUp and TearDown methods must return void or an awaitable type with a void result: " + method.Name);
                 }
             }

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -1,0 +1,83 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework.Attributes;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    public class InFilterTests : TestFilterTests
+    {
+        [Test]
+        public void OptimizeSameKind()
+        {
+            var filter = new OrFilter(new IdFilter("Id-1"), new IdFilter("Id-2"));
+
+            Assert.True(InFilter.TryOptimize(filter, out var optimized));
+
+            Assert.NotNull(optimized);
+            Assert.False(optimized.IsEmpty);
+
+            Assert.True(optimized.Match(new TestDummy { Id = "Id-1" }));
+            Assert.True(optimized.Match(new TestDummy { Id = "Id-2" }));
+
+            Assert.False(optimized.Match(new TestDummy { Id = "id-1" }));
+            Assert.False(optimized.Match(new TestDummy { Id = "Id-" }));
+            Assert.False(optimized.Match(new TestDummy { Id = "" }));
+        }
+
+        [Test]
+        public void OptimizeMixed()
+        {
+            var filter = new OrFilter(new CategoryFilter("Dummy"), new FullNameFilter(ANOTHER_CLASS));
+
+            Assert.That(filter.Match(_dummyFixture));
+            Assert.That(filter.Match(_anotherFixture));
+
+            Assert.False(InFilter.TryOptimize(filter, out _));
+        }
+
+        [Test]
+        public void OptimizeEmpty()
+        {
+            var filter = new OrFilter(new TestFilter[] {});
+
+            Assert.False(InFilter.TryOptimize(filter, out _));
+        }
+
+        [Test]
+        public void OptimizeAllRegex()
+        {
+            var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX) { IsRegex = true }, new FullNameFilter(ANOTHER_CLASS_REGEX) { IsRegex = true });
+
+            Assert.False(InFilter.TryOptimize(filter, out _));
+        }
+
+        [Test]
+        public void OptimizeSomeRegex()
+        {
+            var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX) { IsRegex = true }, new FullNameFilter("Dummy") { IsRegex = false });
+
+            Assert.False(InFilter.TryOptimize(filter, out _));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -58,5 +58,16 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.False(InFilter.TryOptimize(filter, out _));
         }
+        
+        [Test]
+        public void BuildFromXmlFullName()
+        {
+            TestFilter filter = TestFilter.FromXml(
+                $"<filter><or><test>{DUMMY_CLASS}</test><test>{ANOTHER_CLASS}</test></or></filter>");
+
+            Assert.That(filter, Is.TypeOf<InFilter>());
+            Assert.That(filter.Match(_dummyFixture));
+            Assert.That(filter.Match(_anotherFixture));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -69,5 +69,30 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
         }
+        
+        [Test]
+        public void WriteToXml()
+        {
+            var orFilters = new[]
+            {
+                new OrFilter(new ClassNameFilter("Id-1"), new ClassNameFilter("Id-2")),
+                new OrFilter(new FullNameFilter("Id-1"), new FullNameFilter("Id-2")),
+                new OrFilter(new IdFilter("Id-1"), new IdFilter("Id-2")),
+                new OrFilter(new MethodNameFilter("Id-1"), new MethodNameFilter("Id-2")),
+                new OrFilter(new NamespaceFilter("Id-1"), new NamespaceFilter("Id-2")),
+                new OrFilter(new TestNameFilter("Id-1"), new TestNameFilter("Id-2")),
+            };
+
+            foreach (var orFilter in orFilters)
+            {
+                InFilter.TryOptimize(orFilter, out var inFilter);
+                Assert.NotNull(inFilter);
+
+                var orFilterXml = orFilter.ToXml(true).OuterXml;
+                var inFilterXml = inFilter.ToXml(true).OuterXml;
+
+                Assert.That(inFilterXml, Is.EqualTo(orFilterXml));
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -1,25 +1,4 @@
-// ***********************************************************************
-// Copyright (c) 2015 Charlie Poole, Rob Prouse
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// ***********************************************************************
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using NUnit.Framework.Attributes;
 

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -160,7 +160,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <see cref="OrFilter"/> correctly combines the results from its sub-filters.
         /// Furthermore it checks that the result from the correct match-function of the
         /// sub-filters is used to calculate the OR combination.
-        /// 
+        ///
         /// The input is an array of booleans (<paramref name="inputBooleans"/>). For each boolean
         /// value a <see cref="MockTestFilter"/> is added to the <see cref="OrFilter"/>
         /// whose match-function (defined through the parameter <paramref name="matchFunction"/>)
@@ -172,7 +172,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <see cref="OrFilter"/> calls not the same match-function on the
         /// <see cref="MockTestFilter"/>, thus checking that the <see cref="OrFilter"/>
         /// combines the correct results from the sub-filters.
-        /// 
+        ///
         /// See also <see cref="MockTestFilter"/>.
         /// </summary>
         [TestCase(new bool[] { false, false }, false, MockTestFilter.MatchFunction.IsExplicitMatch)]
@@ -241,7 +241,7 @@ namespace NUnit.Framework.Internal.Filters
             TestFilter filter = TestFilter.FromXml(
                 $"<filter><or><test>{DUMMY_CLASS}</test><test>{ANOTHER_CLASS}</test></or></filter>");
 
-            Assert.That(filter, Is.TypeOf<OrFilter>());
+            Assert.That(filter, Is.TypeOf<InFilter>());
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
         }

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -236,17 +236,6 @@ namespace NUnit.Framework.Internal.Filters
         }
 
         [Test]
-        public void BuildFromXmlFullName()
-        {
-            TestFilter filter = TestFilter.FromXml(
-                $"<filter><or><test>{DUMMY_CLASS}</test><test>{ANOTHER_CLASS}</test></or></filter>");
-
-            Assert.That(filter, Is.TypeOf<InFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
-        }
-
-        [Test]
         public void BuildFromXmlFullNameRegex()
         {
             TestFilter filter = TestFilter.FromXml(


### PR DESCRIPTION
First of all, sorry for not pinging beforehand and discussing with you about the change. I got a bit carried away while profiling and worked with the fixes as I went on.

## TLDR;

80k parametrized test case suite (loading suite, counting test cases) down from almost 11 minutes to less than one second when using Rider. So for this specific case it's __over 700x improvement__.

## Backstory

I'm generating test source code for running [ECMAScript test suite](https://github.com/tc39/test262). This test suite is heavy with 86k+ test cases (about 40k files which are tested in both strict and non-strict mode) and they are ideal use case for using `TestCaseAttribute` defining the files for each method (where method is usually a JavaScript target like `Array.prototype.filter`, having many test cases, e.g. files). 

## Problem

I got the generation working and then started to run them with Rider... or actually I didn't as the whole unit testing sub-system froze when I tried to run the full test suite. I could run small subsets without the IDE's unit testing session hanging in waiting state. The pending to start state before tests would actually run could take minutes. Seems that Rider has different approach than VS (based on earlier issue it sends more like full names) to sending tests - Rider uses OR with all the ids - 80k ids that is. Which will cause the inclusion check algorithm to loop with a large set of data using O(n^2) .

[Here's example of generated test case](https://gist.github.com/lahma/ec546e690aebfed4d186f3a02c80b037) and how I then later profiled NUnit with benchmark test case run in console, using data from Rider invocation (`FrameworkController` parameters). I tweaked it a bit on the way, but results are calculated using the same code.

It seems that it's enough to have a test case such as below to make Rider freeze with unit testing operations. This should mimic the situation quite well be creating the 86 test cases we are testing here.

```csharp
public class TestCaseTest
{
    [Test]
    public void Test([Range(1, 86_000)] int i)
    {
    }
}
```


## Results before

Processing 86607 test cases. Loading them and then discovery without filter and then counting with id filter containing every id found. Ryzen 5950X with 32GB RAM. Almost 11 minutes to load tests and go trough them using a OR'ed filter. ExploreTests is using empty filter in Rider's call chain.

```
LoadTests took: 00:00:27.5665738 // total 86k tests, mostly from TestCase attributes
ExploreTests took: 00:00:00.0037093 // empty filter
CountTests took: 00:10:09.3055713 // 86k OR Id filter items - yes, 10 MINUTES
```

## Fixes

Fixes consist of two parts:

### Loading tests: reducing memory allocations and re-calculations when building test cases

It's very costly to do reflection and inspecting same targets multiple times. For a method having 20 test case attributes all introspection against the test method would be done 20 times, when only parameters for the test case in construction will vary.

Now caching static information about `IMethodInfo` for subsequent accesses.

### Filtering tests: combine `OR` filter with same-kind, non-regexp items to single hash-based InFilter

This builds on the earlier https://github.com/nunit/nunit/issues/3786 and its PR https://github.com/nunit/nunit/pull/3787 . Now detecting more filter types and target fields and creating efficient hash set for that case. Created new `InFilter` type dedicated to matching.

/cc @pakrym 

## Results after

```
LoadTests took: 00:00:00.6497215 // total 86k tests, mostly from TestCase attributes
ExploreTests took: 00:00:00.0030948 // empty filter
CountTests took: 00:00:00.1815572 // 86k OR Id filter items
```

/cc @AndreyAkinshin for Rider performance in Unit testing (VS has different filter logic for full test suite I guess)

Related issues: https://github.com/nunit/nunit/issues/3601 https://github.com/nunit/nunit/issues/3786 https://github.com/nunit/nunit/issues/4009 https://github.com/nunit/nunit3-vs-adapter/issues/660