### PR TITLE
Optimize TNode XML reading

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -331,7 +331,7 @@ namespace NUnit.Framework.Api
         public static TNode InsertEnvironmentElement(TNode targetNode)
         {
             TNode env = new TNode("environment");
-            targetNode.ChildNodes.Insert(0, env);
+            targetNode.InsertChildNode(0, env);
 
             env.AddAttribute("framework-version", typeof(FrameworkController).Assembly.GetName().Version?.ToString() ?? "Unknown");
             env.AddAttribute("clr-version", Environment.Version.ToString());
@@ -366,7 +366,7 @@ namespace NUnit.Framework.Api
         public static TNode InsertSettingsElement(TNode targetNode, IDictionary<string, object> settings)
         {
             TNode settingsNode = new TNode("settings");
-            targetNode.ChildNodes.Insert(0, settingsNode);
+            targetNode.InsertChildNode(0, settingsNode);
 
             foreach (string key in settings.Keys)
                 AddSetting(settingsNode, key, settings[key]);
@@ -393,7 +393,7 @@ namespace NUnit.Framework.Api
                 setting.AddAttribute("value", value.ToString()!);
             }
 
-            settingsNode.ChildNodes.Add(setting);
+            settingsNode.AddChildNode(setting);
         }
 
         private static void AddBackwardsCompatibleDictionaryEntries(TNode settingsNode, IDictionary entries)
@@ -414,7 +414,7 @@ namespace NUnit.Framework.Api
                 var entryNode = new TNode("item");
                 entryNode.AddAttribute("key", key.ToString()!);
                 entryNode.AddAttribute("value", value?.ToString() ?? string.Empty);
-                settingNode.ChildNodes.Add(entryNode);
+                settingNode.AddChildNode(entryNode);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Internal
             {
                 var node = result.ToXml(false);
                 var parent = GetParent(result.Test);
-                node.Attributes.Add("parentId", parent != null ? parent.Id : string.Empty);
+                node.AddAttribute("parentId", parent != null ? parent.Id : string.Empty);
                 handler.RaiseCallbackEvent(node.OuterXml);
             }
             catch (Exception ex)

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit3XmlOutputWriter.cs
@@ -62,9 +62,9 @@ namespace NUnitLite
 
             TNode testRun = MakeTestRunElement(result);
 
-            testRun.ChildNodes.Add(MakeCommandLineElement());
-            testRun.ChildNodes.Add(MakeTestFilterElement(filter));
-            testRun.ChildNodes.Add(resultNode);
+            testRun.AddChildNode(MakeCommandLineElement());
+            testRun.AddChildNode(MakeTestFilterElement(filter));
+            testRun.AddChildNode(resultNode);
 
             testRun.WriteTo(xmlWriter);
         }


### PR DESCRIPTION
`XmlDocument` is heavy and by using just `XmlReader` and reading information that is interesting in a forward-only manner, things get faster and less memory-consuming. `TNode` also always created properties and child nodes collections allocating memory even though they might not be needed. `TNode` also allowed something that I call "picking the pockets" as collections allowed direct `.Add` called, now there's separate `InsertChildNode` and `AddChildNode` which also check for backing store initialization. So this PR targets the read part of XML.
 
* change `TNode` to read from `XmlReader`
* change `TNode`'s `_childNodes` and `_attributes` to be lazily initialized only when needed
* create struct-based views for attributes and child nodes which hide nullability of backing stores

# Benchmark results

These are against 60k test suite Jint.Tests.Test262.

``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1631/22H2/2022Update/SunValley2)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.203
  [Host] : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2

Job=InProcess  Toolchain=InProcessEmitToolchain  

```

## NUnit.Framework.FrameworkControllerBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |CountTestsEmptyFilter|91.78 μs|0.527 μs|0 B|
| **New** |	| **90.52 μs (-1%)** | **0.415 μs** | **0 B** |
| Old |CountTestsWithCategoryFilter|573.45 μs|0.812 μs|12953 B|
| **New** |	| **564.48 μs (-2%)** | **0.842 μs** | **10865 B (-16%)** |
| Old |CountTestsWithOrFilterAll|3,545.07 μs|3.139 μs|3957323 B|
| **New** |	| **1,717.27 μs (-52%)** | **12.752 μs** | **1285461 B (-68%)** |
| Old |LoadTests|60,392.06 μs|141.555 μs|24623708 B|
| **New** |	| **60,387.40 μs (0%)** | **101.571 μs** | **24623267 B (0%)** |
