### PR TITLE
Reduce allocations caused by string.Split

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -124,7 +124,7 @@ namespace NUnit.Framework.Api
                         var parametersString = (string?)testParameters;
                         if (!string.IsNullOrEmpty(parametersString))
                         {
-                            foreach (var param in parametersString!.Split(';'))
+                            foreach (var param in parametersString!.Tokenize(';'))
                             {
                                 var eq = param.IndexOf('=');
 

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework
 
             if (culture.IndexOf(',') >= 0)
             {
-                if (IsCultureSupported(culture.Split(new char[] { ',' })))
+                if (IsCultureSupported(culture.Split(',')))
                     return true;
             }
             else

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -260,7 +260,7 @@ namespace NUnit.Framework
             {
                 Guard.ArgumentNotNull(value, nameof(value));
 
-                foreach (string cat in value.Split(new[] { ',' }) )
+                foreach (string cat in value.Tokenize(','))
                     Properties.Add(PropertyNames.Category, cat);
             }
         }

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -197,7 +197,7 @@ namespace NUnit.Framework
                         }
 
                         if (this.Category != null)
-                            foreach (string cat in this.Category.Split(new[] { ',' }))
+                            foreach (string cat in this.Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
 
                         data.Add(parms);

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -216,7 +216,7 @@ namespace NUnit.Framework
             {
                 Guard.ArgumentNotNull(value, nameof(value));
 
-                foreach (string cat in value.Split(new char[] { ',' }))
+                foreach (string cat in value.Tokenize(','))
                     Properties.Add(PropertyNames.Category, cat);
             }
         }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -157,7 +157,7 @@ namespace NUnit.Framework
                         }
 
                         if (this.Category != null)
-                            foreach (string cat in this.Category.Split(new[] { ',' }))
+                            foreach (string cat in this.Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
 
                         data.Add(parms);

--- a/src/NUnitFramework/framework/Internal/CultureDetector.cs
+++ b/src/NUnitFramework/framework/Internal/CultureDetector.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal
 
             if ( culture.IndexOf( ',' ) >= 0 )
             {
-                if ( IsCultureSupported( culture.Split( new char[] { ',' } ) ) )
+                if ( IsCultureSupported( culture.Split(',') ) )
                     return true;
             }
             else

--- a/src/NUnitFramework/framework/Internal/StringTokenEnumerator.cs
+++ b/src/NUnitFramework/framework/Internal/StringTokenEnumerator.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// Allows enumerating sub-strings from a string based on separator char.
+    /// Basically a less allocating version of string.Split.
+    /// </summary>
+    internal struct StringTokenEnumerator : IEnumerator<string>, IEnumerable
+    {
+        private int _currentStartIndex;
+        private readonly string _target;
+        private readonly char _separator;
+        private readonly bool _returnEmptyTokens;
+
+        /// <summary>
+        /// Constructs a new enumerator against given target with given separator.
+        /// </summary>
+        /// <param name="target">Target string to enumerate.</param>
+        /// <param name="separator">Separator between tokens to return.</param>
+        /// <param name="returnEmptyTokens">Whether empty tokens should be returned</param>
+        public StringTokenEnumerator(string target, char separator, bool returnEmptyTokens)
+        {
+            _currentStartIndex = 0;
+            _target = target;
+            _separator = separator;
+            _returnEmptyTokens = returnEmptyTokens;
+            Current = null;
+        }
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            if (!_returnEmptyTokens && _target.Length == 0)
+            {
+                return false;
+            }
+
+            while (FindNextToken())
+            {
+                if (!_returnEmptyTokens && Current!.Length == 0)
+                {
+                    // check for the next one
+                    continue;
+                }
+
+                break;
+            }
+
+            return Current != null;
+        }
+
+        private bool FindNextToken()
+        {
+            int start = _currentStartIndex;
+
+            if (start > _target.Length)
+            {
+                // we've jumped to the end
+                Current = null;
+                return false;
+            }
+
+            var endIndex = _target.IndexOf(_separator, start);
+            if (endIndex == -1)
+            {
+                Current = _target.Substring(start);
+                // signal that we have no more to give, next loop will return false
+                _currentStartIndex = _target.Length + 1;
+                return true;
+            }
+
+            Current = _target.Substring(start, endIndex - start);
+            _currentStartIndex = endIndex + 1;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            throw new NotSupportedException("Resetting enumerator is not supported");
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc />
+        public string Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Return unboxed enumerator when type is well known, do not remove.
+        /// </summary>
+        public StringTokenEnumerator GetEnumerator() => this;
+
+        IEnumerator IEnumerable.GetEnumerator() => this;
+    }
+
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Tokenizes given string with given separator.
+        /// </summary>
+        /// <param name="s">Input string.</param>
+        /// <param name="separator">Separator to use.</param>
+        /// <param name="returnEmptyTokens">Whether to return empty token (length 0), defaults to false.</param>
+        /// <returns></returns>
+        [MethodImpl(256)] // aggressive inlining, not available for old frameworks via enum
+        internal static StringTokenEnumerator Tokenize(this string s, char separator, bool returnEmptyTokens = false)
+        {
+            return new StringTokenEnumerator(s, separator, returnEmptyTokens);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Internal
                 StringBuilder sb = new StringBuilder();
 
                 bool firstClassSeen = false;
-                foreach (string nestedClass in name.Split('+'))
+                foreach (string nestedClass in name.Tokenize('+'))
                 {
                     if (firstClassSeen)
                         sb.Append("+");

--- a/src/NUnitFramework/tests/Internal/StringTokenEnumeratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/StringTokenEnumeratorTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal
+{
+    public class StringTokenEnumeratorTests
+    {
+        [Test]
+        public void Empty()
+        {
+            var tokens = Enumerate("", ',');
+            Assert.AreEqual(0, tokens.Count);
+        }
+
+        [Test]
+        public void Whitespace()
+        {
+            var tokens = Enumerate("  ", ',');
+            Assert.AreEqual(1, tokens.Count);
+            Assert.AreEqual("  ", tokens[0]);
+        }
+
+        [Test]
+        public void Tokens()
+        {
+            var tokens = Enumerate("a,b,c", ',');
+            Assert.AreEqual(3, tokens.Count);
+            Assert.AreEqual("a", tokens[0]);
+            Assert.AreEqual("b", tokens[1]);
+            Assert.AreEqual("c", tokens[2]);
+        }
+
+        [TestCase("aaa,,cccdd", ',', false)]
+        [TestCase("somestring;another", ';', false)]
+        [TestCase(",abc,def,,somelongerstring,", ',', false)]
+        [TestCase("aaa,,cccdd", ',', true)]
+        [TestCase("somestring;another", ';', true)]
+        [TestCase(",abc,def,,somelongerstring,", ',', true)]
+        public void CompareAgainstStringSplit(string input, char separator, bool returnEmptyTokens)
+        {
+            var tokens = Enumerate(input, separator, returnEmptyTokens);
+            var tokens2 = input.Split(new[] { separator }, returnEmptyTokens ? StringSplitOptions.None : StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(tokens, Is.EqualTo(tokens2));
+        }
+
+        private static List<string> Enumerate(string input, char separator, bool returnEmptyTokens = false)
+        {
+            var result = new List<string>();
+            foreach (var token in new StringTokenEnumerator(input, separator, returnEmptyTokens))
+            {
+                result.Add(token);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When you have > 80k test cases mostly via `TestCaseAttribute`  and utilize categories for them, the category information processing (string splitting) is causing a lot of allocations. Below is a profile from a test run against the test suite. `IsAsyncOperation` was fixed in the other PR.

![image](https://user-images.githubusercontent.com/171892/151696243-78b8e469-78b6-4399-b442-029e2c87060e.png)

So about 15% of memory allocations are coming from this setter.

## Fix

I've created `StringTokenEnumerator` that allows foreach'ing against a string with given separator without separate array allocations. There's a convenience extension method to call this using string `myString.Tokenize(',')` . It's always faster compared to `string.Split` and doesn't allocate for empty or single category at all like the split does (string.Split has to create a new string array). Added benefit is that for empty content property bad adding isn't called either.

With these changes the `set_Category` vanishes from allocation traces altogether.

## Benchmark

```csharp
[MemoryDiagnoser]
public class SplitBenchmark
{
    [Params("","single", "category1,category2,category3")]
    public string Input { get; set; }

    [Benchmark]
    public int SplitWithString()
    {
        return Input.Split(new char[] { ',' }).Length;
    }

    [Benchmark]
    public int SplitWithEnumerator()
    {
        int count = 0;
        foreach (var item in new StringTokenEnumerator(Input, ','))
        {
            count++;
        }

        return count;
    }
}
```

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


```
|              Method |                Input |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|-------------------- |--------------------- |----------:|----------:|----------:|-------:|----------:|
|     **SplitWithString** |                     **** |  **8.102 ns** | **0.0279 ns** | **0.0372 ns** | **0.0038** |      **64 B** |
| SplitWithEnumerator |                      |  2.675 ns | 0.0050 ns | 0.0047 ns |      - |         - |
|     **SplitWithString** | **categ(...)gory3 [29]** | **44.790 ns** | **0.2100 ns** | **0.1640 ns** | **0.0119** |     **200 B** |
| SplitWithEnumerator | categ(...)gory3 [29] | 43.417 ns | 0.4088 ns | 0.3413 ns | 0.0072 |     120 B |
|     **SplitWithString** |               **single** | **15.026 ns** | **0.0534 ns** | **0.0473 ns** | **0.0038** |      **64 B** |
| SplitWithEnumerator |               single |  9.322 ns | 0.0169 ns | 0.0159 ns |      - |         - |
