### PR TITLE
Backport PR #4014 to fix Issue #3964 (DictionaryContainsKeyValuePairConstraint supports generic IDictionary)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -21,7 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -61,12 +64,34 @@ namespace NUnit.Framework.Constraints
 
         private bool Matches(object actual)
         {
-            var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
-            foreach (var entry in dictionary)
-                if (ItemsEqual(entry, _expected))
-                    return true;
+            if (actual == null)
+                throw new ArgumentException("Expected: IDictionary But was: null", nameof(actual));
 
-            return false;
+            if (TypeHelper.TryCast<IDictionary>(actual, out var dictionary))
+            {
+                foreach (var entry in dictionary)
+                    if (ItemsEqual(entry, _expected))
+                        return true;
+                return false;
+            }
+
+            // If 'actual' implements IDictionary<TKey, TValue>, construct an 'expected' KeyValuePair<TKey, TValue>
+            // and look it up by iterating using IEnumerable
+            if (actual.GetType().GetInterfaces().Any(i => i.FullName.StartsWith("System.Collections.Generic.IDictionary`2[")))
+            {
+                var expected = new KeyValuePair<object, object>(_expected.Key, _expected.Value);
+                var enumerable = actual as IEnumerable;
+
+                foreach (var item in enumerable)
+                {
+                    if (ItemsEqual(item, expected))
+                        return true;
+                }
+
+                return false;
+            }
+
+            throw new ArgumentException($"Expected: IDictionary But was: {actual.GetType()}", nameof(actual));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
 
             // If 'actual' implements IDictionary<TKey, TValue>, construct an 'expected' KeyValuePair<TKey, TValue>
             // and look it up by iterating using IEnumerable
-            if (actual.GetType().GetInterfaces().Any(i => i.FullName.StartsWith("System.Collections.Generic.IDictionary`2[")))
+            if (actual.GetType().GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
             {
                 var expected = new KeyValuePair<object, object>(_expected.Key, _expected.Value);
                 var enumerable = actual as IEnumerable;

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -83,11 +83,8 @@ namespace NUnit.Framework.Constraints
                 var enumerable = actual as IEnumerable;
 
                 foreach (var item in enumerable)
-                {
                     if (ItemsEqual(item, expected))
                         return true;
-                }
-
                 return false;
             }
 

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -23,8 +23,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-
-using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -111,7 +109,7 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
-        public void SucceedsWithTypeThatImplementsGenericIDictionary()
+        public void WorksWithTypeThatImplementsGenericIDictionary()
         {
             var dictionary = new TestDictionary()
             {
@@ -120,6 +118,8 @@ namespace NUnit.Framework.Constraints
                 { 3, "Mundo" }
             };
             Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint(3, "Mundo"));
+            Assert.That(dictionary, Does.ContainKey(2).WithValue("Universe"));
+            Assert.That(dictionary, Does.Not.ContainKey(1).WithValue("Universe"));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Constraints
         {
             TestDictionary dictionary = null;
 
-            TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("1", "hello"));
+            TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("1", "World"));
 
             Assert.That(act, Throws.ArgumentException.With.Message.Contains("Expected: IDictionary But was: null"));
         }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -120,6 +120,7 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint(3, "Mundo"));
             Assert.That(dictionary, Does.ContainKey(2).WithValue("Universe"));
             Assert.That(dictionary, Does.Not.ContainKey(1).WithValue("Universe"));
+
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -109,5 +109,96 @@ namespace NUnit.Framework.Constraints
             Assert.That(dictionary,
                 new DictionaryContainsKeyValuePairConstraint("HI", "UNIVERSE").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
         }
+
+        [Test]
+        public void SucceedsWithTypeThatImplementsGenericIDictionary()
+        {
+            var dictionary = new TestDictionary()
+            {
+                { 1, "hello" },
+                { 2, "goodbye" },
+                { 3, "hello" },
+                { 4, "goodbye" },
+            };
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint(3, "hello"));
+        }
+
+        [Test]
+        public void FailsWhenNullDictionary()
+        {
+            TestDictionary dictionary = null;
+
+            TestDelegate act = () => Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("1", "hello"));
+
+            Assert.That(act, Throws.ArgumentException.With.Message.Contains("Expected: IDictionary But was: null"));
+        }
+
+        class TestDictionary : IDictionary<int, string>
+        {
+            private readonly Dictionary<int, string> _internalDictionary = new Dictionary<int, string>();
+
+            public string this[int key]
+            {
+                get => _internalDictionary[key];
+                set => _internalDictionary[key] = value;
+            }
+
+            public ICollection<int> Keys => throw new System.NotImplementedException();
+
+            public ICollection<string> Values => throw new System.NotImplementedException();
+
+            public int Count => throw new System.NotImplementedException();
+
+            public bool IsReadOnly => throw new System.NotImplementedException();
+
+            public void Add(int key, string value) => _internalDictionary.Add(key, value);
+
+            public void Add(KeyValuePair<int, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<int, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool ContainsKey(int key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<int, string>[] array, int arrayIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove(int key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<int, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetValue(int key, out string value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => _internalDictionary.GetEnumerator();
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -115,12 +115,11 @@ namespace NUnit.Framework.Constraints
         {
             var dictionary = new TestDictionary()
             {
-                { 1, "hello" },
-                { 2, "goodbye" },
-                { 3, "hello" },
-                { 4, "goodbye" },
+                { 1, "World" },
+                { 2, "Universe" },
+                { 3, "Mundo" }
             };
-            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint(3, "hello"));
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint(3, "Mundo"));
         }
 
         [Test]


### PR DESCRIPTION
A backport of PR #4014 to fix #3964 in v3.13.
Unit tests passed locally for me.