### PR TITLE
fix nunit/nunit#3868 Apply Order Attribute to TestSuite for multiple Test Fixtures

### DIFF
--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework
     /// Defines the order that the test will run in
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class OrderAttribute : NUnitAttribute, IApplyToTest
+    public class OrderAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
     {
           /// <summary>
          /// Defines the order that the test will run in
@@ -37,5 +37,15 @@ namespace NUnit.Framework
             if (!test.Properties.ContainsKey(PropertyNames.Order))
                 test.Properties.Set(PropertyNames.Order, Order);
         }
-     }
+
+        /// <summary>
+        /// Modifies a test suite as defined for the specific attribute.
+        /// </summary>
+        /// <param name="testSuite">The test suite to modify</param>
+        public void ApplyToTestSuite(TestSuite testSuite)
+        {
+            if (!testSuite.Properties.ContainsKey(PropertyNames.Order))
+                testSuite.Properties.Set(PropertyNames.Order, Order);
+        }
+    }
  }

--- a/src/NUnitFramework/framework/Interfaces/IApplyToTestSuite.cs
+++ b/src/NUnitFramework/framework/Interfaces/IApplyToTestSuite.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#nullable enable
+
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework.Interfaces
+{
+    /// <summary>
+    /// The IApplyToTestSuite interface is implemented by self-applying
+    /// attributes that modify the state of a test suite in some way.
+    /// </summary>
+    public interface IApplyToTestSuite
+    {
+        /// <summary>
+        /// Modifies a test suite as defined for the specific attribute.
+        /// </summary>
+        /// <param name="testSuite">The test to modify</param>
+        void ApplyToTestSuite(TestSuite testSuite);
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -111,6 +111,8 @@ namespace NUnit.Framework.Internal.Builders
         {
             TestSuite suite = new ParameterizedFixtureSuite(typeInfo);
 
+            suite.ApplyAttributesToTestSuite(typeInfo.Type);
+
             foreach (var fixture in fixtures)
                 suite.Add(fixture);
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -325,19 +325,6 @@ namespace NUnit.Framework.Internal
                 ApplyAttributesToTest((ICustomAttributeProvider) t);
         }
 
-        /// <summary>
-        /// Returns all nested types, inner first.
-        /// </summary>
-        private IEnumerable<Type> GetNestedTypes(Type inner)
-        {
-            var current = inner;
-            while (current != null)
-            {
-                yield return current;
-                current = current.DeclaringType;
-            }
-        }
-
         private void ApplyAttributesToTest(IEnumerable<IApplyToTest> attributes)
         {
             foreach (IApplyToTest iApply in attributes)
@@ -392,6 +379,19 @@ namespace NUnit.Framework.Internal
 
             if (Properties.Keys.Count > 0)
                 Properties.AddToXml(thisNode, recursive);
+        }
+
+        /// <summary>
+        /// Returns all nested types, inner first.
+        /// </summary>
+        protected IEnumerable<Type> GetNestedTypes(Type inner)
+        {
+            var current = inner;
+            while (current != null)
+            {
+                yield return current;
+                current = current.DeclaringType;
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework;
+
+namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
+{
+    [Order(2)]
+    public class NoTestFixtureAttributeOrder2
+    {
+        [Test]
+        public void A()
+        {
+            Assert.Pass("A");
+        }
+    }
+
+    [TestFixture("1")]
+    [TestFixture("2")]
+    [Order(1)]
+    public class MultipleTestFixtureAttributesOrder1
+    {
+        private string s;
+        public MultipleTestFixtureAttributesOrder1(string s)
+        {
+            this.s = s;
+        }
+
+        [Test]
+        public void B()
+        {
+            Assert.Pass("B");
+        }
+    }
+
+    [Order(0)]
+    public class NoTestFixtureAttributeOrder0
+    {
+        [Test]
+        public void C()
+        {
+            Assert.Pass("C");
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
 using NUnit.TestData;
+using NUnit.TestData.MultipleTestFixturesOrderAttribute;
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Attributes
 
             // This triggers sorting
             TestBuilder.ExecuteWorkItem(work);
-            
+
             Assert.AreEqual(work.Children.Count, 5);
             Assert.AreEqual(work.Children[0].Test.Name, "Y_FirstTest");
             Assert.AreEqual(work.Children[1].Test.Name, "Y_SecondTest");
@@ -69,6 +69,12 @@ namespace NUnit.Framework.Attributes
                 typeof(TestCaseOrderAttributeFixture),
                 typeof(AnotherTestCaseOrderAttributeFixture),
                 typeof(ThirdTestCaseOrderAttributeFixture)
+            },
+            new[]
+            {
+                typeof(NoTestFixtureAttributeOrder2),
+                typeof(MultipleTestFixtureAttributesOrder1),
+                typeof(NoTestFixtureAttributeOrder0)
             }
         };
     }


### PR DESCRIPTION
fix nunit/nunit#3868 Apply Order Attribute to TestSuite for multiple Test Fixtures