### PR TITLE
Added ContainsAny and DoesNotContainAny to CollectionAssert

### DIFF
--- a/src/NUnitFramework/framework/CollectionAssert.cs
+++ b/src/NUnitFramework/framework/CollectionAssert.cs
@@ -294,6 +294,30 @@ namespace NUnit.Framework
         }
         #endregion
 
+        #region ContainsAny
+        /// <summary>
+        /// Asserts that collection contains any element of another collection.
+        /// </summary>
+        /// <param name="collection">IEnumerable of objects to be considered</param>
+        /// <param name="expected">IEnumerable of Objects to be found within collection</param>
+        public static void ContainsAny(IEnumerable collection, IEnumerable expected)
+        {
+            ContainsAny(collection, expected, string.Empty, null);
+        }
+
+        /// <summary>
+        /// Asserts that collection contains any element of another collection.
+        /// </summary>
+        /// <param name="collection">IEnumerable of objects to be considered</param>
+        /// <param name="expected">IEnumerable of Objects to be found within collection</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static void ContainsAny(IEnumerable collection, IEnumerable expected, string message, params object[] args)
+        {
+            Assert.That(collection, Is.ContainedIn(expected), message, args);
+        }
+        #endregion
+
         #region DoesNotContain
 
         /// <summary>
@@ -316,6 +340,30 @@ namespace NUnit.Framework
         public static void DoesNotContain (IEnumerable collection, Object actual, string message, params object[] args)
         {
             Assert.That(collection, Has.No.Member(actual), message, args);
+        }
+        #endregion
+
+        #region DoesNotContainAny
+        /// <summary>
+        /// Asserts that collection does not contain any element of another collection.
+        /// </summary>
+        /// <param name="collection">IEnumerable of objects to be considered</param>
+        /// <param name="expected">IEnumerable of Objects to be found within collection</param>
+        public static void DoesNotContainAny(IEnumerable collection, IEnumerable expected)
+        {
+            DoesNotContainAny(collection, expected, string.Empty, null);
+        }
+
+        /// <summary>
+        /// Asserts that collection does not contain any element of another collection.
+        /// </summary>
+        /// <param name="collection">IEnumerable of objects to be considered</param>
+        /// <param name="expected">IEnumerable of Objects to be found within collection</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        public static void DoesNotContainAny(IEnumerable collection, IEnumerable expected, string message, params object[] args)
+        {
+            Assert.That(collection, Is.Not.ContainedIn(expected), message, args);
         }
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsAnyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsAnyConstraint.cs
@@ -50,8 +50,6 @@ namespace NUnit.Framework.Constraints
         /// Test whether the actual collection contains an element from
         /// the expected collection provided.
         /// </summary>
-        /// <param name="actual"></param>
-        /// <returns></returns>
         protected override bool Matches(IEnumerable actual)
         {
             CollectionTally tally = Tally(_expected);

--- a/src/NUnitFramework/framework/Constraints/CollectionContainsAnyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionContainsAnyConstraint.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// CollectionContainsAnyConstraint is used to determine whether
+    /// one collection contains any element from another collection
+    /// </summary>
+    public class CollectionContainsAnyConstraint : CollectionItemsEqualConstraint
+    {
+        private readonly IEnumerable _expected;
+        private List<object>? _presentItems;
+
+        /// <summary>
+        /// Construct a CollectionContainsAnyConstraint
+        /// </summary>
+        /// <param name="expected">The collection that any element from the actual collection is expected to be in</param>
+        public CollectionContainsAnyConstraint(IEnumerable expected)
+            : base(expected)
+        {
+            _expected = expected;
+        }
+
+        /// <summary> 
+        /// The display name of this Constraint for use by ToString().
+        /// The default value is the name of the constraint with
+        /// trailing "Constraint" removed. Derived classes may set
+        /// this to another name in their constructors.
+        /// </summary>
+        public override string DisplayName { get { return "ContainsAny"; } }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get { return "contains any from " + MsgUtils.FormatValue(_expected); }
+        }
+
+        /// <summary>
+        /// Test whether the actual collection contains an element from
+        /// the expected collection provided.
+        /// </summary>
+        /// <param name="actual"></param>
+        /// <returns></returns>
+        protected override bool Matches(IEnumerable actual)
+        {
+            CollectionTally tally = Tally(_expected);
+            tally.TryRemove(actual);
+
+            _presentItems = tally.Result.PresentItems;
+
+            return _presentItems.Count > 0;
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value.
+        /// </summary>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            IEnumerable enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
+            bool hasElementPresent = Matches(enumerable);
+            return new CollectionContainsAnyConstraintResult(this, actual, hasElementPresent, _presentItems);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied predicate function
+        /// </summary>
+        /// <param name="comparison">The comparison function to use.</param>
+        /// <returns>Self.</returns>
+        public CollectionContainsAnyConstraint Using<TContainsAnyType, TExpectedType>(Func<TContainsAnyType, TExpectedType, bool> comparison)
+        {
+            // internal code reverses the expected order of the arguments.
+            Func<TExpectedType, TContainsAnyType, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
+            base.Using(EqualityAdapter.For(invertedComparison));
+            return this;
+        }
+
+        #region Private CollectionContainsAnyConstraintResult Class
+
+        private sealed class CollectionContainsAnyConstraintResult : ConstraintResult
+        {
+            private readonly List<object>? _presentItems;
+
+            public CollectionContainsAnyConstraintResult(IConstraint constraint, object actualValue, bool isSuccess, List<object>? extraItems)
+                : base(constraint, actualValue, isSuccess)
+            {
+                _presentItems = extraItems;
+            }
+
+            public override void WriteAdditionalLinesTo(MessageWriter writer)
+            {
+                if (_presentItems?.Count > 0)
+                {
+                    string presentItemsMessage = "Present items: ";
+                    presentItemsMessage += MsgUtils.FormatCollection(_presentItems);
+
+                    writer.WriteMessageLine(presentItemsMessage);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -17,13 +17,17 @@ namespace NUnit.Framework.Constraints
             /// <summary>Items that were not in the expected collection.</summary>
             public List<object> ExtraItems { get; }
 
+            /// <summary>Items that are present in both the expected and actual collections.</summary>
+            public List<object> PresentItems { get; }
+
             /// <summary>Items that were not accounted for in the expected collection.</summary>
             public List<object> MissingItems { get; }
 
             /// <summary>Initializes a new instance of the <see cref="CollectionTallyResult"/> class with the given fields.</summary>
-            public CollectionTallyResult(List<object> missingItems, List<object> extraItems)
+            public CollectionTallyResult(List<object> missingItems, List<object> presentItems, List<object> extraItems)
             {
                 MissingItems = missingItems;
+                PresentItems = presentItems;
                 ExtraItems = extraItems;
             }
         }
@@ -42,6 +46,10 @@ namespace NUnit.Framework.Constraints
                 foreach (var o in _missingItems)
                     missingItems.Add(o);
 
+                var presentItems = new List<object>(_presentItems.Count);
+                foreach (var o in _presentItems)
+                    presentItems.Add(o);
+
                 List<object> extraItems = new List<object>(_extraItems.Count);
                 if (_sorted)
                 {
@@ -53,11 +61,13 @@ namespace NUnit.Framework.Constraints
                     extraItems.AddRange(_extraItems);
                 }
 
-                return new CollectionTallyResult(missingItems, extraItems);
+                return new CollectionTallyResult(missingItems, presentItems, extraItems);
             }
         }
 
         private readonly ArrayList _missingItems = new ArrayList();
+
+        private readonly List<object> _presentItems = new List<object>();
 
         private readonly List<object> _extraItems = new List<object>();
 
@@ -91,6 +101,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (ItemsEqual(_missingItems[index], o))
                 {
+                    _presentItems.Add(o);
                     _missingItems.RemoveAt(index);
                     return;
                 }

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -771,6 +771,19 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
+        #region ContainedIn
+
+        /// <summary>
+        /// Returns a constraint that tests whether the actual value
+        /// contains an item of the collection supplied as an argument.
+        /// </summary>
+        public CollectionContainsAnyConstraint ContainedIn(IEnumerable expected)
+        {
+            return (CollectionContainsAnyConstraint)this.Append(new CollectionContainsAnyConstraint(expected));
+        }
+
+        #endregion
+
         #region DictionaryContains
         /// <summary>
         /// Returns a new DictionaryContainsKeyConstraint checking for the
@@ -972,7 +985,6 @@ namespace NUnit.Framework.Constraints
         {
             return this.Append(new IndexerOperator(indexArgs));
         }
-
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -373,6 +373,19 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region ContainedIn
+
+        /// <summary>
+        /// Returns a constraint that tests whether the actual value
+        /// contains a value from the collection supplied as an argument.
+        /// </summary>
+        public static CollectionContainsAnyConstraint ContainedIn(IEnumerable expected)
+        {
+            return new CollectionContainsAnyConstraint(expected);
+        }
+
+        #endregion
+
         #region SubsetOf
 
         /// <summary>

--- a/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using NUnit.TestUtilities.Collections;
 using NUnit.TestUtilities.Comparers;
@@ -561,6 +562,96 @@ namespace NUnit.Framework.Assertions
         }
 #endregion
 
+#region ContainsAny
+        [Test]
+        public void ContainsAny_IList()
+        {
+            var list = new SimpleObjectList("x", "y", "z");
+            var expected = new SimpleObjectList("x", "y");
+            CollectionAssert.ContainsAny(list, expected);
+        }
+
+        [Test]
+        public void ContainsAny_ICollection()
+        {
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            var expected = new SimpleObjectCollection("x", "y");
+            CollectionAssert.ContainsAny(collection,expected);
+        }
+
+        [Test]
+        public void ContainsAnyFails_ILIst()
+        {
+            var list = new SimpleObjectList("x", "y", "z");
+            var expected = new SimpleObjectList("a", "b", "c");
+
+            var expectedMessage =
+                "  Expected: contains any from < \"a\", \"b\", \"c\" >" + Environment.NewLine +
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.ContainsAny(list,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void ContainsAnyFails_ICollection()
+        {
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            var expected = new SimpleObjectCollection("a", "b", "c");
+
+            var expectedMessage =
+                "  Expected: contains any from < \"a\", \"b\", \"c\" >" + Environment.NewLine +
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.ContainsAny(collection,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void ContainsAnyFails_EmptyIList()
+        {
+            var list = new SimpleObjectList();
+            var expected = new SimpleObjectList("x");
+
+            var expectedMessage =
+                "  Expected: contains any from < \"x\" >" + Environment.NewLine +
+                "  But was:  <empty>" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.ContainsAny(list,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void ContainsAnyFails_EmptyICollection()
+        {
+            var ca = new SimpleObjectCollection(Array.Empty<object>());
+            var expected = new SimpleObjectCollection("x");
+
+            var expectedMessage =
+                "  Expected: contains any from < \"x\" >" + Environment.NewLine +
+                "  But was:  <empty>" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.ContainsAny(ca,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void ContainsAnyNull_IList()
+        {
+            Object[] oa = new object[] { 1, 2, 3, null, 4, 5 };
+            Object[] expected = new object[] {null};
+            CollectionAssert.ContainsAny( oa, expected);
+        }
+
+        [Test]
+        public void ContainsAnyNull_ICollection()
+        {
+            var ca = new SimpleObjectCollection(new object[] { 1, 2, 3, null, 4, 5 });
+            var expected = new SimpleObjectCollection(new object[] {null});
+            CollectionAssert.ContainsAny( ca, expected );
+        }
+#endregion
+
 #region DoesNotContain
         [Test]
         public void DoesNotContain()
@@ -624,6 +715,98 @@ namespace NUnit.Framework.Assertions
 
             CollectionAssert.IsSubsetOf(set2,set1);
             Assert.That(set2, Is.SubsetOf(set1));
+        }
+#endregion
+
+#region DoesNotContainAny
+        [Test]
+        public void DoesNotContainAny_IList()
+        {
+            var list = new SimpleObjectList("x", "y", "z");
+            var expected = new SimpleObjectList("a", "b");
+            CollectionAssert.DoesNotContainAny(list, expected);
+        }
+
+        [Test]
+        public void DoesNotContainAny_ICollection()
+        {
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            var expected = new SimpleObjectCollection("a", "b");
+            CollectionAssert.DoesNotContainAny(collection,expected);
+        }
+
+        [Test]
+        public void DoesNotContainAnyFails_ILIst()
+        {
+            var list = new SimpleObjectList("x", "y", "z");
+            var expected = new SimpleObjectList("x", "b", "c");
+
+            var expectedMessage =
+                "  Expected: not contains any from < \"x\", \"b\", \"c\" >" + Environment.NewLine +
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContainAny(list,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void DoesNotContainAnyFails_ICollection()
+        {
+            var collection = new SimpleObjectCollection("x", "y", "z");
+            var expected = new SimpleObjectCollection("x", "b", "c");
+
+            var expectedMessage =
+                "  Expected: not contains any from < \"x\", \"b\", \"c\" >" + Environment.NewLine +
+                "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContainAny(collection,expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void DoesNotContainAny_EmptyIList()
+        {
+            var list = new SimpleObjectList("x");
+            var expected = new SimpleObjectList();
+
+            CollectionAssert.DoesNotContainAny(list, expected);
+        }
+
+        [Test]
+        public void DoesNotContainAny_EmptyICollection()
+        {
+            var ca = new SimpleObjectCollection("x");
+            var expected = new SimpleObjectCollection(Array.Empty<object>());
+
+            CollectionAssert.DoesNotContainAny(ca, expected);
+        }
+
+        [Test]
+        public void DoesNotContainAnyNull_IList()
+        {
+            Object[] oa = new object[] { 1, 2, 3, null, 4, 5 };
+            Object[] expected = new object[] { null };
+
+            var expectedMessage =
+                "  Expected: not contains any from < null >" + Environment.NewLine +
+                "  But was:  < 1, 2, 3, null, 4, 5 >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContainAny(oa, expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public void DoesNotContainAnyNull_ICollection()
+        {
+            var ca = new SimpleObjectCollection(new object[] { 1, 2, 3, null, 4, 5 });
+            var expected = new SimpleObjectCollection(new object[] {null});
+
+            var expectedMessage =
+                "  Expected: not contains any from < null >" + Environment.NewLine +
+                "  But was:  < 1, 2, 3, null, 4, 5 >" + Environment.NewLine;
+
+            var ex = Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContainAny(ca, expected));
+            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 #endregion
 


### PR DESCRIPTION
Mentioned in #4187 - Added feature to allow CollectionAssert to verify if a  IEnumerable contains any or does not contain any elements from a provided IEnumerable