### PR TITLE
Enumerate enumerables to determine emptiness

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
         {
             // NOTE: actual is string will fail for a null typed as string
             Type actualType = actual?.GetType() ?? typeof(TActual);
-            
+
             if (actualType == typeof(string))
                 realConstraint = new EmptyStringConstraint();
             else if (actual is Guid || actualType == typeof(Guid?))
@@ -40,10 +40,10 @@ namespace NUnit.Framework.Constraints
                 realConstraint = new EmptyDirectoryConstraint();
             else if (actual is System.Collections.ICollection)
                 realConstraint = new EmptyCollectionConstraint();       // Uses ICollecion.Count
-            else if (CountZeroConstraint.HasCountProperty(actualType))  // For Collections that have Count but are not ICollection
-                realConstraint = new CountZeroConstraint();
             else if (actual is System.Collections.IEnumerable)          // Enumerates whole collection
                 realConstraint = new EmptyCollectionConstraint();
+            else if (CountZeroConstraint.HasCountProperty(actualType))  // For Collections that have Count but are not ICollection
+                realConstraint = new CountZeroConstraint();
             else
                 throw new ArgumentException($"The actual value must be not-null, a string, Guid, have an int Count property, IEnumerable or DirectoryInfo. The value passed was of type {actualType}.", nameof(actual));
 

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using NUnit.TestUtilities;
@@ -29,16 +30,18 @@ namespace NUnit.Framework.Constraints
             new SingleElementCollection<int>(),
             new NameValueCollection(),
             System.Collections.Immutable.ImmutableArray<int>.Empty,
+            new EnumerableWithIndependentCount(1, new int[0])
         };
 
-        static object[] FailureData = new object[]
+        private static object[] FailureData = new object[]
         {
-            new TestCaseData("Hello", "\"Hello\"" ),
-            new TestCaseData(new object[] { 1, 2, 3 }, "< 1, 2, 3 >" ),
+            new TestCaseData("Hello", "\"Hello\""),
+            new TestCaseData(new object[] { 1, 2, 3 }, "< 1, 2, 3 >"),
             new TestCaseData(new Guid("12345678-1234-1234-1234-123456789012"), "12345678-1234-1234-1234-123456789012"),
             new TestCaseData(new SingleElementCollection<int>(1), "<1>"),
             new TestCaseData(new NameValueCollection { ["Hello"] = "World" }, "< \"Hello\" >"),
             new TestCaseData(System.Collections.Immutable.ImmutableArray.Create(1), "< 1 >"),
+            new TestCaseData(new EnumerableWithIndependentCount(0, new[] { 1 }), "< 1 >"),
         };
 
         [TestCase(null)]
@@ -93,7 +96,7 @@ namespace NUnit.Framework.Constraints
                 _element = element;
                 Count = 1;
             }
-            
+
             public T Get()
             {
                 if (Count == 0)
@@ -116,6 +119,21 @@ namespace NUnit.Framework.Constraints
 #pragma warning disable CA1822 // Mark members as static
             public double Count => 0;
 #pragma warning restore CA1822 // Mark members as static
+        }
+
+        private class EnumerableWithIndependentCount : IEnumerable<int>
+        {
+            private readonly IReadOnlyCollection<int> _items;
+            public int Count { get; }
+
+            public EnumerableWithIndependentCount(int count, IReadOnlyCollection<int> items)
+            {
+                _items = items;
+                Count = count;
+            }
+
+            public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 


### PR DESCRIPTION
The usage of the `Count` property can lead to unexpected results
if the `Count` is not in sync with the enumeration.

It makes sense to use the `Count` on a `ICollection` since the interface
clearly connects the `Count` with the enumeration. On any `IEnumerable`,
this assumption is not always correct, though.

fixes #4111