### PR TITLE
Accumulate further failures if any on AssertMultiple instead of throwing

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -325,6 +325,7 @@ namespace NUnit.Framework
             TestExecutionContext context = TestExecutionContext.CurrentContext;
             Guard.OperationValid(context != null, "There is no current test execution context.");
 
+            var oldCount = context.CurrentResult.AssertionResults.Count;
             context.MultipleAssertLevel++;
 
             try
@@ -339,7 +340,10 @@ namespace NUnit.Framework
             if (context.MultipleAssertLevel == 0 && context.CurrentResult.PendingFailures > 0)
             {
                 context.CurrentResult.RecordTestCompletion();
-                throw new MultipleAssertException(context.CurrentResult);
+                if (context.CurrentResult.AssertionResults.Count > oldCount)
+                {
+                    throw new MultipleAssertException(context.CurrentResult);
+                }
             }
         }
 
@@ -354,6 +358,7 @@ namespace NUnit.Framework
             TestExecutionContext context = TestExecutionContext.CurrentContext;
             Guard.OperationValid(context != null, "There is no current test execution context.");
 
+            var oldCount = context.CurrentResult.AssertionResults.Count;
             context.MultipleAssertLevel++;
 
             try
@@ -368,7 +373,10 @@ namespace NUnit.Framework
             if (context.MultipleAssertLevel == 0 && context.CurrentResult.PendingFailures > 0)
             {
                 context.CurrentResult.RecordTestCompletion();
-                throw new MultipleAssertException(context.CurrentResult);
+                if (context.CurrentResult.AssertionResults.Count > oldCount)
+                {
+                    throw new MultipleAssertException(context.CurrentResult);
+                }
             }
         }
 

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -151,6 +151,28 @@ namespace NUnit.Framework.Assertions
         }
     }
 
+    [Explicit("Used to verify that further failures do not skip the rest of the execution")]
+    public class MultipleAssertFailureAccumulationDemo
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            Console.WriteLine("Teardown Start, expect to see a Teardown End message");
+            Assert.Multiple(() =>
+            {
+                Assert.That(true);
+            });
+            Console.WriteLine("Teardown End");
+        }
+
+        [Test]
+        public void AssertFailureAccumulationDemo()
+        {
+            Console.WriteLine("Test Start");
+            Assert.That(false);
+        }
+    }
+    
     internal class ComplexNumber
     {
         public ComplexNumber(double realPart, double imaginaryPart)


### PR DESCRIPTION
Closes #4264 

This implements the suggested solution. It turns out it was suitable to fix this issue. We still throw on the first fail, but any further one is only cumulated in case one appears after a catch block or in the teardown.