### PR TITLE
Use TryGetValue() instead of old ContainsKey() pattern

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -99,51 +99,42 @@ namespace NUnit.Framework.Api
 
             try
             {
-                if (options.ContainsKey(FrameworkPackageSettings.DefaultTestNamePattern))
-                    TestNameGenerator.DefaultTestNamePattern = options[FrameworkPackageSettings.DefaultTestNamePattern] as string;
+                options.TryGetValue(FrameworkPackageSettings.DefaultTestNamePattern, out object defaultTestNamePattern);
+                TestNameGenerator.DefaultTestNamePattern = defaultTestNamePattern as string;
+                
+                options.TryGetValue(FrameworkPackageSettings.WorkDirectory, out object workDirectory);
+                TestContext.DefaultWorkDirectory = workDirectory as string ?? Directory.GetCurrentDirectory();
 
-                if (options.ContainsKey(FrameworkPackageSettings.WorkDirectory))
-                    TestContext.DefaultWorkDirectory = options[FrameworkPackageSettings.WorkDirectory] as string;
-                else
-                    TestContext.DefaultWorkDirectory = Directory.GetCurrentDirectory();
-
-                if (options.ContainsKey(FrameworkPackageSettings.TestParametersDictionary))
-                {
-                    var testParametersDictionary = options[FrameworkPackageSettings.TestParametersDictionary] as IDictionary<string, string>;
-                    if (testParametersDictionary != null)
-                    {
-                        foreach (var parameter in testParametersDictionary)
-                            TestContext.Parameters.Add(parameter.Key, parameter.Value);
-                    }
-                }
+                options.TryGetValue(FrameworkPackageSettings.TestParametersDictionary, out object testParametersDictionary);
+                if (testParametersDictionary != null)
+                    foreach (var parameter in (IDictionary<string, string>)testParametersDictionary)
+                        TestContext.Parameters.Add(parameter.Key, parameter.Value);
                 else
                 {
                     // This cannot be changed without breaking backwards compatibility with old runners.
                     // Deserializes the way old runners understand.
-
-                    if (options.ContainsKey(FrameworkPackageSettings.TestParameters))
-                    {
-                        string parameters = options[FrameworkPackageSettings.TestParameters] as string;
-                        if (!string.IsNullOrEmpty(parameters))
-                            foreach (string param in parameters.Split(new[] { ';' }))
+                    
+                    options.TryGetValue(FrameworkPackageSettings.TestParameters, out object testParameters);
+                    string parametersString = testParameters as string;
+                    if (!string.IsNullOrEmpty(parametersString))
+                        foreach (string param in parametersString.Split(new[] { ';' }))
+                        {
+                            int eq = param.IndexOf('=');
+                        
+                            if (eq > 0 && eq < param.Length - 1)
                             {
-                                int eq = param.IndexOf('=');
-
-                                if (eq > 0 && eq < param.Length - 1)
-                                {
-                                    var name = param.Substring(0, eq);
-                                    var val = param.Substring(eq + 1);
-
-                                    TestContext.Parameters.Add(name, val);
-                                }
+                                var name = param.Substring(0, eq);
+                                var val = param.Substring(eq + 1);
+                        
+                                TestContext.Parameters.Add(name, val);
                             }
-                    }
+                        }
                 }
 
                 _filter = new PreFilter();
-                if (options.ContainsKey(FrameworkPackageSettings.LOAD))
-                    foreach (string filterText in (IList)options[FrameworkPackageSettings.LOAD])
-                        _filter.Add(filterText);
+                options.TryGetValue(FrameworkPackageSettings.LOAD, out object load);
+                foreach (string filterText in (IList)load)
+                    _filter.Add(filterText);
 
                 var fixtures = GetFixtures(assembly);
 

--- a/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
@@ -98,8 +98,9 @@ namespace NUnit.Framework.Internal.Builders
 
             if( ns  == "" ) return _globalInsertionPoint;
 
-            if (_namespaceIndex.ContainsKey(ns))
-                return _namespaceIndex[ns];
+            _namespaceIndex.TryGetValue(ns, out TestSuite suiteToReturn);
+            if (suiteToReturn != null)
+                return suiteToReturn;
 
             TestSuite suite;
             int index = ns.LastIndexOf('.');


### PR DESCRIPTION
Fixes #4049 

This refactors the sections of code detailed in the first two comments of the issue. This does not change anything in the `WorkItemBuilder.Compare` method or the `NUnit2XmlOutputWriter` class as they are both using `IPropertyBag`s and not `Dictionary<T, T>`s.