### PR TITLE
Ensure Console.Out is not disposed and is restored if it was replaced during the test run

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
 using System.Collections.Generic;
@@ -79,6 +79,38 @@ namespace NUnit.Common.Tests
         {
             writer.WriteLabelLine(LABEL, OPTION, ColorStyle.Pass);
             Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
+        }
+
+        [Test]
+        public void DisposeSkipsStdOut()
+        {
+            var originalStdOut = Console.Out;
+
+            var textWriter = new DisposeCheckerWriter();
+
+            Console.SetOut(textWriter);
+            try
+            {
+                var colorWriter = new ColorConsoleWriter();
+                colorWriter.Dispose();
+
+                Assert.IsFalse(textWriter.IsDisposed);
+            }
+            finally
+            {
+                Console.SetOut(originalStdOut);
+            }
+        }
+
+        class DisposeCheckerWriter : StringWriter
+        {
+            public bool IsDisposed { get; private set; }
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
@@ -22,7 +22,7 @@ namespace NUnit.Common
         /// </summary>
         /// <param name="colorEnabled">Flag indicating whether color should be enabled</param>
         public ColorConsoleWriter(bool colorEnabled)
-            : base(Console.Out)
+            : base(Console.Out, shouldDisposeWriter:false)
         {
             _colorEnabled = colorEnabled;
         }

--- a/src/NUnitFramework/nunitlite/ExtendedTextWrapper.cs
+++ b/src/NUnitFramework/nunitlite/ExtendedTextWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.IO;
 using System.Text;
@@ -14,10 +14,17 @@ namespace NUnit.Common
     public class ExtendedTextWrapper : ExtendedTextWriter
     {
         private readonly TextWriter _writer;
+        private readonly bool _shouldDisposeWriter = true;
 
         public ExtendedTextWrapper(TextWriter writer)
         {
             _writer = writer;
+        }
+
+        public ExtendedTextWrapper(TextWriter writer, bool shouldDisposeWriter)
+            : this(writer)
+        {
+            _shouldDisposeWriter = shouldDisposeWriter;
         }
 
         #region TextWriter Overrides
@@ -56,7 +63,10 @@ namespace NUnit.Common
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            _writer.Dispose();
+            if(_shouldDisposeWriter)
+            {
+                _writer.Dispose();
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -89,6 +89,9 @@ namespace NUnitLite
 
         public int Execute(string[] args)
         {
+            TextWriter originalStdOutWriter = null;
+            TextWriter originalStdErrWriter = null;
+
             _options = new NUnitLiteOptions(_testAssembly == null, args);
 
             ExtendedTextWriter outWriter = null;
@@ -97,6 +100,7 @@ namespace NUnitLite
                 var outFile = Path.Combine(_options.WorkDirectory, _options.OutFile);
                 var textWriter = TextWriter.Synchronized(new StreamWriter(outFile));
                 outWriter = new ExtendedTextWrapper(textWriter);
+                originalStdOutWriter = Console.Out;
                 Console.SetOut(outWriter);
             }
             else
@@ -104,20 +108,41 @@ namespace NUnitLite
                 outWriter = new ColorConsoleWriter(!_options.NoColor);
             }
 
-            using (outWriter)
+            try
             {
-                TextWriter errWriter = null;
-                if (_options.ErrFile != null)
+                using (outWriter)
                 {
-                    var errFile = Path.Combine(_options.WorkDirectory, _options.ErrFile);
-                    errWriter = TextWriter.Synchronized(new StreamWriter(errFile));
-                    Console.SetError(errWriter);
-                }
+                    TextWriter errWriter = null;
+                    if (_options.ErrFile != null)
+                    {
+                        var errFile = Path.Combine(_options.WorkDirectory, _options.ErrFile);
+                        errWriter = TextWriter.Synchronized(new StreamWriter(errFile));
+                        originalStdErrWriter = Console.Error;
+                        Console.SetError(errWriter);
+                    }
 
-                using (errWriter)
+                    try
+                    {
+                        using (errWriter)
+                        {
+                            _textUI = new TextUI(outWriter, Console.In, _options);
+                            return Execute();
+                        }
+                    }
+                    finally
+                    {
+                        if (originalStdErrWriter != null)
+                        {
+                            Console.SetError(originalStdErrWriter);
+                        }
+                    }                    
+                }
+            }
+            finally
+            {
+                if (originalStdOutWriter != null)
                 {
-                    _textUI = new TextUI(outWriter, Console.In, _options);
-                    return Execute();
+                    Console.SetOut(originalStdOutWriter);
                 }
             }
         }


### PR DESCRIPTION
I'm on the AWS .NET team. We got a report from a  user that used `NUnitLite` and got an object disposed exception when using this library in their [AWS Lambda](https://aws.amazon.com/lambda/) functions. Lambda is AWS's serverless compute offering.  

In Lambda we redirect `Console.Out` to our own `StreamWriter` for logging. `NUnitLite` is wrapping `Console.Out` with its own `ColorConsoleWriter` and when it is done it disposes `ColorConsoleWriter` and disposes its inner `TextWriter` which would normally be the console stdout that ignores the dispose call but instead calls our `TextWriter` to dispose. With our `TextWriter` disposed any calls to `Console.Out` now fail.

We have [fixed Lambda](https://github.com/aws/aws-lambda-dotnet/pull/1464) to ignore the dispose call but I though this PR would be helpful for others to ensure `NUnitLite` doesn't accidently dispose of somebody else's custom `Console.Out`.  

I also made sure if `Console.SetOut` or `Console.SetError` are used to be sure to restore to the original `TextWriter`s after the run is complete.

Fixes #4319