### PR TITLE
3.13.3 Regression - CollectionTally correctly handles ImmutableDictionary again

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -170,10 +170,8 @@ namespace NUnit.Framework.Constraints
 
         private static ArrayList ToArrayList(IEnumerable items)
         {
-            if (items is ICollection ic)
-                return new ArrayList(ic);
+            var list = items is ICollection ic ? new ArrayList(ic.Count) : new ArrayList();
 
-            var list = new ArrayList();
             foreach (object o in items)
                 list.Add(o);
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -24,6 +24,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -447,5 +450,17 @@ namespace NUnit.Framework.Constraints
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.EquivalentTo(test2));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -24,6 +24,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -109,5 +113,17 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(subset, Is.SubsetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.SubsetOf(test2));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -24,6 +24,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -185,5 +189,17 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(superSet, Is.SupersetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.SupersetOf(test2));
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes #4095

Allows CollectionTally to work with ImmutableDictionary properly again by avoiding a bulk-add for the ICollection case