### PR TITLE
V3 | Add tests for test assembly builder in a few cultures + fix underlying culture issues

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -148,7 +148,7 @@ namespace NUnit.Framework.Api
                         if (!string.IsNullOrEmpty(parameters))
                             foreach (string param in parameters.Split(new[] { ';' }))
                             {
-                                int eq = param.IndexOf("=");
+                                int eq = param.IndexOf('=');
 
                                 if (eq > 0 && eq < param.Length - 1)
                                 {

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework
         protected CategoryAttribute()
         {
             this.categoryName = this.GetType().Name;
-            if ( categoryName.EndsWith( "Attribute" ) )
+            if ( categoryName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 categoryName = categoryName.Substring( 0, categoryName.Length - 9 );
         }
 

--- a/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CombiningStrategyAttribute.cs
@@ -119,7 +119,7 @@ namespace NUnit.Framework
         public void ApplyToTest(Test test)
         {
             var joinType = _strategy.GetType().Name;
-            if (joinType.EndsWith("Strategy"))
+            if (joinType.EndsWith("Strategy", StringComparison.Ordinal))
                 joinType = joinType.Substring(0, joinType.Length - 8);
 
             test.Properties.Set(PropertyNames.JoinType, joinType);

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework
         protected PropertyAttribute( object propertyValue )
         {
             string propertyName = this.GetType().Name;
-            if ( propertyName.EndsWith( "Attribute" ) )
+            if ( propertyName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 propertyName = propertyName.Substring( 0, propertyName.Length - 9 );
             this.properties.Add(propertyName, propertyValue);
         }

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
             get
             {
                 var name = predicate.GetMethodInfo().Name;
-                return name.StartsWith("<")
+                return name.StartsWith("<", StringComparison.Ordinal)
                     ? "value matching lambda expression"
                     : "value matching " + name;
             }

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Constraints
         private static bool IsSpecialComparisonType(Type type)
         {
             if (type.IsGenericType)
-                return type.FullName.StartsWith("System.Collections.Generic.KeyValuePair`2");
+                return type.FullName.StartsWith("System.Collections.Generic.KeyValuePair`2", StringComparison.Ordinal);
 #pragma warning disable CS0618 // 'Numerics' is only marked as obsolete for public use
             else if (Numerics.IsNumericType(type))
 #pragma warning restore CS0618
@@ -257,7 +257,7 @@ namespace NUnit.Framework.Constraints
         {
             foreach (var type in actual.GetType().GetInterfaces())
             {
-                if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable`1"))
+                if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable`1", StringComparison.Ordinal))
                 {
 #if NET35 || NET40
                     return type.GetGenericArguments()[0];

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -274,7 +274,7 @@ namespace NUnit.Framework.Interfaces
             Guard.ArgumentNotNullOrEmpty(xpath, nameof(xpath));
             if (xpath[0] == '/')
                 throw new ArgumentException("XPath expressions starting with '/' are not supported", nameof(xpath));
-            if (xpath.IndexOf("//") >= 0)
+            if (xpath.IndexOf("//", StringComparison.Ordinal) >= 0)
                 throw new ArgumentException("XPath expressions with '//' are not supported", nameof(xpath));
 
             string head = xpath;
@@ -378,7 +378,7 @@ namespace NUnit.Framework.Interfaces
 
             while (true)
             {
-                int illegal = text.IndexOf("]]>", start);
+                int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
                 if (illegal < 0)
                     break;
                 writer.WriteCData(text.Substring(start, illegal - start + 2));
@@ -410,7 +410,7 @@ namespace NUnit.Framework.Interfaces
                 int lbrack = xpath.IndexOf('[');
                 if (lbrack >= 0)
                 {
-                    if (!xpath.EndsWith("]"))
+                    if (!xpath.EndsWith("]", StringComparison.Ordinal))
                         throw new ArgumentException("Invalid property expression", nameof(xpath));
 
                     _nodeName = xpath.Substring(0, lbrack);

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Internal.Builders
                     if (parms.TestName != null)
                     {
                         // The test is simply for efficiency
-                        testMethod.Name = parms.TestName.Contains("{")
+                        testMethod.Name = parms.TestName.Contains('{')
                             ? new TestNameGenerator(parms.TestName).GetDisplayName(testMethod, parms.OriginalArguments)
                             : parms.TestName;
                     }

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Internal.Builders
                     if (parms.TestName != null)
                     {
                         // The test is simply for efficiency
-                        testMethod.Name = parms.TestName.Contains('{')
+                        testMethod.Name = parms.TestName.IndexOf('{') >= 0
                             ? new TestNameGenerator(parms.TestName).GetDisplayName(testMethod, parms.OriginalArguments)
                             : parms.TestName;
                     }

--- a/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NamespaceTreeBuilder.cs
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Internal.Builders
                 return _namespaceIndex[ns];
 
             TestSuite suite;
-            int index = ns.LastIndexOf(".");
+            int index = ns.LastIndexOf('.');
 
             if( index == -1 )
             {

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -178,7 +178,7 @@ namespace NUnit.Framework.Internal
             if (from == null)
             {
                 // Look for the marker that indicates from was null
-                return to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable");
+                return to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable", StringComparison.Ordinal);
             }
 
             if (convertibleValueTypes.ContainsKey(to) && convertibleValueTypes[to].Contains(from))

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -367,7 +367,7 @@ namespace NUnit.Common
                     // This can be changed without breaking backwards compatibility with frameworks.
                     foreach (string param in parameters.Split(new[] { ';' }))
                     {
-                        int eq = param.IndexOf("=");
+                        int eq = param.IndexOf('=');
                         if (eq == -1 || eq == param.Length - 1)
                         {
                             ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
@@ -459,7 +459,8 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/';
+            return v.StartsWith("-", StringComparison.Ordinal)
+                || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -459,7 +459,7 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith('-') || (v.StartsWith('/') && Path.DirectorySeparatorChar != '/');
+            return v.StartsWith("-", StringComparison.Ordinal) || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -459,8 +459,7 @@ namespace NUnit.Common
 
         private bool LooksLikeAnOption(string v)
         {
-            return v.StartsWith("-", StringComparison.Ordinal)
-                || (v.StartsWith("/", StringComparison.Ordinal) && Path.DirectorySeparatorChar != '/');
+            return v.StartsWith('-') || (v.StartsWith('/') && Path.DirectorySeparatorChar != '/');
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -366,7 +366,7 @@ namespace NUnitLite
             int start = 0;
             while (true)
             {
-                int illegal = text.IndexOf("]]>", start);
+                int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
                 if (illegal < 0)
                     break;
                 xmlWriter.WriteCData(text.Substring(start, illegal - start + 2));

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -266,7 +266,7 @@ namespace NUnitLite
 
                 WriteOutput(result.Output);
 
-                if (!result.Output.EndsWith("\n"))
+                if (!result.Output.EndsWith("\n", StringComparison.Ordinal))
                     Writer.WriteLine();
             }
 
@@ -689,7 +689,7 @@ namespace NUnitLite
             Writer.Write(color, text);
 
             _testCreatedOutput = true;
-            _needsNewLine = !text.EndsWith("\n");
+            _needsNewLine = !text.EndsWith("\n", StringComparison.Ordinal);
         }
 
          private static ColorStyle GetColorForResultStatus(string status)

--- a/src/NUnitFramework/tests/Internal/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultTestAssemblyBuilderTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using NUnit.Framework.Api;
+
+namespace NUnit.Framework.Internal
+{
+    internal class DefaultTestAssemblyBuilderTests
+    {
+        [Test]
+        public void Build_CanBuildTests()
+        {
+            var builder = new DefaultTestAssemblyBuilder();
+            var opts = new Dictionary<string, object>();
+            var asm = Assembly.Load("nunit.testdata");
+
+            var result = builder.Build(asm, opts);
+
+            Assert.That(result.TestCaseCount, Is.GreaterThan(500));
+        }
+
+        [Test]
+        public void Build_CanBuildTestsForCulture([ValueSource(nameof(GetTestedCultures))] string culture)
+        {
+            using var cultureContext = ThreadCultureContext.Capture();
+
+            CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture(culture);
+            Build_CanBuildTests();
+        }
+
+        private static string[] GetTestedCultures() => new[]
+            {
+                "en-US", // US English
+                "th-TH", // Thai
+                "tr-TR"  // Turkish
+            };
+
+        private class ThreadCultureContext : IDisposable
+        {
+            private readonly CultureInfo _culture;
+            private readonly CultureInfo _uiCulture;
+            private bool _disposed = false;
+
+            public ThreadCultureContext(CultureInfo culture, CultureInfo uiCulture)
+            {
+                _culture = culture;
+                _uiCulture = uiCulture;
+            }
+
+            public static ThreadCultureContext Capture()
+                 => new ThreadCultureContext(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    _disposed = true;
+                    CultureInfo.CurrentCulture = _culture;
+                    CultureInfo.CurrentUICulture = _uiCulture;
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultTestAssemblyBuilderTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Internal
         {
             using var cultureContext = ThreadCultureContext.Capture();
 
-            CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture(culture);
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(culture);
             Build_CanBuildTests();
         }
 
@@ -58,8 +58,9 @@ namespace NUnit.Framework.Internal
                 if (!_disposed)
                 {
                     _disposed = true;
-                    CultureInfo.CurrentCulture = _culture;
-                    CultureInfo.CurrentUICulture = _uiCulture;
+
+                    System.Threading.Thread.CurrentThread.CurrentCulture = _culture;
+                    System.Threading.Thread.CurrentThread.CurrentUICulture = _culture;
                 }
             }
         }


### PR DESCRIPTION
Fixes #4246
Relates to #3770 + #4345

Cherry-picks a few commits from PR #3770 which made some string comparisons more culture-safe in NET5+. Adds some tests to the builder for a select few cultures.