### PR TITLE
Optimize progress reporting by reusing StringBuilder

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/TestMessage.cs
+++ b/src/NUnitFramework/framework/Interfaces/TestMessage.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
 using System.Diagnostics;
+using System.IO;
+using System.Xml;
 
 namespace NUnit.Framework.Interfaces
 {
@@ -18,17 +19,10 @@ namespace NUnit.Framework.Interfaces
         /// <param name="destination">Destination of the message</param>
         /// <param name="text">Text to be sent</param>
         /// <param name="testId">ID of the test that produced the message</param>
-        public TestMessage(string destination, string text, string testId)
+        public TestMessage(string destination, string text, string? testId)
         {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
+            Guard.ArgumentNotNull(destination, nameof(destination));
+            Guard.ArgumentNotNull(text, nameof(text));
 
             Destination = destination;
             Message = text;
@@ -56,22 +50,33 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// The ID of the test that sent the message
         /// </summary>
-        public string TestId { get; }
+        public string? TestId { get; }
 
         /// <summary>
         /// Returns the XML representation of the <see cref="TestMessage"/> object.
         /// </summary>
         public string ToXml()
         {
-            TNode tnode = new TNode("test-message", Message, true);
+            using var stringWriter = new StringWriter();
+            using (var writer = XmlWriter.Create(stringWriter, XmlExtensions.FragmentWriterSettings))
+            {
+                ToXml(writer);
+            }
+            return stringWriter.ToString();
+        }
 
-            if (Destination != null)
-                tnode.AddAttribute("destination", Destination);
+        internal void ToXml(XmlWriter writer)
+        {
+            writer.WriteStartElement("test-message");
+
+            writer.WriteAttributeString("destination", Destination);
 
             if (TestId != null)
-                tnode.AddAttribute("testid", TestId);
+                writer.WriteAttributeString("testid", TestId);
 
-            return tnode.OuterXml;
+            writer.WriteCDataSafe(Message);
+
+            writer.WriteEndElement();
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/PropertyBag.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyBag.cs
@@ -144,13 +144,16 @@ namespace NUnit.Framework.Internal
             // enumerating dictionary directly with struct enumerator which is fastest
             foreach (var pair in inner)
             {
-                foreach (var value in pair.Value)
+                // Use for-loop to avoid allocating the enumerator
+                var list = pair.Value;
+                var propertyCount = list.Count;
+                for (var i = 0; i < propertyCount; i++)
                 {
                     TNode prop = properties.AddElement("property");
 
                     // TODO: Format as string
                     prop.AddAttribute("name", pair.Key);
-                    prop.AddAttribute("value", value.ToString()!);
+                    prop.AddAttribute("value", list[i]!.ToString()!);
                 }
             }
 

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.IO;
+using System.Text;
 using System.Web.UI;
+using System.Xml;
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal
@@ -11,11 +14,14 @@ namespace NUnit.Framework.Internal
     /// the async callbacks that are used to inform the client
     /// software about the progress of a test run.
     /// </summary>
-    public class TestProgressReporter : ITestListener
+    public sealed class TestProgressReporter : ITestListener
     {
-        static readonly Logger log = InternalTrace.GetLogger("TestProgressReporter");
+        private static readonly Logger log = InternalTrace.GetLogger("TestProgressReporter");
 
-        private readonly ICallbackEventHandler handler;
+        private readonly ICallbackEventHandler _handler;
+
+        // this reporter is being called synchronously so we can reuse shared string builder
+        private readonly StringBuilder _stringBuilder = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestProgressReporter"/> class.
@@ -23,7 +29,7 @@ namespace NUnit.Framework.Internal
         /// <param name="handler">The callback handler to be used for reporting progress.</param>
         public TestProgressReporter(ICallbackEventHandler handler)
         {
-            this.handler = handler;
+            _handler = handler;
         }
 
         #region ITestListener Members
@@ -34,27 +40,54 @@ namespace NUnit.Framework.Internal
         /// <param name="test">The test that is starting</param>
         public void TestStarted(ITest test)
         {
-            var parent = GetParent(test);
+            var message = CreateTestStartedMessage(test);
+
             try
             {
-                string report;
-                if (test is TestSuite)
-                {
-                    // Only add framework-version for the Assembly start-suite
-                    string version = test.TestType == "Assembly" ? $"framework-version=\"{typeof(TestProgressReporter).Assembly.GetName().Version}\" " : "";
-                    report = $"<start-suite id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" {version}/>";
-                }
-                else
-                {
-                    report = $"<start-test id=\"{test.Id}\" parentId=\"{(parent != null ? parent.Id : string.Empty)}\" name=\"{FormatAttributeValue(test.Name)}\" fullname=\"{FormatAttributeValue(test.FullName)}\" type=\"{test.TestType}\" classname=\"{FormatAttributeValue(test.ClassName ?? "")}\" methodname=\"{FormatAttributeValue(test.MethodName ?? "")}\"/>";
-                }
-
-                handler.RaiseCallbackEvent(report);
+                _handler.RaiseCallbackEvent(message);
             }
             catch (Exception ex)
             {
                 log.Error($"Exception processing {test.FullName}{Environment.NewLine}{ex}");
             }
+        }
+
+        private string CreateTestStartedMessage(ITest test)
+        {
+            var parent = GetParent(test);
+
+            var stringBuilder = GetStringBuilder();
+
+            using var stringWriter = new StringWriter(stringBuilder);
+            using (var writer = XmlWriter.Create(stringWriter, XmlExtensions.FragmentWriterSettings))
+            {
+                var isSuite = test is TestSuite;
+                writer.WriteStartElement(isSuite ? "start-suite" : "start-test");
+
+                writer.WriteAttributeString("id", test.Id);
+                writer.WriteAttributeString("parentId", parent != null ? parent.Id : string.Empty);
+                writer.WriteAttributeStringSafe("name", test.Name);
+                writer.WriteAttributeStringSafe("fullname", test.FullName);
+                writer.WriteAttributeStringSafe("type", test.TestType);
+
+                if (isSuite)
+                {
+                    // Only add framework-version for the Assembly start-suite
+                    if (test.TestType == "Assembly")
+                    {
+                        writer.WriteAttributeString("framework-version", typeof(TestProgressReporter).Assembly.GetName().Version?.ToString());
+                    }
+                }
+                else
+                {
+                    writer.WriteAttributeStringSafe("classname", test.ClassName ?? string.Empty);
+                    writer.WriteAttributeStringSafe("methodname", test.MethodName ?? string.Empty);
+                }
+
+                writer.WriteEndElement();
+            }
+
+            return stringWriter.ToString();
         }
 
         /// <summary>
@@ -63,12 +96,19 @@ namespace NUnit.Framework.Internal
         /// <param name="result">The result of the test</param>
         public void TestFinished(ITestResult result)
         {
+            var node = result.ToXml(false);
+            var parent = GetParent(result.Test);
+            node.AddAttribute("parentId", parent != null ? parent.Id : string.Empty);
+
+            using var stringWriter = new StringWriter(GetStringBuilder());
+            using (var xmlWriter = XmlWriter.Create(stringWriter, XmlExtensions.FragmentWriterSettings))
+            {
+                node.WriteTo(xmlWriter);
+            }
+
             try
             {
-                var node = result.ToXml(false);
-                var parent = GetParent(result.Test);
-                node.AddAttribute("parentId", parent != null ? parent.Id : string.Empty);
-                handler.RaiseCallbackEvent(node.OuterXml);
+                _handler.RaiseCallbackEvent(stringWriter.ToString());
             }
             catch (Exception ex)
             {
@@ -82,9 +122,15 @@ namespace NUnit.Framework.Internal
         /// <param name="output">A TestOutput object containing the text to display</param>
         public void TestOutput(TestOutput output)
         {
+            using var stringWriter = new StringWriter(GetStringBuilder());
+            using (var writer = XmlWriter.Create(stringWriter, XmlExtensions.FragmentWriterSettings))
+            {
+                output.ToXml(writer);
+            }
+
             try
             {
-                handler.RaiseCallbackEvent(output.ToXml());
+                _handler.RaiseCallbackEvent(stringWriter.ToString());
             }
             catch (Exception ex)
             {
@@ -98,9 +144,15 @@ namespace NUnit.Framework.Internal
         /// <param name="message">A <see cref="TestMessage"/> object containing the text to send</param>
         public void SendMessage(TestMessage message)
         {
+            using var stringWriter = new StringWriter(GetStringBuilder());
+            using (var writer = XmlWriter.Create(stringWriter, XmlExtensions.FragmentWriterSettings))
+            {
+                message.ToXml(writer);
+            }
+
             try
             {
-                handler.RaiseCallbackEvent(message.ToXml());
+                _handler.RaiseCallbackEvent(stringWriter.ToString());
             }
             catch (Exception ex)
             {
@@ -119,29 +171,28 @@ namespace NUnit.Framework.Internal
         /// <returns>parent test item</returns>
         private static ITest? GetParent(ITest test)
         {
-            if (test == null || test.Parent == null)
+            while (true)
             {
-                return null;
-            }
+                var parent = test?.Parent;
 
-            return test.Parent.IsSuite ? test.Parent : GetParent(test.Parent);
+                if (parent == null)
+                {
+                    return null;
+                }
+
+                if (parent.IsSuite)
+                {
+                    return parent;
+                }
+
+                test = parent;
+            }
         }
 
-        /// <summary>
-        /// Makes a string safe for use as an attribute, replacing
-        /// characters that can't be used with their
-        /// corresponding XML representations.
-        /// </summary>
-        /// <param name="original">The string to be used</param>
-        /// <returns>A new string with the values replaced</returns>
-        private static string FormatAttributeValue(string original)
+        private StringBuilder GetStringBuilder()
         {
-            return original
-                .Replace("&", "&amp;")
-                .Replace("\"", "&quot;")
-                .Replace("'", "&apos;")
-                .Replace("<", "&lt;")
-                .Replace(">", "&gt;");
+            _stringBuilder.Clear();
+            return _stringBuilder;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/XmlExtensions.cs
+++ b/src/NUnitFramework/framework/XmlExtensions.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Xml;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Contains extension methods that do not require a special <c>using</c> directive.
+    /// </summary>
+    internal static class XmlExtensions
+    {
+        // we want to write just the main element without XML declarations
+        internal static readonly XmlWriterSettings FragmentWriterSettings = new()
+        {
+            ConformanceLevel = ConformanceLevel.Fragment
+        };
+
+        /// <summary>
+        /// Checks that attribute value contains safe content and if not, escapes it.
+        /// </summary>
+        internal static void WriteAttributeStringSafe(this XmlWriter writer, string name, string value)
+        {
+            writer.WriteAttributeString(name, EscapeInvalidXmlCharacters(value));
+        }
+
+        /// <summary>
+        /// Checks that CDATA section contains safe content and if not, escapes it.
+        /// </summary>
+        internal static void WriteCDataSafe(this XmlWriter writer, string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            text = EscapeInvalidXmlCharacters(text);
+
+            int start = 0;
+
+            while (true)
+            {
+                int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
+                if (illegal < 0)
+                    break;
+                writer.WriteCData(text.Substring(start, illegal - start + 2));
+                start = illegal + 2;
+                if (start >= text.Length)
+                    return;
+            }
+
+            if (start > 0)
+                writer.WriteCData(text.Substring(start));
+            else
+                writer.WriteCData(text);
+        }
+
+
+        [return: NotNullIfNotNull("str")]
+        internal static string? EscapeInvalidXmlCharacters(string? str)
+        {
+            if (str == null) return null;
+
+            // quick check when we expect valid input
+            foreach (var c in str)
+            {
+                if (c < 0x20 || c > 0x7F)
+                {
+                    return EscapeInvalidXmlCharactersUnlikely(str);
+                }
+            }
+
+            return str;
+        }
+
+        private static string EscapeInvalidXmlCharactersUnlikely(string str)
+        {
+            StringBuilder? builder = null;
+            for (int i = 0; i < str.Length; i++)
+            {
+                char c = str[i];
+                if (c > 0x20 && c < 0x7F)
+                {
+                    // ASCII characters - break quickly for these
+                    builder?.Append(c);
+                }
+                // From the XML specification: https://www.w3.org/TR/xml/#charsets
+                // Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+                // Any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
+                else if (!(0x0 <= c && c <= 0x8) &&
+                         c != 0xB &&
+                         c != 0xC &&
+                         !(0xE <= c && c <= 0x1F) &&
+                         !(0x7F <= c && c <= 0x84) &&
+                         !(0x86 <= c && c <= 0x9F) &&
+                         !(0xD800 <= c && c <= 0xDFFF) &&
+                         c != 0xFFFE &&
+                         c != 0xFFFF)
+                {
+                    builder?.Append(c);
+                }
+                // Also check if the char is actually a high/low surrogate pair of two characters.
+                // If it is, then it is a valid XML character (from above based on the surrogate blocks).
+                else if (char.IsHighSurrogate(c) &&
+                         i + 1 != str.Length &&
+                         char.IsLowSurrogate(str[i + 1]))
+                {
+                    if (builder != null)
+                    {
+                        builder.Append(c);
+                        builder.Append(str[i + 1]);
+                    }
+
+                    i++;
+                }
+                else
+                {
+                    // We keep the builder null so that we don't allocate a string
+                    // when doing this conversion until we encounter a unicode character.
+                    // Then, we allocate the rest of the string and escape the invalid
+                    // character.
+                    if (builder == null)
+                    {
+                        builder = new StringBuilder();
+                        for (int index = 0; index < i; index++)
+                            builder.Append(str[index]);
+                    }
+
+                    builder.Append(CharToUnicodeSequence(c));
+                }
+            }
+
+            if (builder != null)
+                return builder.ToString();
+            else
+                return str;
+        }
+
+        private static string CharToUnicodeSequence(char symbol)
+        {
+            return $"\\u{(int)symbol:x4}";
+        }
+    }
+}


### PR DESCRIPTION
When lookin at memory allocations during Jint.Tests.Test262 run, seems that most of the allocations come from NUnit itself (12%).  Reporting test progress generates a lot of string so there's some room for improvement. Using reused `StringBuilder` to report progress.

The targets are `OuterXml` which always creates a new `StringBuilder` and `TestStarted` which manually concatenates a larger string. Now new `GetOuterXml()` allows providing reusable `StringBuilder`. Introduced new internal `XmlExtensions` that allows writing things in concise manner.

The root cause is more on the [NUnit.Console side](https://github.com/nunit/nunit-console/pull/1338), but this should also help a bit.

![image](https://user-images.githubusercontent.com/171892/233684583-905929d6-8441-4649-a962-eb9abb885467.png)
