### PR TITLE
Remove unneccessary casts (and a few other minor cleanup)

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Api
 
         class ActionCallback : ICallbackEventHandler
         {
-            Action<string> _callback;
+            private readonly Action<string> _callback;
 
             public ActionCallback(Action<string> callback)
             {
@@ -385,18 +385,14 @@ namespace NUnit.Framework.Api
             TNode setting = new TNode("setting");
             setting.AddAttribute("name", name);
 
-            if (value != null)
+            if (value is IDictionary dict)
             {
-                var dict = value as IDictionary;
-                if (dict != null)
-                {
-                    AddDictionaryEntries(setting, dict);
-                    AddBackwardsCompatibleDictionaryEntries(setting, dict);
-                }
-                else
-                {
-                    setting.AddAttribute("value", value.ToString());
-                }
+                AddDictionaryEntries(setting, dict);
+                AddBackwardsCompatibleDictionaryEntries(setting, dict);
+            }
+            else if (value != null)
+            {
+                setting.AddAttribute("value", value.ToString());
             }
             else
             {

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Api
         /// </summary>
         public ITestResult Result
         {
-            get { return TopLevelWorkItem == null ? null : TopLevelWorkItem.Result; }
+            get { return TopLevelWorkItem?.Result; }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/FixtureLifeCycleAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/FixtureLifeCycleAttribute.cs
@@ -33,8 +33,7 @@ namespace NUnit.Framework
         /// </summary>
         public void ApplyToTest(Test test)
         {
-            var testFixture = test as TestFixture;
-            if (testFixture != null)
+            if (test is TestFixture testFixture)
             {
                 testFixture.LifeCycle = LifeCycle;
             }

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -304,9 +304,8 @@ namespace NUnit.Framework
 
                 foreach (object obj in _source.GetData(parameter))
                 {
-                    if (obj is int)
+                    if (obj is int ival)
                     {
-                        int ival = (int)obj; // unbox first
                         if (parmType == typeof(short))
                             yield return (short)ival;
                         else if (parmType == typeof(ushort))
@@ -318,9 +317,8 @@ namespace NUnit.Framework
                         else if (parmType == typeof(decimal))
                             yield return (decimal)ival;
                     }
-                    else if (obj is double)
+                    else if (obj is double d)
                     {
-                        double d = (double)obj; // unbox first
                         if (parmType == typeof(decimal))
                             yield return (decimal)d;
                     }

--- a/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RangeAttribute.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections;
-using System.Reflection;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -166,8 +166,7 @@ namespace NUnit.Framework
                             // 3. An array was passed, it may be an object[]
                             //    or possibly some other kind of array, which
                             //    TestCaseSource can accept.
-                            var array = item as Array;
-                            if (array != null)
+                            if (item is Array array)
                             {
                                 // If array has the same number of elements as parameters
                                 // and it does not fit exactly into single existing parameter

--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -37,8 +37,7 @@ namespace NUnit.Framework.Internal
             // special quality of blocking until complete in GetResult.
             // As long as the pattern-based adapters are reflection-based, this
             // is much more efficient as well.
-            var task = awaitable as System.Threading.Tasks.Task;
-            if (task != null) return TaskAwaitAdapter.Create(task);
+            if (awaitable is System.Threading.Tasks.Task task) return TaskAwaitAdapter.Create(task);
 
             // Await all the (C# and F#) things
             var adapter =

--- a/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AwaitAdapter.cs
@@ -37,13 +37,15 @@ namespace NUnit.Framework.Internal
             // special quality of blocking until complete in GetResult.
             // As long as the pattern-based adapters are reflection-based, this
             // is much more efficient as well.
-            if (awaitable is System.Threading.Tasks.Task task) return TaskAwaitAdapter.Create(task);
+            if (awaitable is System.Threading.Tasks.Task task)
+                return TaskAwaitAdapter.Create(task);
 
             // Await all the (C# and F#) things
             var adapter =
                 CSharpPatternBasedAwaitAdapter.TryCreate(awaitable)
                 ?? FSharpAsyncAwaitAdapter.TryCreate(awaitable);
-            if (adapter != null) return adapter;
+            if (adapter != null)
+                return adapter;
 
             throw new NotSupportedException("NUnit can only await objects which follow the C# specification for awaitable expressions.");
         }

--- a/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
@@ -27,8 +27,7 @@ namespace NUnit.Framework.Internal.Commands
             {
                 try
                 {
-                    IDisposable disposable = context.TestObject as IDisposable;
-                    if (disposable != null)
+                    if (context.TestObject is IDisposable disposable)
                         disposable.Dispose();
                 }
                 catch (Exception ex)

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -85,8 +85,7 @@ namespace NUnit.Framework.Internal
             if (string.IsNullOrEmpty(message))
             {
                 // Special handling for Mono 5.0, which returns an empty message
-                var fnfEx = ex as System.IO.FileNotFoundException;
-                return fnfEx != null
+                return ex is System.IO.FileNotFoundException fnfEx
                     ? "Could not load assembly. File not found: " + fnfEx.FileName
                     : "No message provided";
             }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -306,8 +306,8 @@ namespace NUnit.Framework.Internal.Execution
                 // even for tests that have been skipped at a higher level.
                 Context.Listener.TestFinished(child.Result);
 
-                if (child is CompositeWorkItem)
-                    SkipChildren((CompositeWorkItem)child, resultState, message);
+                if (child is CompositeWorkItem item)
+                    SkipChildren(item, resultState, message);
             }
         }
 
@@ -350,8 +350,7 @@ namespace NUnit.Framework.Internal.Execution
             // only blocks its own children.
             lock (_childCompletionLock)
             {
-                WorkItem childTask = sender as WorkItem;
-                if (childTask != null)
+                if (sender is WorkItem childTask)
                 {
                     childTask.Completed -= new EventHandler(OnChildItemCompleted);
                     _suiteResult.AddResult(childTask.Result);

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -183,13 +183,14 @@ namespace NUnit.Framework.Internal.Execution
             log.Debug("Using {0} strategy for {1}", strategy, work.Name);
 
             // Currently, we only track CompositeWorkItems - this could be expanded
-            var composite = work as CompositeWorkItem;
-            if (composite != null)
+            if (work is CompositeWorkItem composite)
+            {
                 lock (_activeWorkItems)
                 {
                     _activeWorkItems.Add(composite);
                     composite.Completed += OnWorkItemCompletion;
                 }
+            }
 
             switch (strategy)
             {

--- a/src/NUnitFramework/framework/Internal/IgnoredTestCaseData.cs
+++ b/src/NUnitFramework/framework/Internal/IgnoredTestCaseData.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework
         /// <summary>
         /// The previous RunState
         /// </summary>
-        private RunState _prevRunState;
+        private readonly RunState _prevRunState;
 
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -542,9 +542,9 @@ namespace NUnit.Framework.Internal
             {
                 ex = ValidateAndUnwrap(ex);
 
-                if (ex is ResultStateException)
+                if (ex is ResultStateException exception)
                 {
-                    ResultState = ((ResultStateException)ex).ResultState.WithSite(site);
+                    ResultState = exception.ResultState.WithSite(site);
                     Message = ex.GetMessageWithoutThrowing();
                     StackTrace = StackFilter.DefaultFilter.Filter(ex.GetStackTraceWithoutThrowing());
                 }

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -16,9 +16,9 @@ namespace NUnit.Framework.Internal
         #region Fields
 
 #if NETSTANDARD2_0
-        private static IList<ITest> _emptyArray = Array.Empty<ITest>();
+        private static readonly IList<ITest> _emptyArray = Array.Empty<ITest>();
 #else
-        private static IList<ITest> _emptyArray = new ITest[0];
+        private static readonly IList<ITest> _emptyArray = new ITest[0];
 #endif
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -124,8 +124,7 @@ namespace NUnit.Framework.Internal
 
                 foreach (Test test in Tests)
                 {
-                    TestSuite? suite = test as TestSuite;
-                    if (suite != null)
+                    if (test is TestSuite suite)
                         suite.Sort();
                 }
             }

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.ByteValueGenerator.cs
@@ -8,18 +8,18 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is byte)
+                if (value is byte bValue)
                 {
-                    step = new ComparableStep<byte>((byte)value, (prev, stepValue) => checked((byte)(prev + stepValue)));
+                    step = new ComparableStep<byte>(bValue, (prev, stepValue) => checked((byte)(prev + stepValue)));
                     return true;
                 }
 
                 // ByteValueGenerator is unusual in this regard. We allow byte parameter ranges to start high and end low,
                 // and internally the step is represented as the Int32 value -1 since it can’t be represented as a Byte.
                 // -1 can be converted natively to Int16, SByte and Decimal, so we can fall back on the automatic conversion for them.
-                if (value is int)
+                if (value is int iValue)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((byte)(prev + stepValue)));
+                    step = new ComparableStep<int>(iValue, (prev, stepValue) => checked((byte)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DecimalValueGenerator.cs
@@ -10,9 +10,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is decimal)
+                if (value is decimal dValue)
                 {
-                    step = new ComparableStep<decimal>((decimal)value, (prev, stepValue) =>
+                    step = new ComparableStep<decimal>(dValue, (prev, stepValue) =>
                     {
                         var next = prev + stepValue;
                         if (stepValue > 0 ? next <= prev : prev <= next)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.DoubleValueGenerator.cs
@@ -10,9 +10,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is double)
+                if (value is double dValue)
                 {
-                    step = new ComparableStep<double>((double)value, (prev, stepValue) =>
+                    step = new ComparableStep<double>(dValue, (prev, stepValue) =>
                     {
                         var next = prev + stepValue;
                         if (stepValue > 0 ? next <= prev : prev <= next)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int16ValueGenerator.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is short)
+                if (value is short sValue)
                 {
-                    step = new ComparableStep<short>((short)value, (prev, stepValue) => checked((short)(prev + stepValue)));
+                    step = new ComparableStep<short>(sValue, (prev, stepValue) => checked((short)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int32ValueGenerator.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is int)
+                if (value is int iValue)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked(prev + stepValue));
+                    step = new ComparableStep<int>(iValue, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.Int64ValueGenerator.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is long)
+                if (value is long lValue)
                 {
-                    step = new ComparableStep<long>((long)value, (prev, stepValue) => checked(prev + stepValue));
+                    step = new ComparableStep<long>(lValue, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SByteValueGenerator.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is sbyte)
+                if (value is sbyte sbValue)
                 {
-                    step = new ComparableStep<sbyte>((sbyte)value, (prev, stepValue) => checked((sbyte)(prev + stepValue)));
+                    step = new ComparableStep<sbyte>(sbValue, (prev, stepValue) => checked((sbyte)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.SingleValueGenerator.cs
@@ -10,9 +10,9 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is float)
+                if (value is float fValue)
                 {
-                    step = new ComparableStep<float>((float)value, (prev, stepValue) =>
+                    step = new ComparableStep<float>(fValue, (prev, stepValue) =>
                     {
                         var next = prev + stepValue;
                         if (stepValue > 0 ? next <= prev : prev <= next)

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt16ValueGenerator.cs
@@ -8,15 +8,15 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is ushort)
+                if (value is ushort uValue)
                 {
-                    step = new ComparableStep<ushort>((ushort)value, (prev, stepValue) => checked((ushort)(prev + stepValue)));
+                    step = new ComparableStep<ushort>(uValue, (prev, stepValue) => checked((ushort)(prev + stepValue)));
                     return true;
                 }
 
-                if (value is int)
+                if (value is int iValue)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((ushort)(prev + stepValue)));
+                    step = new ComparableStep<int>(iValue, (prev, stepValue) => checked((ushort)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt32ValueGenerator.cs
@@ -8,15 +8,15 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is uint)
+                if (value is uint uValue)
                 {
-                    step = new ComparableStep<uint>((uint)value, (prev, stepValue) => checked(prev + stepValue));
+                    step = new ComparableStep<uint>(uValue, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 
-                if (value is int)
+                if (value is int iValue)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked((uint)(prev + stepValue)));
+                    step = new ComparableStep<int>(iValue, (prev, stepValue) => checked((uint)(prev + stepValue)));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.UInt64ValueGenerator.cs
@@ -8,15 +8,15 @@ namespace NUnit.Framework.Internal
         {
             public override bool TryCreateStep(object value, out ValueGenerator.Step step)
             {
-                if (value is ulong)
+                if (value is ulong uValue)
                 {
-                    step = new ComparableStep<ulong>((ulong)value, (prev, stepValue) => checked(prev + stepValue));
+                    step = new ComparableStep<ulong>(uValue, (prev, stepValue) => checked(prev + stepValue));
                     return true;
                 }
 
-                if (value is int)
+                if (value is int iValue)
                 {
-                    step = new ComparableStep<int>((int)value, (prev, stepValue) => checked(prev + (ulong)stepValue));
+                    step = new ComparableStep<int>(iValue, (prev, stepValue) => checked(prev + (ulong)stepValue));
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ValueGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/ValueGenerator.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using NUnit.Compatibility;
 
 namespace NUnit.Framework.Internal
 {
@@ -102,8 +101,8 @@ namespace NUnit.Framework.Internal
                 _apply = apply;
             }
 
-            public override bool IsPositive => Comparer<TStep>.Default.Compare(default(TStep), _step) < 0;
-            public override bool IsNegative => Comparer<TStep>.Default.Compare(_step, default(TStep)) < 0;
+            public override bool IsPositive => Comparer<TStep>.Default.Compare(default, _step) < 0;
+            public override bool IsNegative => Comparer<TStep>.Default.Compare(_step, default) < 0;
 
             /// <summary>
             /// Increments the given value and returns the result.

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -85,7 +85,7 @@ namespace NUnit.Framework
         /// </summary>
         public TestAdapter Test
         {
-            get { return _test ?? (_test = new TestAdapter(_testExecutionContext.CurrentTest)); }
+            get { return _test ??= new TestAdapter(_testExecutionContext.CurrentTest); }
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace NUnit.Framework
         /// </summary>
         public ResultAdapter Result
         {
-            get { return _result ?? (_result = new ResultAdapter(_testExecutionContext.CurrentResult)); }
+            get { return _result ??= new ResultAdapter(_testExecutionContext.CurrentResult); }
         }
 
         /// <summary>


### PR DESCRIPTION
A bit of a broad cleanup within the framework to remove unnecessary casts where I found readability wasn't degraded.
While going through I also made a few class-level fields readonly or simplified null checks where I noticed the compiler advising about it. I tried to keep this cleanup focused on changes with a (minor) performance benefit and stayed away from purely stylistic changes.

No corresponding GH issue but I will make one if we prefer, please let me know