### PR TITLE
Add Assert.Charlie() -- Commemorating Charlie Poole's Contributions to the NUnit Project

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -113,16 +113,16 @@ namespace NUnit.Framework
 
         #endregion
 
-            #region Pass
+        #region Pass
 
-            /// <summary>
-            /// Throws a <see cref="SuccessException"/> with the message and arguments
-            /// that are passed in. This allows a test to be cut short, with a result
-            /// of success returned to NUnit.
-            /// </summary>
-            /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-            /// <param name="args">Arguments to be used in formatting the message</param>
-            [DoesNotReturn]
+        /// <summary>
+        /// Throws a <see cref="SuccessException"/> with the message and arguments
+        /// that are passed in. This allows a test to be cut short, with a result
+        /// of success returned to NUnit.
+        /// </summary>
+        /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
+        /// <param name="args">Arguments to be used in formatting the message</param>
+        [DoesNotReturn]
         static public void Pass(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -63,41 +63,7 @@ namespace NUnit.Framework
 
         #region Charlie
 
-        private const string CHARLIE_APPRECIATION = "Charlie Poole was the lead of NUnit for 21+ years, across at least 207 releases in 37 different repositories, authoring 4,898 commits across them. He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure. And those numbers don't include at least 9 additional years of his work. This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.";
-        /// <summary>
-        /// An alias of the Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
-        /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
-        /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
-        /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
-        /// which means there are at least 9 additional years of work not quantified above.
-        ///
-        /// This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.
-        /// </summary>
-        /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        /// <param name="args">Arguments to be used in formatting the message</param>
-        [DoesNotReturn]
-        static public void Charlie(string? message, params object?[]? args)
-        {
-            // NOTE: regardless of what message is passed in, we output the Charlie appreciation. We keep the same structure as Assert.Pass
-            Assert.Pass(CHARLIE_APPRECIATION, args);
-        }
-
-        /// <summary>
-        /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
-        /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
-        /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
-        /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
-        /// which means there are at least 9 additional years of work not quantified above.
-        ///
-        /// This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.
-        /// </summary>
-        /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        [DoesNotReturn]
-        static public void Charlie(string? message)
-        {
-            // NOTE: regardless of what message is passed in, we output the Charlie appreciation.
-            Assert.Pass(CHARLIE_APPRECIATION);
-        }
+        private const string CHARLIE_APPRECIATION = "Charlie Poole led NUnit for 20+ years, across at least 207 releases in 37 different repositories, authoring 4,898 commits across them. He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure. And those numbers don't include at least 9 additional years of his work. This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.";
 
         /// <summary>
         /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -63,8 +63,9 @@ namespace NUnit.Framework
 
         #region Charlie
 
+        private const string CHARLIE_APPRECIATION = "Charlie Poole was the lead of NUnit for 21+ years, across at least 207 releases in 37 different repositories, authoring 4,898 commits across them. He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure. And those numbers don't include at least 9 additional years of his work. This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.";
         /// <summary>
-        /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
+        /// An alias of the Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
         /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
         /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
         /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
@@ -77,7 +78,8 @@ namespace NUnit.Framework
         [DoesNotReturn]
         static public void Charlie(string? message, params object?[]? args)
         {
-            Assert.Pass(message, args);
+            // NOTE: regardless of what message is passed in, we output the Charlie appreciation. We keep the same structure as Assert.Pass
+            Assert.Pass(CHARLIE_APPRECIATION, args);
         }
 
         /// <summary>
@@ -93,7 +95,8 @@ namespace NUnit.Framework
         [DoesNotReturn]
         static public void Charlie(string? message)
         {
-            Assert.Pass(message);
+            // NOTE: regardless of what message is passed in, we output the Charlie appreciation.
+            Assert.Pass(CHARLIE_APPRECIATION);
         }
 
         /// <summary>
@@ -108,7 +111,7 @@ namespace NUnit.Framework
         [DoesNotReturn]
         static public void Charlie()
         {
-            Assert.Pass();
+            Assert.Pass(CHARLIE_APPRECIATION);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -61,16 +61,68 @@ namespace NUnit.Framework
 
         #endregion
 
-        #region Pass
+        #region Charlie
 
         /// <summary>
-        /// Throws a <see cref="SuccessException"/> with the message and arguments
-        /// that are passed in. This allows a test to be cut short, with a result
-        /// of success returned to NUnit.
+        /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
+        /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
+        /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
+        /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
+        /// which means there are at least 9 additional years of work not quantified above.
+        ///
+        /// This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
         [DoesNotReturn]
+        static public void Charlie(string? message, params object?[]? args)
+        {
+            Assert.Pass(message, args);
+        }
+
+        /// <summary>
+        /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
+        /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
+        /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
+        /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
+        /// which means there are at least 9 additional years of work not quantified above.
+        ///
+        /// This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.
+        /// </summary>
+        /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
+        [DoesNotReturn]
+        static public void Charlie(string? message)
+        {
+            Assert.Pass(message);
+        }
+
+        /// <summary>
+        /// An alias of the corresponding Assert.Pass() method. Charlie Poole was the lead of NUnit for 21 years,
+        /// across at least 207 releases in 37 different repositories, authoring 4,898 commits across them.
+        /// He participated in 2,990 issues, 1,305 PRs, and impacted 6,992,983 lines of code. NUnit was downloaded from NuGet 225+ million times during his tenure.
+        /// And those are only the numbers ones we can easily find; our numbers are sourced from after NUnit moved the project to GitHub in 2011,
+        /// which means there are at least 9 additional years of work not quantified above.
+        ///
+        /// This assertion attempts to pay homage to Charlie, who by virtue of his contributions has helped untold millions of tests pass.
+        /// </summary>
+        [DoesNotReturn]
+        static public void Charlie()
+        {
+            Assert.Pass();
+        }
+
+        #endregion
+
+            #region Pass
+
+            /// <summary>
+            /// Throws a <see cref="SuccessException"/> with the message and arguments
+            /// that are passed in. This allows a test to be cut short, with a result
+            /// of success returned to NUnit.
+            /// </summary>
+            /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
+            /// <param name="args">Arguments to be used in formatting the message</param>
+            [DoesNotReturn]
         static public void Pass(string? message, params object?[]? args)
         {
             if (message == null) message = string.Empty;


### PR DESCRIPTION
ℹ️❤️: Please be sure to visit https://github.com/nunit/nunit/discussions/4283 and tell us how NUnit has impacted you, your career, or your organization.

As discussed at <https://nunit.org/news/update/nunit/2023/01/29/celebrating-charlie-poole.html>:

> Announcing Assert.Charlie() – Permanently Celebrating Charlie’s Work
> 
> Charlie’s fingerprints will remain on this project forever, but we wanted to pay a more direct tribute to him. We will be adding a method, Assert.Charlie(), which will be an alias of Assert.Pass() but will also output a message of thanks. We’re doing this to celebrate the countless tests that Charlie has helped bring into being via his enduring love for this library, and the resulting impact on the .NET Community.

This idea has been signed off on by the core team and this PR will merge as soon as it's been validated / checked like a standard PR would be.