### PR TITLE
Fix open generic type deductions

### DIFF
--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -265,7 +265,7 @@ namespace NUnit.Framework.Internal
                 {
                     for (int j = 0; j < arglist.Length; j++)
                     {
-                        if (typeParameters[i].IsGenericParameter || parameters[j].ParameterType.Equals(typeParameters[i]))
+                        if (parameters[j].ParameterType.Equals(typeParameters[i]))
                         {
                             if (!TypeHelper.TryGetBestCommonType(
                                 typeArgs[i],

--- a/src/NUnitFramework/tests/Internal/DeduceTypeArgsFromArgs.cs
+++ b/src/NUnitFramework/tests/Internal/DeduceTypeArgsFromArgs.cs
@@ -23,6 +23,8 @@ namespace NUnit.Framework.Internal
         {
             Assert.That(t1, Is.TypeOf<T1>());
             Assert.That(t2, Is.TypeOf<T2>());
+            Assert.That(t1 is int || t2 is int);
+            Assert.That(t1 is double || t2 is double);
         }
     }
 }


### PR DESCRIPTION
Closes #4243 

When I investigated why it was resolving to double, double, I found that it would try to get the best common type twice for each type args because of this `IsGenericParameter` condition rather than match them via their underlying type. I found it odd: why would it try to check matches between the first arg with the second type param and the second arg with the first one?

I ran some git blame and I found that this if was added as a result of #358 and while I am not too familiar with the project's history, I did some research and it seems NETCF support was removed in this repository a long time ago. It seems to me that it was added due to generics being weirder to support on that platform, but since it isn't supported anymore, it seems that it should be removed if it causes problems which I think it does here.