### PR TITLE
Convert ArrayList usage to List<T> in CollectionTally

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
                 foreach (var o in _missingItems)
                     missingItems.Add(o);
 
-                List<object> extraItems = new List<object>(_extraItems.Count);
+                var extraItems = new List<object>(_extraItems.Count);
                 if (_sorted)
                 {
                     for (int index = _extraItems.Count - 1; index >= 0; index--)
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private readonly ArrayList _missingItems = new ArrayList();
+        private readonly List<object> _missingItems = new List<object>();
 
         private readonly List<object> _extraItems = new List<object>();
 
@@ -65,9 +65,9 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The expected collection to compare against.</param>
         public CollectionTally(NUnitEqualityComparer comparer, IEnumerable c)
         {
-            this._comparer = comparer;
+            _comparer = comparer;
 
-            _missingItems = ToArrayList(c);
+            _missingItems = ToList(c);
 
             if (c.IsSortable())
             {
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
         {
             if (_isSortable && c.IsSortable())
             {
-                var remove = ToArrayList(c);
+                var remove = ToList(c);
                 remove.Sort();
 
                 _sorted = true;
@@ -126,9 +126,9 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private static ArrayList ToArrayList(IEnumerable items)
+        private static List<object> ToList(IEnumerable items)
         {
-            var list = items is ICollection ic ? new ArrayList(ic.Count) : new ArrayList();
+            var list = items is ICollection ic ? new List<object>(ic.Count) : new List<object>();
 
             foreach (object o in items)
                 list.Add(o);


### PR DESCRIPTION
Contributes to #4254 and #53

Something I've been wanting to do for a while, that is easier now that the framework isn't built against some older TFMs.

We've historically used `ArrayList` to track missing items in the CollectionTally class in order to use the in-place sorting. Both [`List<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort?view=net-7.0#system-collections-generic-list-1-sort) and [`ArrayList`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.arraylist.sort?view=net-7.0#system-collections-arraylist-sort) use the same in-place sorting algo though `List<T>` supports using a generic underlying collection while `ArrayList` does not. This "generics all the way down" option should eventually make things easier for us to bring "generics all the way up" and start supporting generic constraints.

`CollectionTally` has recently been a [source](https://github.com/nunit/nunit/pull/3881) of [type-specific](https://github.com/nunit/nunit/pull/4097) [edgecases](https://github.com/nunit/nunit/pull/3978) driven partly by a few attempts to [improve](https://github.com/nunit/nunit/pull/3834) [performance](https://github.com/nunit/nunit/issues/2799). I'm hopeful that moving to a generic underlying collection could help avoid some of these issues while also opening doors to implementing `IEqualityComparer` on our internal classes to better integrate with some of the BCL sorting functions as [suggested here](https://github.com/nunit/nunit/issues/2799#issuecomment-379866290).

I've kept the implementation simple for now, but perhaps in the future a `CollectionTally<T>` could be created