### PR TITLE
Minimize + Centralize empty array declarations

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework
                     return false;
                 }
 
-                if (!typeInfo.HasConstructor(new Type[0]))
+                if (!typeInfo.HasConstructor(ArrayHelper.Empty<Type>()))
                 {
                     reason = string.Format("{0} does not have a default constructor", typeInfo.FullName);
                     return false;

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Default constructor
         /// </summary>
-        public TestFixtureAttribute() : this(Internal.TestParameters.NoArguments) { }
+        public TestFixtureAttribute() : this(ArrayHelper.Empty<object>()) { }
 
         /// <summary>
         /// Construct with a object[] representing a set of arguments.
@@ -58,7 +58,7 @@ namespace NUnit.Framework
         {
             RunState = RunState.Runnable;
             Arguments = arguments ?? new object?[] { null };
-            TypeArgs = new Type[0];
+            TypeArgs = ArrayHelper.Empty<Type>();
             Properties = new PropertyBag();
         }
 

--- a/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ValuesAttribute.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework
         /// </summary>
         public ValuesAttribute()
         {
-            data = Internal.TestParameters.NoArguments;
+            data = ArrayHelper.Empty<object>();
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace NUnit.Framework
                 return new object[] { true, false };
             }
 
-            return Internal.TestParameters.NoArguments;
+            return ArrayHelper.Empty<object>();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Constraints
 
             // Partly optimization, partly makes any subsequent all()/any() calls reliable
             if (allTypes.Count == 0)
-                return new object[0];
+                return ArrayHelper.Empty<object>();
             
             var distinctTypes = allTypes.Distinct().ToList();
             if (distinctTypes.Count == 1)

--- a/src/NUnitFramework/framework/Internal/ArrayHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ArrayHelper.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace NUnit.Framework.Internal
+{
+    internal static class ArrayHelper
+    {
+#if NET45_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static T[] Empty<T>()
+        {
+#if NETSTANDARD2_0_OR_GREATER
+            return Array.Empty<T>();
+#else
+            return InternalArrayHelper<T>.Empty;
+#endif
+        }
+
+#if !NETSTANDARD2_0_OR_GREATER
+        private static class InternalArrayHelper<T>
+        {
+            public static readonly T[] Empty = new T[0];
+        }
+#endif
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Internal.Builders
                         else if (method != null)
                         {
                             instance = method.IsStatic ? null : ProviderCache.GetInstanceOf(fixtureType);
-                            foreach (object data in (IEnumerable)method.Invoke(instance, new Type[0]))
+                            foreach (object data in (IEnumerable)method.Invoke(instance, ArrayHelper.Empty<Type>()))
                                 datapoints.Add(data);
                         }
                     }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="typeInfo">The type being examined for attributes</param>
         private IFixtureBuilder[] GetFixtureBuilderAttributes(ITypeInfo? typeInfo)
         {
-            IFixtureBuilder[] attrs = new IFixtureBuilder[0];
+            IFixtureBuilder[] attrs = ArrayHelper.Empty<IFixtureBuilder>();
 
             while (typeInfo != null && !typeInfo.IsType(typeof(object)))
             {

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -56,9 +56,6 @@ namespace NUnit.Framework.Internal
     {
         internal static readonly BindingFlags AllMembers = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
-        // A zero-length Type array - not provided by System.Type for all CLR versions we support.
-        private static readonly Type[] EmptyTypes = new Type[0];
-
         #region Get Methods of a type
 
         /// <summary>
@@ -89,7 +86,7 @@ namespace NUnit.Framework.Internal
         /// <returns>An instance of the Type</returns>
         public static object Construct(Type type)
         {
-            ConstructorInfo ctor = type.GetConstructor(EmptyTypes);
+            ConstructorInfo ctor = type.GetConstructor(ArrayHelper.Empty<Type>());
             if (ctor == null)
                 throw new InvalidTestFixtureException(type.FullName + " does not have a default constructor");
 

--- a/src/NUnitFramework/framework/Internal/Results/TestCaseResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestCaseResult.cs
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override IEnumerable<ITestResult> Children
         {
-            get { return new ITestResult[0]; }
+            get { return ArrayHelper.Empty<ITestResult>(); }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Internal
                 MethodInfo getDisplayNameMethod = monoRuntimeType.GetMethod(
                     "GetDisplayName", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding);
                 if (getDisplayNameMethod != null)
-                    currentFramework.DisplayName = (string)getDisplayNameMethod.Invoke(null, new object[0]);
+                    currentFramework.DisplayName = (string)getDisplayNameMethod.Invoke(null, ArrayHelper.Empty<object>());
             }
             return currentFramework;
         });

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -34,18 +34,11 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public abstract class TestParameters : ITestData, IApplyToTest
     {
-        internal static readonly object[] NoArguments =
-#if NET35 || NET40 || NET45 // New in net46
-            new object[0];
-#else
-            Array.Empty<object>();
-#endif
-
         /// <summary>
         /// Default Constructor creates an empty parameter set
         /// </summary>
         public TestParameters()
-            : this(RunState.Runnable, NoArguments)
+            : this(RunState.Runnable, ArrayHelper.Empty<object>())
         {
             Properties = new PropertyBag();
         }
@@ -65,7 +58,7 @@ namespace NUnit.Framework.Internal
         /// the provider exception that made it invalid.
         /// </summary>
         public TestParameters(Exception exception)
-            : this(RunState.NotRunnable, NoArguments)
+            : this(RunState.NotRunnable, ArrayHelper.Empty<object>())
         {
             Properties = new PropertyBag();
             Properties.Set(PropertyNames.SkipReason, ExceptionHelper.BuildMessage(exception));

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -108,8 +108,8 @@ namespace NUnit.Framework.Internal
             Method = method;
             Properties = new PropertyBag();
             RunState = RunState.Runnable;
-            SetUpMethods = new IMethodInfo[0];
-            TearDownMethods = new IMethodInfo[0];
+            SetUpMethods = ArrayHelper.Empty<IMethodInfo>();
+            TearDownMethods = ArrayHelper.Empty<IMethodInfo>();
         }
 
         private static string GetNextId()
@@ -367,7 +367,7 @@ namespace NUnit.Framework.Internal
             if (TypeInfo != null)
                 return TypeInfo.GetCustomAttributes<TAttr>(inherit);
 
-            return new TAttr[0];
+            return ArrayHelper.Empty<TAttr>();
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Internal
         {
             return Assembly != null
                 ? Assembly.GetAttributes<TAttr>()
-                : new TAttr[0];
+                : ArrayHelper.Empty<TAttr>();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -36,12 +36,6 @@ namespace NUnit.Framework.Internal
     {
         #region Fields
 
-#if NETSTANDARD2_0
-        private static IList<ITest> _emptyArray = Array.Empty<ITest>();
-#else
-        private static IList<ITest> _emptyArray = new ITest[0];
-#endif
-
         /// <summary>
         /// The ParameterSet used to create this test method
         /// </summary>
@@ -97,7 +91,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override object?[] Arguments
         {
-            get { return parms != null ? parms.Arguments : TestParameters.NoArguments; }
+            get { return parms != null ? parms.Arguments : ArrayHelper.Empty<object>(); }
         }
 
         /// <summary>
@@ -142,7 +136,7 @@ namespace NUnit.Framework.Internal
         /// <value>A list of child tests</value>
         public override IList<ITest> Tests
         {
-            get { return _emptyArray; }
+            get { return ArrayHelper.Empty<ITest>(); }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -52,9 +52,9 @@ namespace NUnit.Framework.Internal
         /// <param name="name">The name of the suite.</param>
         public TestSuite(string name) : base(name)
         {
-            Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new IMethodInfo[0];
-            OneTimeTearDownMethods = new IMethodInfo[0];
+            Arguments = ArrayHelper.Empty<object>();
+            OneTimeSetUpMethods = ArrayHelper.Empty<IMethodInfo>();
+            OneTimeTearDownMethods = ArrayHelper.Empty<IMethodInfo>();
         }
 
         /// <summary>
@@ -65,9 +65,9 @@ namespace NUnit.Framework.Internal
         public TestSuite(string parentSuiteName, string name)
             : base(parentSuiteName, name)
         {
-            Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new IMethodInfo[0];
-            OneTimeTearDownMethods = new IMethodInfo[0];
+            Arguments = ArrayHelper.Empty<object>();
+            OneTimeSetUpMethods = ArrayHelper.Empty<IMethodInfo>();
+            OneTimeTearDownMethods = ArrayHelper.Empty<IMethodInfo>();
         }
 
         /// <summary>
@@ -78,9 +78,9 @@ namespace NUnit.Framework.Internal
         public TestSuite(ITypeInfo fixtureType, object?[]? arguments = null)
             : base(fixtureType)
         {
-            Arguments = arguments ?? TestParameters.NoArguments;
-            OneTimeSetUpMethods = new IMethodInfo[0];
-            OneTimeTearDownMethods = new IMethodInfo[0];
+            Arguments = arguments ?? ArrayHelper.Empty<object>();
+            OneTimeSetUpMethods = ArrayHelper.Empty<IMethodInfo>();
+            OneTimeTearDownMethods = ArrayHelper.Empty<IMethodInfo>();
         }
 
         /// <summary>
@@ -90,9 +90,9 @@ namespace NUnit.Framework.Internal
         public TestSuite(Type fixtureType)
             : base(new TypeWrapper(fixtureType))
         {
-            Arguments = TestParameters.NoArguments;
-            OneTimeSetUpMethods = new IMethodInfo[0];
-            OneTimeTearDownMethods = new IMethodInfo[0];
+            Arguments = ArrayHelper.Empty<object>();
+            OneTimeSetUpMethods = ArrayHelper.Empty<IMethodInfo>();
+            OneTimeTearDownMethods = ArrayHelper.Empty<IMethodInfo>();
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/ArrayHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/ArrayHelperTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class ArrayHelperTests
+    {
+        [Test]
+        public void EmptyCachesReturnedResults()
+        {
+            var first = ArrayHelper.Empty<object>();
+            var second = ArrayHelper.Empty<object>();
+
+            Assert.That(first, Is.SameAs(second));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4041

This PR introduces a helper to cache empty array declarations. It will use `Array.Empty<T>` if possible, falling back to a custom implementation when that's not available.

This should be ported to v4 unless we decide to drop support for net45 there.