### PR TITLE
Handle Exceptions thrown during discovery, such as in Custom Attributes

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -114,11 +114,9 @@ namespace NUnit.Framework.Internal.Builders
             }
             catch (Exception ex)
             {
-                var fixture = new TestFixture(typeInfo);
                 if (ex is System.Reflection.TargetInvocationException)
                     ex = ex.InnerException;
-
-                fixture.MakeInvalid("An exception was thrown while loading the test." + Environment.NewLine + ex.ToString());
+                var fixture = new TestFixture(typeInfo, ex);
 
                 return fixture;
             }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -23,6 +23,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework.Interfaces;
@@ -105,24 +106,33 @@ namespace NUnit.Framework.Internal.Builders
         {
             var tests = new List<TestMethod>();
 
-            var metadata = MethodInfoCache.Get(method);
-
-            List<ITestBuilder> builders = new List<ITestBuilder>(metadata.TestBuilderAttributes);
-
-            // See if we need to add a CombinatorialAttribute for parameterized data
-            if (method.MethodInfo.GetParameters().Any(param => param.HasAttribute<IParameterDataSource>(false))
-                && !builders.Any(builder => builder is CombiningStrategyAttribute))
-                builders.Add(new CombinatorialAttribute());
-
-            foreach (var attr in builders)
+            try
             {
-                foreach (var test in attr.BuildFrom(method, parentSuite))
-                    tests.Add(test);
-            }
+                var metadata = MethodInfoCache.Get(method);
 
-            return builders.Count > 0 && method.GetParameters().Length > 0 || tests.Count > 0
-                ? BuildParameterizedMethodSuite(method, tests)
-                : BuildSingleTestMethod(method, parentSuite);
+                List<ITestBuilder> builders = new List<ITestBuilder>(metadata.TestBuilderAttributes);
+
+                // See if we need to add a CombinatorialAttribute for parameterized data
+                if (method.MethodInfo.GetParameters().Any(param => param.HasAttribute<IParameterDataSource>(false))
+                    && !builders.Any(builder => builder is CombiningStrategyAttribute))
+                    builders.Add(new CombinatorialAttribute());
+
+                foreach (var attr in builders)
+                {
+                    foreach (var test in attr.BuildFrom(method, parentSuite))
+                        tests.Add(test);
+                }
+
+                return builders.Count > 0 && method.GetParameters().Length > 0 || tests.Count > 0
+                    ? BuildParameterizedMethodSuite(method, tests)
+                    : BuildSingleTestMethod(method, parentSuite);
+            }
+            catch (Exception ex)
+            {
+                var testMethod = new TestMethod(method, parentSuite);
+                testMethod.MakeInvalid(ex, "Failure building Test");
+                return testMethod;
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -367,6 +367,20 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Mark the test as Invalid (not runnable) specifying a reason and an exception.
+        /// </summary>
+        /// <param name="exception">The exception that was the cause.</param>
+        /// <param name="reason">The reason the test is not runnable</param>
+        public void MakeInvalid(Exception exception, string reason)
+        {
+            Guard.ArgumentNotNull(exception, nameof(exception));
+            Guard.ArgumentNotNullOrEmpty(reason, nameof(reason));
+
+            MakeInvalid(reason + Environment.NewLine + ExceptionHelper.BuildMessage(exception));
+            Properties.Add(PropertyNames.ProviderStackTrace, ExceptionHelper.BuildStackTrace(exception));
+        }
+
+        /// <summary>
         /// Get custom attributes applied to a test
         /// </summary>
         public virtual TAttr[] GetCustomAttributes<TAttr>(bool inherit) where TAttr : class

--- a/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs
@@ -23,6 +23,7 @@
 
 #nullable enable
 
+using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
@@ -66,6 +67,17 @@ namespace NUnit.Framework.Internal
         private TestFixture(TestFixture fixture, ITestFilter filter) 
             : base(fixture, filter)
         {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestFixture"/> class that failed to load.
+        /// </summary>
+        /// <param name="fixtureType">Type of the fixture.</param>
+        /// <param name="ex">Exception that was thrown during test discovery.</param>
+        public TestFixture(ITypeInfo fixtureType, Exception ex) : base(fixtureType, null)
+        {
+            MakeInvalid(ex, "Failure building TestFixture");
         }
 
         #endregion

--- a/src/NUnitFramework/testdata/AttributeThrowingExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/AttributeThrowingExceptionFixture.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework;
+
+namespace NUnit.TestData.AttributeThrowingExceptionFixture
+{
+    [TestFixture]
+    public class AttributeOnTestMethodThrowingExceptionFixture
+    {
+        [Test]
+        [ExceptionThrowing(nameof(NormalTest))]
+        public void NormalTest()
+        {
+            Assert.Pass();
+        }
+
+        [Test]
+        [ExceptionThrowing("")]
+        public void TestWithFailingAttribute()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    public class AttributeOnOneTimeSetUpMethodsThrowingExceptionFixture : AttributeOnTestMethodThrowingExceptionFixture
+    {
+        [OneTimeSetUp]
+        [ExceptionThrowing(null)]
+        public void FixtureSetup()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class AttributeOnSetUpMethodsThrowingExceptionFixture : AttributeOnTestMethodThrowingExceptionFixture
+    {
+        [SetUp]
+        [ExceptionThrowing(null)]
+        public void FixtureSetup()
+        {
+        }
+    }
+
+    [TestFixture]
+    [ExceptionThrowing(null)]
+    public class AttributeOnFixtureThrowingExceptionFixture : AttributeOnTestMethodThrowingExceptionFixture
+    {
+    }
+
+    public class ExceptionThrowingAttribute : Attribute
+    {
+        public ExceptionThrowingAttribute(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/AttributeThrowingExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/AttributeThrowingExceptionTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.TestData.AttributeThrowingExceptionFixture;
+using NUnit.TestUtilities;
+
+namespace NUnit.Framework.Internal
+{
+    [TestFixture]
+    public class AttributeThrowingExceptionTests
+    {
+        private static ITestResult RunDataTestCase(string methodName)
+        {
+            return TestBuilder.RunTestCase(typeof(AttributeOnTestMethodThrowingExceptionFixture), methodName);
+        }
+
+        [Test]
+        public void FailRecordsExceptionFromAttribute()
+        {
+            ITestResult result = RunDataTestCase(nameof(AttributeOnTestMethodThrowingExceptionFixture.TestWithFailingAttribute));
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
+            Assert.That(result.Message, Does.Contain("Failure building Test"));
+            Assert.That(result.FullName, Does.Contain(nameof(AttributeOnTestMethodThrowingExceptionFixture.TestWithFailingAttribute)));
+            Assert.That(result.StackTrace, Does.Contain(nameof(ExceptionThrowingAttribute) + "..ctor"));
+        }
+
+        [Test]
+        public void OtherTestCasesRunNormally()
+        {
+            ITestResult result = RunDataTestCase(nameof(AttributeOnTestMethodThrowingExceptionFixture.NormalTest));
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+        }
+
+        [TestCase(typeof(AttributeOnTestMethodThrowingExceptionFixture))]
+        [TestCase(typeof(AttributeOnFixtureThrowingExceptionFixture))]
+        public void TestSuiteContainsAllTests(Type fixtureType)
+        {
+            TestSuite suite = TestBuilder.MakeFixture(fixtureType);
+
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            Assert.That(suite.Tests, Has.Count.EqualTo(2));
+        }
+
+        [TestCase(typeof(AttributeOnOneTimeSetUpMethodsThrowingExceptionFixture))]
+        [TestCase(typeof(AttributeOnSetUpMethodsThrowingExceptionFixture))]
+        public void TestSuiteWithErrorsContainsNoTests(Type fixtureType)
+        {
+            TestSuite suite = TestBuilder.MakeFixture(fixtureType);
+
+            Assert.That(suite.RunState, Is.EqualTo(RunState.NotRunnable));
+            Assert.That(suite.Tests, Has.Count.EqualTo(0));
+
+            ITestResult result = TestBuilder.RunTest(suite);
+            Assert.That(result.ResultState.Status, Is.EqualTo(ResultState.NotRunnable.Status));
+            Assert.That(result.Message, Does.Contain("Failure building TestFixture"));
+            Assert.That(result.FullName, Is.EqualTo(fixtureType.FullName));
+            Assert.That(result.StackTrace, Does.Contain(nameof(ExceptionThrowingAttribute) + "..ctor"));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4096 
Fixes #4107

Tests with Exceptions are Marked As Invalid and show up as an Error.
Fixtures with Exceptions are non-runnable and don't show up with `dotnet test`.

One alternative option would be to make a special fixture with one runable method that fails.