### PR TITLE
Fix ParallelizableAttribute with TestFixtureSource

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -107,12 +107,14 @@ namespace NUnit.Framework
             fixtureSuite.ApplyAttributesToTest(typeInfo.Type);
             var assemblyLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type.Assembly);
             var typeLifeCycleAttributeProvider = new AttributeProviderWrapper<FixtureLifeCycleAttribute>(typeInfo.Type);
+            var parallelizableAttributeProvider = new AttributeProviderWrapper<ParallelizableAttribute>(typeInfo.Type);
 
             foreach (ITestFixtureData parms in GetParametersFor(sourceType))
             {
                 TestSuite fixture = _builder.BuildFrom(typeInfo, filter, parms);
                 fixture.ApplyAttributesToTest(assemblyLifeCycleAttributeProvider);
                 fixture.ApplyAttributesToTest(typeLifeCycleAttributeProvider);
+                fixture.ApplyAttributesToTest(parallelizableAttributeProvider);
                 fixtureSuite.Add(fixture);
             }
 

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -7,6 +7,7 @@ using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace NUnit.TestData.TestFixtureSourceData
 {
@@ -508,4 +509,24 @@ public class NoNamespaceTestFixtureSourceWithSingleValue
 #pragma warning disable 414
     static object[] MyData = { 1 };
 #pragma warning restore 414
+}
+
+[TestFixtureSource("Data")]
+[Parallelizable(ParallelScope.All)]
+public class TextFixtureSourceWithParallelizableAttribute
+{
+    public TextFixtureSourceWithParallelizableAttribute(string arg) { }
+
+    static IEnumerable Data()
+    {
+        yield return new TestFixtureData("a");
+        yield return new TestFixtureData("b");
+        yield return new TestFixtureData("c");
+    }
+
+    [Test]
+    public void Test()
+    {
+        Thread.Sleep(1000);
+    }
 }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -165,8 +165,6 @@ namespace NUnit.Framework.Attributes
             Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(GenericFixtureWithConstructorArgsSource.Source.Length));
         }
 
-
-
         [Test]
         public void ParallelizableAttributeOnFixtureSourceIsAppliedToTests()
         {

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -164,5 +164,21 @@ namespace NUnit.Framework.Attributes
             Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
             Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(GenericFixtureWithConstructorArgsSource.Source.Length));
         }
+
+
+
+        [Test]
+        public void ParallelizableAttributeOnFixtureSourceIsAppliedToTests()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(TextFixtureSourceWithParallelizableAttribute));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
+            Assert.That(suite.TestCaseCount, Is.EqualTo(3));
+            Assert.That(suite.Tests.Count, Is.EqualTo(3));
+
+            Assert.That(suite.Tests[0].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+            Assert.That(suite.Tests[1].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+            Assert.That(suite.Tests[2].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+        }
     }
 }


### PR DESCRIPTION
Tests declared like that:

```csharp
[TestFixtureSource("Data")]
[Parallelizable(ParallelScope.All)]
public class TestFixtureSourceWithParallelizableAttribute
```

were no longer run in parallel since that change: https://github.com/nunit/nunit/commit/247ede8aab1f75a99218bcabbe1eae4692b99215

Similar to #3715 I explicitely apply `ParallelizableAttribute` to children tests.

Closes #3735

NB: I couldn't run tests in master branch so I tested in the 3.0 dev branch.