### PR TITLE
Improve XML documentation for `TestCaseSourceAttribute`

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -15,6 +15,12 @@ namespace NUnit.Framework
 {
     /// <summary>
     /// Indicates the source to be used to provide test fixture instances for a test class.
+    /// <list>
+    /// <listheader>The name parameter is a <see cref="string"/> representing the name of the source used to provide test cases. It has the following characteristics:</listheader>
+    /// <item>It must be a static field, property, or method in the same class as the test case.</item>
+    /// <item>It must return an <see cref="IEnumerable"/> or a type that implements <see cref="IEnumerable"/>, such as an array, a <c>List</c>, or your own iterator.</item>
+    /// <item>Each item returned by the enumerator must be compatible with the signature of the method on which the attribute appears.</item>
+    /// </list>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class TestCaseSourceAttribute : NUnitAttribute, ITestBuilder, IImplyFixture
@@ -273,6 +279,6 @@ namespace NUnit.Framework
                                                         ", please check the number of parameters passed in the object is correct in the 3rd parameter for the " +
                                                         "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.";
 
-#endregion
+        #endregion
     }
 }


### PR DESCRIPTION
Closes #4112 

This is similar to some of the content on this page, but with some of the wording changed for brevity: https://docs.nunit.org/articles/nunit/writing-tests/attributes/testcasesource.html

I also hit the automatic format button and fixed the indentation of an `#endregion` to match the others in the file.

Thanks to @mikkelbu for the help.


