### PR TITLE
Optimize filter operations

### DIFF
--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -344,6 +344,7 @@ namespace NUnit.Framework.Api
             if (!test.IsSuite)
                 return filter.Pass(test) ? 1: 0;
 
+            // Use for-loop to avoid allocating the enumerator
             int count = 0;
             var tests = test.Tests;
             for (var i = 0; i < tests.Count; i++)

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -339,15 +339,16 @@ namespace NUnit.Framework.Api
             _runComplete.Set();
         }
 
-        private int CountTestCases(ITest test, ITestFilter filter)
+        private static int CountTestCases(ITest test, ITestFilter filter)
         {
             if (!test.IsSuite)
                 return filter.Pass(test) ? 1: 0;
 
             int count = 0;
-            foreach (ITest child in test.Tests)
+            var tests = test.Tests;
+            for (var i = 0; i < tests.Count; i++)
             {
-                count += CountTestCases(child, filter);
+                count += CountTestCases(tests[i], filter);
             }
 
             return count;

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -192,8 +192,7 @@ namespace NUnit.Framework
             get
             {
                 //return Properties.Get(PropertyNames.Category) as string;
-                var catList = Properties[PropertyNames.Category];
-                if (catList == null)
+                if (!Properties.TryGet(PropertyNames.Category, out var catList))
                     return null;
 
                 switch (catList.Count)

--- a/src/NUnitFramework/framework/Interfaces/IPropertyBag.cs
+++ b/src/NUnitFramework/framework/Interfaces/IPropertyBag.cs
@@ -77,7 +77,15 @@ namespace NUnit.Framework.Interfaces
         bool ContainsKey(string key);
 
         /// <summary>
-        /// Gets or sets the list of values for a particular key
+        /// Tries to retrieve list of values.
+        /// </summary>
+        /// <param name="key">The key for which the values are to be retrieved</param>
+        /// <param name="values">Values, if found</param>
+        /// <returns>true if found</returns>
+        bool TryGet(string key, out IList values);
+
+        /// <summary>
+        /// Gets or sets the list of values for a particular key, initializes new list behind the key if not found.
         /// </summary>
         /// <param name="key">The key for which the values are to be retrieved or set</param>
         IList this[string key] { get; set; }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -98,11 +98,11 @@ namespace NUnit.Framework.Internal.Execution
                 var xKey = int.MaxValue;
                 var yKey = int.MaxValue;
 
-                if (x.Test.Properties.ContainsKey(PropertyNames.Order))
-                    xKey = (int)x.Test.Properties[PropertyNames.Order][0];
+                if (x.Test.Properties.TryGet(PropertyNames.Order, out var xOrders))
+                    xKey = (int)xOrders[0];
 
-                if (y.Test.Properties.ContainsKey(PropertyNames.Order))
-                    yKey = (int)y.Test.Properties[PropertyNames.Order][0];
+                if (y.Test.Properties.TryGet(PropertyNames.Order, out var yOrders))
+                    yKey = (int)yOrders[0];
 
                 return xKey.CompareTo(yKey);
             }

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -30,6 +30,8 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if all the component filters pass, otherwise false</returns>
         public override bool Pass( ITest test, bool negated )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
+
             if (negated)
             {
                 foreach (var filter in Filters)
@@ -61,6 +63,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if all the component filters match, otherwise false</returns>
         public override bool Match( ITest test )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
             foreach (var filter in Filters)
             {
                 if (!filter.Match(test))
@@ -79,6 +82,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if all the component filters explicit match, otherwise false</returns>
         public override bool IsExplicitMatch( ITest test )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
             foreach (var filter in Filters)
             {
                 if (!filter.IsExplicitMatch(test))

--- a/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/AndFilter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #nullable enable
-using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -32,9 +31,27 @@ namespace NUnit.Framework.Internal.Filters
         public override bool Pass( ITest test, bool negated )
         {
             if (negated)
-                return Filters.Any(f => f.Pass(test, negated));
+            {
+                foreach (var filter in Filters)
+                {
+                    if (filter.Pass(test, negated))
+                    {
+                        return true;
+                    }
+                }
 
-            return Filters.All(f => f.Pass(test, negated));
+                return false;
+            }
+
+            foreach (var filter in Filters)
+            {
+                if (!filter.Pass(test, negated))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -44,7 +61,15 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if all the component filters match, otherwise false</returns>
         public override bool Match( ITest test )
         {
-            return Filters.All(filter => filter.Match(test));
+            foreach (var filter in Filters)
+            {
+                if (!filter.Match(test))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -54,9 +79,13 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if all the component filters explicit match, otherwise false</returns>
         public override bool IsExplicitMatch( ITest test )
         {
-            foreach( TestFilter filter in Filters )
-                if ( !filter.IsExplicitMatch( test ) )
+            foreach (var filter in Filters)
+            {
+                if (!filter.IsExplicitMatch(test))
+                {
                     return false;
+                }
+            }
 
             return true;
         }

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #nullable enable
-using System.Collections;
-using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -27,9 +25,18 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns></returns>
         public override bool Match(ITest test)
         {
-            IList testCategories = test.Properties[PropertyNames.Category];
+            if (test.Properties.TryGet(PropertyNames.Category, out var testCategories))
+            {
+                for (var i = 0; i < testCategories.Count; ++i)
+                {
+                    if (Match((string) testCategories[i]))
+                    {
+                        return true;
+                    }
+                }
+            }
 
-            return testCategories.Cast<string>().Any(Match);
+            return false;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CategoryFilter.cs
@@ -27,6 +27,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             if (test.Properties.TryGet(PropertyNames.Category, out var testCategories))
             {
+                // Use for-loop to avoid allocating the enumerator
                 for (var i = 0; i < testCategories.Count; ++i)
                 {
                     if (Match((string) testCategories[i]))

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #nullable enable
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -17,7 +16,7 @@ namespace NUnit.Framework.Internal.Filters
         /// </summary>
         public CompositeFilter()
         {
-            Filters = new List<TestFilter>();
+            Filters = Array.Empty<TestFilter>();
         }
 
         /// <summary>
@@ -26,13 +25,13 @@ namespace NUnit.Framework.Internal.Filters
         /// <param name="filters"></param>
         public CompositeFilter( params TestFilter[] filters )
         {
-            Filters = new ReadOnlyCollection<TestFilter>(filters);
+            Filters = filters;
         }
 
         /// <summary>
         /// Return a list of the composing filters.
         /// </summary>
-        public IList<TestFilter> Filters { get; }
+        public TestFilter[] Filters { get; }
 
         /// <summary>
         /// Checks whether the CompositeFilter is matched by a test.

--- a/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Internal.Filters
             // eagerly build expected value collection
             var expectedValues = new List<string?>(orFilter.Filters.Length);
 
-            // use for for faster traversal without boxed enumerator
+            // Use foreach-loop against array instead of LINQ for best performance
             foreach (var filter in orFilter.Filters)
             {
                 // make sure invariants are valid
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal.Filters
                     NamespaceFilter _ => test => test.TypeInfo?.Namespace,
                     TestNameFilter _ => test => test.Name,
                     _ => throw new InvalidOperationException("Invalid filter, logic wrong")
-                }; 
+                };
                 string xmlElementName = orFilter.Filters[0] switch
                 {
                     ClassNameFilter _ => ClassNameFilter.XmlElementName,

--- a/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/InFilter.cs
@@ -37,17 +37,15 @@ namespace NUnit.Framework.Internal.Filters
         public static bool TryOptimize(OrFilter orFilter, [NotNullWhen(true)] out InFilter? optimized)
         {
             // check if we have all filters accessing same field in OR fashion without regex
-            var hashCommonTypeAndNonRegex = orFilter.Filters.Count > 0;
+            var hashCommonTypeAndNonRegex = orFilter.Filters.Length > 0;
             Type? commonType = null;
 
             // eagerly build expected value collection
-            var expectedValues = new List<string?>(orFilter.Filters.Count);
+            var expectedValues = new List<string?>(orFilter.Filters.Length);
 
             // use for for faster traversal without boxed enumerator
-            for (var i = 0; i < orFilter.Filters.Count; i++)
+            foreach (var filter in orFilter.Filters)
             {
-                var filter = orFilter.Filters[i];
-
                 // make sure invariants are valid
                 commonType ??= filter.GetType();
                 hashCommonTypeAndNonRegex &= commonType == filter.GetType();

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #nullable enable
-using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -66,7 +65,15 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if any of the component filters match, otherwise false</returns>
         public override bool Match( ITest test )
         {
-            return Filters.Any(filter => filter.Match(test));
+            foreach (var filter in Filters)
+            {
+                if (filter.Match(test))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -76,7 +83,15 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if any of the component filters explicit match, otherwise false</returns>
         public override bool IsExplicitMatch( ITest test )
         {
-            return Filters.Any(filter => filter.IsExplicitMatch(test));
+            foreach (var filter in Filters)
+            {
+                if (filter.IsExplicitMatch(test))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/OrFilter.cs
@@ -34,6 +34,8 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if any of the component filters pass, otherwise false</returns>
         public override bool Pass( ITest test, bool negated )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
+
             if (negated)
             {
                 foreach (var filter in Filters)
@@ -65,6 +67,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if any of the component filters match, otherwise false</returns>
         public override bool Match( ITest test )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
             foreach (var filter in Filters)
             {
                 if (filter.Match(test))
@@ -83,6 +86,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <returns>True if any of the component filters explicit match, otherwise false</returns>
         public override bool IsExplicitMatch( ITest test )
         {
+            // Use foreach-loop against array instead of LINQ for best performance
             foreach (var filter in Filters)
             {
                 if (filter.IsExplicitMatch(test))

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -32,6 +32,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             if (test.Properties.TryGet(_propertyName, out var values))
             {
+                // Use for-loop to avoid allocating the enumerator
                 for (var i = 0; i < values.Count; ++i)
                 {
                     if (Match((string) values[i]))

--- a/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PropertyFilter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #nullable enable
-using System.Collections;
-using System.Linq;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Filters
@@ -32,9 +30,18 @@ namespace NUnit.Framework.Internal.Filters
         /// <param name="test">The test to be matched</param>
         public override bool Match(ITest test)
         {
-            IList values = test.Properties[_propertyName];
+            if (test.Properties.TryGet(_propertyName, out var values))
+            {
+                for (var i = 0; i < values.Count; ++i)
+                {
+                    if (Match((string) values[i]))
+                    {
+                        return true;
+                    }
+                }
+            }
 
-            return values.Cast<string>().Any(Match);
+            return false;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
 
@@ -200,7 +199,7 @@ namespace NUnit.Framework.Internal
             private bool MatchSetUpFixture(Type type)
             {
                 return IsSubNamespace(type.Namespace) &&
-                       type.GetCustomAttributes(typeof(SetUpFixtureAttribute), true).Any();
+                       type.GetCustomAttributes(typeof(SetUpFixtureAttribute), true).Length > 0;
             }
 
             private bool IsSubNamespace(string typeNamespace)

--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -198,6 +198,7 @@ namespace NUnit.Framework.Internal
 
             private bool MatchSetUpFixture(Type type)
             {
+                // checking length instead of for example LINQ .Any(), which would need to box array into IEnumerable
                 return IsSubNamespace(type.Namespace) &&
                        type.GetCustomAttributes(typeof(SetUpFixtureAttribute), true).Length > 0;
             }

--- a/src/NUnitFramework/framework/Internal/PropertyBag.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyBag.cs
@@ -84,6 +84,17 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Tries to retrieve list of values.
+        /// </summary>
+        /// <param name="key">The key for which the values are to be retrieved</param>
+        /// <param name="values">Values, if found</param>
+        /// <returns>true if found</returns>
+        public bool TryGet(string key, out IList values)
+        {
+            return inner.TryGetValue(key, out values);
+        }
+
+        /// <summary>
         /// Gets a collection containing all the keys in the property set
         /// </summary>
         /// <value></value>
@@ -131,14 +142,14 @@ namespace NUnit.Framework.Internal
         {
             TNode properties = parentNode.AddElement("properties");
 
-            foreach (string key in Keys)
+            foreach (var pair in inner)
             {
-                foreach (object value in this[key])
+                foreach (var value in pair.Value)
                 {
                     TNode prop = properties.AddElement("property");
 
                     // TODO: Format as string
-                    prop.AddAttribute("name", key);
+                    prop.AddAttribute("name", pair.Key);
                     prop.AddAttribute("value", value.ToString());
                 }
             }

--- a/src/NUnitFramework/framework/Internal/PropertyBag.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyBag.cs
@@ -142,6 +142,7 @@ namespace NUnit.Framework.Internal
         {
             TNode properties = parentNode.AddElement("properties");
 
+            // enumerating dictionary directly with struct enumerator which is fastest
             foreach (var pair in inner)
             {
                 foreach (var value in pair.Value)

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -111,8 +111,14 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestFilter FromXml(string xmlText)
         {
-            if (string.IsNullOrEmpty(xmlText))
-                xmlText = "<filter />";
+            const string emptyFilterXml1 = "<filter />";
+            const string emptyFilterXml2 = "<filter/>";
+
+            // check for fast cases
+            if (string.IsNullOrEmpty(xmlText) || xmlText.Length < 11 && xmlText is emptyFilterXml1 or emptyFilterXml2)
+            {
+                return Empty;
+            }
 
             TNode topNode = TNode.FromXml(xmlText);
 
@@ -208,7 +214,7 @@ namespace NUnit.Framework.Internal
         /// returns true when called. It never matches explicitly.
         /// </summary>
         [Serializable]
-        private class EmptyFilter : TestFilter
+        private sealed class EmptyFilter : TestFilter
         {
             public override bool Match( ITest test )
             {

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -111,11 +111,11 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestFilter FromXml(string xmlText)
         {
-            const string emptyFilterXml1 = "<filter />";
-            const string emptyFilterXml2 = "<filter/>";
+            const string emptyFilterXmlWithSpace = "<filter />";
+            const string emptyFilterWithoutSpace = "<filter/>";
 
             // check for fast cases
-            if (string.IsNullOrEmpty(xmlText) || xmlText.Length < 11 && xmlText is emptyFilterXml1 or emptyFilterXml2)
+            if (string.IsNullOrEmpty(xmlText) || xmlText.Length < 11 && xmlText is emptyFilterXmlWithSpace or emptyFilterWithoutSpace)
             {
                 return Empty;
             }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -222,10 +222,11 @@ namespace NUnit.Framework.Internal
             {
                 int count = 0;
 
-                foreach (Test test in Tests)
+                for (var i = 0; i < Tests.Count; i++)
                 {
-                    count += test.TestCaseCount;
+                    count += Tests[i].TestCaseCount;
                 }
+
                 return count;
             }
         }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -222,9 +222,11 @@ namespace NUnit.Framework.Internal
             {
                 int count = 0;
 
-                for (var i = 0; i < Tests.Count; i++)
+                // Use for-loop to avoid allocating the enumerator
+                var testsToCheck = Tests;
+                for (var i = 0; i < testsToCheck.Count; i++)
                 {
-                    count += Tests[i].TestCaseCount;
+                    count += testsToCheck[i].TestCaseCount;
                 }
 
                 return count;
@@ -293,8 +295,15 @@ namespace NUnit.Framework.Internal
 
 
             if (recursive)
-                foreach (Test test in this.Tests)
+            {
+                // Use for-loop to avoid allocating the enumerator
+                var testsToAdd = Tests;
+                for (var i = 0; i < testsToAdd.Count; i++)
+                {
+                    var test = testsToAdd[i];
                     test.AddToXml(thisNode, recursive);
+                }
+            }
 
             return thisNode;
         }

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -512,13 +512,13 @@ namespace NUnit.Framework
             {
                 get
                 {
-                    var list = new List<object>();
-                    foreach(var item in _source[key])
+                    if (_source.TryGet(key, out var values))
                     {
-                        list.Add(item);
+                        foreach(var item in values)
+                        {
+                            yield return item;
+                        }
                     }
-
-                    return list;
                 }
             }
 
@@ -527,7 +527,7 @@ namespace NUnit.Framework
             /// </summary>
             public int Count(string key)
             {
-                return _source[key].Count;
+                return _source.TryGet(key, out var values) ? values.Count : 0;
             }
 
             /// <summary>

--- a/src/NUnitFramework/nunitlite.tests/CreateTestFilterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CreateTestFilterTests.cs
@@ -31,7 +31,7 @@ namespace NUnitLite.Tests
             var filter = GetFilter("--test:My.First.Test", "--test:My.Second.Test", "--test:My.Third.Test");
             Assert.That(filter, Is.TypeOf<OrFilter>());
             var filters = ((OrFilter)filter).Filters;
-            Assert.That(filters.Count, Is.EqualTo(3));
+            Assert.That(filters.Length, Is.EqualTo(3));
 
             Assert.That(filters[0], Is.TypeOf<FullNameFilter>());
             Assert.That(((FullNameFilter)filters[0]).ExpectedValue, Is.EqualTo("My.First.Test"));
@@ -51,7 +51,7 @@ namespace NUnitLite.Tests
                 var filter = GetFilter("--testlist:" + tf.File.FullName);
                 Assert.That(filter, Is.TypeOf<OrFilter>());
                 var filters = ((OrFilter)filter).Filters;
-                Assert.That(filters.Count, Is.EqualTo(3));
+                Assert.That(filters.Length, Is.EqualTo(3));
 
                 Assert.That(filters[0], Is.TypeOf<FullNameFilter>());
                 Assert.That(((FullNameFilter)filters[0]).ExpectedValue, Is.EqualTo("My.First.Test"));
@@ -73,7 +73,7 @@ namespace NUnitLite.Tests
                 var filter = GetFilter("--testlist:" + tf.File.FullName, "--testlist:" + tf2.File.FullName );
                 Assert.That(filter, Is.TypeOf<OrFilter>());
                 var filters = ((OrFilter)filter).Filters;
-                Assert.That(filters.Count, Is.EqualTo(6));
+                Assert.That(filters.Length, Is.EqualTo(6));
 
                 Assert.That(filters[0], Is.TypeOf<FullNameFilter>());
                 Assert.That(((FullNameFilter)filters[0]).ExpectedValue, Is.EqualTo("My.First.Test"));
@@ -121,14 +121,14 @@ namespace NUnitLite.Tests
 
             Assert.That(filter, Is.TypeOf<AndFilter>());
             var filters = ((AndFilter)filter).Filters;
-            Assert.That(filters.Count, Is.EqualTo(2));
+            Assert.That(filters.Length, Is.EqualTo(2));
 
             Assert.That(filters[1], Is.TypeOf<CategoryFilter>());
             Assert.That(((CategoryFilter)filters[1]).ExpectedValue, Is.EqualTo("Urgent"));
 
             Assert.That(filters[0], Is.TypeOf<OrFilter>());
             filters = ((OrFilter)filters[0]).Filters;
-            Assert.That(filters.Count, Is.EqualTo(2));
+            Assert.That(filters.Length, Is.EqualTo(2));
 
             Assert.That(filters[0], Is.TypeOf<FullNameFilter>());
             Assert.That(((FullNameFilter)filters[0]).ExpectedValue, Is.EqualTo("My.First.Test"));


### PR DESCRIPTION
I was investigating how to make filtering and test case traversal faster as this is what I believe directly correlates with user experience and lag when things are being calculated and discovered. I tried to stay on filtering side for now, but I have other interesting branches as work in progress too 😉 

The `CountTestsWithCategoryFilter` numbers pretty nicely sum up the pitfalls of using LINQ in capturing context memory-wise (from 68MB to 12KB).

* change `CompositeFilter.Filters` to be an array for fast traversal - internal type so signature change should be OK
* replace LINQ usage with non-allocating plain loops
* add `TryGet` to `PropertyBag` which will not allocate on retrieval in contrast to indexer, name OK?
* detect empty filter from string without the need to parse the XML

I'm adding some comments to PR to clarify my suggestions/reasons behind the changes.

Following testing has been done against `Jint.Tests.Test262` test project as the source for discovery, which has the > 60k test cases to traverse.

Please also consider the delta of change instead of the original nano/milliseconds as I have quite beefy desktop - so halving the wait time on older hardware / CI pipelines can shine.

``` ini
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1631/22H2/2022Update/SunValley2)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.203
  [Host] : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2

Job=InProcess  Toolchain=InProcessEmitToolchain  
```

## NUnit.Framework.FrameworkControllerBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |CountTestsEmptyFilter|960.0 μs|4.16 μs|47.38 KB|
| **New** |	| **736.3 μs (-23%)** | **9.67 μs** | **1 B (-100%)** |
| Old |CountTestsWithCategoryFilter|40,061.2 μs|764.54 μs|68642.27 KB|
| **New** |	| **15,705.2 μs (-61%)** | **191.34 μs** | **12974 B (-100%)** |
| Old |CountTestsWithOrFilterAll|72,789.7 μs|548.23 μs|35458.02 KB|
| **New** |	| **71,194.9 μs (-2%)** | **399.37 μs** | **36272121 B (0%)** |
| Old |LoadTests|337,160.2 μs|3,950.07 μs|208299.28 KB|
| **New** |	| **332,760.1 μs (-1%)** | **4,875.89 μs** | **213225540 B (0%)** |



