### PR TITLE
Add TestMetadataCache to improve CompositeWorkItem build speed

### DIFF
--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/CompositeWorkItemBenchmark.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/CompositeWorkItemBenchmark.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework.Api;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Abstractions;
+using NUnit.Framework.Internal.Execution;
+
+namespace NUnit.Framework;
+
+[MemoryDiagnoser]
+public class CompositeWorkItemBenchmark
+{
+    private Dictionary<string, object> _loaderOptions;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _loaderOptions = new Dictionary<string, object>
+        {
+            { "ProcessModel", "InProcess" },
+            { "DomainUsage", "None" },
+            { "ShadowCopyFiles", false },
+            { "TestParametersDictionary", "" },
+            { "NumberOfTestWorkers", 0 },
+            { "SynchronousEvents", "false" },
+            { "RandomSeed", 878248866 },
+            { "LOAD", new List<string> { "NUnit.Framework.TestWithTestActionAttribute" } },
+            { "WorkDirectory", Path.GetTempPath() },
+        };
+    }
+
+    [Benchmark]
+    public void TestActionUsage()
+    {
+        DefaultTestAssemblyBuilder builder = new DefaultTestAssemblyBuilder();
+        var test = builder.Build(typeof(TestWithTestActionAttribute).Assembly, _loaderOptions);
+        WorkItem workItem = WorkItemBuilder.CreateWorkItem(test, TestFilter.Empty, new DebuggerProxy(), recursive: true);
+        var context = new TestExecutionContext();
+        context.Dispatcher = new SuperSimpleDispatcher();
+        workItem.InitializeContext(context);
+        workItem.Execute();
+    }
+}
+
+[SomeTestAttr]
+[TestFixtureSource(nameof(_fixtureArgs))]
+public class TestWithTestActionAttribute
+{
+    private static object[] _fixtureArgs = Enumerable.Range(0, 100)
+                                                     .Select(a => new object[] { $"a{a:000}" })
+                                                     .ToArray();
+
+    public TestWithTestActionAttribute(string arg) { }
+
+    [Test]
+    public void Test1([Range(0, 10)] int x) { }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class SomeTestAttrAttribute : Attribute, ITestAction
+{
+    private object _data = Enumerable.Range(0, 1000000).ToArray();
+
+    public SomeTestAttrAttribute()
+    {
+    }
+
+    public void BeforeTest(ITest test) { }
+
+    public void AfterTest(ITest test) { }
+
+    public ActionTargets Targets { get; }
+}
+
+internal sealed class SuperSimpleDispatcher : IWorkItemDispatcher
+{
+    public int LevelOfParallelism => 0;
+
+    public void Start(WorkItem topLevelWorkItem) => topLevelWorkItem.Execute();
+
+    public void Dispatch(WorkItem work) => work.Execute();
+
+    public void CancelRun(bool force) => throw new NotImplementedException();
+}

--- a/src/NUnitFramework/framework/Internal/Builders/TestMetadataCache.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/TestMetadataCache.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal.Builders
+{
+    /// <summary>
+    /// Caches static information for ITestAction to reduce re-calculations and memory allocations from reflection.
+    /// </summary>
+    internal static class TestMetadataCache
+    {
+        private static readonly ConcurrentDictionary<Type, TestMetadata> Cache = new();
+
+        /// <summary>
+        /// Returns cached metadata for method instance.
+        /// </summary>
+        internal static TestMetadata Get(Type testType)
+        {
+            return Cache.GetOrAdd(testType, static m => new TestMetadata(m));
+        }
+
+        /// <summary>
+        /// Memoization of Test information to reduce subsequent allocations from parameter and attribute information.
+        /// </summary>
+        internal sealed class TestMetadata
+        {
+            public TestMetadata(Type testType)
+            {
+                TestActionAttributes = GetActionsForType(testType);
+            }
+
+            public ITestAction[] TestActionAttributes { get; }
+
+            private static ITestAction[] GetActionsForType(Type type)
+            {
+                if (type == null || type == typeof(object))
+                {
+                    return Array.Empty<ITestAction>();
+                }
+
+                var actions = new List<ITestAction>();
+
+                actions.AddRange(GetActionsForType(type.GetTypeInfo().BaseType));
+
+                foreach (Type interfaceType in TypeHelper.GetDeclaredInterfaces(type))
+                    actions.AddRange(interfaceType.GetTypeInfo().GetAttributes<ITestAction>(false));
+
+                actions.AddRange(type.GetTypeInfo().GetAttributes<ITestAction>(false));
+
+                return actions.ToArray();
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -282,7 +282,7 @@ namespace NUnit.Framework.Internal
                     // Otherwise we just get the attributes
                     if (Method == null && TypeInfo != null)
                     {
-                        _actions = GetActionsForType(TypeInfo.Type);
+                        _actions = TestMetadataCache.Get(TypeInfo.Type).TestActionAttributes;
                     }
                     else if (Method != null)
                     {
@@ -412,27 +412,6 @@ namespace NUnit.Framework.Internal
                 yield return current;
                 current = current.DeclaringType;
             }
-        }
-
-#endregion
-
-#region Private Methods
-
-        private static ITestAction[] GetActionsForType(Type type)
-        {
-            var actions = new List<ITestAction>();
-
-            if (type != null && type != typeof(object))
-            {
-                actions.AddRange(GetActionsForType(type.BaseType));
-
-                foreach (Type interfaceType in TypeHelper.GetDeclaredInterfaces(type))
-                    actions.AddRange(interfaceType.GetAttributes<ITestAction>(false));
-
-                actions.AddRange(type.GetAttributes<ITestAction>(false));
-            }
-
-            return actions.ToArray();
         }
 
 #endregion


### PR DESCRIPTION
Addresses high memory usage reported in #3858 . Adds `TestCache` the same way there is `MethodInfoCache` and caches the action attributes just like in method info cache - other cached items could be added later if needed. 

``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1343/22H2/2022Update/SunValley2)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.114
  [Host]     : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2


```

## Before

|          Method |     Mean |   Error |  StdDev |     Gen0 |     Gen1 |     Gen2 | Allocated |
|---------------- |---------:|--------:|--------:|---------:|---------:|---------:|----------:|
| TestActionUsage | 161.4 ms | 3.19 ms | 5.76 ms | 750.0000 | 500.0000 | 500.0000 | 386.22 MB |

## After

|          Method |     Mean |     Error |    StdDev |     Gen0 |     Gen1 | Allocated |
|---------------- |---------:|----------:|----------:|---------:|---------:|----------:|
| TestActionUsage | 8.975 ms | 0.1141 ms | 0.1068 ms | 281.2500 | 140.6250 |   4.71 MB |
