### PR TITLE
Use pattern matching instead of casting in Constraints namespace

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionConstraint.cs
@@ -32,8 +32,7 @@ namespace NUnit.Framework.Constraints
         /// </returns>
         protected static bool IsEmpty(IEnumerable enumerable)
         {
-            ICollection collection = enumerable as ICollection;
-            if (collection != null)
+            if (enumerable is ICollection collection)
                 return collection.Count == 0;
 
             foreach (object o in enumerable)

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private readonly NUnitEqualityComparer comparer;
+        private readonly NUnitEqualityComparer _comparer;
 
         private readonly bool _isSortable;
         private bool _sorted = false;
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The expected collection to compare against.</param>
         public CollectionTally(NUnitEqualityComparer comparer, IEnumerable c)
         {
-            this.comparer = comparer;
+            this._comparer = comparer;
 
             _missingItems = ToArrayList(c);
 
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Constraints
         private bool ItemsEqual(object expected, object actual)
         {
             Tolerance tolerance = Tolerance.Default;
-            return comparer.AreEqual(expected, actual, ref tolerance);
+            return _comparer.AreEqual(expected, actual, ref tolerance);
         }
 
         /// <summary>Try to remove an object from the tally.</summary>

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -101,7 +101,6 @@ namespace NUnit.Framework.Constraints
             return ApplyTo(GetTestObject(del));
         }
 
-#pragma warning disable 3006
         /// <summary>
         /// Test whether the constraint is satisfied by a given reference.
         /// The default implementation simply dereferences the value but
@@ -113,7 +112,6 @@ namespace NUnit.Framework.Constraints
         {
             return ApplyTo(actual);
         }
-#pragma warning restore 3006
 
         /// <summary>
         /// Retrieves the value to be tested from an ActualValueDelegate.
@@ -156,20 +154,19 @@ namespace NUnit.Framework.Constraints
             foreach (object arg in Arguments)
             {
                 sb.Append(" ");
-                sb.Append(_displayable(arg));
+                sb.Append(Displayable(arg));
             }
 
             sb.Append(">");
 
             return sb.ToString();
-        }
 
-        private static string _displayable(object o)
-        {
-            if (o == null) return "null";
-
-            string fmt = o is string ? "\"{0}\"" : "{0}";
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, fmt, o);
+            static string Displayable(object o)
+            {
+                if (o == null) return "null";
+                else if (o is string s) return $"\"{s}\"";
+                else return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", o);
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/DateTimes.cs
+++ b/src/NUnitFramework/framework/Constraints/DateTimes.cs
@@ -13,14 +13,14 @@ namespace NUnit.Framework.Constraints
 
         internal static object Difference(object x, object y)
         {
-            if (x is DateTime && y is DateTime)
-                return ((DateTime)x - (DateTime)y).Duration();
+            if (x is DateTime xDateTime && y is DateTime yDateTime)
+                return (xDateTime - yDateTime).Duration();
 
-            if (x is TimeSpan && y is TimeSpan)
-                return ((TimeSpan)x - (TimeSpan)y).Duration();
+            if (x is TimeSpan xTimeSpan && y is TimeSpan yTimeSpan)
+                return (xTimeSpan - yTimeSpan).Duration();
 
-            if (x is DateTimeOffset && y is DateTimeOffset)
-                return ((DateTimeOffset)x - (DateTimeOffset)y).Duration();
+            if (x is DateTimeOffset xDateTimeOffset && y is DateTimeOffset yDateTimeOffset)
+                return (xDateTimeOffset - yDateTimeOffset).Duration();
 
             throw new ArgumentException("Both arguments must be DateTime, DateTimeOffset or TimeSpan");
         }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -63,14 +63,14 @@ namespace NUnit.Framework.Constraints
 
         private void DisplayDifferences(MessageWriter writer, object expected, object actual, int depth)
         {
-            if (expected is string && actual is string)
-                DisplayStringDifferences(writer, (string)expected, (string)actual);
-            else if (expected is ICollection && actual is ICollection)
-                DisplayCollectionDifferences(writer, (ICollection)expected, (ICollection)actual, depth);
-            else if (expected is IEnumerable && actual is IEnumerable)
-                DisplayEnumerableDifferences(writer, (IEnumerable)expected, (IEnumerable)actual, depth);
-            else if (expected is Stream && actual is Stream)
-                DisplayStreamDifferences(writer, (Stream)expected, (Stream)actual, depth);
+            if (expected is string expectedString && actual is string actualString)
+                DisplayStringDifferences(writer, expectedString, actualString);
+            else if (expected is ICollection expectedCollection && actual is ICollection actualCollection)
+                DisplayCollectionDifferences(writer, expectedCollection, actualCollection, depth);
+            else if (expected is IEnumerable expectedEnumerable && actual is IEnumerable actualEnumerable)
+                DisplayEnumerableDifferences(writer, expectedEnumerable, actualEnumerable, depth);
+            else if (expected is Stream expectedStream && actual is Stream actualStream)
+                DisplayStreamDifferences(writer, expectedStream, actualStream, depth);
             else if (tolerance != null)
                 writer.DisplayDifferences(expected, actual, tolerance);
             else
@@ -153,12 +153,12 @@ namespace NUnit.Framework.Constraints
         private void DisplayTypesAndSizes(MessageWriter writer, IEnumerable expected, IEnumerable actual, int indent)
         {
             string sExpected = MsgUtils.GetTypeRepresentation(expected);
-            if (expected is ICollection && !(expected is Array))
-                sExpected += string.Format(" with {0} elements", ((ICollection)expected).Count);
+            if (expected is ICollection expectedCollection && !(expected is Array))
+                sExpected += string.Format(" with {0} elements", expectedCollection.Count);
 
             string sActual = MsgUtils.GetTypeRepresentation(actual);
-            if (actual is ICollection && !(actual is Array))
-                sActual += string.Format(" with {0} elements", ((ICollection)actual).Count);
+            if (actual is ICollection actualCollection && !(actual is Array))
+                sActual += string.Format(" with {0} elements", actualCollection.Count);
 
             if (sExpected == sActual)
                 writer.WriteMessageLine(indent, CollectionType_1, sExpected);

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints
         {
             ConstraintUtils.RequireActual<Exception>(actual, nameof(actual), allowNull: true);
 
-            actualType = actual == null ? null : actual.GetType();
+            actualType = actual?.GetType();
 
             return new ExceptionTypeConstraintResult(this, actual, actualType, this.Matches(actual));
         }
@@ -46,15 +46,13 @@ namespace NUnit.Framework.Constraints
             {
                 if (this.Status == ConstraintStatus.Failure)
                 {
-                    Exception ex = caughtException as Exception;
-
-                    if (ex == null)
+                    if (caughtException is Exception ex)
                     {
-                        base.WriteActualValueTo(writer);
+                        writer.WriteActualValue(ex);
                     }
                     else
                     {
-                        writer.WriteActualValue(ex);
+                        base.WriteActualValueTo(writer);
                     }
                 }
             }

--- a/src/NUnitFramework/framework/Constraints/FileOrDirectoryExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/FileOrDirectoryExistsConstraint.cs
@@ -85,20 +85,17 @@ namespace NUnit.Framework.Constraints
             if (actual == null)
                 throw new ArgumentNullException(nameof(actual), "The actual value must be a non-null string" + ErrorSubstring);
 
-            var stringValue = actual as string;
-            if (stringValue != null)
+            if (actual is string stringValue)
             {
                 return CheckString(stringValue);
             }
 
-            var fileInfo = actual as FileInfo;
-            if (!_ignoreFiles && fileInfo != null)
+            if (!_ignoreFiles && actual is FileInfo fileInfo)
             {
                 return new ConstraintResult(this, actual, fileInfo.Exists);
             }
 
-            var directoryInfo = actual as DirectoryInfo;
-            if (!_ignoreDirectories && directoryInfo != null)
+            if (!_ignoreDirectories && actual is DirectoryInfo directoryInfo)
             {
                 return new ConstraintResult(this, actual, directoryInfo.Exists);
             }

--- a/src/NUnitFramework/framework/Constraints/IConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/IConstraint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 namespace NUnit.Framework.Constraints
 {
@@ -52,7 +52,6 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del);
 
-        #pragma warning disable 3006
         /// <summary>
         /// Test whether the constraint is satisfied by a given reference.
         /// The default implementation simply dereferences the value but
@@ -61,7 +60,6 @@ namespace NUnit.Framework.Constraints
         /// <param name="actual">A reference to the value to be tested</param>
         /// <returns>A ConstraintResult</returns>
         ConstraintResult ApplyTo<TActual>(ref TActual actual);
-        #pragma warning restore 3006
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -70,21 +70,21 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val is ValueType ? string.Format(Fmt_ValueType, val) : next(val));
 
-            AddFormatter(next => val => val is DateTime ? FormatDateTime((DateTime)val) : next(val));
+            AddFormatter(next => val => val is DateTime value ? FormatDateTime(value) : next(val));
 
-            AddFormatter(next => val => val is DateTimeOffset ? FormatDateTimeOffset((DateTimeOffset)val) : next(val));
+            AddFormatter(next => val => val is DateTimeOffset value ? FormatDateTimeOffset(value) : next(val));
 
-            AddFormatter(next => val => val is decimal ? FormatDecimal((decimal)val) : next(val));
+            AddFormatter(next => val => val is decimal value ? FormatDecimal(value) : next(val));
 
-            AddFormatter(next => val => val is float ? FormatFloat((float)val) : next(val));
+            AddFormatter(next => val => val is float value ? FormatFloat(value) : next(val));
 
-            AddFormatter(next => val => val is double ? FormatDouble((double)val) : next(val));
+            AddFormatter(next => val => val is double value ? FormatDouble(value) : next(val));
 
             AddFormatter(next => val => val is char ? string.Format(Fmt_Char, val) : next(val));
 
-            AddFormatter(next => val => val is IEnumerable ? FormatCollection((IEnumerable)val) : next(val));
+            AddFormatter(next => val => val is IEnumerable value ? FormatCollection(value) : next(val));
 
-            AddFormatter(next => val => val is string ? FormatString((string)val) : next(val));
+            AddFormatter(next => val => val is string value ? FormatString(value) : next(val));
 
             AddFormatter(next => val => val is DictionaryEntry de ? FormatKeyValuePair(de.Key, de.Value) : next(val));
 
@@ -353,8 +353,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public static string GetTypeRepresentation(object obj)
         {
-            Array? array = obj as Array;
-            if (array == null)
+            if (!(obj is Array array))
                 return string.Format("<{0}>", obj.GetType());
 
             StringBuilder sb = new StringBuilder();

--- a/src/NUnitFramework/framework/Constraints/NaNConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NaNConstraint.cs
@@ -24,8 +24,8 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             return new ConstraintResult(this, actual, 
-                actual is double && double.IsNaN((double)(object)actual) ||
-                actual is float && float.IsNaN((float)(object)actual));
+                actual is double d && double.IsNaN(d) ||
+                actual is float f && float.IsNaN(f));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A ConstraintResult</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            actualType = actual == null ? null : actual.GetType();
+            actualType = actual?.GetType();
 
             if (actual is Exception)
                 return new ConstraintResult(this, actual, this.Matches(actual));


### PR DESCRIPTION
Fixes #4072
Use pattern matching in everything under Constraints namespace to avoid unnecessary casts or comparisons to give a minor perf boost.