### PR TITLE
Fixed issue where TextRunner accidentally disposes System.Out

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/TextRunnerTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextRunnerTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitLite.Tests
+{
+    [TestFixture]
+    public class TextRunnerTests
+    {
+        [Test]
+        public void CommandLineTests()
+        {
+            Console.SetOut(new WriteToStreamAndConsole(Console.Out, new MemoryStream()));
+            
+            var textRunner = new TextRunner();
+            textRunner.Execute(new[] { "--noresult" });
+            Console.Out.WriteLine("Broken");
+        }
+    }
+
+    public class WriteToStreamAndConsole : TextWriter
+    {
+        private readonly TextWriter _writer;
+        private readonly StreamWriter _streamWriter;
+        
+        public WriteToStreamAndConsole(TextWriter writer, Stream stream)
+        {
+            _writer = writer;
+            _streamWriter = new StreamWriter(stream);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _writer.Dispose();
+                _streamWriter.Dispose();
+            }
+            
+            base.Dispose(disposing);
+        }
+
+        // Only overriden WriteLine for simplicity sake
+        public override void WriteLine(string value)
+        {
+            _writer.WriteLine(value);
+            _streamWriter.WriteLine(value);
+            
+            base.WriteLine(value);
+        }
+
+        public override Encoding Encoding => _writer.Encoding;
+    }
+}

--- a/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
@@ -104,6 +104,13 @@ namespace NUnit.Common
             WriteLine();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            // The base class disposes the writer it's wrapping
+            // In our case the writer is System.Out,
+            // We don't want to dispose of System.Out as it could potentially break other peoples code
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
It is possible to replace `System.Out` with your own implementation of `TextWriter`.
One reason why you would want to do that is if you want to both capture all output to a stream and write it to console.

I was using this approach and I stumbled upon an issue when using `TextRunner`.
When using `TextRunner`, and not providing a file, `TextRunner` defaults to `System.Out`.
When `TextRunner` is done running it disposes the underlying stream that it was writing to. This is correct behaviour when using files, but not desired behaviour when using `System.Out`.
See: [source code
](https://github.com/nunit/nunit/blob/92180f13381621e308b01f0abd1a397cc1350c12/src/NUnitFramework/nunitlite/TextRunner.cs#L104)

I modified `ConsoleColorWriter` so `Dispose` is a NOP. (The base class disposes the writer provided by `ConsoleColorWriter` = `System.Out`).

I've also added a unit test to verify that the fix works. If you want a code example of what crashes, check the unit test.