### PR TITLE
Change release builds to be optimized

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -24,7 +24,6 @@
 
   <!-- We always want a good debugging experience in tests -->
   <PropertyGroup>
-    <Optimize>false</Optimize>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/Program.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/Program.cs
@@ -1,32 +1,6 @@
-﻿// ***********************************************************************
-// Copyright (c) 2022 Charlie Poole
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// ***********************************************************************
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using NUnit.Framework;
 
-BenchmarkSwitcher.FromAssembly(typeof(FrameworkControllerBenchmark).Assembly).Run(args,
-    ManualConfig
-        .Create(DefaultConfig.Instance)
-        // while optimize is false for main framework output
-        .WithOptions(ConfigOptions.DisableOptimizationsValidator));
+BenchmarkSwitcher.FromAssembly(typeof(FrameworkControllerBenchmark).Assembly).Run(args);

--- a/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
+++ b/src/NUnitFramework/testdata.fsharp/nunit.testdata.fsharp.fsproj
@@ -6,6 +6,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
     <NoWarn>$(NoWarn);NU1604</NoWarn>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>NUnit.TestData</RootNamespace>
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/NUnitFramework/tests/Constraints/DefaultConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DefaultConstraintTests.cs
@@ -20,8 +20,7 @@ namespace NUnit.Framework.Constraints
         [Test] public void Success_Int() => AssertSuccess(default(int));
         [Test] public void Success_NullableInt() => AssertSuccess(default(int?));
         [Test] public void Success_Long() => AssertSuccess(default(long));
-        [Test] public void Success_DefaultStructWithOverriddenEquals() => AssertSuccess(default(StructWithStrangeEquals));
-        [Test] public void Success_ImmutableArray() => AssertSuccess(default(StructWithStrangeEquals));
+        [Test] public void Success_ImmutableArray() => AssertSuccess(default(ImmutableArray<int>));
 
         [Test] public void Failure_NewObject() => AssertFailure(new object());
         [Test] public void Failure_EmptyString() => AssertFailure(string.Empty);
@@ -29,7 +28,6 @@ namespace NUnit.Framework.Constraints
         [Test] public void Failure_BoxedInt_Zero() => AssertFailure((object)0);
         [Test] public void Failure_Int_NonZero() => AssertFailure(1);
         [Test] public void Failure_Double_NaN() => AssertFailure(double.NaN);
-        [Test] public void Failure_NonDefaultStructWithOverriddenEquals() => AssertFailure(new StructWithStrangeEquals { SomeField = 1, EqualsResult = true });
         [Test] public void Failure_ImmutableArray_Empty() => AssertFailure(ImmutableArray.Create<int>());
 
         private void AssertSuccess<T>(T actual)
@@ -47,16 +45,6 @@ namespace NUnit.Framework.Constraints
         {
             var constraintResult = TheConstraint.ApplyTo(actual);
             Assert.That(!constraintResult.IsSuccess);
-        }
-
-        private struct StructWithStrangeEquals
-        {
-            public int SomeField { get; set; }
-            public bool EqualsResult { get; set; }
-
-            public override bool Equals(object obj) => EqualsResult;
-
-            public override int GetHashCode() => 0;
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -166,7 +166,7 @@ namespace NUnit.Framework.Constraints
             constraint.ApplyTo(items);
             stopwatch.Stop();
 
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(50));
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(30));
         }
 
         [TestCaseSource(nameof(DuplicateItemsData))]


### PR DESCRIPTION
As discussed in #4149 , seems like a good time with 4.0 nearing to try out again distributing optimized release builds. With this PR removing the forced no-optimize and BenchmarkDotNet project proves that artifacts can now be consumed as release builds (no longer need to disable validator).

Quick benchmark test for changes. Shows > 10% time reduction in best cases (very feature-limited benchmarks of course).

``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i9-12900H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.203
  [Host] : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2

Job=InProcess  Toolchain=InProcessEmitToolchain  

```

## Before (master)

|                       Method |        Mean |       Error |      StdDev |      Gen0 |     Gen1 |     Gen2 |  Allocated |
|----------------------------- |------------:|------------:|------------:|----------:|---------:|---------:|-----------:|
|        CountTestsEmptyFilter |    138.5 us |     1.89 us |     1.77 us |    4.1504 |        - |        - |    51.6 KB |
| CountTestsWithCategoryFilter |  2,758.3 us |    52.83 us |    49.41 us |  500.0000 |        - |        - | 6172.07 KB |
|    CountTestsWithOrFilterAll |  4,806.7 us |    58.17 us |    51.56 us |  312.5000 | 125.0000 |  23.4375 | 3903.07 KB |
|                    LoadTests | 66,056.0 us | 1,224.24 us | 1,202.37 us | 2125.0000 | 875.0000 | 250.0000 | 24510.9 KB |

## After (this PR)

|                       Method |        Mean |       Error |    StdDev |      Gen0 |      Gen1 |     Gen2 |   Allocated |
|----------------------------- |------------:|------------:|----------:|----------:|----------:|---------:|------------:|
|        CountTestsEmptyFilter |    116.8 us |     1.72 us |   1.61 us |    4.1504 |         - |        - |     51.6 KB |
| CountTestsWithCategoryFilter |  2,332.5 us |    28.56 us |  26.72 us |  500.0000 |         - |        - |  6172.07 KB |
|    CountTestsWithOrFilterAll |  3,921.2 us |    76.52 us |  71.58 us |  312.5000 |  125.0000 |  23.4375 |  3903.08 KB |
|                    LoadTests | 61,599.0 us | 1,057.11 us | 988.82 us | 2222.2222 | 1000.0000 | 333.3333 | 24131.66 KB |
