### PR TITLE
add [NotNull] to Assert.NotNull

### DIFF
--- a/src/NUnitFramework/framework/Assert.Conditions.cs
+++ b/src/NUnitFramework/framework/Assert.Conditions.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using NUnit.Framework.Constraints;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NUnit.Framework
 {
@@ -187,6 +188,7 @@ namespace NUnit.Framework
 
         #region NotNull
 
+#pragma warning disable CS8777
         /// <summary>
         /// Verifies that the object that is passed in is not equal to <see langword="null"/>. Returns without throwing an
         /// exception when inside a multiple assert block.
@@ -194,9 +196,9 @@ namespace NUnit.Framework
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotNull(object? anObject, string? message, params object?[]? args)
+        public static void NotNull([NotNull] object? anObject, string? message, params object?[]? args)
         {
-            Assert.That(anObject, Is.Not.Null ,message, args);
+            Assert.That(anObject, Is.Not.Null, message, args);
         }
 
         /// <summary>
@@ -204,7 +206,7 @@ namespace NUnit.Framework
         /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void NotNull(object? anObject)
+        public static void NotNull([NotNull]object? anObject)
         {
             Assert.That(anObject, Is.Not.Null ,null, null);
         }
@@ -216,7 +218,7 @@ namespace NUnit.Framework
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotNull(object? anObject, string? message, params object?[]? args)
+        public static void IsNotNull([NotNull] object? anObject, string? message, params object?[]? args)
         {
             Assert.That(anObject, Is.Not.Null ,message, args);
         }
@@ -226,11 +228,12 @@ namespace NUnit.Framework
         /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="anObject">The object that is to be tested</param>
-        public static void IsNotNull(object? anObject)
+        public static void IsNotNull([NotNull] object? anObject)
         {
             Assert.That(anObject, Is.Not.Null ,null, null);
         }
 
+#pragma warning restore CS8777
         #endregion
 
         #region Null


### PR DESCRIPTION
so the compiler knows the value is not null when the mothod returns (doesnt throw)