### PR TITLE
Ensure tolerance is available to EqualityAdapters and is not silently ignored

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -15,6 +15,8 @@ namespace NUnit.Framework.Constraints.Comparers
         {
             if (equalityComparer.CompareAsCollection && state.TopLevelComparison)
                 return null;
+            if (tolerance != null && tolerance.HasVariance)
+                return null;
 
             Type xType = x.GetType();
             Type yType = y.GetType();

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Constraints
             StringBuilder sb = new StringBuilder(comparisonText);
             sb.Append(MsgUtils.FormatValue(_expected));
                 
-            if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
+            if (_tolerance != null && _tolerance.HasVariance)
             {
                 sb.Append(" within ");
                 sb.Append(MsgUtils.FormatValue(_tolerance.Amount));

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -373,7 +373,7 @@ namespace NUnit.Framework.Constraints
             {
                 System.Text.StringBuilder sb = new System.Text.StringBuilder(MsgUtils.FormatValue(_expected));
 
-                if (_tolerance != null && !_tolerance.IsUnsetOrDefault)
+                if (_tolerance != null && _tolerance.HasVariance)
                 {
                     sb.Append(" +/- ");
                     sb.Append(MsgUtils.FormatValue(_tolerance.Amount));

--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -23,6 +23,24 @@ namespace NUnit.Framework.Constraints
         public abstract bool AreEqual(object x, object y);
 
         /// <summary>
+        /// Compares two objects, within a tolerance returning true if they are equal
+        /// </summary>
+        public virtual bool AreEqual(object x, object y, ref Tolerance tolerance)
+        {
+            // For backwards compatibility all existing equality operators can continue
+            // to use the existing AreEqual.  Attempting to use a tolerance when it's
+            // not supported is now thrown to the caller, rather than silently ignored.
+            if (!tolerance.HasVariance)
+            {
+                return AreEqual(x, y);
+            }
+            else
+            {
+                throw new InvalidOperationException("Tolerance is not supported for this comparison");
+            }
+        }
+
+        /// <summary>
         /// Returns true if the two objects can be compared by this adapter.
         /// The base adapter cannot handle IEnumerables except for strings.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -155,14 +155,20 @@ namespace NUnit.Framework.Constraints
                 return false;
 
             EqualityAdapter externalComparer = GetExternalComparer(x, y);
+
             if (externalComparer != null)
-                return externalComparer.AreEqual(x, y);
+                return externalComparer.AreEqual(x, y, ref tolerance);
 
             foreach (EqualMethod equalMethod in _comparers)
             {
                 bool? result = equalMethod(x, y, ref tolerance, state, this);
                 if (result.HasValue)
                     return result.Value;
+            }
+
+            if (tolerance.HasVariance)
+            {
+                throw new InvalidOperationException("Tolerance is not supported for this comparison");
             }
 
             return x.Equals(y);

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Constraints
         private const string NumericToleranceRequired = "A numeric tolerance is required";
 
         /// <summary>
-        /// Returns a default Tolerance object, equivalent to an default matching rules.
+        /// Returns a default Tolerance object, equivalent to a default matching rules.
         /// </summary>
         public static readonly Tolerance Default = new Tolerance(0, ToleranceMode.Unset);
 

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -21,14 +21,14 @@ namespace NUnit.Framework.Constraints
         private const string NumericToleranceRequired = "A numeric tolerance is required";
 
         /// <summary>
-        /// Returns a default Tolerance object, equivalent to an exact match.
+        /// Returns a default Tolerance object, equivalent to an default matching rules.
         /// </summary>
-        public static Tolerance Default => new Tolerance(0, ToleranceMode.Unset);
+        public static readonly Tolerance Default = new Tolerance(0, ToleranceMode.Unset);
 
         /// <summary>
         /// Returns an empty Tolerance object, equivalent to an exact match.
         /// </summary>
-        public static Tolerance Exact => new Tolerance(0, ToleranceMode.Linear);
+        public static readonly Tolerance Exact = new Tolerance(0, ToleranceMode.Linear);
 
         #endregion
 
@@ -169,10 +169,14 @@ namespace NUnit.Framework.Constraints
         public object Amount { get; }
 
         /// <summary>
-        /// Returns true if the current tolerance has not been set or is using the .
+        /// Returns true if the current tolerance has not been set or is using the default.
         /// </summary>
         public bool IsUnsetOrDefault => Mode == ToleranceMode.Unset;
 
+        /// <summary>
+        /// Returns true if the current tolerance varies from exact and default. Indicating tolerance needs processing.
+        /// </summary>
+        public bool HasVariance => Mode != ToleranceMode.Unset && this != Exact && this != Default;
         #endregion
 
         #region Public Methods

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -257,7 +257,7 @@ namespace NUnit.Framework.Internal
             if (_sameValDiffTypes) {
                 Write(_expectedType);
             }
-            if (tolerance != null && !tolerance.IsUnsetOrDefault)
+            if (tolerance != null && tolerance.HasVariance)
             {
                 Write(" +/- ");
                 Write(MsgUtils.FormatValue(tolerance.Amount));

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -46,6 +46,20 @@ namespace NUnit.Framework.Constraints
         }
 
         [Test]
+        public void TestToleranceVarianceExact()
+        {
+            var noneTolerance = Tolerance.Exact;
+            Assert.IsFalse(noneTolerance.HasVariance);
+        }
+
+        [Test]
+        public void TestToleranceVarianceDefault()
+        {
+            var noneTolerance = Tolerance.Default;
+            Assert.IsFalse(noneTolerance.HasVariance);
+        }
+
+        [Test]
         public void TestWithinCanOnlyBeUsedOnce()
         {
             Assert.That(() => Is.EqualTo(1.1d).Within(0.5d).Within(0.2d),
@@ -74,6 +88,18 @@ namespace NUnit.Framework.Constraints
             var tolerance = Tolerance.Default; // which is new Tolerance(0, ToleranceMode.Unset)
             Assert.That(() => tolerance.Percent,
                 Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Tolerance amount must be specified"));
+        }
+
+        [Test]
+        public void TestToleranceDefaultIsSameAs()
+        {
+            Assert.That(Tolerance.Default, Is.SameAs(Tolerance.Default));
+        }
+
+        [Test]
+        public void TestToleranceExactIsSameAs()
+        {
+            Assert.That(Tolerance.Exact, Is.SameAs(Tolerance.Exact));
         }
     }
 }


### PR DESCRIPTION
Tolerance has been silently ignored in cases where certain types of equality were requested.  It was also impossible for someone to implement an External Comparer that considered tolerance.  This enables that and automates most comparisons in a linear range, without the need for custom NUnit expansions.

Tolerance gained the concept of HasVariance to better determine if strict equals could be applied or not.  Within() calls that were previously ignored can now determine if it's possible to apply the tolerance, and if not an error is raised.