### PR TITLE
Multi-rank arrays equivalency tests

### DIFF
--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -435,5 +435,17 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(test1, Is.EquivalentTo(test2));
         }
+
+        [Test(Description = "Issue #4252 - CollectionAssert.AreEquivalent with multidimensional arrays throws System.RankException")]
+        public void WorksWithMultiRankArray()
+        {
+            var expected = new string[,,] { { { "value1", "value2", "value3" } } };
+            var actual = new string[,,] { { { "value2", "value3", "value1" } } };
+
+            var constraint = new CollectionEquivalentConstraint(expected);
+            var constraintResult = constraint.ApplyTo(actual);
+
+            Assert.That(constraintResult.IsSuccess, Is.True);
+        }
     }
 }


### PR DESCRIPTION
Related to #4252

This is broken in 3.13.3 but fixed already in the unreleased 3.13.4 + main via https://github.com/nunit/nunit/issues/4095
This will be a test to verify against a future functional regressions.
