### PR TITLE
WIP: Revert "remove System.Runtime"

### DIFF
--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime" version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
This reverts commit 1981e2b510bbdd00a071b2aa4e430ce7b99d92e1. We found it was needed at runtime in the `AsyncToSyncAdapter.IsAsyncOperation`.

https://github.com/nunit/nunit/blob/aeed2b0/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs#L12-L18

Making this as a draft for now for discussion