### PR TITLE
Constraints + AssemblyHelper use in-place string comparisions

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#nullable enable
+
 using System;
 
 namespace NUnit.Framework.Constraints.Comparers
@@ -14,10 +16,8 @@ namespace NUnit.Framework.Constraints.Comparers
             if (!(x is string xString) || !(y is string yString))
                 return null;
 
-            if (equalityComparer.IgnoreCase)
-                return xString.Equals(yString, StringComparison.CurrentCultureIgnoreCase);
-
-            return xString.Equals(yString);
+            var stringComparison = equalityComparer.IgnoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+            return xString.Equals(yString, stringComparison);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
@@ -14,12 +14,10 @@ namespace NUnit.Framework.Constraints.Comparers
             if (!(x is string xString) || !(y is string yString))
                 return null;
 
-            bool caseInsensitive = equalityComparer.IgnoreCase;
+            if (equalityComparer.IgnoreCase)
+                return xString.Equals(yString, StringComparison.CurrentCultureIgnoreCase);
 
-            string s1 = caseInsensitive ? xString.ToLower() : xString;
-            string s2 = caseInsensitive ? yString.ToLower() : yString;
-
-            return s1.Equals(s2);
+            return xString.Equals(yString);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual != null && actual.EndsWith(expected, stringComparison);
         }
     }

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#nullable enable
+
+using System;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -26,10 +30,8 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            if (this.caseInsensitive)
-                return actual != null && actual.EndsWith(expected, System.StringComparison.CurrentCultureIgnoreCase);
-            else
-                return actual != null && actual.EndsWith(expected);
+            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+            return actual != null && actual.EndsWith(expected, stringComparison);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Constraints
         protected override bool Matches(string actual)
         {
             if (this.caseInsensitive)
-                return actual != null && actual.ToLower().EndsWith(expected.ToLower());
+                return actual != null && actual.EndsWith(expected, System.StringComparison.CurrentCultureIgnoreCase);
             else
                 return actual != null && actual.EndsWith(expected);
         }

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual != null && actual.StartsWith(expected, stringComparison);
         }
     }

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#nullable enable
+
+using System;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -26,10 +30,8 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            if (this.caseInsensitive)
-                return actual != null && actual.StartsWith(expected, System.StringComparison.CurrentCultureIgnoreCase);
-            else
-                return actual != null && actual.StartsWith(expected);
+            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+            return actual != null && actual.StartsWith(expected, stringComparison);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Constraints
         protected override bool Matches(string actual)
         {
             if (this.caseInsensitive)
-                return actual != null && actual.ToLower().StartsWith(expected.ToLower());
+                return actual != null && actual.StartsWith(expected, System.StringComparison.CurrentCultureIgnoreCase);
             else
                 return actual != null && actual.StartsWith(expected);
         }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -263,7 +263,7 @@ namespace NUnit.Framework.Constraints
                 if (obj is null)
                     return 0;
                 else if (_ignoreCase)
-                    return obj.ToLower().GetHashCode();
+                    return StringComparer.CurrentCultureIgnoreCase.GetHashCode(obj);
                 else
                     return obj.GetHashCode();
             }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -254,10 +254,8 @@ namespace NUnit.Framework.Constraints
 
             public bool Equals(string x, string y)
             {
-                if (_ignoreCase)
-                    return x.Equals(y, StringComparison.CurrentCultureIgnoreCase);
-
-                return x.Equals(y);
+                var stringComparison = _ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
+                return x.Equals(y, stringComparison);
             }
 
             public int GetHashCode(string obj)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -254,10 +254,10 @@ namespace NUnit.Framework.Constraints
 
             public bool Equals(string x, string y)
             {
-                string s1 = _ignoreCase ? x.ToLower() : x;
-                string s2 = _ignoreCase ? y.ToLower() : y;
+                if (_ignoreCase)
+                    return x.Equals(y, StringComparison.CurrentCultureIgnoreCase);
 
-                return s1.Equals(s2);
+                return x.Equals(y);
             }
 
             public int GetHashCode(string obj)

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -12,8 +12,8 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class AssemblyHelper
     {
-        static readonly string UriSchemeFile = Uri.UriSchemeFile;
-        static readonly string SchemeDelimiter = Uri.SchemeDelimiter;
+        private static readonly string UriSchemeFile = Uri.UriSchemeFile;
+        private static readonly string SchemeDelimiter = Uri.SchemeDelimiter;
 
         #region GetAssemblyPath
 
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Internal
 
         private static bool IsFileUri(string uri)
         {
-            return uri.StartsWith(UriSchemeFile, StringComparison.CurrentCultureIgnoreCase);
+            return uri.StartsWith(UriSchemeFile, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -140,10 +140,10 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static Assembly Load(string nameOrPath)
         {
-            var ext = Path.GetExtension(nameOrPath).ToLower();
+            var ext = Path.GetExtension(nameOrPath);
 
             // Handle case where this is the path to an assembly
-            if (ext == ".dll" || ext == ".exe")
+            if (ext.Equals(".dll", StringComparison.OrdinalIgnoreCase) || ext.Equals(".exe", StringComparison.OrdinalIgnoreCase))
             {
                 return Assembly.Load(AssemblyName.GetAssemblyName(nameOrPath));
             }
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Internal
 
         private static bool IsFileUri(string uri)
         {
-            return uri.ToLower().StartsWith(UriSchemeFile);
+            return uri.StartsWith(UriSchemeFile, StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
@@ -24,6 +24,15 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( "say hello to Fred", "\"say hello to Fred\"" ),
             new TestCaseData( string.Empty, "<string.Empty>" ),
             new TestCaseData( null , "null" ) };
+
+        [Test]
+        public void RespectsCulture()
+        {
+            var constraint = new EndsWithConstraint("r\u00E9sum\u00E9");
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+            Assert.That(result.IsSuccess, Is.True);
+        }
     }
 
     [TestFixture]
@@ -46,5 +55,14 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( "say hello to Fred", "\"say hello to Fred\"" ),
             new TestCaseData( string.Empty, "<string.Empty>" ),
             new TestCaseData( null , "null" ) };
+
+        [Test]
+        public void RespectsCulture()
+        {
+            var constraint = new EndsWithConstraint("r\u00E9sum\u00E9").IgnoreCase;
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+            Assert.That(result.IsSuccess, Is.True);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -37,6 +37,29 @@ namespace NUnit.Framework.Constraints
             Assert.AreEqual(new System.Numerics.Complex(1, 100), new System.Numerics.Complex(1, 100));
         }
 
+        #region StringEquality
+        [Test]
+        public void RespectsCultureWhenCaseIgnored()
+        {
+            var constraint = new EqualConstraint("r\u00E9sum\u00E9").IgnoreCase;
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public void DoesntRespectCultureWhenCasingMatters()
+        {
+            var constraint = new EqualConstraint("r\u00E9sum\u00E9");
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        #endregion
+
         #region DateTimeEquality
 
         public class DateTimeEquality

--- a/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
@@ -25,6 +25,15 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( "say hello to Fred", "\"say hello to Fred\"" ),
             new TestCaseData( string.Empty, "<string.Empty>" ),
             new TestCaseData( null , "null" ) };
+
+        [Test]
+        public void RespectsCulture()
+        {
+            var constraint = new StartsWithConstraint("r\u00E9sum\u00E9");
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+            Assert.That(result.IsSuccess, Is.True);
+        }
     }
 
     [TestFixture]
@@ -47,5 +56,14 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( "say hello to Fred", "\"say hello to Fred\"" ),
             new TestCaseData( string.Empty, "<string.Empty>" ),
             new TestCaseData( null , "null" ) };
+
+        [Test]
+        public void RespectsCulture()
+        {
+            var constraint = new EndsWithConstraint("r\u00E9sum\u00E9").IgnoreCase;
+
+            var result = constraint.ApplyTo("re\u0301sume\u0301");
+            Assert.That(result.IsSuccess, Is.True);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/StringConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/StringConstraintTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
 

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -180,6 +180,28 @@ namespace NUnit.Framework.Constraints
             Assert.That(result.NonUniqueItems, Is.EqualTo(expectedFailures));
         }
 
+        [Test]
+        public void RespectsCultureWhenCaseIgnored()
+        {
+            var constraint = new UniqueItemsConstraint().IgnoreCase;
+            var items = new[] { "r\u00E9sum\u00E9", "re\u0301sume\u0301" };
+
+            var result = constraint.ApplyTo(items) as UniqueItemsConstraintResult;
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void DoesntRespectCultureWhenCasingMatters()
+        {
+            var constraint = new UniqueItemsConstraint();
+            var items = new[] { "r\u00E9sum\u00E9", "re\u0301sume\u0301" };
+
+            var result = constraint.ApplyTo(items) as UniqueItemsConstraintResult;
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
         private static TestCaseData[] RequiresDefaultComparer
         {
             get


### PR DESCRIPTION
Fixes #4086 
Uses in-place comparisons instead of calling `ToLower()`. According to MSDN docs, the existing calls to `ToLower()` use a culture-aware comparer by default so I used `StringComparison.CurrentCultureIgnoreCase` for case-insensitive in-place comparisons to try and preserve existing behaviour.