### PR TITLE
Indicate that SetupFixtureAttribute should not be used on base-classes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework
     /// <see cref="OneTimeTearDownAttribute" /> methods for all the test fixtures
     /// under a given namespace.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class SetUpFixtureAttribute : NUnitAttribute, IFixtureBuilder
     {
         #region ISuiteBuilder Members

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.7.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>
 

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -82,6 +82,15 @@ namespace NUnit.Framework.Attributes
                 Assert.That(fixture.RunState, Is.EqualTo(RunState.Runnable));
         }
 
+        [Test]
+        public void AttributeUsage_NoInheritance()
+        {
+            var usageAttrib = Attribute.GetCustomAttribute(typeof(SetUpFixtureAttribute), typeof(AttributeUsageAttribute)) as AttributeUsageAttribute;
+
+            Assert.NotNull(usageAttrib);
+            Assert.False(usageAttrib.Inherited);
+        }
+
         private static class StaticSetupClass
         {
             [OneTimeSetUp]


### PR DESCRIPTION
As discussed in #4158. This PR contains the changes for NUnit v3.