### PR TITLE
Cherrypick PR #4097 onto main

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -129,10 +129,8 @@ namespace NUnit.Framework.Constraints
 
         private static ArrayList ToArrayList(IEnumerable items)
         {
-            if (items is ICollection ic)
-                return new ArrayList(ic);
+            var list = items is ICollection ic ? new ArrayList(ic.Count) : new ArrayList();
 
-            var list = new ArrayList();
             foreach (object o in items)
                 list.Add(o);
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -3,6 +3,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -424,5 +427,17 @@ namespace NUnit.Framework.Constraints
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.EquivalentTo(test2));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET35 || NET40)
 using System.Collections.Immutable;
-#endif
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -428,7 +426,6 @@ namespace NUnit.Framework.Constraints
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
-#if !(NET35 || NET40)
         [Test]
         public void WorksWithImmutableDictionary()
         {
@@ -438,6 +435,5 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(test1, Is.EquivalentTo(test2));
         }
-#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET35 || NET40)
 using System.Collections.Immutable;
-#endif
 using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
@@ -93,7 +91,6 @@ namespace NUnit.Framework.Constraints
             Assert.That(subset, Is.SubsetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
 
-#if !(NET35 || NET40)
         [Test]
         public void WorksWithImmutableDictionary()
         {
@@ -103,6 +100,5 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(test1, Is.SubsetOf(test2));
         }
-#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -3,6 +3,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -88,5 +92,17 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(subset, Is.SubsetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.SubsetOf(test2));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET35 || NET40)
 using System.Collections.Immutable;
-#endif
 using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
@@ -167,7 +165,6 @@ namespace NUnit.Framework.Constraints
             Assert.That(superSet, Is.SupersetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
 
-#if !(NET35 || NET40)
         [Test]
         public void WorksWithImmutableDictionary()
         {
@@ -177,6 +174,5 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(test1, Is.SupersetOf(test2));
         }
-#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -3,6 +3,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !(NET35 || NET40)
+using System.Collections.Immutable;
+#endif
+using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.TestUtilities.Collections;
 
@@ -162,5 +166,17 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(superSet, Is.SupersetOf(set).Using<int, string>((i, s) => i.ToString() == s));
         }
+
+#if !(NET35 || NET40)
+        [Test]
+        public void WorksWithImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 3);
+            var test1 = numbers.ToImmutableDictionary(t => t);
+            var test2 = numbers.ToImmutableDictionary(t => t);
+
+            Assert.That(test1, Is.SupersetOf(test2));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -28,9 +28,7 @@ namespace NUnit.Framework.Constraints
             Guid.Empty,
             new SingleElementCollection<int>(),
             new NameValueCollection(),
-#if !NET35 && !NET40
             System.Collections.Immutable.ImmutableArray<int>.Empty,
-#endif
         };
 
         static object[] FailureData = new object[]
@@ -40,9 +38,7 @@ namespace NUnit.Framework.Constraints
             new TestCaseData(new Guid("12345678-1234-1234-1234-123456789012"), "12345678-1234-1234-1234-123456789012"),
             new TestCaseData(new SingleElementCollection<int>(1), "<1>"),
             new TestCaseData(new NameValueCollection { ["Hello"] = "World" }, "< \"Hello\" >"),
-#if !NET35 && !NET40
             new TestCaseData(System.Collections.Immutable.ImmutableArray.Create(1), "< 1 >"),
-#endif
         };
 
         [TestCase(null)]


### PR DESCRIPTION
Contributes to #4095
Migrates the fix from PR #4097 onto v4 / main

Contains 2 extra commits:
- 1 to remove the unneeded net35/40 ifdefs from tests related to the bugfix
- 1 to remove some unneeded net35/40 ifdefs from a test unrelated to the bugfix