### PR TITLE
Backport PR 4317 - Ensure Console.Out is not disposed and is restored

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -100,6 +100,38 @@ namespace NUnit.Common.Tests
         {
             writer.WriteLabelLine(LABEL, OPTION, ColorStyle.Pass);
             Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
+        }
+
+        [Test]
+        public void DisposeSkipsStdOut()
+        {
+            var originalStdOut = Console.Out;
+
+            var textWriter = new DisposeCheckerWriter();
+
+            Console.SetOut(textWriter);
+            try
+            {
+                var colorWriter = new ColorConsoleWriter();
+                colorWriter.Dispose();
+
+                Assert.IsFalse(textWriter.IsDisposed);
+            }
+            finally
+            {
+                Console.SetOut(originalStdOut);
+            }
+        }
+
+        class DisposeCheckerWriter : StringWriter
+        {
+            public bool IsDisposed { get; private set; }
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
@@ -43,7 +43,7 @@ namespace NUnit.Common
         /// </summary>
         /// <param name="colorEnabled">Flag indicating whether color should be enabled</param>
         public ColorConsoleWriter(bool colorEnabled)
-            : base(Console.Out)
+            : base(Console.Out, shouldDisposeWriter: false)
         {
             _colorEnabled = colorEnabled;
         }

--- a/src/NUnitFramework/nunitlite/ExtendedTextWrapper.cs
+++ b/src/NUnitFramework/nunitlite/ExtendedTextWrapper.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -35,10 +35,17 @@ namespace NUnit.Common
     public class ExtendedTextWrapper : ExtendedTextWriter
     {
         private readonly TextWriter _writer;
+        private readonly bool _shouldDisposeWriter = true;
 
         public ExtendedTextWrapper(TextWriter writer)
         {
             _writer = writer;
+        }
+
+        public ExtendedTextWrapper(TextWriter writer, bool shouldDisposeWriter)
+            : this(writer)
+        {
+            _shouldDisposeWriter = shouldDisposeWriter;
         }
 
         #region TextWriter Overrides
@@ -80,7 +87,10 @@ namespace NUnit.Common
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            _writer.Dispose();
+            if (_shouldDisposeWriter)
+            {
+                _writer.Dispose();
+            }
         }
 
         #endregion


### PR DESCRIPTION
PR backporting https://github.com/nunit/nunit/pull/4317

In AWS Lambda we redirect `Console.Out` to our own `StreamWriter` for logging. `NUnitLite` is wrapping `Console.Out` with its own `ColorConsoleWriter` and when it is done it disposes `ColorConsoleWriter` and disposes its inner `TextWriter` which would normally be the console stdout that ignores the dispose call but instead calls our `TextWriter` to dispose. With our `TextWriter` disposed any calls to `Console.Out` now fail.

I also made sure if `Console.SetOut` or `Console.SetError` are used to be sure to restore to the original `TextWriter`s after the run is complete.