### PR TITLE
Add NUnit.Analyzer to nunit.framework.tests

### DIFF
--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -165,15 +165,29 @@ namespace NUnit.TestUtilities
 
         public static ITestResult ExecuteWorkItem(WorkItem work)
         {
-            work.Execute();
+            var savedContext = TestExecutionContext.CurrentContext;
 
-            // TODO: Replace with an event - but not while method is static
-            while (work.State != WorkItemState.Complete)
+            try
             {
-                Thread.Sleep(1);
+                return ExecuteUntilComplete(work);
+            }
+            finally
+            {
+                savedContext.EstablishExecutionEnvironment();
             }
 
-            return work.Result;
+            static ITestResult ExecuteUntilComplete(WorkItem work)
+            {
+                work.Execute();
+
+                // TODO: Replace with an event - but not while method is static
+                while (work.State != WorkItemState.Complete)
+                {
+                    Thread.Sleep(1);
+                }
+
+                return work.Result;
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -39,14 +39,14 @@ namespace NUnit.TestUtilities
         public static TestSuite MakeParameterizedMethodSuite(Type type, string methodName)
         {
             var suite = MakeTestFromMethod(type, methodName) as TestSuite;
-            Assert.NotNull(suite, "Unable to create parameterized suite - most likely there is no data provided");
+            Assert.That(suite, Is.Not.Null, "Unable to create parameterized suite - most likely there is no data provided");
             return suite;
         }
 
         public static TestMethod MakeTestCase(Type type, string methodName)
         {
             var test = MakeTestFromMethod(type, methodName) as TestMethod;
-            Assert.NotNull(test, "Unable to create TestMethod from {0}", methodName);
+            Assert.That(test, Is.Not.Null, "Unable to create TestMethod from {0}", methodName);
 
             return test;
         }

--- a/src/NUnitFramework/tests/.editorconfig
+++ b/src/NUnitFramework/tests/.editorconfig
@@ -1,0 +1,15 @@
+# Exception to default Analyzer rules
+
+[*.cs]
+
+# Field is never used.
+# NUnit heavily relies on System.Reflection
+dotnet_diagnostic.CS0169.severity = silent
+
+# NUnit2007: The actual value should not be a constant
+# To verify proper behaviour of tests, we need known numbers.
+# Unlike other code we do not compare results of calculations with a known outcome.
+dotnet_diagnostic.NUnit2007.severity = silent
+
+# NUnit2009: The same value has been provided as both the actual and the expected argument
+dotnet_diagnostic.NUnit2009.severity = silent

--- a/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
+++ b/src/NUnitFramework/tests/Api/FrameworkControllerTests.cs
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Api
 
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             // in parallel, an additional node is added with number of test workers
-            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(3));
+            Assert.That(inserted.ChildNodes, Has.Count.EqualTo(3));
             Assert.That(inserted.ChildNodes[0].Attributes["name"], Is.EqualTo("key1"));
             Assert.That(inserted.ChildNodes[0].Attributes["value"], Is.EqualTo("value1"));
 
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Api
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
 
             // in parallel, an additional node is added with number of test workers
-            Assert.That(inserted.ChildNodes.Count, Is.EqualTo(3));
+            Assert.That(inserted.ChildNodes, Has.Count.EqualTo(3));
         }
 
         [TestCaseSource(nameof(SettingsData))]
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Api
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             var settingNode = inserted.FirstChild;
 
-            Assert.That(settingNode.ChildNodes.Count, Is.EqualTo(2));
+            Assert.That(settingNode.ChildNodes, Has.Count.EqualTo(2));
         }
 
         [TestCaseSource(nameof(SettingsData))]
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Api
             var inserted = FrameworkController.InsertSettingsElement(outerNode, testSettings);
             var settingNode = inserted.FirstChild;
 
-            Assert.That(settingNode.ChildNodes.Count, Is.EqualTo(2));
+            Assert.That(settingNode.ChildNodes, Has.Count.EqualTo(2));
             Assert.That(settingNode.Attributes["value"], Is.EqualTo($"[key1, value1], [key2, {value}]"));
         }
 
@@ -188,7 +188,7 @@ namespace NUnit.Framework.Api
             Assert.That(key2Node.Attributes["value"], Is.EqualTo(value));
         }
 
-        public static IEnumerable SettingsData()
+        private static IEnumerable SettingsData()
         {
             yield return new TestCaseData("value");
             yield return new TestCaseData("");
@@ -224,7 +224,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["name"], Is.EqualTo(EXPECTED_NAME));
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockAssembly.Tests.ToString()));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
         [Test]
@@ -240,7 +240,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["name"], Is.EqualTo(EXPECTED_NAME).IgnoreCase);
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockAssembly.Tests.ToString()));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
         [Test]
@@ -255,7 +255,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo("0"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(MISSING_NAME));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
         [Test]
@@ -269,7 +269,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["runstate"], Is.EqualTo("NotRunnable"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(BAD_FILE));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
         #endregion
@@ -288,7 +288,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["name"], Is.EqualTo(EXPECTED_NAME));
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockTestFixture.Tests.ToString()));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Not.Empty, "Explore result should have child tests");
         }
 
         [TestCaseSource(nameof(EmptyFilters))]
@@ -304,7 +304,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["name"], Is.EqualTo(EXPECTED_NAME));
             Assert.That(result.Attributes["runstate"], Is.EqualTo("Runnable"));
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo(MockAssembly.Tests.ToString()));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Not.Empty, "Explore result should have child tests");
         }
 
         [TestCase(FIXTURE_CAT_FILTER)]
@@ -345,7 +345,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo("0"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(MISSING_NAME));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Result should not have child tests");
         }
 
         [Test]
@@ -362,7 +362,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo("0"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(BAD_FILE));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Result should not have child tests");
         }
 
 #endregion
@@ -427,7 +427,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["warnings"], Is.EqualTo(MockAssembly.Warnings.ToString()));
             Assert.That(result.Attributes["skipped"], Is.EqualTo(MockAssembly.Skipped.ToString()));
             Assert.That(result.Attributes["inconclusive"], Is.EqualTo(MockAssembly.Inconclusive.ToString()));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Run result should have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Not.Empty, "Run result should have child tests");
         }
 
         [Test]
@@ -452,7 +452,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo("0"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(MISSING_NAME));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
         [Test]
@@ -469,7 +469,7 @@ namespace NUnit.Framework.Api
             Assert.That(result.Attributes["testcasecount"], Is.EqualTo("0"));
             // Minimal check here to allow for platform differences
             Assert.That(GetSkipReason(result), Contains.Substring(BAD_FILE));
-            Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
+            Assert.That(result.SelectNodes("test-suite"), Is.Empty, "Load result should not have child tests");
         }
 
 #endregion

--- a/src/NUnitFramework/tests/Api/ResultStateTests.cs
+++ b/src/NUnitFramework/tests/Api/ResultStateTests.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(status);
 
-            Assert.AreEqual(status, resultState.Status);
+            Assert.That(resultState.Status, Is.EqualTo(status));
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed);
 
-            Assert.AreEqual(string.Empty, resultState.Label);
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty));
         }
 
         [TestCase(TestStatus.Failed)]
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(status, string.Empty);
 
-            Assert.AreEqual(status, resultState.Status);
+            Assert.That(resultState.Status, Is.EqualTo(status));
         }
 
         [TestCase("")]
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed, label);
 
-            Assert.AreEqual(label, resultState.Label);
+            Assert.That(resultState.Label, Is.EqualTo(label));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed, null);
 
-            Assert.AreEqual(string.Empty, resultState.Label);
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed);
 
-            Assert.AreEqual(FailureSite.Test, resultState.Site);
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test));
         }
 
         [TestCase("")]
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed, label);
 
-            Assert.AreEqual(FailureSite.Test, resultState.Site);
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test));
         }
 
         [TestCase("", FailureSite.Parent)]
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(TestStatus.Failed, label, site);
 
-            Assert.AreEqual(site, resultState.Site);
+            Assert.That(resultState.Site, Is.EqualTo(site));
         }
 
         [TestCase(TestStatus.Skipped, null, "Skipped")]
@@ -89,7 +89,7 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = new ResultState(status, label);
 
-            Assert.AreEqual(expected, resultState.ToString());
+            Assert.That(resultState.ToString(), Is.EqualTo(expected));
         }
 
         #region EqualityTests
@@ -97,43 +97,43 @@ namespace NUnit.Framework.Api
         [Test]
         public void TestEquality_StatusSpecified()
         {
-            Assert.AreEqual(new ResultState(TestStatus.Failed), new ResultState(TestStatus.Failed));
+            Assert.That(new ResultState(TestStatus.Failed), Is.EqualTo(new ResultState(TestStatus.Failed)));
         }
 
         [Test]
         public void TestEquality_StatusAndLabelSpecified()
         {
-            Assert.AreEqual(new ResultState(TestStatus.Skipped, "Ignored"), new ResultState(TestStatus.Skipped, "Ignored"));
+            Assert.That(new ResultState(TestStatus.Skipped, "Ignored"), Is.EqualTo(new ResultState(TestStatus.Skipped, "Ignored")));
         }
 
         [Test]
         public void TestEquality_StatusAndSiteSpecified()
         {
-            Assert.AreEqual(new ResultState(TestStatus.Failed, FailureSite.SetUp), new ResultState(TestStatus.Failed, FailureSite.SetUp));
+            Assert.That(new ResultState(TestStatus.Failed, FailureSite.SetUp), Is.EqualTo(new ResultState(TestStatus.Failed, FailureSite.SetUp)));
         }
 
         [Test]
         public void TestEquality_StatusLabelAndSiteSpecified()
         {
-            Assert.AreEqual(new ResultState(TestStatus.Failed, "Error", FailureSite.Child), new ResultState(TestStatus.Failed, "Error", FailureSite.Child));
+            Assert.That(new ResultState(TestStatus.Failed, "Error", FailureSite.Child), Is.EqualTo(new ResultState(TestStatus.Failed, "Error", FailureSite.Child)));
         }
 
         [Test]
         public void TestEquality_StatusDiffers()
         {
-            Assert.AreNotEqual(new ResultState(TestStatus.Passed), new ResultState(TestStatus.Failed));
+            Assert.That(new ResultState(TestStatus.Failed), Is.Not.EqualTo(new ResultState(TestStatus.Passed)));
         }
 
         [Test]
         public void TestEquality_LabelDiffers()
         {
-            Assert.AreNotEqual(new ResultState(TestStatus.Failed, "Error"), new ResultState(TestStatus.Failed));
+            Assert.That(new ResultState(TestStatus.Failed), Is.Not.EqualTo(new ResultState(TestStatus.Failed, "Error")));
         }
 
         [Test]
         public void TestEquality_SiteDiffers()
         {
-            Assert.AreNotEqual(new ResultState(TestStatus.Failed, "Error", FailureSite.Child), new ResultState(TestStatus.Failed, "Error", FailureSite.SetUp));
+            Assert.That(new ResultState(TestStatus.Failed, "Error", FailureSite.SetUp), Is.Not.EqualTo(new ResultState(TestStatus.Failed, "Error", FailureSite.Child)));
         }
 
 
@@ -143,18 +143,24 @@ namespace NUnit.Framework.Api
             var rs = new ResultState(TestStatus.Passed);
             var s = "123";
 
-            Assert.AreNotEqual(rs, s);
-            Assert.AreNotEqual(s, rs);
-            Assert.False(rs.Equals(s));
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(s, Is.Not.EqualTo(rs));
+            Assert.That(rs, Is.Not.EqualTo(s));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
         }
 
         [Test]
         public void TestEquality_Null()
         {
             var rs = new ResultState(TestStatus.Passed);
-            Assert.AreNotEqual(null, rs);
-            Assert.AreNotEqual(rs, null);
-            Assert.False(rs.Equals(null));
+
+            // Ensure real Equals fails, before checking nunit constraint
+#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+            Assert.That(rs.Equals(null), Is.False);
+#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+
+            Assert.That(rs, Is.Not.EqualTo(null));
+            Assert.That(default(ResultState), Is.Not.EqualTo(rs));
         }
 
         #endregion
@@ -168,9 +174,12 @@ namespace NUnit.Framework.Api
         {
             var result = new ResultState(status, label).WithSite(site);
 
-            Assert.That(result.Status, Is.EqualTo(status));
-            Assert.That(result.Label, Is.EqualTo(label));
-            Assert.That(result.Site, Is.EqualTo(site));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Status, Is.EqualTo(status));
+                Assert.That(result.Label, Is.EqualTo(label));
+                Assert.That(result.Site, Is.EqualTo(site));
+            });
         }
 
         #endregion
@@ -182,9 +191,12 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Inconclusive;
 
-            Assert.AreEqual(TestStatus.Inconclusive, resultState.Status, "Status not correct.");
-            Assert.AreEqual(string.Empty, resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultState.Status, Is.EqualTo(TestStatus.Inconclusive), "Status not correct.");
+                Assert.That(resultState.Label, Is.EqualTo(string.Empty), "Label not correct.");
+                Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
+            });
         }
 
         [Test]
@@ -192,9 +204,12 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.NotRunnable;
 
-            Assert.AreEqual(TestStatus.Failed, resultState.Status, "Status not correct.");
-            Assert.AreEqual("Invalid", resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultState.Status, Is.EqualTo(TestStatus.Failed), "Status not correct.");
+                Assert.That(resultState.Label, Is.EqualTo("Invalid"), "Label not correct.");
+                Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
+            });
         }
 
         [Test]
@@ -202,9 +217,12 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Skipped;
 
-            Assert.AreEqual(TestStatus.Skipped, resultState.Status, "Status not correct.");
-            Assert.AreEqual(string.Empty, resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultState.Status, Is.EqualTo(TestStatus.Skipped), "Status not correct.");
+                Assert.That(resultState.Label, Is.EqualTo(string.Empty), "Label not correct.");
+                Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
+            });
         }
 
         [Test]
@@ -212,9 +230,12 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Ignored;
 
-            Assert.AreEqual(TestStatus.Skipped, resultState.Status, "Status not correct.");
-            Assert.AreEqual("Ignored", resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultState.Status, Is.EqualTo(TestStatus.Skipped), "Status not correct.");
+                Assert.That(resultState.Label, Is.EqualTo("Ignored"), "Label not correct.");
+                Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
+            });
         }
 
         [Test]
@@ -222,9 +243,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Success;
 
-            Assert.AreEqual(TestStatus.Passed, resultState.Status, "Status not correct.");
-            Assert.AreEqual(string.Empty, resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Passed), "Status not correct.");
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty), "Label not correct.");
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
         }
 
         [Test]
@@ -232,9 +253,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Warning;
 
-            Assert.AreEqual(TestStatus.Warning, resultState.Status, "Status not correct.");
-            Assert.AreEqual(string.Empty, resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Warning), "Status not correct.");
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty), "Label not correct.");
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
         }
 
         [Test]
@@ -242,9 +263,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Failure;
 
-            Assert.AreEqual(TestStatus.Failed, resultState.Status, "Status not correct.");
-            Assert.AreEqual(string.Empty, resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Failed), "Status not correct.");
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty), "Label not correct.");
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
         }
 
         [Test]
@@ -252,9 +273,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.ChildFailure;
 
-            Assert.AreEqual(TestStatus.Failed, resultState.Status);
-            Assert.AreEqual(string.Empty, resultState.Label);
-            Assert.AreEqual(FailureSite.Child, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Failed));
+            Assert.That(resultState.Label, Is.EqualTo(string.Empty));
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Child), "Site not correct.");
         }
 
         [Test]
@@ -262,9 +283,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Error;
 
-            Assert.AreEqual(TestStatus.Failed, resultState.Status, "Status not correct.");
-            Assert.AreEqual("Error", resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Failed), "Status not correct.");
+            Assert.That(resultState.Label, Is.EqualTo("Error"), "Label not correct.");
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
         }
 
         [Test]
@@ -272,9 +293,9 @@ namespace NUnit.Framework.Api
         {
             ResultState resultState = ResultState.Cancelled;
 
-            Assert.AreEqual(TestStatus.Failed, resultState.Status, "Status not correct.");
-            Assert.AreEqual("Cancelled", resultState.Label, "Label not correct.");
-            Assert.AreEqual(FailureSite.Test, resultState.Site, "Site not correct.");
+            Assert.That(resultState.Status, Is.EqualTo(TestStatus.Failed), "Status not correct.");
+            Assert.That(resultState.Label, Is.EqualTo("Cancelled"), "Label not correct.");
+            Assert.That(resultState.Site, Is.EqualTo(FailureSite.Test), "Site not correct.");
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+#if THREAD_ABORT
 using System.Text;
+#endif
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -226,7 +228,7 @@ namespace NUnit.Framework.Api
 
         private void CheckForDuplicates(ITest test, Dictionary<string, bool> dict)
         {
-            Assert.False(dict.ContainsKey(test.Id), "Duplicate key: {0}", test.Id);
+            Assert.That(dict.ContainsKey(test.Id), Is.False, "Duplicate key: {0}", test.Id);
             dict.Add(test.Id, true);
 
             foreach (var child in test.Tests)
@@ -264,7 +266,7 @@ namespace NUnit.Framework.Api
             var runnerFixture = _runner.LoadedTest.Tests[0].Tests[0].Tests[0].Tests[0];
             var explorerFixture = explorer.Tests[0].Tests[0].Tests[0].Tests[0];
 
-            Assert.That(explorerFixture.Properties.Keys.Count, Is.EqualTo(runnerFixture.Properties.Keys.Count));
+            Assert.That(explorerFixture.Properties.Keys, Has.Count.EqualTo(runnerFixture.Properties.Keys.Count));
             Assert.That(explorerFixture.Properties.Get(PropertyNames.Category),
                 Is.EqualTo(explorerFixture.Properties.Get(PropertyNames.Category)));
             Assert.That(explorerFixture.Properties.Get(PropertyNames.Description),
@@ -396,7 +398,7 @@ namespace NUnit.Framework.Api
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
-            Assert.NotNull(_runner.Result, "No result returned");
+            Assert.That(_runner.Result, Is.Not.Null, "No result returned");
             Assert.That(_runner.Result.Test.IsSuite);
             Assert.That(_runner.Result.Test, Is.TypeOf<TestAssembly>());
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.Runnable));
@@ -439,7 +441,7 @@ namespace NUnit.Framework.Api
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
-            Assert.NotNull(_runner.Result, "No result returned");
+            Assert.That(_runner.Result, Is.Not.Null, "No result returned");
             Assert.That(_runner.Result.Test.IsSuite);
             Assert.That(_runner.Result.Test, Is.TypeOf<TestAssembly>());
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -456,7 +458,7 @@ namespace NUnit.Framework.Api
             _runner.RunAsync(TestListener.NULL, TestFilter.Empty);
             _runner.WaitForCompletion(Timeout.Infinite);
 
-            Assert.NotNull(_runner.Result, "No result returned");
+            Assert.That(_runner.Result, Is.Not.Null, "No result returned");
             Assert.That(_runner.Result.Test.IsSuite);
             Assert.That(_runner.Result.Test, Is.TypeOf<TestAssembly>());
             Assert.That(_runner.Result.Test.RunState, Is.EqualTo(RunState.NotRunnable));
@@ -504,8 +506,8 @@ namespace NUnit.Framework.Api
             // Use Assert.Multiple so we can see everything that went wrong at one time
             Assert.Multiple(() =>
             {
-                Assert.True(completionWasSignaled, "Runner never signaled completion");
-                Assert.True(_runner.IsTestComplete, "Test is not recorded as complete");
+                Assert.That(completionWasSignaled, Is.True, "Runner never signaled completion");
+                Assert.That(_runner.IsTestComplete, Is.True, "Test is not recorded as complete");
 
                 if (_activeTests.Count > 0)
                 {
@@ -574,7 +576,7 @@ namespace NUnit.Framework.Api
         /// Called when a test produces output for immediate display
         /// </summary>
         /// <param name="output">A TestOutput object containing the text to display</param>
-        public void TestOutput(TestOutput output)
+        void ITestListener.TestOutput(TestOutput output)
         {
             _testOutputCount++;
         }
@@ -583,9 +585,8 @@ namespace NUnit.Framework.Api
         /// Called when a test produces message to be sent to listeners
         /// </summary>
         /// <param name="message">A TestMessage object containing the text to send</param>
-        public void SendMessage(TestMessage message)
+        void ITestListener.SendMessage(TestMessage message)
         {
-
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Assertions/.editorconfig
+++ b/src/NUnitFramework/tests/Assertions/.editorconfig
@@ -1,0 +1,28 @@
+[*.cs]
+
+# These are classic assertion tests and
+# should not be converted to the constraint model
+dotnet_diagnostic.NUnit2001.severity = none
+dotnet_diagnostic.NUnit2002.severity = none
+dotnet_diagnostic.NUnit2003.severity = none
+dotnet_diagnostic.NUnit2004.severity = none
+dotnet_diagnostic.NUnit2005.severity = none
+dotnet_diagnostic.NUnit2006.severity = none
+dotnet_diagnostic.NUnit2015.severity = none
+dotnet_diagnostic.NUnit2016.severity = none
+dotnet_diagnostic.NUnit2017.severity = none
+dotnet_diagnostic.NUnit2018.severity = none
+dotnet_diagnostic.NUnit2019.severity = none
+dotnet_diagnostic.NUnit2027.severity = none
+dotnet_diagnostic.NUnit2028.severity = none
+dotnet_diagnostic.NUnit2029.severity = none
+dotnet_diagnostic.NUnit2030.severity = none
+dotnet_diagnostic.NUnit2031.severity = none
+dotnet_diagnostic.NUnit2032.severity = none
+dotnet_diagnostic.NUnit2033.severity = none
+dotnet_diagnostic.NUnit2034.severity = none
+dotnet_diagnostic.NUnit2035.severity = none
+dotnet_diagnostic.NUnit2036.severity = none
+dotnet_diagnostic.NUnit2037.severity = none
+dotnet_diagnostic.NUnit2038.severity = none
+dotnet_diagnostic.NUnit2039.severity = none

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Assertions
 
             static public void TestValidContext()
             {
-                Assert.NotNull(TestExecutionContext.CurrentContext);
+                Assert.That(TestExecutionContext.CurrentContext, Is.Not.Null);
                 Assert.That(TestExecutionContext.CurrentContext, Is.TypeOf<TestExecutionContext.AdhocContext>());
             }
 

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
@@ -152,7 +152,9 @@ namespace NUnit.Framework.Assertions
                 TextMessageWriter.Pfx_Expected + "1" + NL +
                 TextMessageWriter.Pfx_Actual + "< 1, 2, 3 >" + NL;
 
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertEqualsTests.cs
@@ -3,12 +3,16 @@
 using NUnit.TestUtilities;
 using System;
 using System.IO;
+using System.Text;
 
 namespace NUnit.Framework.Assertions
 {
     [TestFixture]
     public class AssertEqualsTests
     {
+        // Here we use real comparison to validate NUnit Assert.AreEquals behaviour matches.
+#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+
         [Test]
         public void Equals()
         {
@@ -42,17 +46,10 @@ namespace NUnit.Framework.Assertions
         }
 
         [Test]
-        public void Bug524CharIntWithoutOverload()
-        {
-            char c = '\u0000';
-            Assert.That(c, Is.EqualTo(0));
-        }
-
-        [Test]
         public void CharCharComparison()
         {
             char c = 'a';
-            Assert.That(c, Is.EqualTo('a'));
+            Assert.AreEqual('a', c);
         }
 
         [Test]
@@ -91,9 +88,9 @@ namespace NUnit.Framework.Assertions
         {
             var expectedMessage =
                 "  Expected: 1.234d +/- 0.0d" + Environment.NewLine +
-                "  But was:  " + Double.NaN + Environment.NewLine;
+                "  But was:  " + double.NaN + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(1.234, Double.NaN, 0.0));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(1.234, double.NaN, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -102,39 +99,39 @@ namespace NUnit.Framework.Assertions
         public void NanEqualsFails()
         {
             var expectedMessage =
-                "  Expected: " + Double.NaN + Environment.NewLine +
+                "  Expected: " + double.NaN + Environment.NewLine +
                 "  But was:  1.234d" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.NaN, 1.234, 0.0));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(double.NaN, 1.234, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void NanEqualsNaNSucceeds()
         {
-            Assert.AreEqual(Double.NaN, Double.NaN, 0.0);
+            Assert.AreEqual(double.NaN, double.NaN, 0.0);
         }
 
         [Test]
         public void NegInfinityEqualsInfinity()
         {
-            Assert.AreEqual(Double.NegativeInfinity, Double.NegativeInfinity, 0.0);
+            Assert.AreEqual(double.NegativeInfinity, double.NegativeInfinity, 0.0);
         }
 
         [Test]
         public void PosInfinityEqualsInfinity()
         {
-            Assert.AreEqual(Double.PositiveInfinity, Double.PositiveInfinity, 0.0);
+            Assert.AreEqual(double.PositiveInfinity, double.PositiveInfinity, 0.0);
         }
 
         [Test]
         public void PosInfinityNotEquals()
         {
             var expectedMessage =
-                "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
+                "  Expected: " + double.PositiveInfinity + Environment.NewLine +
                 "  But was:  1.23d" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.PositiveInfinity, 1.23, 0.0));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(double.PositiveInfinity, 1.23, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -142,10 +139,10 @@ namespace NUnit.Framework.Assertions
         public void PosInfinityNotEqualsNegInfinity()
         {
             var expectedMessage =
-                "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
-                "  But was:  " + Double.NegativeInfinity + Environment.NewLine;
+                "  Expected: " + double.PositiveInfinity + Environment.NewLine +
+                "  But was:  " + double.NegativeInfinity + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Double.PositiveInfinity, Double.NegativeInfinity, 0.0));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(double.PositiveInfinity, double.NegativeInfinity, 0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -153,8 +150,8 @@ namespace NUnit.Framework.Assertions
         public void SinglePosInfinityNotEqualsNegInfinity()
         {
             var expectedMessage =
-                "  Expected: " + Double.PositiveInfinity + Environment.NewLine +
-                "  But was:  " + Double.NegativeInfinity + Environment.NewLine;
+                "  Expected: " + double.PositiveInfinity + Environment.NewLine +
+                "  But was:  " + double.NegativeInfinity + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(float.PositiveInfinity, float.NegativeInfinity, (float)0.0));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
@@ -163,14 +160,14 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void EqualsThrowsException()
         {
-            object o = new object();
+            var o = new object();
             Assert.Throws<InvalidOperationException>(() => Assert.Equals(o, o));
         }
 
         [Test]
         public void ReferenceEqualsThrowsException()
         {
-            object o = new object();
+            var o = new object();
             Assert.Throws<InvalidOperationException>(() => Assert.ReferenceEquals(o, o));
         }
 
@@ -200,7 +197,7 @@ namespace NUnit.Framework.Assertions
         public void String()
         {
             string s1 = "test";
-            string s2 = new System.Text.StringBuilder(s1).ToString();
+            string s2 = new StringBuilder(s1).ToString();
 
             Assert.IsTrue(s1.Equals(s2));
             Assert.AreEqual(s1,s2);
@@ -279,19 +276,19 @@ namespace NUnit.Framework.Assertions
             char      c1 = '3';
             char      c2 = 'a';
 
-            System.Byte    b12  = 35;
-            System.SByte   sb13 = 35;
-            System.Decimal d14  = 35;
-            System.Double  d15  = 35;
-            System.Single  s16  = 35;
-            System.Int32   i17  = 35;
-            System.UInt32  ui18 = 35;
-            System.Int64   i19  = 35;
-            System.UInt64  ui20 = 35;
-            System.Int16   i21  = 35;
-            System.UInt16  i22  = 35;
-            System.Char    c12 = '3';
-            System.Char    c22 = 'a';
+            byte b12  = 35;
+            sbyte sb13 = 35;
+            decimal d14  = 35;
+            double d15  = 35;
+            float s16  = 35;
+            int i17  = 35;
+            uint ui18 = 35;
+            long i19  = 35;
+            ulong ui20 = 35;
+            short i21  = 35;
+            ushort i22  = 35;
+            char c12 = '3';
+            char c22 = 'a';
 
             Assert.AreEqual(35, b1);
             Assert.AreEqual(35, sb2);
@@ -369,16 +366,16 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void DateTimeEqual()
         {
-            DateTime dt1 = new DateTime( 2005, 6, 1, 7, 0, 0 );
-            DateTime dt2 = new DateTime( 2005, 6, 1, 0, 0, 0 ) + TimeSpan.FromHours( 7.0 );
+            var dt1 = new DateTime( 2005, 6, 1, 7, 0, 0 );
+            var dt2 = new DateTime( 2005, 6, 1, 0, 0, 0 ) + TimeSpan.FromHours( 7.0 );
             Assert.AreEqual( dt1, dt2 );
         }
 
         [Test]
         public void DateTimeNotEqual_DifferenceInHours()
         {
-            DateTime dt1 = new DateTime( 2005, 6, 1, 7, 0, 0 );
-            DateTime dt2 = new DateTime( 2005, 6, 1, 0, 0, 0 );
+            var dt1 = new DateTime( 2005, 6, 1, 7, 0, 0 );
+            var dt2 = new DateTime( 2005, 6, 1, 0, 0, 0 );
             var expectedMessage =
                 "  Expected: 2005-06-01 07:00:00" + Environment.NewLine +
                 "  But was:  2005-06-01 00:00:00" + Environment.NewLine;
@@ -386,17 +383,18 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(dt1, dt2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
+
         [Test]
         public void DateTimeNotEqual_DifferenceInTicks()
         {
-            DateTime dt1 = new DateTime(1914, 06, 28, 12, 00, 00);
-            DateTime dt2 = dt1.AddTicks(666);
+            var dt1 = new DateTime(1914, 06, 28, 12, 00, 00);
+            var dt2 = dt1.AddTicks(666);
             var expectedMessage =
                 "  Expected: 1914-06-28 12:00:00" + Environment.NewLine +
                 "  But was:  1914-06-28 12:00:00.0000666" + Environment.NewLine;
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(dt1, dt2));
-            Assert.That(ex.Message, Is.EqualTo(expectedMessage));
+            Assert.That(() => Assert.AreEqual(dt1, dt2),
+                Throws.InstanceOf<AssertionException>().With.Message.EqualTo(expectedMessage));
         }
 
         [Test]
@@ -510,7 +508,7 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IEquatableSuccess_OldSyntax()
         {
-            IntEquatable a = new IntEquatable(1);
+            var a = new IntEquatable(1);
 
             Assert.AreEqual(1, a);
             Assert.AreEqual(a, 1);
@@ -519,24 +517,27 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void IEquatableSuccess_ConstraintSyntax()
         {
-            IntEquatable a = new IntEquatable(1);
+            var a = new IntEquatable(1);
 
-            Assert.That(a, Is.EqualTo(1));
-            Assert.That(1, Is.EqualTo(a));
+            Assert.Multiple(() =>
+            {
+                Assert.That(a, Is.EqualTo(1));
+                Assert.That(1, Is.EqualTo(a));
+            });
         }
 
         [Test]
         public void EqualsFailsWhenUsed()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => Assert.Equals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assert.Equals should not be used."));
+            Assert.That(() => Assert.Equals(string.Empty, string.Empty),
+                Throws.InvalidOperationException.With.Message.StartWith("Assert.Equals should not be used."));
         }
 
         [Test]
         public void ReferenceEqualsFailsWhenUsed()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => Assert.ReferenceEquals(string.Empty, string.Empty));
-            Assert.That(ex.Message, Does.StartWith("Assert.ReferenceEquals should not be used."));
+            Assert.That(() => Assert.ReferenceEquals(string.Empty, string.Empty),
+                Throws.InvalidOperationException.With.Message.StartWith("Assert.ReferenceEquals should not be used."));
         }
 
         [Test]
@@ -548,18 +549,20 @@ namespace NUnit.Framework.Assertions
             Assert.AreEqual(expected, actual);
         }
 
-        class IntEquatable : IEquatable<int>
+#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+
+        private sealed class IntEquatable : IEquatable<int>
         {
-            readonly int i;
+            readonly int _i;
 
             public IntEquatable(int i)
             {
-                this.i = i;
+                _i = i;
             }
 
             public bool Equals(int other)
             {
-                return i.Equals(other);
+                return _i.Equals(other);
             }
         }
     }
@@ -569,7 +572,7 @@ namespace NUnit.Framework.Assertions
     /// a class to create the description of the constraint even where that
     /// description is not used because the test passes.
     /// </summary>
-    internal class ThrowsIfToStringIsCalled
+    internal sealed class ThrowsIfToStringIsCalled
     {
         readonly int _x;
 

--- a/src/NUnitFramework/tests/Assertions/AssertFailTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertFailTests.cs
@@ -69,8 +69,11 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreEqual(1, result.AssertionResults.Count);
             var assertion = result.AssertionResults[0];
-            Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
-            Assert.That(assertion.Message, Is.EqualTo("MESSAGE"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
+                Assert.That(assertion.Message, Is.EqualTo("MESSAGE"));
+            });
         }
 
         [Test]
@@ -85,8 +88,11 @@ namespace NUnit.Framework.Assertions
 
             Assert.AreEqual(1, result.AssertionResults.Count);
             var assertion = result.AssertionResults[0];
-            Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
-            Assert.That(assertion.Message, Is.EqualTo("MESSAGE: 2+2=4"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(assertion.Status, Is.EqualTo(AssertionStatus.Failed));
+                Assert.That(assertion.Message, Is.EqualTo("MESSAGE: 2+2=4"));
+            });
         }
 
         [Test]
@@ -96,18 +102,18 @@ namespace NUnit.Framework.Assertions
                 typeof(AssertFailFixture),
                 nameof(AssertFailFixture.HandleAssertionException));
 
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(1));
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
-            Assert.That(result.Message, Is.EqualTo("Custom message"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AssertionResults, Has.Count.EqualTo(1));
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+                Assert.That(result.Message, Is.EqualTo("Custom message"));
+            });
         }
 
         [Test]
         public void AssertCatchMakesTestPass()
         {
-            Assert.Catch(() =>
-            {
-                Assert.Fail("This should not be seen");
-            });
+            Assert.Catch(() => Assert.Fail("This should not be seen"));
 
             // Ensure that no spurious info was recorded from the assertion
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.AssertionResults, Is.Empty);
@@ -116,13 +122,10 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AssertThrowsMakesTestPass()
         {
-            Assert.Throws<AssertionException>(() =>
-            {
-                Assert.Fail("This should not be seen");
-            });
+            Assert.Throws<AssertionException>(() => Assert.Fail("This should not be seen"));
 
             // Ensure that no spurious info was recorded from the assertion
-            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.AssertionResults.Count, Is.EqualTo(0));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentResult.AssertionResults, Is.Empty);
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 using NUnit.TestData.AssertMultipleData;
 using NUnit.TestUtilities;
 using AM = NUnit.TestData.AssertMultipleData.AssertMultipleFixture;
@@ -90,9 +91,12 @@ namespace NUnit.Framework.Assertions
         {
             ITestResult result = TestBuilder.RunTestCase(typeof(AssertMultipleFixture), methodName);
 
-            Assert.That(result.ResultState, Is.EqualTo(expectedResultState), "ResultState");
-            Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "AssertCount");
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(assertionMessageRegex.Length), "Number of AssertionResults");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(expectedResultState), "ResultState");
+                Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "AssertCount");
+                Assert.That(result.AssertionResults, Has.Count.EqualTo(assertionMessageRegex.Length), "Number of AssertionResults");
+            });
 
             PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
             {
@@ -121,11 +125,8 @@ namespace NUnit.Framework.Assertions
                     // NOTE: This test expects the stack trace to contain the name of the method
                     // that actually caused the failure. To ensure it is not optimized away, we
                     // compile the testdata assembly with optimizations disabled.
-
-                    PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
-                    {
-                        Assert.That(assertion.StackTrace, Is.Not.Null.And.Contains(methodName), errmsg);
-                    });
+                    PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(
+                        () => Assert.That(assertion.StackTrace, Is.Not.Null.And.Contains(methodName), errmsg));
                 }
             }
 

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -13,6 +13,7 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class AssertThatTests
     {
+#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
         [Test]
         public void AssertionPasses_Boolean()
         {
@@ -37,6 +38,7 @@ namespace NUnit.Framework.Assertions
             Func<string> getExceptionMessage = () => $"Not Equal to {4}";
             Assert.That(2 + 2 == 4, getExceptionMessage);
         }
+#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
 
         [Test]
         public void AssertionPasses_ActualAndConstraint()
@@ -117,6 +119,7 @@ namespace NUnit.Framework.Assertions
         {
             return 4;
         }
+#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
 
         [Test]
         public void FailureThrowsAssertionException_Boolean()
@@ -145,6 +148,7 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, getExceptionMessage));
             Assert.That(ex.Message, Does.Contain("Not Equal to 4"));
         }
+#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
 
         [Test]
         public void FailureThrowsAssertionException_ActualAndConstraint()
@@ -304,9 +308,11 @@ namespace NUnit.Framework.Assertions
         [Test, Platform(Exclude="Linux", Reason="Intermittent failures on Linux")]
         public void AssertThatErrorTask()
         {
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             var exception =
             Assert.Throws<InvalidOperationException>(() =>
                 Assert.That(async () => await ThrowInvalidOperationExceptionTask(), Is.EqualTo(1)));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
 
             Assert.That(exception.StackTrace, Does.Contain("ThrowInvalidOperationExceptionTask"));
         }
@@ -317,16 +323,6 @@ namespace NUnit.Framework.Assertions
             var exception =
             Assert.Throws<InvalidOperationException>(() =>
                 Assert.That(async () => await ThrowInvalidOperationExceptionGenericTask(), Is.EqualTo(1)));
-
-            Assert.That(exception.StackTrace, Does.Contain("ThrowInvalidOperationExceptionGenericTask"));
-        }
-
-        [Test]
-        public void AssertThatErrorVoid()
-        {
-            var exception =
-            Assert.Throws<InvalidOperationException>(() =>
-                Assert.That(async () => { await ThrowInvalidOperationExceptionGenericTask(); }, Is.EqualTo(1)));
 
             Assert.That(exception.StackTrace, Does.Contain("ThrowInvalidOperationExceptionGenericTask"));
         }
@@ -342,7 +338,7 @@ namespace NUnit.Framework.Assertions
             throw new InvalidOperationException();
         }
 
-        private static async System.Threading.Tasks.Task ThrowInvalidOperationExceptionTask()
+        private static async Task ThrowInvalidOperationExceptionTask()
         {
             await AsyncReturnOne();
             throw new InvalidOperationException();

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -236,7 +236,7 @@ namespace NUnit.Framework.Assertions
         private static void CheckForSpuriousAssertionResults()
         {
             var result = TestExecutionContext.CurrentContext.CurrentResult;
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(0),
+            Assert.That(result.AssertionResults, Is.Empty,
                 "Spurious result left by Assert.Fail()");
         }
 

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
@@ -27,9 +27,9 @@ namespace NUnit.Framework.Assertions
             });
             Console.WriteLine(4);
 
-            var NL = Environment.NewLine;
+            var nl = Environment.NewLine;
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output,
-                Is.EqualTo($"1{NL}2{NL}3{NL}4{NL}"));
+                Is.EqualTo($"1{nl}2{nl}3{nl}4{nl}"));
         }
 
         [Test]
@@ -41,9 +41,9 @@ namespace NUnit.Framework.Assertions
                 Throws.Exception);
             Console.WriteLine(4);
 
-            var NL = Environment.NewLine;
+            var nl = Environment.NewLine;
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.Output,
-                Is.EqualTo($"1{NL}2{NL}3{NL}4{NL}"));
+                Is.EqualTo($"1{nl}2{nl}3{nl}4{nl}"));
         }
 
         [Test]
@@ -64,19 +64,19 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ThrowsSucceedsWithLambda()
         {
-            Assert.Throws(typeof(ArgumentException), () => { throw new ArgumentException(); });
+            Assert.Throws(typeof(ArgumentException), () => throw new ArgumentException());
         }
 
         [Test]
         public void GenericThrowsSucceedsWithLambda()
         {
-            Assert.Throws<ArgumentException>(() => { throw new ArgumentException(); });
+            Assert.Throws<ArgumentException>(() => throw new ArgumentException());
         }
 
         [Test]
         public void ThrowsConstraintSucceedsWithLambda()
         {
-            Assert.That(() => { throw new ArgumentException(); },
+            Assert.That(() => throw new ArgumentException(),
                 Throws.Exception.TypeOf<ArgumentException>());
         }
 
@@ -87,9 +87,11 @@ namespace NUnit.Framework.Assertions
                 delegate { throw new ArgumentException("myMessage", "myParam"); }) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.StartWith("myMessage"));
+                Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+            });
             CheckForSpuriousAssertionResults();
         }
 
@@ -100,9 +102,11 @@ namespace NUnit.Framework.Assertions
                 delegate { throw new ArgumentException("myMessage", "myParam"); } ) as ArgumentException;
 
             Assert.IsNotNull(ex, "No ArgumentException thrown");
-            Assert.That(ex.Message, Does.StartWith("myMessage"));
-            Assert.That(ex.ParamName, Is.EqualTo("myParam"));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.StartWith("myMessage"));
+                Assert.That(ex.ParamName, Is.EqualTo("myParam"));
+            });
             CheckForSpuriousAssertionResults();
         }
 
@@ -169,7 +173,7 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ThrowsConstraintWrappingAssertFail()
         {
-            Assert.That(() => { Assert.Fail(); },
+            Assert.That(() => Assert.Fail(),
                 Throws.Exception.TypeOf<AssertionException>());
 
             CheckForSpuriousAssertionResults();
@@ -195,7 +199,7 @@ namespace NUnit.Framework.Assertions
         private static void CheckForSpuriousAssertionResults()
         {
             var result = TestExecutionContext.CurrentContext.CurrentResult;
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(0),
+            Assert.That(result.AssertionResults, Is.Empty,
                 "Spurious result left by Assert.Fail()");
         }
 

--- a/src/NUnitFramework/tests/Assertions/AssertWarnTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertWarnTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Assertions
                 "TwoWarningsAndFailure");
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(3));
+            Assert.That(result.AssertionResults, Has.Count.EqualTo(3));
             Assert.That(result.Message, Contains.Substring("First warning"));
             Assert.That(result.Message, Contains.Substring("Second warning"));
             Assert.That(result.Message, Contains.Substring("This fails"));
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Assertions
                 "TwoWarningsAndIgnore");
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Ignored));
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(3));
+            Assert.That(result.AssertionResults, Has.Count.EqualTo(3));
             Assert.That(result.Message, Contains.Substring("First warning"));
             Assert.That(result.Message, Contains.Substring("Second warning"));
             Assert.That(result.Message, Contains.Substring("Ignore this"));
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Assertions
                 "TwoWarningsAndInconclusive");
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Inconclusive));
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(3));
+            Assert.That(result.AssertionResults, Has.Count.EqualTo(3));
             Assert.That(result.Message, Contains.Substring("First warning"));
             Assert.That(result.Message, Contains.Substring("Second warning"));
             Assert.That(result.Message, Contains.Substring("This is inconclusive"));

--- a/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
@@ -155,9 +155,8 @@ namespace NUnit.Framework.Assertions
             var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(7, 99));
 
             var msg = ex.Message;
-
-            StringAssert.Contains( TextMessageWriter.Pfx_Expected + "greater than or equal to 99", msg);
-            StringAssert.Contains( TextMessageWriter.Pfx_Actual + "7", msg);
+            Assert.That(msg, Contains.Substring(TextMessageWriter.Pfx_Expected + "greater than or equal to 99"));
+            Assert.That(msg, Contains.Substring(TextMessageWriter.Pfx_Actual + "7"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/LessFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LessFixture.cs
@@ -139,8 +139,9 @@ namespace NUnit.Framework.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.Less(9, 4));
 
-            StringAssert.Contains( TextMessageWriter.Pfx_Expected + "less than 4", ex.Message );
-            StringAssert.Contains( TextMessageWriter.Pfx_Actual + "9", ex.Message );
+            var msg = ex.Message;
+            Assert.That(msg, Contains.Substring(TextMessageWriter.Pfx_Expected + "less than 4"));
+            Assert.That(msg, Contains.Substring(TextMessageWriter.Pfx_Actual + "9"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/SameFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/SameFixture.cs
@@ -33,7 +33,9 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: same as 2" + Environment.NewLine +
                 "  But was:  2" + Environment.NewLine;
+#pragma warning disable NUnit2040 // Non-reference types for SameAs constraint
             var ex = Assert.Throws<AssertionException>(() => Assert.AreSame(index, index));
+#pragma warning restore NUnit2040 // Non-reference types for SameAs constraint
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -59,9 +59,12 @@ namespace NUnit.Framework.Assertions
         {
             var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
-            Assert.That(result.AssertCount, Is.EqualTo(1), "Incorrect AssertCount");
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(0), "There should be no AssertionResults");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+                Assert.That(result.AssertCount, Is.EqualTo(1), "Incorrect AssertCount");
+                Assert.That(result.AssertionResults, Is.Empty, "There should be no AssertionResults");
+            });
         }
 
         [TestCase(nameof(WarningFixture.WarnUnless_Fails_Boolean), null)]
@@ -110,20 +113,31 @@ namespace NUnit.Framework.Assertions
         {
             var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Warning));
-            Assert.That(result.AssertCount, Is.EqualTo(1), "Incorrect AssertCount");
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(1), "Incorrect number of AssertionResults");
-            Assert.That(result.AssertionResults[0].Status, Is.EqualTo(AssertionStatus.Warning));
-            Assert.That(result.AssertionResults[0].Message, Is.Not.Null, "Assertion Message should not be null");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Warning));
+                Assert.That(result.AssertCount, Is.EqualTo(1), "Incorrect AssertCount");
+            });
+
+            Assert.That(result.AssertionResults, Has.Count.EqualTo(1), "Incorrect number of AssertionResults");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AssertionResults[0].Status, Is.EqualTo(AssertionStatus.Warning));
+                Assert.That(result.AssertionResults[0].Message, Is.Not.Null, "Assertion Message should not be null");
+                Assert.That(result.AssertionResults[0].StackTrace, Does.Contain("WarningFixture"));
+                Assert.That(result.AssertionResults[0].StackTrace.Split(new[] { '\n' }), Has.Length.LessThan(3));
+            });
+
             Assert.That(result.Message, Is.Not.Null, "Result Message should not be null");
             Assert.That(result.Message, Contains.Substring(result.AssertionResults[0].Message), "Result message should contain assertion message");
-            Assert.That(result.AssertionResults[0].StackTrace, Does.Contain("WarningFixture"));
-            Assert.That(result.AssertionResults[0].StackTrace.Split(new[] { '\n' }).Length, Is.LessThan(3));
 
             if (expectedMessage != null)
             {
-                Assert.That(result.Message, Does.Contain(expectedMessage));
-                Assert.That(result.AssertionResults[0].Message, Does.Contain(expectedMessage));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message, Does.Contain(expectedMessage));
+                    Assert.That(result.AssertionResults[0].Message, Does.Contain(expectedMessage));
+                });
             }
         }
 
@@ -143,9 +157,12 @@ namespace NUnit.Framework.Assertions
         {
             var result = TestBuilder.RunTestCase(fixtureType, methodName);
 
-            Assert.That(result.ResultState, Is.EqualTo(expectedWarnings == 0 ? ResultState.Success : ResultState.Warning));
-            Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "Incorrect AssertCount");
-            Assert.That(result.AssertionResults.Count, Is.EqualTo(expectedWarnings), $"There should be {expectedWarnings} AssertionResults");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(expectedWarnings == 0 ? ResultState.Success : ResultState.Warning));
+                Assert.That(result.AssertCount, Is.EqualTo(expectedAsserts), "Incorrect AssertCount");
+                Assert.That(result.AssertionResults, Has.Count.EqualTo(expectedWarnings), $"There should be {expectedWarnings} AssertionResults");
+            });
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework
             // No need for the overhead of parallel execution here
             options["NumberOfTestWorkers"] = 0;
 
-            Assert.NotNull(runner.Load(ASSEMBLY_PATH, options), "Assembly not loaded");
+            Assert.That(runner.Load(ASSEMBLY_PATH, options), Is.Not.Null, "Assembly not loaded");
             Assert.That(runner.LoadedTest.RunState, Is.EqualTo(RunState.Runnable));
 
             _result = runner.Run(TestListener.NULL, TestFilter.Empty);
@@ -128,7 +128,7 @@ namespace NUnit.Framework
         [Test]
         public void CorrectNumberOfEventsReceived()
         {
-            Assert.That(ActionAttributeFixture.Events.Count, Is.EqualTo(
+            Assert.That(ActionAttributeFixture.Events, Has.Count.EqualTo(
                 NumTestCaseEvents + 2 * (NumParameterizedTestActions + NumTestFixtureActions + NumSetUpFixtureActions + NumAssemblyActions)));
         }
 
@@ -169,8 +169,11 @@ namespace NUnit.Framework
             for (int i = 0; i < numActions; i++)
                 CheckBeforeAfterActionPair(index - i - 1, index + i + 1, testName, ExpectedTestCaseActions[i]);
 
-            Assert.That(ActionAttributeFixture.Events[index - numActions - 1], Does.Not.StartWith(testName), "Extra ActionAttribute Before");
-            Assert.That(ActionAttributeFixture.Events[index + numActions + 1], Does.Not.StartWith(testName), "Extra ActionAttribute After");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ActionAttributeFixture.Events[index - numActions - 1], Does.Not.StartWith(testName), "Extra ActionAttribute Before");
+                Assert.That(ActionAttributeFixture.Events[index + numActions + 1], Does.Not.StartWith(testName), "Extra ActionAttribute After");
+            });
         }
 
         private void CheckBeforeAfterActionPair(int index1, int index2, string testName, string tag)
@@ -178,8 +181,11 @@ namespace NUnit.Framework
             var event1 = ActionAttributeFixture.Events[index1];
             var event2 = ActionAttributeFixture.Events[index2];
 
-            Assert.That(event1, Does.StartWith(testName + "." + tag + ".Before"));
-            Assert.That(event2, Does.StartWith(testName + "." + tag + ".After"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(event1, Does.StartWith(testName + "." + tag + ".Before"));
+                Assert.That(event2, Does.StartWith(testName + "." + tag + ".After"));
+            });
 
             int index = event1.LastIndexOf('.');
             var target1 = event1.Substring(index); // Target is last in string

--- a/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApartmentAttributeTests.cs
@@ -139,7 +139,7 @@ namespace NUnit.Framework.Attributes
             [TestCase(2)]
             public void TestCasesShouldInheritApartmentFromFixture(int n)
             {
-                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA), "TestCase" + n);
             }
         }
 
@@ -163,7 +163,7 @@ namespace NUnit.Framework.Attributes
             [Apartment(ApartmentState.MTA)]
             public void TestCasesShouldRespectTheirApartment(int n)
             {
-                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA), "TestCase" + n);
             }
         }
 
@@ -185,7 +185,7 @@ namespace NUnit.Framework.Attributes
             [TestCase(2)]
             public void TestCasesShouldInheritApartmentFromFixture(int n)
             {
-                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA), "TestCase" + n);
             }
         }
 
@@ -209,7 +209,7 @@ namespace NUnit.Framework.Attributes
             [Apartment(ApartmentState.MTA)]
             public void TestCasesShouldRespectTheirApartment(int n)
             {
-                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA));
+                Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.MTA), "TestCase" + n);
             }
         }
     }

--- a/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToContextTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Attributes
         {
             var attr = new SingleThreadedAttribute();
             attr.ApplyToContext(_context);
-            Assert.True(_context.IsSingleThreaded);
+            Assert.That(_context.IsSingleThreaded, Is.True);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -99,8 +99,11 @@ namespace NUnit.Framework.Attributes
         {
             test.MakeInvalid("UNCHANGED");
             new IgnoreAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+                Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
+            });
         }
 
         [Test]
@@ -373,10 +376,12 @@ namespace NUnit.Framework.Attributes
             var invalidPlatform = "FakePlatform";
             new PlatformAttribute(invalidPlatform).ApplyToTest(test);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
-                Does.StartWith("Invalid platform name"));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
-                Does.Contain(invalidPlatform));
+            string skipReason = (string)test.Properties.Get(PropertyNames.SkipReason);
+            Assert.Multiple(() =>
+            {
+                Assert.That(skipReason, Does.StartWith("Invalid platform name"));
+                Assert.That(skipReason, Does.Contain(invalidPlatform));
+            });
         }
 
         string GetMyPlatform()
@@ -472,9 +477,12 @@ namespace NUnit.Framework.Attributes
         public void RequiresThreadAttributeMaySetApartmentState()
         {
             new RequiresThreadAttribute(ApartmentState.STA).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
-            Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
-                Is.EqualTo(ApartmentState.STA));
+            Assert.Multiple(() =>
+            {
+                Assert.That(test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
+                Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+                    Is.EqualTo(ApartmentState.STA));
+            });
         }
 
         #endregion
@@ -500,12 +508,14 @@ namespace NUnit.Framework.Attributes
 
         #region SetCultureAttribute
 
+        [Test]
         public void SetCultureAttributeSetsSetCultureProperty()
         {
             new SetCultureAttribute("fr-FR").ApplyToTest(test);
             Assert.That(test.Properties.Get(PropertyNames.SetCulture), Is.EqualTo("fr-FR"));
         }
 
+        [Test]
         public void SetCultureAttributeSetsSetCulturePropertyOnNonRunnableTest()
         {
             test.RunState = RunState.NotRunnable;
@@ -517,12 +527,14 @@ namespace NUnit.Framework.Attributes
 
         #region SetUICultureAttribute
 
+        [Test]
         public void SetUICultureAttributeSetsSetUICultureProperty()
         {
             new SetUICultureAttribute("fr-FR").ApplyToTest(test);
             Assert.That(test.Properties.Get(PropertyNames.SetUICulture), Is.EqualTo("fr-FR"));
         }
 
+        [Test]
         public void SetUICultureAttributeSetsSetUICulturePropertyOnNonRunnableTest()
         {
             test.RunState = RunState.NotRunnable;

--- a/src/NUnitFramework/tests/Attributes/AttributeInheritanceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/AttributeInheritanceTests.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Attributes
         public void InheritedTestAttributeIsRecognized()
         {
             Test fixture = TestBuilder.MakeFixture( typeof( When_collecting_test_fixtures ) );
-            Assert.AreEqual( 1, fixture.TestCaseCount );
+            Assert.That( fixture.TestCaseCount, Is.EqualTo(1));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/AuthorTests.cs
+++ b/src/NUnitFramework/tests/Attributes/AuthorTests.cs
@@ -19,21 +19,21 @@ namespace NUnit.Framework.Attributes
         public void ReflectionTest()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.Method));
-            Assert.AreEqual(RunState.Runnable, testCase.RunState);
+            Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
         public void Author()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.Method));
-            Assert.AreEqual("Rob Prouse", testCase.Properties.Get(PropertyNames.Author));
+            Assert.That(testCase.Properties.Get(PropertyNames.Author), Is.EqualTo("Rob Prouse"));
         }
 
         [Test]
         public void NoAuthor()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.NoAuthorMethod));
-            Assert.IsNull(testCase.Properties.Get(PropertyNames.Author));
+            Assert.That(testCase.Properties.Get(PropertyNames.Author), Is.Null);
         }
 
         [Test]
@@ -44,30 +44,30 @@ namespace NUnit.Framework.Attributes
 
             var mockFixtureSuite = (TestSuite)suite.Tests[0];
 
-            Assert.AreEqual("Rob Prouse", mockFixtureSuite.Properties.Get(PropertyNames.Author));
+            Assert.That(mockFixtureSuite.Properties.Get(PropertyNames.Author), Is.EqualTo("Rob Prouse"));
         }
 
         [Test]
         public void SeparateAuthorAttribute()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.SeparateAuthorMethod));
-            Assert.AreEqual("Rob Prouse", testCase.Properties.Get(PropertyNames.Author));
+            Assert.That(testCase.Properties.Get(PropertyNames.Author), Is.EqualTo("Rob Prouse"));
         }
 
         [Test]
         public void SeparateAuthorWithEmailAttribute()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(AuthorFixture.SeparateAuthorWithEmailMethod));
-            Assert.AreEqual("Rob Prouse <rob@prouse.org>", testCase.Properties.Get(PropertyNames.Author));
+            Assert.That(testCase.Properties.Get(PropertyNames.Author), Is.EqualTo("Rob Prouse <rob@prouse.org>"));
         }
 
         [Test]
         public void AuthorOnTestCase()
         {
             TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(AuthorFixture.TestCaseWithAuthor));
-            Assert.AreEqual("Rob Prouse", parameterizedMethodSuite.Properties.Get(PropertyNames.Author));
+            Assert.That(parameterizedMethodSuite.Properties.Get(PropertyNames.Author), Is.EqualTo("Rob Prouse"));
             var testCase = (Test)parameterizedMethodSuite.Tests[0];
-            Assert.AreEqual("Charlie Poole", testCase.Properties.Get(PropertyNames.Author));
+            Assert.That(testCase.Properties.Get(PropertyNames.Author), Is.EqualTo("Charlie Poole"));
         }
 
         #region Multiple Authors

--- a/src/NUnitFramework/tests/Attributes/CombinatorialTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CombinatorialTests.cs
@@ -36,8 +36,11 @@ namespace NUnit.Framework.Attributes
             [Values(10, 20)] int y,
             [Values("Charlie", "Joe", "Frank")] string name)
         {
-            Assert.That(x > 0 && x < 4 && y % 10 == 0);
-            Assert.That(name.Length >= 2);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x > 0 && x < 4 && y % 10 == 0);
+                Assert.That(name, Has.Length.GreaterThanOrEqualTo(2));
+            });
         }
 
         [Test, Sequential]
@@ -46,8 +49,11 @@ namespace NUnit.Framework.Attributes
             [Values(10, 20)] int y,
             [Values("Charlie", "Joe", "Frank")] string name)
         {
-            Assert.That(x > 0 && x < 4 && y % 10 == 0);
-            Assert.That(name.Length >= 2);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x > 0 && x < 4 && y % 10 == 0);
+                Assert.That(name, Has.Length.GreaterThanOrEqualTo(2));
+            });
         }
 
         [Test]
@@ -55,6 +61,11 @@ namespace NUnit.Framework.Attributes
             [Range(0.2, 0.6, 0.2)] double a,
             [Range(10, 20, 5)] int b)
         {
+            Assert.Multiple(() =>
+            {
+                Assert.That(a, Is.InRange(0.2, 0.6));
+                Assert.That(b, Is.InRange(10, 20));
+            });
         }
 
         [Test, Sequential]
@@ -63,9 +74,12 @@ namespace NUnit.Framework.Attributes
             [Random(5)] double y,
             [Random(5)] AttributeTargets z)
         {
-            Assert.That(x,Is.InRange(32,212));
-            Assert.That(y,Is.InRange(0.0,1.0));
-            Assert.That(z, Is.TypeOf<AttributeTargets>());
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.InRange(32, 212));
+                Assert.That(y, Is.InRange(0.0, 1.0));
+                Assert.That(z, Is.TypeOf<AttributeTargets>());
+            });
         }
 
         [Test, Sequential]
@@ -73,7 +87,7 @@ namespace NUnit.Framework.Attributes
             [Random(1)] double x,
             [Random(1)] double y)
         {
-            Assert.AreNotEqual(x, y);
+            Assert.That(y, Is.Not.EqualTo(x));
         }
 
         [Test, Combinatorial]

--- a/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
 using NUnit.Framework.Interfaces;
@@ -13,42 +13,54 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CorrectExceptionThrown()
         {
-            var result = TestBuilder.RunTestCase(this, "ThrowsCorrectException");
+            var result = TestBuilder.RunTestCase(this, nameof(ThrowsCorrectException));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
         }
 
+#pragma warning disable NUnit1028 // The non-test method is public
         [ExpectedException(typeof(NullReferenceException))]
         public void ThrowsCorrectException()
         {
             throw new NullReferenceException();
         }
+#pragma warning restore NUnit1028 // The non-test method is public
 
         [Test]
         public void NoExceptionThrown()
         {
-            var result = TestBuilder.RunTestCase(this, "ThrowsNoException");
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
-            Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but no exception was thrown"));
+            var result = TestBuilder.RunTestCase(this, nameof(ThrowsNoException));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+                Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but no exception was thrown"));
+            });
         }
 
+#pragma warning disable NUnit1028 // The non-test method is public
         [ExpectedException(typeof(NullReferenceException))]
         public void ThrowsNoException()
         {
         }
+#pragma warning restore NUnit1028 // The non-test method is public
 
         [Test]
         public void WrongExceptionThrown()
         {
-            var result = TestBuilder.RunTestCase(this, "ThrowsWrongException");
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
-            Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but got Exception"));
+            var result = TestBuilder.RunTestCase(this, nameof(ThrowsWrongException));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
+                Assert.That(result.Message, Is.EqualTo("Expected NullReferenceException but got Exception"));
+            });
         }
 
+#pragma warning disable NUnit1028 // The non-test method is public
         [ExpectedException(typeof(NullReferenceException))]
         public void ThrowsWrongException()
         {
             throw new Exception();
         }
+#pragma warning restore NUnit1028 // The non-test method is public
 
         /// <summary>
         /// Extremely simple ExpectedException implementation for use in the test

--- a/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DerivedPropertyAttributeTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Attributes
         public void ConstructWithOneArg<T>(Type attrType, string propName, T propValue)
         {
             var attr = Reflect.Construct(attrType, new object[] { propValue }) as PropertyAttribute;
-            Assert.NotNull(attr, "{0} is not a PropertyAttribute", attrType.Name);
+            Assert.That(attr, Is.Not.Null, "{0} is not a PropertyAttribute", attrType.Name);
             Assert.That(attr.Properties.Get(propName), Is.EqualTo(propValue));
         }
 
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Attributes
         public void ConstructWithNoArgs<T>(Type attrType, string propName, T propValue)
         {
             var attr = Reflect.Construct(attrType) as PropertyAttribute;
-            Assert.NotNull(attr, "{0} is not a PropertyAttribute", attrType.Name);
+            Assert.That(attr, Is.Not.Null, "{0} is not a PropertyAttribute", attrType.Name);
             Assert.That(attr.Properties.Get(propName), Is.EqualTo(propValue));
         }
     }

--- a/src/NUnitFramework/tests/Attributes/DescriptionTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DescriptionTests.cs
@@ -19,28 +19,28 @@ namespace NUnit.Framework.Attributes
         public void ReflectionTest()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.Method));
-            Assert.AreEqual( RunState.Runnable, testCase.RunState );
+            Assert.That( testCase.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
         public void Description()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.Method));
-            Assert.AreEqual("Test Description", testCase.Properties.Get(PropertyNames.Description));
+            Assert.That(testCase.Properties.Get(PropertyNames.Description), Is.EqualTo("Test Description"));
         }
 
         [Test]
         public void NoDescription()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.NoDescriptionMethod) );
-            Assert.IsNull(testCase.Properties.Get(PropertyNames.Description));
+            Assert.That(testCase.Properties.Get(PropertyNames.Description), Is.Null);
         }
 
         [Test]
         public void LongDescription()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.TestWithLongDescription));
-            Assert.AreEqual("This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description", testCase.Properties.Get(PropertyNames.Description));
+            Assert.That(testCase.Properties.Get(PropertyNames.Description), Is.EqualTo("This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description"));
         }
 
         [Test]
@@ -51,23 +51,23 @@ namespace NUnit.Framework.Attributes
 
             TestSuite mockFixtureSuite = (TestSuite)suite.Tests[0];
 
-            Assert.AreEqual("Fixture Description", mockFixtureSuite.Properties.Get(PropertyNames.Description));
+            Assert.That(mockFixtureSuite.Properties.Get(PropertyNames.Description), Is.EqualTo("Fixture Description"));
         }
 
         [Test]
         public void SeparateDescriptionAttribute()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(DescriptionFixture.SeparateDescriptionMethod));
-            Assert.AreEqual("Separate Description", testCase.Properties.Get(PropertyNames.Description));
+            Assert.That(testCase.Properties.Get(PropertyNames.Description), Is.EqualTo("Separate Description"));
         }
 
         [Test]
         public void DescriptionOnTestCase()
         {
             TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(DescriptionFixture.TestCaseWithDescription));
-            Assert.AreEqual("method description", parameterizedMethodSuite.Properties.Get(PropertyNames.Description));
+            Assert.That(parameterizedMethodSuite.Properties.Get(PropertyNames.Description), Is.EqualTo("method description"));
             Test testCase = (Test)parameterizedMethodSuite.Tests[0];
-            Assert.AreEqual("case description", testCase.Properties.Get(PropertyNames.Description));
+            Assert.That(testCase.Properties.Get(PropertyNames.Description), Is.EqualTo("case description"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTest(fixture);
 
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            Assert.AreEqual(3, RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter);
+            Assert.That(RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter, Is.EqualTo(3));
             BaseLifeCycle.VerifyInstancePerTestCase(3);
         }
 

--- a/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Attributes
         public void MaxTimeExceeded()
         {
             ITestResult suiteResult = TestBuilder.RunTestFixture(typeof(MaxTimeFixture));
-            Assert.AreEqual(ResultState.ChildFailure, suiteResult.ResultState);
+            Assert.That(suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
             ITestResult result = suiteResult.Children.ToArray()[0];
             Assert.That(result.Message, Does.Contain("exceeds maximum of 1ms"));
         }
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Attributes
         public void MaxTimeExceededOnTestCase()
         {
             ITestResult suiteResult = TestBuilder.RunTestFixture(typeof(MaxTimeFixtureWithTestCase));
-            Assert.AreEqual(ResultState.ChildFailure, suiteResult.ResultState);
+            Assert.That(suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
             ITestResult result = suiteResult.Children.ToArray()[0].Children.ToArray()[0];
             Assert.That(result.Message, Does.Contain("exceeds maximum of 1ms"));
         }
@@ -49,9 +49,9 @@ namespace NUnit.Framework.Attributes
         public void FailureReportHasPriorityOverMaxTime()
         {
             ITestResult result = TestBuilder.RunTestFixture(typeof(MaxTimeFixtureWithFailure));
-            Assert.AreEqual(ResultState.ChildFailure, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.ChildFailure));
             result = result.Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Failure, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Is.EqualTo("Intentional Failure"));
         }
 
@@ -59,9 +59,9 @@ namespace NUnit.Framework.Attributes
         public void ErrorReportHasPriorityOverMaxTime()
         {
             ITestResult result = TestBuilder.RunTestFixture(typeof(MaxTimeFixtureWithError));
-            Assert.AreEqual(ResultState.ChildFailure, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.ChildFailure));
             result = result.Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Error, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
             Assert.That(result.Message, Does.Contain("Exception message"));
         }
     }

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -20,8 +20,8 @@ namespace NUnit.Framework.Attributes
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount, "SetUp");
-            Assert.AreEqual(1, fixture.TearDownCount, "TearDown");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "SetUp");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "TearDown");
         }
 
         [Test]
@@ -30,8 +30,8 @@ namespace NUnit.Framework.Attributes
             var fixture = new SetUpAndTearDownFixtureWithTestCases();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount, "SetUp");
-            Assert.AreEqual(1, fixture.TearDownCount, "TearDown");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "SetUp");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "TearDown");
         }
 
         [Test]
@@ -40,8 +40,8 @@ namespace NUnit.Framework.Attributes
             var fixture = new SetUpAndTearDownFixtureWithTheories();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount, "SetUp");
-            Assert.AreEqual(1, fixture.TearDownCount, "TearDown");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "SetUp");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "TearDown");
         }
 
         [Test]
@@ -50,8 +50,8 @@ namespace NUnit.Framework.Attributes
             ExplicitSetUpAndTearDownFixture fixture = new ExplicitSetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(0, fixture.SetUpCount, "SetUp");
-            Assert.AreEqual(0, fixture.TearDownCount, "TearDown");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(0), "SetUp");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(0), "TearDown");
         }
 
         [Test]
@@ -60,8 +60,8 @@ namespace NUnit.Framework.Attributes
             InheritSetUpAndTearDown fixture = new InheritSetUpAndTearDown();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount);
-            Assert.AreEqual(1, fixture.TearDownCount);
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1));
         }
 
         [Test]
@@ -71,8 +71,8 @@ namespace NUnit.Framework.Attributes
             StaticSetUpAndTearDownFixture.TearDownCount = 0;
             TestBuilder.RunTestFixture(typeof(StaticSetUpAndTearDownFixture));
 
-            Assert.AreEqual(1, StaticSetUpAndTearDownFixture.SetUpCount);
-            Assert.AreEqual(1, StaticSetUpAndTearDownFixture.TearDownCount);
+            Assert.That(StaticSetUpAndTearDownFixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(StaticSetUpAndTearDownFixture.TearDownCount, Is.EqualTo(1));
         }
 
         [Test]
@@ -83,8 +83,8 @@ namespace NUnit.Framework.Attributes
 
             TestBuilder.RunTestFixture(typeof(StaticClassSetUpAndTearDownFixture));
 
-            Assert.AreEqual(1, StaticClassSetUpAndTearDownFixture.SetUpCount);
-            Assert.AreEqual(1, StaticClassSetUpAndTearDownFixture.TearDownCount);
+            Assert.That(StaticClassSetUpAndTearDownFixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(StaticClassSetUpAndTearDownFixture.TearDownCount, Is.EqualTo(1));
         }
 
         [Test]
@@ -93,10 +93,10 @@ namespace NUnit.Framework.Attributes
             OverrideSetUpAndTearDown fixture = new OverrideSetUpAndTearDown();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(0, fixture.SetUpCount);
-            Assert.AreEqual(0, fixture.TearDownCount);
-            Assert.AreEqual(1, fixture.DerivedSetUpCount);
-            Assert.AreEqual(1, fixture.DerivedTearDownCount);
+            Assert.That(fixture.SetUpCount, Is.EqualTo(0));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(0));
+            Assert.That(fixture.DerivedSetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.DerivedTearDownCount, Is.EqualTo(1));
         }
 
         [Test]
@@ -105,10 +105,10 @@ namespace NUnit.Framework.Attributes
             DerivedSetUpAndTearDownFixture fixture = new DerivedSetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount);
-            Assert.AreEqual(1, fixture.TearDownCount);
-            Assert.AreEqual(1, fixture.DerivedSetUpCount);
-            Assert.AreEqual(1, fixture.DerivedTearDownCount);
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1));
+            Assert.That(fixture.DerivedSetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.DerivedTearDownCount, Is.EqualTo(1));
             Assert.That(fixture.BaseSetUpCalledFirst, "Base SetUp called first");
             Assert.That(fixture.BaseTearDownCalledLast, "Base TearDown called last");
         }
@@ -120,10 +120,10 @@ namespace NUnit.Framework.Attributes
             fixture.ThrowInBaseSetUp = true;
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount);
-            Assert.AreEqual(1, fixture.TearDownCount);
-            Assert.AreEqual(0, fixture.DerivedSetUpCount);
-            Assert.AreEqual(0, fixture.DerivedTearDownCount);
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1));
+            Assert.That(fixture.DerivedSetUpCount, Is.EqualTo(0));
+            Assert.That(fixture.DerivedTearDownCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -137,10 +137,10 @@ namespace NUnit.Framework.Attributes
             DerivedStaticSetUpAndTearDownFixture fixture = new DerivedStaticSetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, DerivedStaticSetUpAndTearDownFixture.SetUpCount);
-            Assert.AreEqual(1, DerivedStaticSetUpAndTearDownFixture.TearDownCount);
-            Assert.AreEqual(1, DerivedStaticSetUpAndTearDownFixture.DerivedSetUpCount);
-            Assert.AreEqual(1, DerivedStaticSetUpAndTearDownFixture.DerivedTearDownCount);
+            Assert.That(DerivedStaticSetUpAndTearDownFixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(DerivedStaticSetUpAndTearDownFixture.TearDownCount, Is.EqualTo(1));
+            Assert.That(DerivedStaticSetUpAndTearDownFixture.DerivedSetUpCount, Is.EqualTo(1));
+            Assert.That(DerivedStaticSetUpAndTearDownFixture.DerivedTearDownCount, Is.EqualTo(1));
             Assert.That(DerivedStaticSetUpAndTearDownFixture.BaseSetUpCalledFirst, "Base SetUp called first");
             Assert.That(DerivedStaticSetUpAndTearDownFixture.BaseTearDownCalledLast, "Base TearDown called last");
         }
@@ -152,15 +152,15 @@ namespace NUnit.Framework.Attributes
             fixture.BlowUpInSetUp = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual( 1, fixture.SetUpCount, "setUpCount" );
-            Assert.AreEqual( 1, fixture.TearDownCount, "tearDownCount" );
+            Assert.That( fixture.SetUpCount, Is.EqualTo(1), "setUpCount" );
+            Assert.That( fixture.TearDownCount, Is.EqualTo(1), "tearDownCount" );
 
-            Assert.AreEqual(ResultState.SetUpError, result.ResultState);
-            Assert.AreEqual("System.Exception : This was thrown from fixture setup", result.Message, "TestSuite Message");
-            Assert.IsNotNull(result.StackTrace, "TestSuite StackTrace should not be null");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.SetUpError));
+            Assert.That(result.Message, Is.EqualTo("System.Exception : This was thrown from fixture setup"), "TestSuite Message");
+            Assert.That(result.StackTrace, Is.Not.Null, "TestSuite StackTrace should not be null");
 
-            Assert.AreEqual(1, result.Children.Count(), "Child result count");
-            Assert.AreEqual(1, result.FailCount, "Failure count");
+            Assert.That(result.Children.Count(), Is.EqualTo(1), "Child result count");
+            Assert.That(result.FailCount, Is.EqualTo(1), "Failure count");
         }
 
         [Test]
@@ -170,16 +170,16 @@ namespace NUnit.Framework.Attributes
             fixture.BlowUpInSetUp = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(ResultState.SetUpError, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.SetUpError));
 
             //fix the blow up in setup
             fixture.Reinitialize();
             result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual( 1, fixture.SetUpCount, "setUpCount" );
-            Assert.AreEqual( 1, fixture.TearDownCount, "tearDownCount" );
+            Assert.That( fixture.SetUpCount, Is.EqualTo(1), "setUpCount" );
+            Assert.That( fixture.TearDownCount, Is.EqualTo(1), "tearDownCount" );
 
-            Assert.AreEqual(ResultState.Success, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
         }
 
         [Test]
@@ -189,12 +189,12 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
             // should have one suite and one fixture
-            Assert.AreEqual(ResultState.Ignored.WithSite(FailureSite.SetUp), result.ResultState, "Suite should be ignored");
-            Assert.AreEqual("OneTimeSetUp called Ignore", result.Message);
-            Assert.IsNotNull(result.StackTrace, "StackTrace should not be null");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Ignored.WithSite(FailureSite.SetUp)), "Suite should be ignored");
+            Assert.That(result.Message, Is.EqualTo("OneTimeSetUp called Ignore"));
+            Assert.That(result.StackTrace, Is.Not.Null, "StackTrace should not be null");
 
-            Assert.AreEqual(1, result.Children.Count(), "Child result count");
-            Assert.AreEqual(1, result.SkipCount, "SkipCount");
+            Assert.That(result.Children.Count(), Is.EqualTo(1), "Child result count");
+            Assert.That(result.SkipCount, Is.EqualTo(1), "SkipCount");
         }
 
         [Test]
@@ -203,13 +203,13 @@ namespace NUnit.Framework.Attributes
             MisbehavingFixture fixture = new MisbehavingFixture();
             fixture.BlowUpInTearDown = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
-            Assert.AreEqual(1, result.Children.Count());
-            Assert.AreEqual(ResultState.TearDownError, result.ResultState);
+            Assert.That(result.Children.Count(), Is.EqualTo(1));
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.TearDownError));
 
-            Assert.AreEqual(1, fixture.SetUpCount, "setUpCount");
-            Assert.AreEqual(1, fixture.TearDownCount, "tearDownCount");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "setUpCount");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "tearDownCount");
 
-            Assert.AreEqual("TearDown : System.Exception : This was thrown from fixture teardown", result.Message);
+            Assert.That(result.Message, Is.EqualTo("TearDown : System.Exception : This was thrown from fixture teardown"));
             Assert.That(result.StackTrace, Does.Contain("--TearDown"));
         }
 
@@ -220,13 +220,13 @@ namespace NUnit.Framework.Attributes
             fixture.BlowUpInTest = true;
             fixture.BlowUpInTearDown = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
-            Assert.AreEqual(1, result.Children.Count());
-            Assert.AreEqual(ResultState.TearDownError, result.ResultState);
+            Assert.That(result.Children.Count(), Is.EqualTo(1));
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.TearDownError));
 
-            Assert.AreEqual(1, fixture.SetUpCount, "setUpCount");
-            Assert.AreEqual(1, fixture.TearDownCount, "tearDownCount");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "setUpCount");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "tearDownCount");
 
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE + Environment.NewLine + "TearDown : System.Exception : This was thrown from fixture teardown", result.Message);
+            Assert.That(result.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE + Environment.NewLine + "TearDown : System.Exception : This was thrown from fixture teardown"));
             Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.TearDown));
             Assert.That(result.StackTrace, Does.Contain("--TearDown"));
         }
@@ -238,14 +238,14 @@ namespace NUnit.Framework.Attributes
             fixture.BlowUpInSetUp = true;
             fixture.BlowUpInTearDown = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
-            Assert.AreEqual(1, result.Children.Count());
-            Assert.AreEqual(ResultState.TearDownError, result.ResultState);
+            Assert.That(result.Children.Count(), Is.EqualTo(1));
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.TearDownError));
 
-            Assert.AreEqual(1, fixture.SetUpCount, "setUpCount");
-            Assert.AreEqual(1, fixture.TearDownCount, "tearDownCount");
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1), "setUpCount");
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1), "tearDownCount");
 
-            Assert.AreEqual("System.Exception : This was thrown from fixture setup" + Environment.NewLine +
-                "TearDown : System.Exception : This was thrown from fixture teardown", result.Message);
+            Assert.That(result.Message, Is.EqualTo("System.Exception : This was thrown from fixture setup" + Environment.NewLine +
+                "TearDown : System.Exception : This was thrown from fixture teardown"));
             Assert.That(result.StackTrace, Does.Contain("--TearDown"));
         }
 
@@ -254,12 +254,12 @@ namespace NUnit.Framework.Attributes
         {
             ITestResult result = TestBuilder.RunTestFixture( typeof( ExceptionInConstructor ) );
 
-            Assert.AreEqual(ResultState.SetUpError, result.ResultState);
-            Assert.AreEqual("System.Exception : This was thrown in constructor", result.Message, "TestSuite Message");
-            Assert.IsNotNull(result.StackTrace, "TestSuite StackTrace should not be null");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.SetUpError));
+            Assert.That(result.Message, Is.EqualTo("System.Exception : This was thrown in constructor"), "TestSuite Message");
+            Assert.That(result.StackTrace, Is.Not.Null, "TestSuite StackTrace should not be null");
 
-            Assert.AreEqual(1, result.Children.Count(), "Child result count");
-            Assert.AreEqual(1, result.FailCount, "Failure count");
+            Assert.That(result.Children.Count(), Is.EqualTo(1), "Child result count");
+            Assert.That(result.FailCount, Is.EqualTo(1), "Failure count");
         }
 
         [Test]
@@ -268,13 +268,13 @@ namespace NUnit.Framework.Attributes
             MisbehavingFixture fixture = new MisbehavingFixture();
             fixture.BlowUpInTearDown = true;
             ITestResult result = TestBuilder.RunTestFixture(fixture);
-            Assert.AreEqual(1, result.Children.Count());
+            Assert.That(result.Children.Count(), Is.EqualTo(1));
 
             fixture.Reinitialize();
             result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual( 1, fixture.SetUpCount, "setUpCount" );
-            Assert.AreEqual( 1, fixture.TearDownCount, "tearDownCount" );
+            Assert.That( fixture.SetUpCount, Is.EqualTo(1), "setUpCount" );
+            Assert.That( fixture.TearDownCount, Is.EqualTo(1), "tearDownCount" );
         }
 
         [Test]
@@ -283,8 +283,8 @@ namespace NUnit.Framework.Attributes
             SetUpAndTearDownWithTestInName fixture = new SetUpAndTearDownWithTestInName();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(1, fixture.SetUpCount);
-            Assert.AreEqual(1, fixture.TearDownCount);
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1));
         }
 
         //[Test]
@@ -311,16 +311,16 @@ namespace NUnit.Framework.Attributes
             suite.Add( fixtureSuite );
 
             TestBuilder.RunTest(fixtureSuite, fixture);
-            Assert.IsFalse( fixture.SetupCalled, "OneTimeSetUp called running fixture");
-            Assert.IsFalse( fixture.TeardownCalled, "OneTimeSetUp called running fixture");
+            Assert.That( fixture.SetupCalled, Is.False, "OneTimeSetUp called running fixture");
+            Assert.That( fixture.TeardownCalled, Is.False, "OneTimeSetUp called running fixture");
 
             TestBuilder.RunTest(suite, fixture);
-            Assert.IsFalse( fixture.SetupCalled, "OneTimeSetUp called running enclosing suite");
-            Assert.IsFalse( fixture.TeardownCalled, "OneTimeTearDown called running enclosing suite");
+            Assert.That( fixture.SetupCalled, Is.False, "OneTimeSetUp called running enclosing suite");
+            Assert.That( fixture.TeardownCalled, Is.False, "OneTimeTearDown called running enclosing suite");
 
             TestBuilder.RunTest(testMethod, fixture);
-            Assert.IsFalse( fixture.SetupCalled, "OneTimeSetUp called running a test case");
-            Assert.IsFalse( fixture.TeardownCalled, "OneTimeTearDown called running a test case");
+            Assert.That( fixture.SetupCalled, Is.False, "OneTimeSetUp called running a test case");
+            Assert.That( fixture.TeardownCalled, Is.False, "OneTimeTearDown called running a test case");
         }
 
         [Test]
@@ -370,17 +370,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestThatChangesPersistUsingSameThread()
         {
-            Assert.AreEqual("foo", Thread.CurrentPrincipal.Identity.Name);
-            Assert.AreEqual("en-GB", Thread.CurrentThread.CurrentCulture.Name);
-            Assert.AreEqual("en-GB", Thread.CurrentThread.CurrentUICulture.Name);
+            Assert.That(Thread.CurrentPrincipal.Identity.Name, Is.EqualTo("foo"));
+            Assert.That(Thread.CurrentThread.CurrentCulture.Name, Is.EqualTo("en-GB"));
+            Assert.That(Thread.CurrentThread.CurrentUICulture.Name, Is.EqualTo("en-GB"));
         }
 
         [Test, RequiresThread]
         public void TestThatChangesPersistUsingSeparateThread()
         {
-            Assert.AreEqual("foo", Thread.CurrentPrincipal.Identity.Name);
-            Assert.AreEqual("en-GB", Thread.CurrentThread.CurrentCulture.Name, "#CurrentCulture");
-            Assert.AreEqual("en-GB", Thread.CurrentThread.CurrentUICulture.Name, "#CurrentUICulture");
+            Assert.That(Thread.CurrentPrincipal.Identity.Name, Is.EqualTo("foo"));
+            Assert.That(Thread.CurrentThread.CurrentCulture.Name, Is.EqualTo("en-GB"), "#CurrentCulture");
+            Assert.That(Thread.CurrentThread.CurrentUICulture.Name, Is.EqualTo("en-GB"), "#CurrentUICulture");
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Attributes
             [OneTimeTearDown]
             public void OneTimeTearDown()
             {
-                Assert.That(pairsTested.Count, Is.EqualTo(16));
+                Assert.That(pairsTested, Has.Count.EqualTo(16));
             }
 
             [Test, Pairwise]
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Attributes
                 for (int j = 0; j < i; j++)
                     expectedPairs += dimensions[i] * dimensions[j];
 
-            Assert.That(pairs.Count, Is.EqualTo(expectedPairs), "Number of pairs is incorrect");
+            Assert.That(pairs, Has.Count.EqualTo(expectedPairs), "Number of pairs is incorrect");
             Assert.That(cases, Is.AtMost(bestSoFar), "Regression: Number of test cases exceeded target previously reached");
 #if DEBUG
             //Assert.That(cases, Is.AtMost(targetCases), "Number of test cases exceeded target");

--- a/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParallelizableAttributeTests.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Attributes
 
         public class FixtureClass { }
 
-        public void DummyMethod() { }
+        private void DummyMethod() { }
 
         [TestCase(1)]
         public void DummyTestCase(int i) { }

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -70,17 +70,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestEquality()
         {
-            Assert.AreEqual(eq1, eq2);
+            Assert.That(eq2, Is.EqualTo(eq1));
             if (eq1 != null && eq2 != null)
-                Assert.AreEqual(eq1.GetHashCode(), eq2.GetHashCode());
+                Assert.That(eq2.GetHashCode(), Is.EqualTo(eq1.GetHashCode()));
         }
 
         [Test]
         public void TestInequality()
         {
-            Assert.AreNotEqual(eq1, neq);
+            Assert.That(neq, Is.Not.EqualTo(eq1));
             if (eq1 != null && neq != null)
-                Assert.AreNotEqual(eq1.GetHashCode(), neq.GetHashCode());
+                Assert.That(neq.GetHashCode(), Is.Not.EqualTo(eq1.GetHashCode()));
         }
     }
 
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SuiteHasCorrectNumberOfInstances()
         {
-            Assert.That(fixture.Tests.Count, Is.EqualTo(2));
+            Assert.That(fixture.Tests, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -152,14 +152,14 @@ namespace NUnit.Framework.Attributes
         public void CanSpecifyCategory()
         {
             Test fixture = TestBuilder.MakeFixture(typeof(NUnit.TestData.TestFixtureWithSingleCategory));
-            Assert.AreEqual("XYZ", fixture.Properties.Get(PropertyNames.Category));
+            Assert.That(fixture.Properties.Get(PropertyNames.Category), Is.EqualTo("XYZ"));
         }
 
         [Test]
         public void CanSpecifyMultipleCategories()
         {
             Test fixture = TestBuilder.MakeFixture(typeof(NUnit.TestData.TestFixtureWithMultipleCategories));
-            Assert.AreEqual(new[] { "X", "Y", "Z" }, fixture.Properties[PropertyNames.Category]);
+            Assert.That(fixture.Properties[PropertyNames.Category], Is.EqualTo(new[] { "X", "Y", "Z" }));
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MakeSureTypeIsInSystemNamespace()
         {
-            Assert.AreEqual("System", _someType.Namespace);
+            Assert.That(_someType.Namespace, Is.EqualTo("System"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/PropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PropertyAttributeTests.cs
@@ -28,41 +28,41 @@ namespace NUnit.Framework.Attributes
         public void PropertiesWithNumericValues()
         {
             Test test2 = (Test)fixture.Tests[1];
-            Assert.AreEqual(10.0, test2.Properties.Get("X"));
-            Assert.AreEqual(17.0, test2.Properties.Get("Y"));
+            Assert.That(test2.Properties.Get("X"), Is.EqualTo(10.0));
+            Assert.That(test2.Properties.Get("Y"), Is.EqualTo(17.0));
         }
 
         [Test]
         public void PropertyWorksOnFixtures()
         {
-            Assert.AreEqual("SomeClass", fixture.Properties.Get("ClassUnderTest"));
+            Assert.That(fixture.Properties.Get("ClassUnderTest"), Is.EqualTo("SomeClass"));
         }
 
         [Test]
         public void CanDeriveFromPropertyAttribute()
         {
             Test test3 = (Test)fixture.Tests[2];
-            Assert.AreEqual(5, test3.Properties.Get("Priority"));
+            Assert.That(test3.Properties.Get("Priority"), Is.EqualTo(5));
         }
 
         [Test]
         public void CustomPropertyAttribute()
         {
             Test test4 = (Test)fixture.Tests[3];
-            Assert.IsNotNull(test4.Properties.Get("CustomProperty"));
+            Assert.That(test4.Properties.Get("CustomProperty"), Is.Not.Null);
         }
 
         [Test]
         public void ManyProperties()
         {
             Test test5 = (Test)fixture.Tests[4];
-            Assert.AreEqual(6, test5.Properties.Keys.Count);
-            Assert.AreEqual("A", test5.Properties.Get("A"));
-            Assert.AreEqual("B", test5.Properties.Get("B"));
-            Assert.AreEqual("C", test5.Properties.Get("C"));
-            Assert.AreEqual("D", test5.Properties.Get("D"));
-            Assert.AreEqual("E", test5.Properties.Get("E"));
-            Assert.AreEqual("F", test5.Properties.Get("F"));
+            Assert.That(test5.Properties.Keys, Has.Count.EqualTo(6));
+            Assert.That(test5.Properties.Get("A"), Is.EqualTo("A"));
+            Assert.That(test5.Properties.Get("B"), Is.EqualTo("B"));
+            Assert.That(test5.Properties.Get("C"), Is.EqualTo("C"));
+            Assert.That(test5.Properties.Get("D"), Is.EqualTo("D"));
+            Assert.That(test5.Properties.Get("E"), Is.EqualTo("E"));
+            Assert.That(test5.Properties.Get("F"), Is.EqualTo("F"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.Framework.Attributes
     {
         #region Shared specs
 
-        public static IEnumerable<Type> TestedParameterTypes() => new[]
+        private static IEnumerable<Type> TestedParameterTypes() => new[]
         {
             typeof(sbyte),
             typeof(byte),

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -38,11 +38,11 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
             Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
-            Assert.AreEqual(1, fixture.FixtureSetupCount);
-            Assert.AreEqual(1, fixture.FixtureTeardownCount);
-            Assert.AreEqual(nTries, fixture.SetupCount);
-            Assert.AreEqual(nTries, fixture.TeardownCount);
-            Assert.AreEqual(nTries, fixture.Count);
+            Assert.That(fixture.FixtureSetupCount, Is.EqualTo(1));
+            Assert.That(fixture.FixtureTeardownCount, Is.EqualTo(1));
+            Assert.That(fixture.SetupCount, Is.EqualTo(nTries));
+            Assert.That(fixture.TeardownCount, Is.EqualTo(nTries));
+            Assert.That(fixture.Count, Is.EqualTo(nTries));
         }
 
         [Test]
@@ -51,8 +51,8 @@ namespace NUnit.Framework.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, nameof(RepeatedTestVerifyAttempt.PassesTwoTimes));
 
-            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.AreEqual(result.FailCount, 1, "expected that the test failed the last repetition");
+            Assert.That(fixture.TearDownResults, Has.Count.EqualTo(fixture.Count + 1), "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.That(result.FailCount, Is.EqualTo(1), "expected that the test failed the last repetition");
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace NUnit.Framework.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RepeatedTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, nameof(RepeatedTestVerifyAttempt.AlwaysPasses));
 
-            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.AreEqual(result.FailCount, 0, "expected that the test passes all repetitions without a failure");
+            Assert.That(fixture.TearDownResults, Has.Count.EqualTo(fixture.Count + 1), "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.That(result.FailCount, Is.EqualTo(0), "expected that the test passes all repetitions without a failure");
         }
 
         [Test]
@@ -71,9 +71,9 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeFixture(typeof(RepeatedTestWithCategory));
             Test test = suite.Tests[0] as Test;
             System.Collections.IList categories = test.Properties["Category"];
-            Assert.IsNotNull(categories);
-            Assert.AreEqual(1, categories.Count);
-            Assert.AreEqual("SAMPLE", categories[0]);
+            Assert.That(categories, Is.Not.Null);
+            Assert.That(categories, Has.Count.EqualTo(1));
+            Assert.That(categories[0], Is.EqualTo("SAMPLE"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Attributes
         public void ShouldPassAfter3Retries()
         {
             retryOnlyCount++;
-            Assert.True(retryOnlyCount >= 2);
+            Assert.That(retryOnlyCount, Is.GreaterThanOrEqualTo(2));
         }
 
         public class HelperMethodForTimeoutsClass
@@ -109,9 +109,12 @@ namespace NUnit.Framework.Attributes
             var workItem = TestBuilder.CreateWorkItem(testCase);
             var result = TestBuilder.ExecuteWorkItem(workItem);
 
-            Assert.AreEqual(TestStatus.Failed, result.ResultState.Status);
-            Assert.AreEqual(FailureSite.Test, result.ResultState.Site);
-            Assert.AreEqual("Invalid", result.ResultState.Label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));
+                Assert.That(result.ResultState.Label, Is.EqualTo("Invalid"));
+            });
         }
 
         [Test]
@@ -121,16 +124,19 @@ namespace NUnit.Framework.Attributes
             var workItem = TestBuilder.CreateWorkItem(testCase);
             var result = TestBuilder.ExecuteWorkItem(workItem);
 
-            Assert.AreEqual(TestStatus.Failed, result.ResultState.Status);
-            Assert.AreEqual(FailureSite.Test, result.ResultState.Site);
-            Assert.AreEqual("Invalid", result.ResultState.Label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));
+                Assert.That(result.ResultState.Label, Is.EqualTo("Invalid"));
+            });
         }
 
         [Repeat(1), Retry(1)]
-        public void TestMethodForRepeatAndRetryExpectedFail() { }
+        private void TestMethodForRepeatAndRetryExpectedFail() { }
 
         [Repeat(1), CustomRepeater]
-        public void TestMethodForRepeatAndCustomRepeatExpectedFail() { }
+        private void TestMethodForRepeatAndCustomRepeatExpectedFail() { }
 
         #region TestCustomAttribute
 
@@ -151,7 +157,7 @@ namespace NUnit.Framework.Attributes
         public virtual void ShouldBeOveridden()
         {
             RepeatCount++;
-            Assert.True(RepeatCount >= 1);
+            Assert.That(RepeatCount, Is.GreaterThanOrEqualTo(1));
         }
     }
 
@@ -162,7 +168,7 @@ namespace NUnit.Framework.Attributes
         public override void ShouldBeOveridden()
         {
             RepeatCount++;
-            Assert.True(RepeatCount >= 2);
+            Assert.That(RepeatCount, Is.GreaterThanOrEqualTo(2));
         }
     }
 
@@ -173,7 +179,7 @@ namespace NUnit.Framework.Attributes
         public override void ShouldBeOveridden()
         {
             RepeatCount++;
-            Assert.True(RepeatCount == 1);
+            Assert.That(RepeatCount, Is.EqualTo(1));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -29,11 +29,11 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
             Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
-            Assert.AreEqual(1, fixture.FixtureSetupCount);
-            Assert.AreEqual(1, fixture.FixtureTeardownCount);
-            Assert.AreEqual(nTries, fixture.SetupCount);
-            Assert.AreEqual(nTries, fixture.TeardownCount);
-            Assert.AreEqual(nTries, fixture.Count);
+            Assert.That(fixture.FixtureSetupCount, Is.EqualTo(1));
+            Assert.That(fixture.FixtureTeardownCount, Is.EqualTo(1));
+            Assert.That(fixture.SetupCount, Is.EqualTo(nTries));
+            Assert.That(fixture.TeardownCount, Is.EqualTo(nTries));
+            Assert.That(fixture.Count, Is.EqualTo(nTries));
         }
 
         [TestCase(typeof(RetrySucceedsOnFirstTryFixture), "Passed")]
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.AreEqual(results.Length, fixture.TearDownResults.Count);
+            Assert.That(fixture.TearDownResults, Has.Count.EqualTo(results.Length));
             for (int i = 0; i < results.Length; i++)
                 Assert.That(fixture.TearDownResults[i], Is.EqualTo(results[i]), $"Teardown {i} received incorrect result");
         }
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Attributes
             ITestResult result = TestBuilder.RunTestCase(fixture, methodName);
 
             Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
-            Assert.AreEqual(nTries, fixture.Count);
+            Assert.That(fixture.Count, Is.EqualTo(nTries));
         }
 
 
@@ -75,9 +75,9 @@ namespace NUnit.Framework.Attributes
             TestSuite suite = TestBuilder.MakeFixture(typeof(RetryTestWithCategoryFixture));
             Test test = suite.Tests[0] as Test;
             System.Collections.IList categories = test.Properties["Category"];
-            Assert.IsNotNull(categories);
-            Assert.AreEqual(1, categories.Count);
-            Assert.AreEqual("SAMPLE", categories[0]);
+            Assert.That(categories, Is.Not.Null);
+            Assert.That(categories, Has.Count.EqualTo(1));
+            Assert.That(categories[0], Is.EqualTo("SAMPLE"));
         }
 
         [Test]
@@ -86,8 +86,8 @@ namespace NUnit.Framework.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, "NeverPasses");
 
-            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.AreEqual(result.FailCount, 1, "expected that the test failed all retries");
+            Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.That(1, Is.EqualTo(result.FailCount), "expected that the test failed all retries");
         }
 
         [Test]
@@ -96,8 +96,8 @@ namespace NUnit.Framework.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, "PassesOnLastRetry");
 
-            Assert.AreEqual(fixture.TearDownResults.Count, fixture.Count + 1, "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.AreEqual(result.FailCount, 0, "expected that the test passed final retry");
+            Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
+            Assert.That(0, Is.EqualTo(result.FailCount), "expected that the test passed final retry");
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
@@ -21,57 +21,57 @@ namespace NUnit.Framework.Attributes
         [Test, SetUICulture("fr-FR")]
         public void SetUICultureOnlyToFrench()
         {
-            Assert.AreEqual(CultureInfo.CurrentCulture, originalCulture, "Culture should not change");
-            Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-FR"), "UICulture not set correctly");
         }
 
         [Test, SetUICulture("fr-CA")]
         public void SetUICultureOnlyToFrenchCanadian()
         {
-            Assert.AreEqual(CultureInfo.CurrentCulture, originalCulture, "Culture should not change");
-            Assert.AreEqual("fr-CA", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-CA"), "UICulture not set correctly");
         }
 
         [Test, SetUICulture("ru-RU")]
         public void SetUICultureOnlyToRussian()
         {
-            Assert.AreEqual(CultureInfo.CurrentCulture, originalCulture, "Culture should not change");
-            Assert.AreEqual("ru-RU", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("ru-RU"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("fr-FR"), SetUICulture("fr-FR")]
         public void SetBothCulturesToFrench()
         {
-            Assert.AreEqual("fr-FR", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-            Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-FR"), "Culture not set correctly");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-FR"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("fr-CA"), SetUICulture("fr-CA")]
         public void SetBothCulturesToFrenchCanadian()
         {
-            Assert.AreEqual("fr-CA", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-            Assert.AreEqual("fr-CA", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-CA"), "Culture not set correctly");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-CA"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("ru-RU"), SetUICulture("ru-RU")]
         public void SetBothCulturesToRussian()
         {
-            Assert.AreEqual("ru-RU", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-            Assert.AreEqual("ru-RU", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("ru-RU"), "Culture not set correctly");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("ru-RU"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("fr-FR"), SetUICulture("fr-CA")]
         public void SetMixedCulturesToFrenchAndUIFrenchCanadian()
         {
-            Assert.AreEqual("fr-FR", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-            Assert.AreEqual("fr-CA", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-FR"), "Culture not set correctly");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-CA"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("ru-RU"), SetUICulture("en-US")]
         public void SetMixedCulturesToRussianAndUIEnglishUS()
         {
-            Assert.AreEqual("ru-RU", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-            Assert.AreEqual("en-US", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+            Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("ru-RU"), "Culture not set correctly");
+            Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("en-US"), "UICulture not set correctly");
         }
 
         [TestFixture, SetCulture("ru-RU"), SetUICulture("ru-RU")]
@@ -80,15 +80,15 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void InheritedRussian()
             {
-                Assert.AreEqual("ru-RU", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-                Assert.AreEqual("ru-RU", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+                Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("ru-RU"), "Culture not set correctly");
+                Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("ru-RU"), "UICulture not set correctly");
             }
 
             [Test, SetUICulture("fr-FR")]
             public void InheritedRussianWithUIFrench()
             {
-                Assert.AreEqual("ru-RU", CultureInfo.CurrentCulture.Name, "Culture not set correctly");
-                Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name, "UICulture not set correctly");
+                Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("ru-RU"), "Culture not set correctly");
+                Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-FR"), "UICulture not set correctly");
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -66,8 +66,8 @@ namespace NUnit.Framework.Attributes
         {
             var usageAttrib = Attribute.GetCustomAttribute(typeof(SetUpFixtureAttribute), typeof(AttributeUsageAttribute)) as AttributeUsageAttribute;
 
-            Assert.NotNull(usageAttrib);
-            Assert.False(usageAttrib.Inherited);
+            Assert.That(usageAttrib, Is.Not.Null);
+            Assert.That(usageAttrib.Inherited, Is.False);
         }
 
         private static class StaticSetupClass

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(12, 4, 3)]
         public void IntegerDivisionWithResultPassedToTest(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [TestCase(12, 3, ExpectedResult = 4)]
@@ -80,19 +80,19 @@ namespace NUnit.Framework.Attributes
         {
             var test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), methodName).Tests[0];
-            Assert.AreEqual(expectedState, test.RunState);
+            Assert.That(test.RunState, Is.EqualTo(expectedState));
         }
 
         [TestCase("12-October-1942")]
         public void CanConvertStringToDateTime(DateTime dt)
         {
-            Assert.AreEqual(1942, dt.Year);
+            Assert.That(dt.Year, Is.EqualTo(1942));
         }
 
         [TestCase("1942-10-12")]
         public void CanConvertIso8601DateStringToDateTime(DateTime dt)
         {
-            Assert.AreEqual(new DateTime(1942,10,12), dt);
+            Assert.That(dt, Is.EqualTo(new DateTime(1942,10,12)));
         }
 
         [TestCase("1942-10-12", ExpectedResult = "1942-10-12")]
@@ -104,9 +104,9 @@ namespace NUnit.Framework.Attributes
         [TestCase("4:44:15")]
         public void CanConvertStringToTimeSpan(TimeSpan ts)
         {
-            Assert.AreEqual(4, ts.Hours);
-            Assert.AreEqual(44, ts.Minutes);
-            Assert.AreEqual(15, ts.Seconds);
+            Assert.That(ts.Hours, Is.EqualTo(4));
+            Assert.That(ts.Minutes, Is.EqualTo(44));
+            Assert.That(ts.Seconds, Is.EqualTo(15));
         }
 
         [TestCase("4:44:15", ExpectedResult = "4:44:15")]
@@ -118,16 +118,16 @@ namespace NUnit.Framework.Attributes
         [TestCase("2018-10-09 15:15:00+02:30")]
         public void CanConvertStringToDateTimeOffset(DateTimeOffset offset)
         {
-            Assert.AreEqual(2018, offset.Year);
-            Assert.AreEqual(10, offset.Month);
-            Assert.AreEqual(9, offset.Day);
+            Assert.That(offset.Year, Is.EqualTo(2018));
+            Assert.That(offset.Month, Is.EqualTo(10));
+            Assert.That(offset.Day, Is.EqualTo(9));
 
-            Assert.AreEqual(15, offset.Hour);
-            Assert.AreEqual(15, offset.Minute);
-            Assert.AreEqual(0, offset.Second);
+            Assert.That(offset.Hour, Is.EqualTo(15));
+            Assert.That(offset.Minute, Is.EqualTo(15));
+            Assert.That(offset.Second, Is.EqualTo(0));
 
-            Assert.AreEqual(2, offset.Offset.Hours);
-            Assert.AreEqual(30, offset.Offset.Minutes);
+            Assert.That(offset.Offset.Hours, Is.EqualTo(2));
+            Assert.That(offset.Offset.Minutes, Is.EqualTo(30));
         }
 
         [TestCase("2018-10-09 15:15:00+02:30", ExpectedResult = "2018-10-09 15:15:00+02:30")]
@@ -139,7 +139,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(null)]
         public void CanPassNullAsFirstArgument(object a)
         {
-            Assert.IsNull(a);
+            Assert.That(a, Is.Null);
         }
 
         [TestCase(new object[] { 1, "two", 3.0 })]
@@ -151,22 +151,22 @@ namespace NUnit.Framework.Attributes
         [TestCase(new object[] { "a", "b" })]
         public void CanPassArrayAsArgument(object[] array)
         {
-            Assert.AreEqual("a", array[0]);
-            Assert.AreEqual("b", array[1]);
+            Assert.That(array[0], Is.EqualTo("a"));
+            Assert.That(array[1], Is.EqualTo("b"));
         }
 
         [TestCase("a", "b")]
         public void ArgumentsAreCoalescedInObjectArray(object[] array)
         {
-            Assert.AreEqual("a", array[0]);
-            Assert.AreEqual("b", array[1]);
+            Assert.That(array[0], Is.EqualTo("a"));
+            Assert.That(array[1], Is.EqualTo("b"));
         }
 
         [TestCase(1, "b")]
         public void ArgumentsOfDifferentTypeAreCoalescedInObjectArray(object[] array)
         {
-            Assert.AreEqual(1, array[0]);
-            Assert.AreEqual("b", array[1]);
+            Assert.That(array[0], Is.EqualTo(1));
+            Assert.That(array[1], Is.EqualTo("b"));
         }
 
         [TestCase(new object[] { null })]
@@ -184,39 +184,39 @@ namespace NUnit.Framework.Attributes
         [TestCase("a", "b")]
         public void HandlesParamsArrayAsSoleArgument(params string[] array)
         {
-            Assert.AreEqual("a", array[0]);
-            Assert.AreEqual("b", array[1]);
+            Assert.That(array[0], Is.EqualTo("a"));
+            Assert.That(array[1], Is.EqualTo("b"));
         }
 
         [TestCase("a")]
         public void HandlesParamsArrayWithOneItemAsSoleArgument(params string[] array)
         {
-            Assert.AreEqual("a", array[0]);
+            Assert.That(array[0], Is.EqualTo("a"));
         }
 
         [TestCase("a", "b", "c", "d")]
         public void HandlesParamsArrayAsLastArgument(string s1, string s2, params object[] array)
         {
-            Assert.AreEqual("a", s1);
-            Assert.AreEqual("b", s2);
-            Assert.AreEqual("c", array[0]);
-            Assert.AreEqual("d", array[1]);
+            Assert.That(s1, Is.EqualTo("a"));
+            Assert.That(s2, Is.EqualTo("b"));
+            Assert.That(array[0], Is.EqualTo("c"));
+            Assert.That(array[1], Is.EqualTo("d"));
         }
 
         [TestCase("a", "b")]
         public void HandlesParamsArrayWithNoItemsAsLastArgument(string s1, string s2, params object[] array)
         {
-            Assert.AreEqual("a", s1);
-            Assert.AreEqual("b", s2);
-            Assert.AreEqual(0, array.Length);
+            Assert.That(s1, Is.EqualTo("a"));
+            Assert.That(s2, Is.EqualTo("b"));
+            Assert.That(array, Is.Empty);
         }
 
         [TestCase("a", "b", "c")]
         public void HandlesParamsArrayWithOneItemAsLastArgument(string s1, string s2, params object[] array)
         {
-            Assert.AreEqual("a", s1);
-            Assert.AreEqual("b", s2);
-            Assert.AreEqual("c", array[0]);
+            Assert.That(s1, Is.EqualTo("a"));
+            Assert.That(s2, Is.EqualTo("b"));
+            Assert.That(array[0], Is.EqualTo("c"));
         }
 
         [TestCase("x", ExpectedResult = new []{"x", "b", "c"})]
@@ -235,18 +235,20 @@ namespace NUnit.Framework.Attributes
             return new[] {s1, s2};
         }
 
+#pragma warning disable NUnit1004 // The TestCaseAttribute provided too many arguments
         [TestCase("a", "b", Explicit = true)]
         public void ShouldNotRunAndShouldNotFailInConsoleRunner()
         {
             Assert.Fail();
         }
+#pragma warning restore NUnit1004 // The TestCaseAttribute provided too many arguments
 
         [Test]
         public void CanSpecifyDescription()
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasDescriptionSpecified)).Tests[0];
-            Assert.AreEqual("My Description", test.Properties.Get(PropertyNames.Description));
+            Assert.That(test.Properties.Get(PropertyNames.Description), Is.EqualTo("My Description"));
         }
 
         [Test]
@@ -254,8 +256,8 @@ namespace NUnit.Framework.Attributes
         {
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasTestNameSpecified_FixedText)).Tests[0];
-            Assert.AreEqual("XYZ", test.Name);
-            Assert.AreEqual("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture.XYZ", test.FullName);
+            Assert.That(test.Name, Is.EqualTo("XYZ"));
+            Assert.That(test.FullName, Is.EqualTo("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture.XYZ"));
         }
 
         [Test]
@@ -264,8 +266,8 @@ namespace NUnit.Framework.Attributes
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasTestNameSpecified_WithMethodName)).Tests[0];
             var expectedName = "MethodHasTestNameSpecified_WithMethodName+XYZ";
-            Assert.AreEqual(expectedName, test.Name);
-            Assert.AreEqual("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture." + expectedName, test.FullName);
+            Assert.That(test.Name, Is.EqualTo(expectedName));
+            Assert.That(test.FullName, Is.EqualTo("NUnit.TestData.TestCaseAttributeFixture.TestCaseAttributeFixture." + expectedName));
         }
 
         [Test]
@@ -274,7 +276,7 @@ namespace NUnit.Framework.Attributes
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasSingleCategory)).Tests[0];
             IList categories = test.Properties["Category"];
-            Assert.AreEqual(new[] { "XYZ" }, categories);
+            Assert.That(categories, Is.EqualTo(new[] { "XYZ" }));
         }
 
         [Test]
@@ -283,7 +285,7 @@ namespace NUnit.Framework.Attributes
             Test test = (Test)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseAttributeFixture), nameof(TestCaseAttributeFixture.MethodHasMultipleCategories)).Tests[0];
             IList categories = test.Properties["Category"];
-            Assert.AreEqual(new[] { "X", "Y", "Z" }, categories);
+            Assert.That(categories, Is.EqualTo(new[] { "X", "Y", "Z" }));
         }
 
         [Test]
@@ -531,7 +533,7 @@ namespace NUnit.Framework.Attributes
         [TestCase(12, 4, 3)]
         public void NullableIntegerDivisionWithResultPassedToTest(int? n, int? d, int? q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [TestCase(12, 3, ExpectedResult = 4)]
@@ -630,7 +632,7 @@ namespace NUnit.Framework.Attributes
         public void CanConvertStringToNullableDateTime(DateTime? dt)
         {
             Assert.That(dt.HasValue);
-            Assert.AreEqual(1942, dt.Value.Year);
+            Assert.That(dt.Value.Year, Is.EqualTo(1942));
         }
 
         [TestCase(null)]
@@ -643,9 +645,9 @@ namespace NUnit.Framework.Attributes
         public void CanConvertStringToNullableTimeSpan(TimeSpan? ts)
         {
             Assert.That(ts.HasValue);
-            Assert.AreEqual(4, ts.Value.Hours);
-            Assert.AreEqual(44, ts.Value.Minutes);
-            Assert.AreEqual(15, ts.Value.Seconds);
+            Assert.That(ts.Value.Hours, Is.EqualTo(4));
+            Assert.That(ts.Value.Minutes, Is.EqualTo(44));
+            Assert.That(ts.Value.Seconds, Is.EqualTo(15));
         }
 
         [TestCase(null)]
@@ -657,13 +659,13 @@ namespace NUnit.Framework.Attributes
         [TestCase(1)]
         public void NullableSimpleFormalParametersWithArgument(int? a)
         {
-            Assert.AreEqual(1, a);
+            Assert.That(a, Is.EqualTo(1));
         }
 
         [TestCase(null)]
         public void NullableSimpleFormalParametersWithNullArgument(int? a)
         {
-            Assert.IsNull(a);
+            Assert.That(a, Is.Null);
         }
 
         [TestCase(null, ExpectedResult = null)]

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -20,13 +20,13 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(nameof(StaticProperty))]
         public void SourceCanBeStaticProperty(string source)
         {
-            Assert.AreEqual("StaticProperty", source);
+            Assert.That(source, Is.EqualTo("StaticProperty"));
         }
 
         [Test, TestCaseSource(nameof(InheritedStaticProperty))]
         public void TestSourceCanBeInheritedStaticProperty(bool source)
         {
-            Assert.AreEqual(true, source);
+            Assert.That(source, Is.EqualTo(true));
         }
 
         static IEnumerable StaticProperty =>
@@ -39,13 +39,13 @@ namespace NUnit.Framework.Attributes
         public void SourceUsingInstancePropertyIsNotRunnable()
         {
             var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstancePropertyAsSource));
-            Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
+            Assert.That(ResultState.NotRunnable, Is.EqualTo(result.Children.ToArray()[0].ResultState));
         }
 
         [Test, TestCaseSource(nameof(StaticMethod))]
         public void SourceCanBeStaticMethod(string source)
         {
-            Assert.AreEqual("StaticMethod", source);
+            Assert.That(source, Is.EqualTo("StaticMethod"));
         }
 
         static IEnumerable StaticMethod()
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Attributes
         public void SourceUsingInstanceMethodIsNotRunnable()
         {
             var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstanceMethodAsSource));
-            Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
+            Assert.That(ResultState.NotRunnable, Is.EqualTo(result.Children.ToArray()[0].ResultState));
         }
 
         IEnumerable InstanceMethod()
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(nameof(StaticField))]
         public void SourceCanBeStaticField(string source)
         {
-            Assert.AreEqual("StaticField", source);
+            Assert.That(source, Is.EqualTo("StaticField"));
         }
 
         static object[] StaticField =
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Attributes
         public void SourceUsingInstanceFieldIsNotRunnable()
         {
             var result = TestBuilder.RunParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithInstanceFieldAsSource));
-            Assert.AreEqual(result.Children.ToArray()[0].ResultState, ResultState.NotRunnable);
+            Assert.That(ResultState.NotRunnable, Is.EqualTo(result.Children.ToArray()[0].ResultState));
         }
 
         #endregion
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(typeof(DataSourceClass))]
         public void SourceCanBeInstanceOfIEnumerable(string source)
         {
-            Assert.AreEqual("DataSourceClass", source);
+            Assert.That(source, Is.EqualTo("DataSourceClass"));
         }
 
         class DataSourceClass : IEnumerable
@@ -108,19 +108,19 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(nameof(MyData))]
         public void SourceMayReturnArgumentsAsObjectArray(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [TestCaseSource(nameof(MyData))]
         public void TestAttributeIsOptional(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [Test, TestCaseSource(nameof(MyIntData))]
         public void SourceMayReturnArgumentsAsIntArray(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [Test, TestCaseSource(nameof(MyArrayData))]
@@ -132,7 +132,7 @@ namespace NUnit.Framework.Attributes
         [Test, TestCaseSource(nameof(EvenNumbers))]
         public void SourceMayReturnSinglePrimitiveArgumentAlone(int n)
         {
-            Assert.AreEqual(0, n % 2);
+            Assert.That(n % 2, Is.EqualTo(0));
         }
 
         [Test, TestCaseSource(nameof(Params))]
@@ -147,32 +147,32 @@ namespace NUnit.Framework.Attributes
         [TestCase(12, 2, 6)]
         public void TestMayUseMultipleSourceAttributes(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [Test, TestCaseSource(nameof(FourArgs))]
         public void TestWithFourArguments(int n, int d, int q, int r)
         {
-            Assert.AreEqual(q, n / d);
-            Assert.AreEqual(r, n % d);
+            Assert.That(n / d, Is.EqualTo(q));
+            Assert.That(n % d, Is.EqualTo(r));
         }
 
         [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.HereIsTheData))]
         public void SourceMayBeInAnotherClass(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
-        [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), "HereIsTheDataWithParameters", new object[] { 100, 4, 25 })]
+        [Test, Category("Top"), TestCaseSource(typeof(DivideDataProvider), nameof(DivideDataProvider.HereIsTheDataWithParameters), new object[] { 100, 4, 25 })]
         public void SourceInAnotherClassPassingSomeDataToConstructor(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [Test, Category("Top"), TestCaseSource(nameof(StaticMethodDataWithParameters), new object[] { 8000, 8, 1000 })]
         public void SourceCanBeStaticMethodPassingSomeDataToConstructor(int n, int d, int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         [Test]
@@ -180,12 +180,12 @@ namespace NUnit.Framework.Attributes
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingParamsToField)).Tests[0];
-            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.NotRunnable));
             ITestResult result = TestBuilder.RunTest(testMethod, null);
-            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
-            Assert.AreEqual("You have specified a data source field but also given a set of parameters. Fields cannot take parameters, " +
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
+            Assert.That(result.Message, Is.EqualTo("You have specified a data source field but also given a set of parameters. Fields cannot take parameters, " +
                             "please revise the 3rd parameter passed to the TestCaseSourceAttribute and either remove " +
-                            "it or specify a method.", result.Message);
+                            "it or specify a method."));
         }
 
         [Test]
@@ -193,12 +193,12 @@ namespace NUnit.Framework.Attributes
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingParamsToProperty)).Tests[0];
-            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.NotRunnable));
             ITestResult result = TestBuilder.RunTest(testMethod, null);
-            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
-            Assert.AreEqual("You have specified a data source property but also given a set of parameters. " +
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
+            Assert.That(result.Message, Is.EqualTo("You have specified a data source property but also given a set of parameters. " +
                             "Properties cannot take parameters, please revise the 3rd parameter passed to the " +
-                            "TestCaseSource attribute and either remove it or specify a method.", result.Message);
+                            "TestCaseSource attribute and either remove it or specify a method."));
         }
 
         [Test]
@@ -206,12 +206,12 @@ namespace NUnit.Framework.Attributes
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.SourceInAnotherClassPassingSomeDataToConstructorWrongNumberParam)).Tests[0];
-            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.NotRunnable));
             ITestResult result = TestBuilder.RunTest(testMethod, null);
-            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
-            Assert.AreEqual("You have given the wrong number of arguments to the method in the TestCaseSourceAttribute" +
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
+            Assert.That(result.Message, Is.EqualTo("You have given the wrong number of arguments to the method in the TestCaseSourceAttribute" +
                             ", please check the number of parameters passed in the object is correct in the 3rd parameter for the " +
-                            "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.", result.Message);
+                            "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again."));
         }
 
         [Test, TestCaseSource(typeof(DivideDataProviderWithReturnValue), nameof(DivideDataProviderWithReturnValue.TestCases))]
@@ -225,8 +225,8 @@ namespace NUnit.Framework.Attributes
         {
             var result = TestBuilder.RunParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodCallsIgnore)).Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Ignored, result.ResultState);
-            Assert.AreEqual("Ignore this", result.Message);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Ignored));
+            Assert.That(result.Message, Is.EqualTo("Ignore this"));
         }
 
         [Test]
@@ -294,16 +294,16 @@ namespace NUnit.Framework.Attributes
         {
             var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithSourceThrowingException)).Tests[0];
-            Assert.AreEqual(RunState.NotRunnable, testMethod.RunState);
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.NotRunnable));
             ITestResult result = TestBuilder.RunTest(testMethod, null);
-            Assert.AreEqual(ResultState.NotRunnable, result.ResultState);
-            Assert.AreEqual("System.Exception : my message", result.Message);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
+            Assert.That(result.Message, Is.EqualTo("System.Exception : my message"));
         }
 
         [TestCaseSource(nameof(exception_source)), Explicit("Used for GUI tests")]
         public void HandlesExceptionInTestCaseSource_GuiDisplay(string lhs, string rhs)
         {
-            Assert.AreEqual(lhs, rhs);
+            Assert.That(rhs, Is.EqualTo(lhs));
         }
 
 
@@ -319,8 +319,8 @@ namespace NUnit.Framework.Attributes
         {
             TestSuite suiteToTest = TestBuilder.MakeParameterizedMethodSuite(typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithNonExistingSource));
             
-            Assert.That(suiteToTest.Tests.Count == 1);
-            Assert.AreEqual(RunState.NotRunnable, suiteToTest.Tests[0].RunState);
+            Assert.That(suiteToTest.Tests, Has.Count.EqualTo(1));
+            Assert.That(suiteToTest.Tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
         static object[] testCases =
@@ -347,7 +347,7 @@ namespace NUnit.Framework.Attributes
 
         #region Test name tests
 
-        public static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
+        private static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
         {
             var suite = (ParameterizedMethodSuite)TestBuilder.MakeParameterizedMethodSuite(
                 typeof(TestCaseSourceAttributeFixture),
@@ -413,7 +413,7 @@ namespace NUnit.Framework.Attributes
             new[] { 12, 6, 2 }
         };
 
-        public static IEnumerable StaticMethodDataWithParameters(int inject1, int inject2, int inject3)
+        private static IEnumerable StaticMethodDataWithParameters(int inject1, int inject2, int inject3)
         {
             yield return new object[] { inject1, inject2, inject3 };
         }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
@@ -14,24 +14,33 @@ namespace NUnit.Framework.Attributes
         public void ConstructWithoutArguments()
         {
             TestFixtureAttribute attr = new TestFixtureAttribute();
-            Assert.That(attr.Arguments.Length == 0);
-            Assert.That(attr.TypeArgs.Length == 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Is.Empty);
+                Assert.That(attr.TypeArgs, Is.Empty);
+            });
         }
 
         [Test]
         public void ConstructWithFixtureArgs()
         {
             TestFixtureAttribute attr = new TestFixtureAttribute(fixtureArgs);
-            Assert.That(attr.Arguments, Is.EqualTo( fixtureArgs ) );
-            Assert.That(attr.TypeArgs.Length == 0 );
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Is.EqualTo(fixtureArgs));
+                Assert.That(attr.TypeArgs, Is.Empty);
+            });
         }
 
         [Test]
         public void ConstructWithJustTypeArgs()
         {
             TestFixtureAttribute attr = new TestFixtureAttribute(typeArgs);
-            Assert.That(attr.Arguments.Length == 2);
-            Assert.That(attr.TypeArgs.Length == 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Has.Length.EqualTo(2));
+                Assert.That(attr.TypeArgs, Is.Empty);
+            });
         }
 
         [Test]
@@ -39,8 +48,11 @@ namespace NUnit.Framework.Attributes
         {
             TestFixtureAttribute attr = new TestFixtureAttribute();
             attr.TypeArgs = typeArgs;
-            Assert.That(attr.Arguments.Length == 0);
-            Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Is.Empty);
+                Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+            });
         }
 
         [Test]
@@ -48,16 +60,22 @@ namespace NUnit.Framework.Attributes
         {
             TestFixtureAttribute attr = new TestFixtureAttribute(fixtureArgs);
             attr.TypeArgs = typeArgs;
-            Assert.That(attr.Arguments, Is.EqualTo(fixtureArgs));
-            Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Is.EqualTo(fixtureArgs));
+                Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+            });
         }
 
         [Test]
         public void ConstructWithCombinedArgs()
         {
             TestFixtureAttribute attr = new TestFixtureAttribute(combinedArgs);
-            Assert.That(attr.Arguments, Is.EqualTo(combinedArgs));
-            Assert.That(attr.TypeArgs.Length, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments, Is.EqualTo(combinedArgs));
+                Assert.That(attr.TypeArgs, Is.Empty);
+            });
         }
 
         [Test]
@@ -65,8 +83,11 @@ namespace NUnit.Framework.Attributes
         {
             TestFixtureAttribute attr = new TestFixtureAttribute(null);
             Assert.That(attr.Arguments, Is.Not.Null);
-            Assert.That(attr.Arguments[0], Is.Null);
-            Assert.That(attr.TypeArgs, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(attr.Arguments[0], Is.Null);
+                Assert.That(attr.TypeArgs, Is.Not.Null);
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -28,8 +28,12 @@ namespace NUnit.Framework.Attributes
         public void CheckArgument(Type type)
         {
             var result = TestBuilder.RunTestFixture(type);
-            Assert.That(result.HasChildren, Is.True);
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HasChildren, Is.True);
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+            });
         }
 
         [TestCase(typeof(InstanceField_SameClass))]
@@ -38,8 +42,12 @@ namespace NUnit.Framework.Attributes
         public void CheckNotRunnable(Type type)
         {
             var suite = TestBuilder.MakeFixture(type);
-            Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(suite.Tests[0].Properties.Get(PropertyNames.SkipReason), Is.EqualTo(TestFixtureSourceAttribute.MUST_BE_STATIC));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
+                Assert.That(suite.Tests[0].Properties.Get(PropertyNames.SkipReason), Is.EqualTo(TestFixtureSourceAttribute.MUST_BE_STATIC));
+            });
             //var result = TestBuilder.RunTestSuite(suite, null);
             //Assert.That(result.ResultState, Is.EqualTo(ResultState.NotRunnable));
         }
@@ -49,11 +57,14 @@ namespace NUnit.Framework.Attributes
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(IndividualInstancesMayBeIgnored));
 
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[1].RunState, Is.EqualTo(RunState.Ignored));
-            Assert.That(suite.Tests[1].Properties.Get(PropertyNames.SkipReason), Is.EqualTo("There must be a reason"));
-            Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Runnable));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[1].RunState, Is.EqualTo(RunState.Ignored));
+                Assert.That(suite.Tests[1].Properties.Get(PropertyNames.SkipReason), Is.EqualTo("There must be a reason"));
+                Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Runnable));
+            });
         }
 
         [Test]
@@ -61,16 +72,19 @@ namespace NUnit.Framework.Attributes
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(IndividualInstancesMayBeExplicit));
 
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[1].RunState, Is.EqualTo(RunState.Explicit));
-            Assert.That(suite.Tests[1].Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Runs long"));
-            Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Explicit));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[1].RunState, Is.EqualTo(RunState.Explicit));
+                Assert.That(suite.Tests[1].Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Runs long"));
+                Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Explicit));
+            });
         }
 
         #region Test name tests
 
-        public static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
+        private static IEnumerable<TestCaseData> IndividualInstanceNameTestDataSource()
         {
             var suite = (ParameterizedFixtureSuite)TestBuilder.MakeFixture(typeof(IndividualInstanceNameTestDataFixture));
 
@@ -102,33 +116,45 @@ namespace NUnit.Framework.Attributes
         public void Issue1118()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(Issue1118_Fixture));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests.Count, Is.EqualTo(3));
-            Assert.That(suite.TestCaseCount, Is.EqualTo(6));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests, Has.Count.EqualTo(3));
+                Assert.That(suite.TestCaseCount, Is.EqualTo(6));
+            });
         }
 
         [Test]
         public void NoNamespaceSourceWithTwoValues()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(NoNamespaceTestFixtureSourceWithTwoValues));
-            Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
-            Assert.That(suite.Tests.Count, Is.EqualTo(2));
-            Assert.That(suite.Tests, Is.All.TypeOf<TestFixture>());
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.TestCaseCount, Is.EqualTo(2));
+                Assert.That(suite.Tests, Has.Count.EqualTo(2));
+                Assert.That(suite.Tests, Is.All.TypeOf<TestFixture>());
+            });
         }
 
         [Test]
         public void NoNamespaceSourceWithSingleValue()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(NoNamespaceTestFixtureSourceWithSingleValue));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
-            Assert.That(suite.TestCaseCount, Is.EqualTo(1));
-            Assert.That(suite.Tests.Count, Is.EqualTo(1));
-            Assert.That(suite.Tests[0], Is.TypeOf<TestFixture>());
-            Assert.That(suite.Tests[0].TestCaseCount, Is.EqualTo(1));
-            Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
+                Assert.That(suite.TestCaseCount, Is.EqualTo(1));
+            });
+            Assert.That(suite.Tests, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0], Is.TypeOf<TestFixture>());
+                Assert.That(suite.Tests[0].TestCaseCount, Is.EqualTo(1));
+            });
+            Assert.That(suite.Tests[0].Tests, Has.Count.EqualTo(1));
             Assert.That(suite.Tests[0].Tests[0], Is.TypeOf<TestMethod>());
         }
 
@@ -136,47 +162,71 @@ namespace NUnit.Framework.Attributes
         public void CanRunGenericFixtureSourceWithProperTypeArgsProvided()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithProperArgsProvided<>));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(1));
-            Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(GenericFixtureSource.Source.Length));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite is ParameterizedFixtureSuite);
+            });
+            Assert.That(suite.Tests, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
+                Assert.That(suite.Tests[0].Tests, Has.Count.EqualTo(GenericFixtureSource.Source.Length));
+            });
         }
 
         [Test]
         public void CanRunGenericFixtureSourceWithProperTypeAndConstructorArgsProvided()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithTypeAndConstructorArgs<>));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(1));
-            Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(GenericFixtureWithTypeAndConstructorArgsSource.Source.Length));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite is ParameterizedFixtureSuite);
+            });
+            Assert.That(suite.Tests, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
+                Assert.That(suite.Tests[0].Tests, Has.Count.EqualTo(GenericFixtureWithTypeAndConstructorArgsSource.Source.Length));
+            });
         }
 
         [Test]
         public void CanRunGenericFixtureSourceWithConstructorArgsProvidedAndTypeArgsDeduced()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(GenericFixtureSourceWithConstructorArgs<>));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(1));
-            Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests[0].Tests.Count, Is.EqualTo(GenericFixtureWithConstructorArgsSource.Source.Length));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite is ParameterizedFixtureSuite);
+            });
+            Assert.That(suite.Tests, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0] is ParameterizedFixtureSuite);
+                Assert.That(suite.Tests[0].Tests, Has.Count.EqualTo(GenericFixtureWithConstructorArgsSource.Source.Length));
+            });
         }
 
         [Test]
         public void ParallelizableAttributeOnFixtureSourceIsAppliedToTests()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(TextFixtureSourceWithParallelizableAttribute));
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
-            Assert.That(suite.TestCaseCount, Is.EqualTo(3));
-            Assert.That(suite.Tests.Count, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite, Is.TypeOf<ParameterizedFixtureSuite>());
+                Assert.That(suite.TestCaseCount, Is.EqualTo(3));
+            });
 
-            Assert.That(suite.Tests[0].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
-            Assert.That(suite.Tests[1].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
-            Assert.That(suite.Tests[2].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+            Assert.That(suite.Tests, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Tests[0].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+                Assert.That(suite.Tests[1].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+                Assert.That(suite.Tests[2].Properties.Get(PropertyNames.ParallelScope), Is.EqualTo(ParallelScope.All));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestAttribute_NoArgs_Runnable()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             TestMethod test = new TestAttribute().BuildFrom(method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestAttribute_WithArgs_NotRunnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
+            var method = GetMethod(nameof(MethodWithIntArgs));
             TestMethod test = new TestAttribute().BuildFrom(method, null);
             Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -34,27 +34,27 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseAttribute_NoArgs_NotRunnable()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(1));
+            Assert.That(tests, Has.Count.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
         [Test]
         public void TestCaseAttribute_RightArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
+            var method = GetMethod(nameof(MethodWithIntArgs));
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42).BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(1));
+            Assert.That(tests, Has.Count.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
         public void TestCaseAttribute_WrongArgs_NotRunnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
+            var method = GetMethod(nameof(MethodWithIntArgs));
             List<TestMethod> tests = new List<TestMethod>(new TestCaseAttribute(5, 42, 99).BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(1));
+            Assert.That(tests, Has.Count.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
@@ -65,9 +65,9 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_NoArgs_NotRunnable()
         {
-            var method = GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(3));
+            var method = GetMethod(nameof(MethodWithoutArgs));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute(nameof(GoodData)).BuildFrom(method, null));
+            Assert.That(tests, Has.Count.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -75,18 +75,18 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_NoArgs_NoData_NotRunnable()
         {
-            var method = GetMethod("MethodWithoutArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("ZeroData").BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(1));
+            var method = GetMethod(nameof(MethodWithoutArgs));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute(nameof(ZeroData)).BuildFrom(method, null));
+            Assert.That(tests, Has.Count.EqualTo(1));
             Assert.That(tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
         [Test]
         public void TestCaseSourceAttribute_RightArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("GoodData").BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(3));
+            var method = GetMethod(nameof(MethodWithIntArgs));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute(nameof(GoodData)).BuildFrom(method, null));
+            Assert.That(tests, Has.Count.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -94,9 +94,9 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestCaseSourceAttribute_WrongArgs_NotRunnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
-            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute("BadData").BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(3));
+            var method = GetMethod(nameof(MethodWithIntArgs));
+            List<TestMethod> tests = new List<TestMethod>(new TestCaseSourceAttribute(nameof(BadData)).BuildFrom(method, null));
+            Assert.That(tests, Has.Count.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
@@ -108,17 +108,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TheoryAttribute_NoArgs_NoCases()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(0));
+            Assert.That(tests, Is.Empty);
         }
 
         [Test]
         public void TheoryAttribute_WithArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntArgs");
+            var method = GetMethod(nameof(MethodWithIntArgs));
             List<TestMethod> tests = new List<TestMethod>(new TheoryAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(9));
+            Assert.That(tests, Has.Count.EqualTo(9));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -130,17 +130,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CombinatorialAttribute_NoArgs_NoCases()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(0));
+            Assert.That(tests, Is.Empty);
         }
 
         [Test]
         public void CombinatorialAttribute_WithArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntValues");
+            var method = GetMethod(nameof(MethodWithIntValues));
             List<TestMethod> tests = new List<TestMethod>(new CombinatorialAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(6));
+            Assert.That(tests, Has.Count.EqualTo(6));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -152,17 +152,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void PairwiseAttribute_NoArgs_NoCases()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(0));
+            Assert.That(tests, Is.Empty);
         }
 
         [Test]
         public void PairwiseAttribute_WithArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntValues");
+            var method = GetMethod(nameof(MethodWithIntValues));
             List<TestMethod> tests = new List<TestMethod>(new PairwiseAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(6));
+            Assert.That(tests, Has.Count.EqualTo(6));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -174,17 +174,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SequentialAttribute_NoArgs_NoCases()
         {
-            var method = GetMethod("MethodWithoutArgs");
+            var method = GetMethod(nameof(MethodWithoutArgs));
             List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(0));
+            Assert.That(tests, Is.Empty);
         }
 
         [Test]
         public void SequentialAttribute_WithArgs_Runnable()
         {
-            var method = GetMethod("MethodWithIntValues");
+            var method = GetMethod(nameof(MethodWithIntValues));
             List<TestMethod> tests = new List<TestMethod>(new SequentialAttribute().BuildFrom(method, null));
-            Assert.That(tests.Count, Is.EqualTo(3));
+            Assert.That(tests, Has.Count.EqualTo(3));
             foreach (var test in tests)
                 Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
@@ -198,20 +198,23 @@ namespace NUnit.Framework.Attributes
             return new MethodWrapper(GetType(), methodName);
         }
 
+        // These are indirect test method and therefore need to be public
+#pragma warning disable NUnit1028 // The non-test method is public
         public static void MethodWithoutArgs() { }
         public static void MethodWithIntArgs(int x, int y) { }
         public static void MethodWithIntValues(
             [Values(1, 2, 3)]int x,
             [Values(10, 20)]int y) { }
+#pragma warning restore NUnit1028 // The non-test method is public
 
-        static object[] ZeroData = Array.Empty<object>();
+        private static object[] ZeroData = Array.Empty<object>();
 
-        static object[] GoodData = new object[] {
+        private static object[] GoodData = new object[] {
             new object[] { 12, 3 },
             new object[] { 12, 4 },
             new object[] { 12, 6 } };
 
-        static object[] BadData = new object[] {
+        private static object[] BadData = new object[] {
             new object[] { 12, 3, 4 },
             new object[] { 12, 4, 3 },
             new object[] { 12, 6, 2 } };

--- a/src/NUnitFramework/tests/Attributes/TestOfTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOfTests.cs
@@ -19,21 +19,21 @@ namespace NUnit.Framework.Attributes
         public void ReflectionTest()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.Method));
-            Assert.AreEqual(RunState.Runnable, testCase.RunState);
+            Assert.That(testCase.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
         public void TestOf()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.Method));
-            Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
+            Assert.That(testCase.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestOfAttribute"));
         }
 
         [Test]
         public void NoTestOf()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.NoTestOfMethod));
-            Assert.IsNull(testCase.Properties.Get(PropertyNames.TestOf));
+            Assert.That(testCase.Properties.Get(PropertyNames.TestOf), Is.Null);
         }
 
         [Test]
@@ -44,30 +44,30 @@ namespace NUnit.Framework.Attributes
 
             var mockFixtureSuite = (TestSuite)suite.Tests[0];
 
-            Assert.AreEqual("NUnit.Framework.TestOfAttribute", mockFixtureSuite.Properties.Get(PropertyNames.TestOf));
+            Assert.That(mockFixtureSuite.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestOfAttribute"));
         }
 
         [Test]
         public void SeparateTestOfAttribute()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.SeparateTestOfTypeMethod));
-            Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
+            Assert.That(testCase.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestOfAttribute"));
         }
 
         [Test]
         public void SeparateTestOfStringMethod()
         {
             Test testCase = TestBuilder.MakeTestCase(FixtureType, nameof(TestOfFixture.SeparateTestOfStringMethod));
-            Assert.AreEqual("NUnit.Framework.TestOfAttribute", testCase.Properties.Get(PropertyNames.TestOf));
+            Assert.That(testCase.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestOfAttribute"));
         }
 
         [Test]
         public void TestOfOnTestCase()
         {
             TestSuite parameterizedMethodSuite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, "TestCaseWithTestOf");
-            Assert.AreEqual("NUnit.Framework.TestAttribute", parameterizedMethodSuite.Properties.Get(PropertyNames.TestOf));
+            Assert.That(parameterizedMethodSuite.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestAttribute"));
             var testCase = (Test)parameterizedMethodSuite.Tests[0];
-            Assert.AreEqual("NUnit.Framework.TestCaseAttribute", testCase.Properties.Get(PropertyNames.TestOf));
+            Assert.That(testCase.Properties.Get(PropertyNames.TestOf), Is.EqualTo("NUnit.Framework.TestCaseAttribute"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestOrderAttributeTests.cs
@@ -20,10 +20,13 @@ namespace NUnit.Framework.Attributes
             // This triggers sorting
             TestBuilder.ExecuteWorkItem(work);
 
-            Assert.AreEqual(work.Children.Count, 5);
-            Assert.AreEqual(work.Children[0].Test.Name, "Y_FirstTest");
-            Assert.AreEqual(work.Children[1].Test.Name, "Y_SecondTest");
-            Assert.AreEqual(work.Children[2].Test.Name, "Z_ThirdTest");
+            Assert.That(work.Children, Has.Count.EqualTo(5));
+            Assert.Multiple(() =>
+            {
+                Assert.That(work.Children[0].Test.Name, Is.EqualTo("Y_FirstTest"));
+                Assert.That(work.Children[1].Test.Name, Is.EqualTo("Y_SecondTest"));
+                Assert.That(work.Children[2].Test.Name, Is.EqualTo("Z_ThirdTest"));
+            });
         }
 
         [Test]
@@ -36,13 +39,13 @@ namespace NUnit.Framework.Attributes
 
             var fixtureWorkItems = work.Children;
 
-            Assert.AreEqual(candidateTypes.Length, fixtureWorkItems.Count);
+            Assert.That(fixtureWorkItems, Has.Count.EqualTo(candidateTypes.Length));
             for (var i = 1; i < fixtureWorkItems.Count; i++)
             {
                 var previousTestOrder = GetOrderAttributeValue(fixtureWorkItems[i - 1]);
                 var currentTestOrder = GetOrderAttributeValue(fixtureWorkItems[i]);
 
-                Assert.IsTrue(previousTestOrder < currentTestOrder);
+                Assert.That(previousTestOrder, Is.LessThan(currentTestOrder));
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/TheoryTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TheoryTests.cs
@@ -66,8 +66,8 @@ namespace NUnit.Framework.Attributes
         [Theory]
         public void NullDatapointIsOK(object o)
         {
-            Assert.Null(o);
-            Assert.Null(nullObj); // to avoid a warning
+            Assert.That(o, Is.Null);
+            Assert.That(nullObj, Is.Null); // to avoid a warning
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Attributes
         [Theory]
         public void ArrayWithDatapointsAttributeIsUsed(string s)
         {
-            Assert.That(s.StartsWith("xyz"));
+            Assert.That(s, Does.StartWith("xyz"));
         }
 
         private static void SquareRootTest(double d)
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Attributes
             Assume.That(d > 0);
             double root = Math.Sqrt(d);
             Assert.That(root * root, Is.EqualTo(d).Within(0.000001));
-            Assert.That(root > 0);
+            Assert.That(root, Is.GreaterThan(0));
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace NUnit.Framework.Attributes
 
                 double sqrt = Math.Sqrt(num);
 
-                Assert.That(sqrt >= 0.0);
+                Assert.That(sqrt, Is.GreaterThanOrEqualTo(0.0));
                 Assert.That(sqrt * sqrt, Is.EqualTo(num).Within(0.000001));
             }
         }
@@ -291,7 +291,7 @@ namespace NUnit.Framework.Attributes
 
                     double sqrt = Math.Sqrt(num);
 
-                    Assert.That(sqrt >= 0.0);
+                    Assert.That(sqrt, Is.GreaterThanOrEqualTo(0.0));
                     Assert.That(sqrt * sqrt, Is.EqualTo(num).Within(0.000001));
                 }
             }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -3,12 +3,16 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+#if THREAD_ABORT
 using System.Linq;
+#endif
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Abstractions;
+#if THREAD_ABORT
 using NUnit.TestData;
+#endif
 using NUnit.TestUtilities;
 
 namespace NUnit.Framework.Attributes
@@ -374,7 +378,7 @@ namespace NUnit.Framework.Attributes
             var result = TestBuilder.RunTest(testThatTimesOutButOtherwisePasses, new SampleTests(), detachedDebugger);
 
             // then
-            Assert.That(_testRanToCompletion == false, () => "Test ran to completion");
+            Assert.That(_testRanToCompletion, Is.False, () => "Test ran to completion");
 
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
             Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));

--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Attributes
         public void ValueSourceCanBeStaticProperty(
             [ValueSource(nameof(StaticProperty))] string source)
         {
-            Assert.AreEqual("StaticProperty", source);
+            Assert.That(source, Is.EqualTo("StaticProperty"));
         }
 
         static IEnumerable StaticProperty
@@ -32,20 +32,22 @@ namespace NUnit.Framework.Attributes
         public void ValueSourceCanBeInheritedStaticProperty(
             [ValueSource(nameof(InheritedStaticProperty))] bool source)
         {
-            Assert.AreEqual(true, source);
+            Assert.That(source, Is.EqualTo(true));
         }
 
         [Test]
         public void ValueSourceMayNotBeInstanceProperty()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceProperty");
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), nameof(MethodWithValueSourceInstanceProperty));
             Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
         }
 
-        public void MethodWithValueSourceInstanceProperty(
+        private void MethodWithValueSourceInstanceProperty(
+#pragma warning disable NUnit1022 // The specified source is not static
             [ValueSource(nameof(InstanceProperty))] string source)
+#pragma warning restore NUnit1022 // The specified source is not static
         {
-            Assert.AreEqual("InstanceProperty", source);
+            Assert.Fail("This is not a valid test case: " + source);
         }
 
         IEnumerable InstanceProperty => new object[] { "InstanceProperty" };
@@ -54,7 +56,7 @@ namespace NUnit.Framework.Attributes
         public void ValueSourceCanBeStaticMethod(
             [ValueSource(nameof(StaticMethod))] string source)
         {
-            Assert.AreEqual("StaticMethod", source);
+            Assert.That(source, Is.EqualTo("StaticMethod"));
         }
 
         static IEnumerable StaticMethod()
@@ -65,14 +67,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ValueSourceMayNotBeInstanceMethod()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceMethod");
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), nameof(MethodWithValueSourceInstanceMethod));
             Assert.That(result.Children.ToArray()[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
         }
 
-        public void MethodWithValueSourceInstanceMethod(
+        private void MethodWithValueSourceInstanceMethod(
+#pragma warning disable NUnit1022 // The specified source is not static
             [ValueSource(nameof(InstanceMethod))] string source)
+#pragma warning restore NUnit1022 // The specified source is not static
         {
-            Assert.AreEqual("InstanceMethod", source);
+            Assert.Fail("This is not a valid test case: " + source);
         }
 
         IEnumerable InstanceMethod()
@@ -84,7 +88,7 @@ namespace NUnit.Framework.Attributes
         public void ValueSourceCanBeStaticField(
             [ValueSource(nameof(StaticField))] string source)
         {
-            Assert.AreEqual("StaticField", source);
+            Assert.That(source, Is.EqualTo("StaticField"));
         }
 
         internal static object[] StaticField = { "StaticField" };
@@ -92,14 +96,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ValueSourceMayNotBeInstanceField()
         {
-            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), "MethodWithValueSourceInstanceField");
+            var result = TestBuilder.RunParameterizedMethodSuite(GetType(), nameof(MethodWithValueSourceInstanceField));
             Assert.That(result.Children.ToArray ()[0].ResultState, Is.EqualTo(ResultState.NotRunnable));
         }
 
-        public void MethodWithValueSourceInstanceField(
+        private void MethodWithValueSourceInstanceField(
+#pragma warning disable NUnit1022 // The specified source is not static
             [ValueSource(nameof(InstanceField))] string source)
+#pragma warning restore NUnit1022 // The specified source is not static
         {
-            Assert.AreEqual("InstanceField", source);
+            Assert.Fail("This is not a valid test case: " + source);
         }
 
         internal object[] InstanceField = { "InstanceField" };
@@ -110,7 +116,7 @@ namespace NUnit.Framework.Attributes
             [ValueSource(nameof(Denominators))] int d,
             [ValueSource(nameof(Quotients))] int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         internal static int[] Numerators = new[] { 12, 12, 12 };
@@ -123,7 +129,7 @@ namespace NUnit.Framework.Attributes
             [ValueSource(typeof(DivideDataProvider), nameof(DivideDataProvider.Denominators))] int d,
             [ValueSource(typeof(DivideDataProvider), nameof(DivideDataProvider.Quotients))] int q)
         {
-            Assert.AreEqual(q, n / d);
+            Assert.That(n / d, Is.EqualTo(q));
         }
 
         private class DivideDataProvider
@@ -160,9 +166,9 @@ namespace NUnit.Framework.Attributes
             }
         }
 
-        public static string NullSource = null;
+        private static readonly string NullSource;
 
-        public static IEnumerable<int> NullDataSourceProvider()
+        private static IEnumerable<int> NullDataSourceProvider()
         {
             return null;
         }
@@ -176,7 +182,9 @@ namespace NUnit.Framework.Attributes
             [ValueSource(typeof(ValueProvider), nameof(ValueProvider.ForeignNullResultProvider))] string nullDataSourceProvider,
             [ValueSource(typeof(object), sourceName: null)] string typeNotImplementingIEnumerableAndNullSourceName,
             [ValueSource(nameof(NullDataSourceProperty))] int nullDataSourceProperty,
+#pragma warning disable NUnit1025 // The ValueSource argument does not specify an existing member
             [ValueSource("SomeNonExistingMemberSource")] int nonExistingMember)
+#pragma warning restore NUnit1025 // The ValueSource argument does not specify an existing member
         {
             Assert.Fail();
         }

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -154,13 +154,13 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NullableSimpleFormalParametersWithArgument([Values(1)] int? a)
         {
-            Assert.AreEqual(1, a);
+            Assert.That(a, Is.EqualTo(1));
         }
 
         [Test]
         public void NullableSimpleFormalParametersWithNullArgument([Values(null)] int? a)
         {
-            Assert.IsNull(a);
+            Assert.That(a, Is.Null);
         }
 
 

--- a/src/NUnitFramework/tests/Compatibility/AttributeHelperTests.cs
+++ b/src/NUnitFramework/tests/Compatibility/AttributeHelperTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(assembly, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(assembly, typeof(AssemblyCompanyAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.GreaterThanOrEqualTo(1));
+            Assert.That(attr, Is.Not.Empty);
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(type, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(type, typeof(CategoryAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(1));
+            Assert.That(attr, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(type, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(type, typeof(CategoryAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(1));
+            Assert.That(attr, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(type, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(type, typeof(CategoryAttribute), false);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(0));
+            Assert.That(attr, Is.Empty);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(method, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(method, typeof(AuthorAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(1));
+            Assert.That(attr, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(property, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(property, typeof(DatapointSourceAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(1));
+            Assert.That(attr, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Compatibility
             Assert.That(field, Is.Not.Null);
             var attr = AttributeHelper.GetCustomAttributes(field, typeof(DatapointAttribute), true);
             Assert.That(attr, Is.Not.Null);
-            Assert.That(attr.Length, Is.EqualTo(1));
+            Assert.That(attr, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -92,12 +92,12 @@ namespace NUnit.Framework.Compatibility
             Assert.That(method, Is.Not.Null);
             ParameterInfo[] param = method.GetParameters();
             Assert.That(param, Is.Not.Null);
-            Assert.That(param.Length, Is.EqualTo(2));
+            Assert.That(param, Has.Length.EqualTo(2));
             foreach (var p in param)
             {
                 var attr = AttributeHelper.GetCustomAttributes(p, typeof(RandomAttribute), true);
                 Assert.That(attr, Is.Not.Null);
-                Assert.That(attr.Length, Is.EqualTo(1));
+                Assert.That(attr, Has.Length.EqualTo(1));
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AsyncDelayedConstraintTests.cs
@@ -11,15 +11,15 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void ConstraintSuccess()
         {
-            Assert.IsTrue(new DelayedConstraint(new EqualConstraint(1), 100)
-                          .ApplyTo(async () => await One()).IsSuccess);
+            Assert.That(new DelayedConstraint(new EqualConstraint(1), 100)
+                          .ApplyTo(async () => await One()).IsSuccess, Is.True);
         }
 
         [Test]
         public void ConstraintFailure()
         {
-            Assert.IsFalse(new DelayedConstraint(new EqualConstraint(2), 100)
-                           .ApplyTo(async () => await One()).IsSuccess);
+            Assert.That(new DelayedConstraint(new EqualConstraint(2), 100)
+                           .ApplyTo(async () => await One()).IsSuccess, Is.False);
         }
 
         [Test]
@@ -32,15 +32,15 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void ConstraintVoidDelegateFailureAsDelegateIsNotCalled()
         {
-            Assert.IsFalse(new DelayedConstraint(new EqualConstraint(1), 100)
-                           .ApplyTo(new TestDelegate(async () => { await One(); })).IsSuccess);
+            Assert.That(new DelayedConstraint(new EqualConstraint(1), 100)
+                           .ApplyTo(new TestDelegate(async () => { await One(); })).IsSuccess, Is.False);
         }
 
         [Test]
         public void ConstraintVoidDelegateExceptionIsFailureAsDelegateIsNotCalled()
         {
-            Assert.IsFalse(new DelayedConstraint(new EqualConstraint(1), 100)
-                           .ApplyTo(new TestDelegate(async () => { await Throw(); })).IsSuccess);
+            Assert.That(new DelayedConstraint(new EqualConstraint(1), 100)
+                           .ApplyTo(new TestDelegate(async () => { await Throw(); })).IsSuccess, Is.False);
         }
 
         [Test]
@@ -68,8 +68,10 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void SyntaxVoidDelegateExceptionIsFailureAsCodeIsNotCalled()
         {
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             Assert.Throws<AssertionException>(() =>
                 Assert.That(new TestDelegate(async () => await Throw()), Is.EqualTo(1).After(100)));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
         }
 
         private static async Task<int> One()
@@ -77,7 +79,7 @@ namespace NUnit.Framework.Constraints
             return await Task.Run(() => 1);
         }
 
-        private static async Task Throw()
+        private static async Task<int> Throw()
         {
             await One();
             throw new InvalidOperationException();

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  < \"one\" >" + Environment.NewLine +
                 "  Missing (1): < \"two\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine +
                 "  Missing (2): < \"one\", \"two\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  < \"one\", \"two\", \"three\", \"four\" >" + Environment.NewLine +
                 "  Extra (2): < \"three\", \"four\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  < \"three\", \"one\", \"two\" >" + Environment.NewLine +
                 "  Extra (1): < \"three\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
                 "  But was:  < \"three\", \"one\" >" + Environment.NewLine +
                 "  Missing (1): < \"two\" >" + Environment.NewLine +
                 "  Extra (1): < \"three\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  < \"one\", \"two\", \"two\" >" + Environment.NewLine +
                 "  Extra (1): < \"two\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Constraints
                 "  Expected: equivalent to < \"one\", \"two\" >" + Environment.NewLine +
                 "  But was:  < \"one\", \"two\", \"one\", \"two\", \"three\", \"four\", \"five\", \"six\", \"seven\", \"eight\"... >" + Environment.NewLine +
                 "  Extra (11): < \"one\", \"two\", \"three\", \"four\", \"five\", \"six\", \"seven\", \"eight\", \"nine\", \"ten\"... >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, _writer.ToString());
+            Assert.That(_writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Constraints
             ICollection set1 = new SimpleObjectCollection("x", "y", "z");
             ICollection set2 = new SimpleObjectCollection("x", "y", "x");
 
-            Assert.False(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess);
+            Assert.That(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess, Is.False);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Constraints
             ICollection set1 = new SimpleObjectCollection("x", "y", "x");
             ICollection set2 = new SimpleObjectCollection("x", "y", "z");
 
-            Assert.False(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess);
+            Assert.That(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess, Is.False);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Constraints
             ICollection set1 = new SimpleObjectCollection("x", "y");
             ICollection set2 = new SimpleObjectCollection("x", "x", "y");
 
-            Assert.False(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess);
+            Assert.That(new CollectionEquivalentConstraint(set1).ApplyTo(set2).IsSuccess, Is.False);
         }
 
         [Test]
@@ -176,8 +176,7 @@ namespace NUnit.Framework.Constraints
             IEnumerable<string> set1 = new List<string>() { "one" };
             IEnumerable<string> set2 = new List<string>() { "two" };
 
-            Assert.IsInstanceOf(typeof(CollectionEquivalentConstraintResult),
-                new CollectionEquivalentConstraint(set1).ApplyTo(set2));
+            Assert.That(new CollectionEquivalentConstraint(set1).ApplyTo(set2), Is.InstanceOf(typeof(CollectionEquivalentConstraintResult)));
         }
 
         /// <summary>
@@ -205,7 +204,7 @@ namespace NUnit.Framework.Constraints
                 "  But was:  < \"three\", \"one\" >" + Environment.NewLine +
                 "  Missing (1): < \"two\" >" + Environment.NewLine +
                 "  Extra (1): < \"three\" >" + Environment.NewLine;
-            Assert.AreEqual(expectedMsg, writer.ToString());
+            Assert.That(writer.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -245,7 +244,7 @@ namespace NUnit.Framework.Constraints
 
             var constraint = new CollectionEquivalentConstraint(hash);
             var constraintResult = constraint.ApplyTo(array);
-            Assert.False(constraintResult.IsSuccess);
+            Assert.That(constraintResult.IsSuccess, Is.False);
 
             TextMessageWriter writer = new TextMessageWriter();
             constraintResult.WriteMessageTo(writer);

--- a/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSubsetConstraintTests.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Constraints
         public void FailsWithBadValues(object badActualValue, string actualMessage, string extraMessage)
         {
             var constraintResult = TheConstraint.ApplyTo(badActualValue);
-            Assert.IsFalse(constraintResult.IsSuccess);
+            Assert.That(constraintResult.IsSuccess, Is.False);
 
             TextMessageWriter writer = new TextMessageWriter();
             constraintResult.WriteMessageTo(writer);

--- a/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionSupersetConstraintTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
         public void FailsWithBadValues(object badActualValue, string actualMessage, string missingMessage)
         {
             var constraintResult = TheConstraint.ApplyTo(badActualValue);
-            Assert.IsFalse(constraintResult.IsSuccess);
+            Assert.That(constraintResult.IsSuccess, Is.False);
 
             TextMessageWriter writer = new TextMessageWriter();
             constraintResult.WriteMessageTo(writer);

--- a/src/NUnitFramework/tests/Constraints/ConstraintTestBase.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintTestBase.cs
@@ -26,7 +26,13 @@ namespace NUnit.Framework.Constraints
 
     public abstract class ConstraintTestBase : ConstraintTestBaseNoData
     {
-        [Test, TestCaseSource("SuccessData")]
+        private const string Message = ": Must be implemented in derived class";
+
+        static object[] SuccessData => throw new NotImplementedException(nameof(SuccessData) + Message);
+
+        static object[] FailureData => throw new NotImplementedException(nameof(FailureData) + Message);
+
+        [Test, TestCaseSource(nameof(SuccessData))]
         public void SucceedsWithGoodValues(object value)
         {
             var constraintResult = TheConstraint.ApplyTo(value);
@@ -38,13 +44,13 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        [Test, TestCaseSource("FailureData")]
+        [Test, TestCaseSource(nameof(FailureData))]
         public void FailsWithBadValues(object badValue, string message)
         {
             string NL = Environment.NewLine;
 
             var constraintResult = TheConstraint.ApplyTo(badValue);
-            Assert.IsFalse(constraintResult.IsSuccess);
+            Assert.That(constraintResult.IsSuccess, Is.False);
 
             TextMessageWriter writer = new TextMessageWriter();
             constraintResult.WriteMessageTo(writer);

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Constraints
         [Test, TestCaseSource(nameof(FailureDelegates))]
         public void FailsWithBadDelegates(ActualValueDelegate<object> del)
         {
-            Assert.IsFalse(TheConstraint.ApplyTo(del).IsSuccess);
+            Assert.That(TheConstraint.ApplyTo(del).IsSuccess, Is.False);
         }
 
         [Test]
@@ -109,7 +109,12 @@ namespace NUnit.Framework.Constraints
         public void CanTestContentsOfList()
         {
             SetValuesAfterDelay(1);
+
+            // https://github.com/nunit/nunit.analyzers/issues/431
+            // It was decided to keep to analyzer warning
+#pragma warning disable NUnit2044 // Non-delegate actual parameter
             Assert.That(list, Has.Count.EqualTo(1).After(AFTER, POLLING));
+#pragma warning restore NUnit2044 // Non-delegate actual parameter
         }
 
         [Test]
@@ -226,7 +231,7 @@ namespace NUnit.Framework.Constraints
         public void PreservesOriginalResultAdditionalLines()
         {
             var exception = Assert.Throws<AssertionException>(
-                () => Assert.That(new[] { 1, 2 }, Is.EquivalentTo(new[] { 2, 3 }).After(1)));
+                () => Assert.That(() => new[] { 1, 2 }, Is.EquivalentTo(new[] { 2, 3 }).After(1)));
 
             var expectedMessage =
                 "  Expected: equivalent to < 2, 3 > after 1 millisecond delay" + Environment.NewLine +
@@ -238,8 +243,6 @@ namespace NUnit.Framework.Constraints
         }
 
         private static int setValuesDelay;
-
-        private static void MethodReturningVoid() { }
 
         private static object MethodReturningValue() { return boolValue; }
 

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void Complex_PassesEquality()
         {
-            Assert.AreEqual(new System.Numerics.Complex(1, 100), new System.Numerics.Complex(1, 100));
+            Assert.That(new System.Numerics.Complex(1, 100), Is.EqualTo(new System.Numerics.Complex(1, 100)));
         }
 
         #region StringEquality
@@ -56,6 +56,13 @@ namespace NUnit.Framework.Constraints
             var result = constraint.ApplyTo("re\u0301sume\u0301");
 
             Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void Bug524CharIntWithoutOverload()
+        {
+            char c = '\u0000';
+            Assert.That(c, Is.EqualTo(0));
         }
 
         #endregion
@@ -355,52 +362,45 @@ namespace NUnit.Framework.Constraints
             [Test]
             public void CanMatchDictionaries_SameOrder()
             {
-                Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
-                                new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}});
+                Assert.That(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}}, Is.EqualTo(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}}));
             }
 
             [Test]
             public void CanMatchDictionaries_Failure()
             {
                 Assert.Throws<AssertionException>(
-                    () => Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
-                                          new Dictionary<int, int> {{0, 0}, {1, 5}, {2, 2}}));
+                    () => Assert.That(new Dictionary<int, int> {{0, 0}, {1, 5}, {2, 2}}, Is.EqualTo(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}})));
             }
 
             [Test]
             public void CanMatchDictionaries_DifferentOrder()
             {
-                Assert.AreEqual(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}},
-                                new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}});
+                Assert.That(new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}}, Is.EqualTo(new Dictionary<int, int> {{0, 0}, {1, 1}, {2, 2}}));
             }
 
             [Test]
             public void CanMatchHashtables_SameOrder()
             {
-                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
-                                new Hashtable {{0, 0}, {1, 1}, {2, 2}});
+                Assert.That(new Hashtable {{0, 0}, {1, 1}, {2, 2}}, Is.EqualTo(new Hashtable {{0, 0}, {1, 1}, {2, 2}}));
             }
 
             [Test]
             public void CanMatchHashtables_Failure()
             {
                 Assert.Throws<AssertionException>(
-                    () => Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
-                                          new Hashtable {{0, 0}, {1, 5}, {2, 2}}));
+                    () => Assert.That(new Hashtable {{0, 0}, {1, 5}, {2, 2}}, Is.EqualTo(new Hashtable {{0, 0}, {1, 1}, {2, 2}})));
             }
 
             [Test]
             public void CanMatchHashtables_DifferentOrder()
             {
-                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
-                                new Hashtable {{0, 0}, {2, 2}, {1, 1}});
+                Assert.That(new Hashtable {{0, 0}, {2, 2}, {1, 1}}, Is.EqualTo(new Hashtable {{0, 0}, {1, 1}, {2, 2}}));
             }
 
             [Test]
             public void CanMatchHashtableWithDictionary()
             {
-                Assert.AreEqual(new Hashtable {{0, 0}, {1, 1}, {2, 2}},
-                                new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}});
+                Assert.That(new Dictionary<int, int> {{0, 0}, {2, 2}, {1, 1}}, Is.EqualTo(new Hashtable {{0, 0}, {1, 1}, {2, 2}}));
             }
         }
 
@@ -590,7 +590,9 @@ namespace NUnit.Framework.Constraints
             [Test]
             public void CanCompareUncomparableTypes()
             {
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
                 Assert.That(2 + 2, Is.Not.EqualTo("4"));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
                 var comparer = new ConvertibleComparer();
                 Assert.That(2 + 2, Is.EqualTo("4").Using(comparer));
             }
@@ -784,8 +786,10 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void SameValueDifferentTypeExactMessageMatch()
         {
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(0, new System.IntPtr(0)));
-            Assert.AreEqual(ex.Message, "  Expected: 0 (Int32)"+ NL + "  But was:  0 (IntPtr)"+ NL);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(new IntPtr(0), Is.EqualTo(0)));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That("  Expected: 0 (Int32)"+ NL + "  But was:  0 (IntPtr)"+ NL, Is.EqualTo(ex.Message));
         }
 
         class Dummy
@@ -841,25 +845,27 @@ namespace NUnit.Framework.Constraints
             var dc1 = new DummyGenericClass<Dummy>(d1);
             var dc2 = new DummyGenericClass<Dummy1>(d2);
 
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(dc1, dc2));
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(dc2, Is.EqualTo(dc1)));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
             var expectedMsg =
                 "  Expected: <Dummy 12> (EqualConstraintTests+DummyGenericClass`1[EqualConstraintTests+Dummy])" + Environment.NewLine +
                 "  But was:  <Dummy 12> (EqualConstraintTests+DummyGenericClass`1[EqualConstraintTests+Dummy1])" + Environment.NewLine;
 
-            Assert.AreEqual(expectedMsg, ex.Message);
+            Assert.That(ex.Message, Is.EqualTo(expectedMsg));
         }
 
         [Test]
         public void SameValueAndTypeButDifferentReferenceShowNotShowTypeDifference()
         {
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(Is.Zero, Is.Zero));
-            Assert.AreEqual(ex.Message, "  Expected: <<equal 0>>"+ NL + "  But was:  <<equal 0>>"+ NL);
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Is.Zero, Is.EqualTo(Is.Zero)));
+            Assert.That("  Expected: <<equal 0>>"+ NL + "  But was:  <<equal 0>>"+ NL, Is.EqualTo(ex.Message));
         }
 
         [Test, TestCaseSource(nameof(DifferentTypeSameValueTestData))]
         public void SameValueDifferentTypeRegexMatch(object expected, object actual)
         {
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreEqual(expected, actual));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
             Assert.That(ex.Message, Does.Match(@"\s*Expected\s*:\s*.*\s*\(.+\)\r?\n\s*But\s*was\s*:\s*.*\s*\(.+\)"));
         }
     }

--- a/src/NUnitFramework/tests/Constraints/ExactlyOneConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactlyOneConstraintTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void ExactlyOneItemMustMatchButNoneInCollection()
         {
-            Assert.IsFalse(Has.One.EqualTo("item").ApplyTo(testCollectionLen0).IsSuccess);
+            Assert.That(Has.One.EqualTo("item").ApplyTo(testCollectionLen0).IsSuccess, Is.False);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/FileOrDirectoryExistsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/FileOrDirectoryExistsConstraintTests.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Constraints
             using (var tf = new TestFile(RESOURCE_FILE))
             {
                 var constraint = new FileOrDirectoryExistsConstraint().IgnoreFiles;
-                Assert.That(constraint.ApplyTo(tf.File.FullName).Status == ConstraintStatus.Failure);
+                Assert.That(constraint.ApplyTo(tf.File.FullName).Status, Is.EqualTo(ConstraintStatus.Failure));
             }
         }
 
@@ -89,7 +89,7 @@ namespace NUnit.Framework.Constraints
         public void FailsWhenIgnoreDirectoriesIsTrueWithDirectoryString()
         {
             var constraint = new FileOrDirectoryExistsConstraint().IgnoreDirectories;
-            Assert.That(constraint.ApplyTo(_goodDir.ToString()).Status == ConstraintStatus.Failure);
+            Assert.That(constraint.ApplyTo(_goodDir.ToString()).Status, Is.EqualTo(ConstraintStatus.Failure));
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
         public void FailsWhenDirectoryInfoDoesNotExist()
         {
             var actual = new DirectoryInfo(BAD_DIRECTORY);
-            Assert.That(_constraint.ApplyTo(actual).Status == ConstraintStatus.Failure);
+            Assert.That(_constraint.ApplyTo(actual).Status, Is.EqualTo(ConstraintStatus.Failure));
             Assert.That(actual, Does.Not.Exist);
         }
 
@@ -112,21 +112,21 @@ namespace NUnit.Framework.Constraints
         public void FailsWhenFileInfoDoesNotExist()
         {
             var actual = new FileInfo(BAD_FILE);
-            Assert.That(_constraint.ApplyTo(actual).Status == ConstraintStatus.Failure);
+            Assert.That(_constraint.ApplyTo(actual).Status, Is.EqualTo(ConstraintStatus.Failure));
             Assert.That(actual, Does.Not.Exist);
         }
 
         [Test]
         public void FailsWhenFileStringDoesNotExist()
         {
-            Assert.That(_constraint.ApplyTo(BAD_FILE).Status == ConstraintStatus.Failure);
+            Assert.That(_constraint.ApplyTo(BAD_FILE).Status, Is.EqualTo(ConstraintStatus.Failure));
             Assert.That(BAD_FILE, Does.Not.Exist);
         }
 
         [Test]
         public void FailsWhenDirectoryStringDoesNotExist()
         {
-            Assert.That(_constraint.ApplyTo(BAD_DIRECTORY).Status == ConstraintStatus.Failure);
+            Assert.That(_constraint.ApplyTo(BAD_DIRECTORY).Status, Is.EqualTo(ConstraintStatus.Failure));
             Assert.That(BAD_DIRECTORY, Does.Not.Exist);
         }
 

--- a/src/NUnitFramework/tests/Constraints/FloatingPointNumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/FloatingPointNumericsTest.cs
@@ -10,44 +10,44 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void FloatEqualityWithUlps()
         {
-            Assert.IsTrue(
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(0.00000001f, 0.0000000100000008f, 1)
-            );
-            Assert.IsFalse(
+, Is.True);
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(0.00000001f, 0.0000000100000017f, 1)
-            );
+, Is.False);
 
-            Assert.IsTrue(
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(1000000.00f, 1000000.06f, 1)
-            );
-            Assert.IsFalse(
+, Is.True);
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(1000000.00f, 1000000.13f, 1)
-            );
-            Assert.IsFalse( // Ensure we don't overflow on twos complement values
+, Is.False);
+            Assert.That( // Ensure we don't overflow on twos complement values
                 FloatingPointNumerics.AreAlmostEqualUlps(2.0f, -2.0f, 1)
-            );
+, Is.False);
         }
 
         /// <summary>Tests the double precision floating point value comparison helper</summary>
         [Test]
         public void DoubleEqualityWithUlps()
         {
-            Assert.IsTrue(
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(0.00000001, 0.000000010000000000000002, 1)
-            );
-            Assert.IsFalse(
+, Is.True);
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(0.00000001, 0.000000010000000000000004, 1)
-            );
+, Is.False);
 
-            Assert.IsTrue(
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(1000000.00, 1000000.0000000001, 1)
-            );
-            Assert.IsFalse(
+, Is.True);
+            Assert.That(
                 FloatingPointNumerics.AreAlmostEqualUlps(1000000.00, 1000000.0000000002, 1)
-            );
-            Assert.IsFalse( // Ensure we don't overflow on twos complement values
+, Is.False);
+            Assert.That( // Ensure we don't overflow on twos complement values
                 FloatingPointNumerics.AreAlmostEqualUlps(2.0, -2.0, 1)
-            );
+, Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/IntervalTests.cs
+++ b/src/NUnitFramework/tests/Constraints/IntervalTests.cs
@@ -11,10 +11,10 @@ namespace NUnit.Framework.Tests.Constraints
         public void IsNonZeroInterval()
         {
             var interval = new Interval(1);
-            Assert.IsTrue(interval.IsNotZero);
+            Assert.That(interval.IsNotZero, Is.True);
 
             interval =  new Interval(0);
-            Assert.IsFalse(interval.IsNotZero);
+            Assert.That(interval.IsNotZero, Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Constraints
         public static void FormatValue_DoubleIsWrittenToSeventeenDigits()
         {
             string s = MsgUtils.FormatValue(0.33333333333333333333333333333333333333333333d);
-            Assert.That(s.Length, Is.EqualTo(20)); // add 3 for leading 0, decimal and trailing d
+            Assert.That(s, Has.Length.EqualTo(20)); // add 3 for leading 0, decimal and trailing d
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)4)]
         public void EqualItems(object x, object y)
         {
-            Assert.That(comparer.Compare(x, y) == 0);
+            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
         }
 
         [TestCase(4, 2)]
@@ -48,8 +48,11 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)2)]
         public void UnequalItems(object greater, object lesser)
         {
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         [Test]
@@ -58,8 +61,11 @@ namespace NUnit.Framework.Constraints
             var greater = new ClassWithIComparable(42);
             var lesser = new ClassWithIComparable(-42);
 
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         [Test]
@@ -68,8 +74,11 @@ namespace NUnit.Framework.Constraints
             var greater = new ClassWithIComparableOfT(42);
             var lesser = new ClassWithIComparableOfT(-42);
 
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         [Test]
@@ -78,8 +87,11 @@ namespace NUnit.Framework.Constraints
             int greater = 42;
             var lesser = new ClassWithIComparableOfT(-42);
 
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         [Test]
@@ -88,8 +100,11 @@ namespace NUnit.Framework.Constraints
             var greater = new ClassWithIComparableOfT(42);
             int lesser = -42;
 
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         [Test]
@@ -98,8 +113,11 @@ namespace NUnit.Framework.Constraints
             short greater = 42;
             var lesser = new ClassWithIComparableOfT(-42);
 
-            Assert.That(comparer.Compare(greater, lesser) > 0);
-            Assert.That(comparer.Compare(lesser, greater) < 0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+            });
         }
 
         #region Comparison Test Classes

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -56,8 +56,8 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)2)]
         public void UnequalItems(object greater, object lesser)
         {
-            Assert.False(comparer.AreEqual(greater, lesser, ref tolerance));
-            Assert.False(comparer.AreEqual(lesser, greater, ref tolerance));
+            Assert.That(comparer.AreEqual(greater, lesser, ref tolerance), Is.False);
+            Assert.That(comparer.AreEqual(lesser, greater, ref tolerance), Is.False);
         }
 
         [TestCase(double.PositiveInfinity, double.PositiveInfinity)]
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Constraints
             object[] array = new object[1];
             array[0] = array;
 
-            Assert.True(comparer.AreEqual(array, array, ref tolerance));
+            Assert.That(comparer.AreEqual(array, array, ref tolerance), Is.True);
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithoutEqualsOverridden x = new IEquatableWithoutEqualsOverridden(1);
             IEquatableWithoutEqualsOverridden y = new IEquatableWithoutEqualsOverridden(1);
 
-            Assert.IsTrue(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Constraints
 
             // y.Equals(x) is what gets actually called
             // TODO: This should work both ways
-            Assert.IsTrue(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Constraints
 
             // y.Equals(x) is what gets actually called
             // TODO: This should work both ways
-            Assert.IsTrue(comparer.AreEqual(y, x, ref tolerance));
+            Assert.That(comparer.AreEqual(y, x, ref tolerance), Is.True);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
             IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(1);
 
-            Assert.IsTrue(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
             IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(2);
 
-            Assert.IsFalse(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
         {
             NeverEqualIEquatable z = new NeverEqualIEquatable();
 
-            Assert.IsTrue(comparer.AreEqual(z, z, ref tolerance));
+            Assert.That(comparer.AreEqual(z, z, ref tolerance), Is.True);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Framework.Constraints
             NeverEqualIEquatableWithOverriddenAlwaysTrueEquals x = new NeverEqualIEquatableWithOverriddenAlwaysTrueEquals();
             NeverEqualIEquatableWithOverriddenAlwaysTrueEquals y = new NeverEqualIEquatableWithOverriddenAlwaysTrueEquals();
 
-            Assert.IsFalse(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
         }
 
         [Test]
@@ -284,7 +284,7 @@ namespace NUnit.Framework.Constraints
         public void IEnumeratorIsDisposed()
         {
             var enumeration = new EnumerableWithDisposeChecks<int>(new[] { 0, 1, 2, 3 });
-            Assert.True(comparer.AreEqual(enumeration, enumeration, ref tolerance));
+            Assert.That(comparer.AreEqual(enumeration, enumeration, ref tolerance), Is.True);
             Assert.That(enumeration.EnumeratorsDisposed);
         }
 
@@ -295,8 +295,7 @@ namespace NUnit.Framework.Constraints
             var tolerance = Tolerance.Default;
             var equality = equalityComparer.AreEqual(x, y, ref tolerance);
 
-            Assert.IsFalse(equality);
-            Assert.Contains(x, y);
+            Assert.That(equality, Is.False);
             Assert.That(y, Contains.Item(x));
             Assert.That(y, Does.Contain(x));
         }
@@ -321,10 +320,10 @@ namespace NUnit.Framework.Constraints
             var x = new[] { equalInstance1, equalInstance1 };
             var y = new[] { equalInstance2, equalInstance2 };
 
-            Assert.True(equalityComparer.AreEqual(x, y, ref tolerance));
+            Assert.That(equalityComparer.AreEqual(x, y, ref tolerance), Is.True);
         }
 
-        public static IEnumerable<TestCaseData> GetRecursiveComparerTestCases()
+        private static IEnumerable<TestCaseData> GetRecursiveComparerTestCases()
         {
             // Separate from 'GetRecursiveContainsTestCases' until a stackoverflow issue in
             // 'MsgUtils.FormatValue()' can be fixed for the below cases
@@ -340,7 +339,7 @@ namespace NUnit.Framework.Constraints
             yield return new TestCaseData(dictItem, dict);
         }
 
-        public static IEnumerable<TestCaseData> GetRecursiveContainsTestCases()
+        private static IEnumerable<TestCaseData> GetRecursiveContainsTestCases()
         {
             var enumerable = new SelfContainer();
             var enumerableContainer = new[] { new SelfContainer(), enumerable };

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -26,14 +26,14 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanMatchWithoutToleranceMode(object value)
         {
-            Assert.IsTrue(Numerics.AreEqual(value, value, ref zeroTolerance));
+            Assert.That(Numerics.AreEqual(value, value, ref zeroTolerance), Is.True);
         }
 
         // Separate test case because you can't use decimal in an attribute (24.1.3)
         [Test]
         public void CanMatchDecimalWithoutToleranceMode()
         {
-            Assert.IsTrue(Numerics.AreEqual(123m, 123m, ref zeroTolerance));
+            Assert.That(Numerics.AreEqual(123m, 123m, ref zeroTolerance), Is.True);
         }
 
         [TestCase((int)9500)]
@@ -51,15 +51,15 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanMatchIntegralsWithPercentage(object value)
         {
-            Assert.IsTrue(Numerics.AreEqual(10000, value, ref tenPercent));
+            Assert.That(Numerics.AreEqual(10000, value, ref tenPercent), Is.True);
         }
 
         [Test]
         public void CanMatchDecimalWithPercentage()
         {
-            Assert.IsTrue(Numerics.AreEqual(10000m, 9500m, ref tenPercent));
-            Assert.IsTrue(Numerics.AreEqual(10000m, 10000m, ref tenPercent));
-            Assert.IsTrue(Numerics.AreEqual(10000m, 10500m, ref tenPercent));
+            Assert.That(Numerics.AreEqual(10000m, 9500m, ref tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000m, 10000m, ref tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000m, 10500m, ref tenPercent), Is.True);
         }
 
         [Test]
@@ -165,25 +165,25 @@ namespace NUnit.Framework.Constraints
         [TestCase((ulong)11500)]
         public void FailsOnIntegralsOutsideOfPercentage(object value)
         {
-            Assert.Throws<AssertionException>(() => Assert.IsTrue(Numerics.AreEqual(10000, value, ref tenPercent)));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000, value, ref tenPercent), Is.True));
         }
 
         [Test]
         public void FailsOnDecimalBelowPercentage()
         {
-            Assert.Throws<AssertionException>(() => Assert.IsTrue(Numerics.AreEqual(10000m, 8500m, ref tenPercent)));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 8500m, ref tenPercent), Is.True));
         }
 
         [Test]
         public void FailsOnDecimalAbovePercentage()
         {
-            Assert.Throws<AssertionException>(() => Assert.IsTrue(Numerics.AreEqual(10000m, 11500m, ref tenPercent)));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 11500m, ref tenPercent), Is.True));
         }
 
         [Test]
         public void FailsOnDecimalIsPartOfIsFixedPointNumericMethod()
         {
-            Assert.IsFalse(Numerics.IsFixedPointNumeric(1000m));
+            Assert.That(Numerics.IsFixedPointNumeric(1000m), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -64,6 +64,7 @@ namespace NUnit.Framework.Constraints
             new TestCaseData( new List<int>(), "<System.Collections.Generic.List`1[System.Int32]>" ),
             new TestCaseData( typeof(Int32), "<System.Int32>" ) };
 
+        [Test]
         public void NullDataThrowsArgumentNullException()
         {
             object value = null;
@@ -89,7 +90,10 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
+                // TODO: NUnit.Analyzer doesn't know the special case where actual is a type.
+#pragma warning disable NUnit2022 // Missing property required for constraint
                 Assert.That(type, Has.Property("Length"), "TActual");
+#pragma warning restore NUnit2022 // Missing property required for constraint
                 Assert.That((object)type, Has.Property("Length"), "GetType");
             });
         }
@@ -206,8 +210,8 @@ namespace NUnit.Framework.Constraints
             //Verify message contains "Equivalent Constraint" message too.
             Assert.That(result.Status, Is.EqualTo(ConstraintStatus.Failure));
             Assert.That(result.GetType().Name, Is.EqualTo("PropertyConstraintResult"));
-            Assert.IsTrue(textMessageWriter.ToString().Contains("Missing"));
-            Assert.IsTrue(textMessageWriter.ToString().Contains("Extra"));
+            Assert.That(textMessageWriter.ToString(), Does.Contain("Missing"));
+            Assert.That(textMessageWriter.ToString(), Does.Contain("Extra"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/RangeTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeTests.cs
@@ -87,14 +87,14 @@ namespace NUnit.Framework.Constraints
         public void InRangeNoIComparableTest(object testObj, object from, object to, ObjectToStringComparer comparer)
         {
             Assert.That(testObj, Is.InRange(from, to).Using(comparer));
-            Assert.AreEqual(comparer.WasCalled, true);
+            Assert.That(true, Is.EqualTo(comparer.WasCalled));
         }
 
         [Test, TestCaseSource(nameof(NotInRangeObjectsWithNoIComparable))]
         public void NotInRangeNoIComparableTest(object testObj, object from, object to, ObjectToStringComparer comparer)
         {
             Assert.That(testObj, Is.Not.InRange(from, to).Using(comparer));
-            Assert.AreEqual(comparer.WasCalled, true);
+            Assert.That(true, Is.EqualTo(comparer.WasCalled));
         }
         [TestCaseSource(nameof(InRangeObjectsWithNoIComparableAndNotUsingComparerException))]
         public void InRangeNoIComparableThrowsExceptionTest(object testObj, object from, object to)

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -85,7 +85,13 @@ namespace NUnit.Framework.Constraints
 
     public abstract class ThrowsConstraintTestBase : ConstraintTestBaseNoData
     {
-        [Test, TestCaseSource("SuccessData")]
+        private const string Message = ": Must be implemented in derived class";
+
+        static object[] SuccessData => throw new NotImplementedException(nameof(SuccessData) + Message);
+
+        static object[] FailureData => throw new NotImplementedException(nameof(FailureData) + Message);
+
+        [Test, TestCaseSource(nameof(SuccessData))]
         public void SucceedsWithGoodValues(object value)
         {
             var constraintResult = TheConstraint.ApplyTo(value);
@@ -97,18 +103,18 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        [Test, TestCaseSource("FailureData"), SetUICulture("en-US")]
+        [Test, TestCaseSource(nameof(FailureData)), SetUICulture("en-US")]
         public void FailsWithBadValues(object badValue, string message)
         {
-            string NL = Environment.NewLine;
+            string nl = Environment.NewLine;
 
             var constraintResult = TheConstraint.ApplyTo(badValue);
-            Assert.IsFalse(constraintResult.IsSuccess);
+            Assert.That(constraintResult.IsSuccess, Is.False);
 
             TextMessageWriter writer = new TextMessageWriter();
             constraintResult.WriteMessageTo(writer);
             Assert.That(writer.ToString(), Does.StartWith(
-                TextMessageWriter.Pfx_Expected + ExpectedDescription + NL +
+                TextMessageWriter.Pfx_Expected + ExpectedDescription + nl +
                 TextMessageWriter.Pfx_Actual + message));
         }
     }

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -23,34 +23,34 @@ namespace NUnit.Framework.Constraints
         public void TestToleranceDefault()
         {
             var defaultTolerance = Tolerance.Default;
-            Assert.IsTrue(defaultTolerance.IsUnsetOrDefault);
+            Assert.That(defaultTolerance.IsUnsetOrDefault, Is.True);
 
             var comparer = new NUnitEqualityComparer();
-            Assert.IsTrue(comparer.AreEqual(2.0d, 2.1d, ref defaultTolerance ));
+            Assert.That(comparer.AreEqual(2.0d, 2.1d, ref defaultTolerance ), Is.True);
         }
 
         [Test, DefaultFloatingPointTolerance(0.5)]
         public void TestToleranceExact()
         {
             var noneTolerance = Tolerance.Exact;
-            Assert.IsFalse(noneTolerance.IsUnsetOrDefault);
+            Assert.That(noneTolerance.IsUnsetOrDefault, Is.False);
 
             var comparer = new NUnitEqualityComparer();
-            Assert.IsFalse(comparer.AreEqual(2.0d, 2.1d, ref noneTolerance));
+            Assert.That(comparer.AreEqual(2.0d, 2.1d, ref noneTolerance), Is.False);
         }
 
         [Test]
         public void TestToleranceVarianceExact()
         {
             var noneTolerance = Tolerance.Exact;
-            Assert.IsFalse(noneTolerance.HasVariance);
+            Assert.That(noneTolerance.HasVariance, Is.False);
         }
 
         [Test]
         public void TestToleranceVarianceDefault()
         {
             var noneTolerance = Tolerance.Default;
-            Assert.IsFalse(noneTolerance.HasVariance);
+            Assert.That(noneTolerance.HasVariance, Is.False);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
@@ -49,7 +49,9 @@ namespace NUnit.Framework.Constraints
         {
             var tuple1 = Tuple.Create("Hello", 3);
             var tuple2 = Tuple.Create("Hello", 3, 1);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             Assert.That(tuple1, Is.Not.EqualTo(tuple2));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncTestMethodTests.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Internal
         }
 
         [Test]
-        [TestCaseSource("TestCases")]
+        [TestCaseSource(nameof(TestCases))]
         public void RunTests(IMethodInfo method, ResultState resultState, int assertionCount)
         {
             var test = _builder.BuildFrom(method);

--- a/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
+++ b/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
@@ -23,20 +23,20 @@ namespace NUnit.Framework.Internal
         {
             List<string> strings = new List<string>(_testStrings);
 
-            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(3));
+            Assert.That(_collectionTally.Result.ExtraItems, Is.Empty);
 
             _collectionTally.TryRemove((object)strings[0]);
-            Assert.AreEqual(2, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(2));
+            Assert.That(_collectionTally.Result.ExtraItems, Is.Empty);
 
             _collectionTally.TryRemove((object)strings[1]);
-            Assert.AreEqual(1, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(1));
+            Assert.That(_collectionTally.Result.ExtraItems, Is.Empty);
 
             _collectionTally.TryRemove((object)strings[2]);
-            Assert.AreEqual(0, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
+            Assert.That(_collectionTally.Result.MissingItems, Is.Empty);
+            Assert.That(_collectionTally.Result.ExtraItems, Is.Empty);
         }
 
         [Test]
@@ -45,8 +45,8 @@ namespace NUnit.Framework.Internal
             List<string> strings = new List<string>(_testStrings);
 
             _collectionTally.TryRemove(strings);
-            Assert.AreEqual(0, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(0, _collectionTally.Result.ExtraItems.Count);
+            Assert.That(_collectionTally.Result.MissingItems, Is.Empty);
+            Assert.That(_collectionTally.Result.ExtraItems, Is.Empty);
         }
 
         [Test]
@@ -54,9 +54,9 @@ namespace NUnit.Framework.Internal
         {
             _collectionTally.TryRemove((object)"notFound");
 
-            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(1, _collectionTally.Result.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound"));
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(3));
+            Assert.That(_collectionTally.Result.ExtraItems, Has.Count.EqualTo(1));
+            Assert.That(_collectionTally.Result.ExtraItems.Contains("notFound"), Is.True);
         }
 
         [Test]
@@ -66,10 +66,10 @@ namespace NUnit.Framework.Internal
 
             _collectionTally.TryRemove(nonExistingElems);
 
-            Assert.AreEqual(3, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(2, _collectionTally.Result.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound"));
-            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound2"));
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(3));
+            Assert.That(_collectionTally.Result.ExtraItems, Has.Count.EqualTo(2));
+            Assert.That(_collectionTally.Result.ExtraItems.Contains("notFound"), Is.True);
+            Assert.That(_collectionTally.Result.ExtraItems.Contains("notFound2"), Is.True);
         }
 
         [Test]
@@ -79,9 +79,9 @@ namespace NUnit.Framework.Internal
 
             _collectionTally.TryRemove(someExistingElems);
 
-            Assert.AreEqual(2, _collectionTally.Result.MissingItems.Count);
-            Assert.AreEqual(1, _collectionTally.Result.ExtraItems.Count);
-            Assert.IsTrue(_collectionTally.Result.ExtraItems.Contains("notFound2"));
+            Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(2));
+            Assert.That(_collectionTally.Result.ExtraItems, Has.Count.EqualTo(1));
+            Assert.That(_collectionTally.Result.ExtraItems.Contains("notFound2"), Is.True);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -31,14 +31,14 @@ namespace NUnit.Framework.Internal
         {
             if ( detector.IsCultureSupported( culture ) )
                 Assert.Fail($"Should not match \"{culture}\"");
-            Assert.AreEqual( "Only supported under culture " + culture, detector.Reason );
+            Assert.That( detector.Reason, Is.EqualTo("Only supported under culture " + culture));
         }
 
         private void ExpectFailure( CultureAttribute attr, string msg )
         {
             if ( detector.IsCultureSupported( attr ) )
                 Assert.Fail($"Should not match attribute with Include=\"{attr.Include}\",Exclude=\"{attr.Exclude}\"");
-            Assert.AreEqual( msg, detector.Reason );
+            Assert.That( detector.Reason, Is.EqualTo(msg));
         }
 
         [Test]
@@ -91,37 +91,37 @@ namespace NUnit.Framework.Internal
         [Test,SetCulture("fr-FR")]
         public void LoadWithFrenchCulture()
         {
-            Assert.AreEqual( "fr-FR", CultureInfo.CurrentCulture.Name, "Culture not set correctly" );
+            Assert.That( CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-FR"), "Culture not set correctly" );
             TestSuite fixture = TestBuilder.MakeFixture( typeof( FixtureWithCultureAttribute ) );
-            Assert.AreEqual( RunState.Runnable, fixture.RunState, "Fixture" );
+            Assert.That( fixture.RunState, Is.EqualTo(RunState.Runnable), "Fixture" );
             foreach( Test test in fixture.Tests )
             {
                 RunState expected = test.Name == "FrenchTest" ? RunState.Runnable : RunState.Skipped;
-                Assert.AreEqual( expected, test.RunState, test.Name );
+                Assert.That( test.RunState, Is.EqualTo(expected), test.Name );
             }
         }
 
         [Test,SetCulture("fr-CA")]
         public void LoadWithFrenchCanadianCulture()
         {
-            Assert.AreEqual( "fr-CA", CultureInfo.CurrentCulture.Name, "Culture not set correctly" );
+            Assert.That( CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-CA"), "Culture not set correctly" );
             TestSuite fixture = TestBuilder.MakeFixture( typeof( FixtureWithCultureAttribute ) );
-            Assert.AreEqual( RunState.Runnable, fixture.RunState, "Fixture" );
+            Assert.That( fixture.RunState, Is.EqualTo(RunState.Runnable), "Fixture" );
             foreach( Test test in fixture.Tests )
             {
                 RunState expected = test.Name.StartsWith( "French" ) ? RunState.Runnable : RunState.Skipped;
-                Assert.AreEqual( expected, test.RunState, test.Name );
+                Assert.That( test.RunState, Is.EqualTo(expected), test.Name );
             }
         }
 
         [Test,SetCulture("ru-RU")]
         public void LoadWithRussianCulture()
         {
-            Assert.AreEqual( "ru-RU", CultureInfo.CurrentCulture.Name, "Culture not set correctly" );
+            Assert.That( CultureInfo.CurrentCulture.Name, Is.EqualTo("ru-RU"), "Culture not set correctly" );
             TestSuite fixture = TestBuilder.MakeFixture( typeof( FixtureWithCultureAttribute ) );
-            Assert.AreEqual( RunState.Skipped, fixture.RunState, "Fixture" );
+            Assert.That( fixture.RunState, Is.EqualTo(RunState.Skipped), "Fixture" );
             foreach( Test test in fixture.Tests )
-                Assert.AreEqual( RunState.Skipped, test.RunState, test.Name );
+                Assert.That( test.RunState, Is.EqualTo(RunState.Skipped), test.Name );
         }
 
         [TestFixture, SetCulture("en-GB")]
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Internal
             [Test]
             public void CanSetCultureOnFixture()
             {
-                Assert.AreEqual( "en-GB", CultureInfo.CurrentCulture.Name );
+                Assert.That( CultureInfo.CurrentCulture.Name, Is.EqualTo("en-GB"));
             }
         }
     }

--- a/src/NUnitFramework/tests/Internal/DeduceTypeArgsFromArgs.cs
+++ b/src/NUnitFramework/tests/Internal/DeduceTypeArgsFromArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 namespace NUnit.Framework.Internal
 {
@@ -16,7 +16,10 @@ namespace NUnit.Framework.Internal
             this.t2 = t2;
         }
 
+        // TODO: NUnit.Analyzers doesn't handle generics
+#pragma warning disable NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         [TestCase(5, 7)]
+#pragma warning restore NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         public void TestMyArgTypes(T1 t1, T2 t2)
         {
             Assert.That(t1, Is.TypeOf<T1>());

--- a/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Internal
         {
             var suite = new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(typeof(ImpliedFixture))) as TestFixture;
 
-            Assert.NotNull(suite, "No test fixture was built");
+            Assert.That(suite, Is.Not.Null, "No test fixture was built");
             Assert.That(suite.Name, Is.EqualTo(nameof(ImpliedFixture)));
         }
     }

--- a/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventListenerTextWriterTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(format, arg);
 
             var expected = "Hello 4 2 World";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(format, arg0);
 
             var expected = $"{arg0:dd MMM yyyy}";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(format, arg0, arg1);
 
             var expected = $"{5:00.00} @";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(format, arg0, arg1, arg2);
 
             var expected = $"Quick {9:#.00} Fox";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
 
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(obj);
 
             var expected = "{ Mary = Lamb, Sheep = White }";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -124,7 +124,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(str);
 
             var expected = "Insert coin here";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -138,7 +138,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = $"{2.731:0.000}";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = $"{-1.5:0.0}";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -166,7 +166,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "1234567890123456";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -180,7 +180,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "-987654321";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -194,7 +194,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "255";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -208,7 +208,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "255";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -222,7 +222,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = Boolean.TrueString;
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -236,7 +236,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "x";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -250,7 +250,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(buffer);
 
             var expected = "Hello World";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -266,7 +266,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(buffer, index, count);
 
             var expected = " Miss M";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -280,7 +280,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine(value);
 
             var expected = "-5";
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(2));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(2));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
             Assert.That(ListenerResult.Outputs[1], Is.EqualTo(expected + NL));
         }
@@ -291,7 +291,7 @@ namespace NUnit.Framework.Internal
             ListenerWriter.WriteLine();
 
             var expected = NL;
-            Assert.That(ListenerResult.Outputs.Count, Is.EqualTo(1));
+            Assert.That(ListenerResult.Outputs, Has.Count.EqualTo(1));
             Assert.That(ListenerResult.Outputs[0], Is.EqualTo(expected));
         }
 
@@ -320,7 +320,7 @@ namespace NUnit.Framework.Internal
 
             void ITestListener.TestOutput(TestOutput output)
             {
-                Assert.IsNotNull(output);
+                Assert.That(output, Is.Not.Null);
                 Outputs.Add(output.Text);
 
                 DefaultListener?.TestOutput(output);

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal.Execution
             for (int index = 0; index < events.Length; index++)
             {
                 Event e = q.Dequeue(false);
-                Assert.AreEqual(events[index].GetType(), e.GetType(), $"Event {index}");
+                Assert.That(e.GetType(), Is.EqualTo(events[index].GetType()), $"Event {index}");
             }
         }
 
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Internal.Execution
         public void DequeueEmpty()
         {
             EventQueue q = new EventQueue();
-            Assert.IsNull(q.Dequeue(false));
+            Assert.That(q.Dequeue(false), Is.Null);
         }
 
         [TestFixture]
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Internal.Execution
                 this.q = new EventQueue();
                 this.receivedEvents = 0;
                 this.RunProducerConsumer();
-                Assert.AreEqual(events.Length + 1, this.receivedEvents);
+                Assert.That(this.receivedEvents, Is.EqualTo(events.Length + 1));
             }
 
             protected override void Producer()
@@ -228,7 +228,7 @@ namespace NUnit.Framework.Internal.Execution
                     consumerThread.Start();
                     this.Producer();
                     bool consumerStopped = consumerThread.Join(1000);
-                    Assert.IsTrue(consumerStopped);
+                    Assert.That(consumerStopped, Is.True);
                 }
                 finally
                 {
@@ -237,7 +237,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
                 }
 
-                Assert.IsNull(this.myConsumerException);
+                Assert.That(this.myConsumerException, Is.Null);
             }
 
             protected abstract void Producer();

--- a/src/NUnitFramework/tests/Internal/Execution/ParallelWorkItemDispatcherTests.cs
+++ b/src/NUnitFramework/tests/Internal/Execution/ParallelWorkItemDispatcherTests.cs
@@ -36,26 +36,26 @@ namespace NUnit.Framework.Internal.Execution
 
             Assert.That(shifts, Is.Unique);
 
-            Assert.That(shifts.Count, Is.EqualTo(3));
+            Assert.That(shifts, Has.Count.EqualTo(3));
 
             // Parallel Shift
             Assert.That(shifts[0].Name, Is.EqualTo("Parallel"));
-            Assert.That(shifts[0].Queues.Count, Is.EqualTo(2));
+            Assert.That(shifts[0].Queues, Has.Count.EqualTo(2));
             Assert.That(shifts[0].Queues[0].Name, Is.EqualTo("ParallelQueue"));
             Assert.That(shifts[0].Queues[1].Name, Is.EqualTo("ParallelSTAQueue"));
-            Assert.That(shifts[0].Workers.Count, Is.EqualTo(LEVEL_OF_PARALLELISM + 1));
+            Assert.That(shifts[0].Workers, Has.Count.EqualTo(LEVEL_OF_PARALLELISM + 1));
 
             // NonParallel Shift
             Assert.That(shifts[1].Name, Is.EqualTo("NonParallel"));
-            Assert.That(shifts[1].Queues.Count, Is.EqualTo(1));
+            Assert.That(shifts[1].Queues, Has.Count.EqualTo(1));
             Assert.That(shifts[1].Queues[0].Name, Is.EqualTo("NonParallelQueue"));
-            Assert.That(shifts[1].Workers.Count, Is.EqualTo(1));
+            Assert.That(shifts[1].Workers, Has.Count.EqualTo(1));
 
             // NonParallelSTAShift
             Assert.That(shifts[2].Name, Is.EqualTo("NonParallelSTA"));
-            Assert.That(shifts[2].Queues.Count, Is.EqualTo(1));
+            Assert.That(shifts[2].Queues, Has.Count.EqualTo(1));
             Assert.That(shifts[2].Queues[0].Name, Is.EqualTo("NonParallelSTAQueue"));
-            Assert.That(shifts[2].Workers.Count, Is.EqualTo(1));
+            Assert.That(shifts[2].Workers, Has.Count.EqualTo(1));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
 
-            Assert.False(filter.IsEmpty);
+            Assert.That(filter.IsEmpty, Is.False);
         }
 
         [Test]
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Internal.Filters
             var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
 
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Pass(_dummyFixture));
             Assert.That(filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(filter.Pass(_anotherFixture));
+            Assert.That(filter.Pass(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -43,9 +43,9 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -57,9 +57,9 @@ namespace NUnit.Framework.Internal.Filters
                 new NotFilter(
                     new IdFilter(_dummyFixture.Id)));
 
-            Assert.False(filter.IsExplicitMatch(_topLevelSuite));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch(_topLevelSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
             Assert.That(filter.Match(_anotherFixture), "4");
         }
@@ -103,14 +103,14 @@ namespace NUnit.Framework.Internal.Filters
             foreach (var inputBool in inputBooleans)
             {
                 var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
-                Assert.AreEqual(inputBool, ExecuteMatchFunction(strictFilter, matchFunction));
+                Assert.That(ExecuteMatchFunction(strictFilter, matchFunction), Is.EqualTo(inputBool));
 
                 filters.Add(strictFilter);
             }
 
             var filter = new AndFilter(filters.ToArray());
             bool calculatedResult = ExecuteMatchFunction(filter, matchFunction);
-            Assert.AreEqual(expectedResult, calculatedResult);
+            Assert.That(calculatedResult, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<AndFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<AndFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/CategoryFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/CategoryFilterTests.cs
@@ -15,14 +15,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -40,9 +40,9 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/ClassNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/ClassNameFilterTests.cs
@@ -16,14 +16,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -41,9 +41,9 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Internal.Filters {
                     disagreements.Add(test.FullName);
             }
             var message = CaseErrorMessage("Pass", andFilter, orFilter);
-            Assert.IsEmpty(disagreements, message);
+            Assert.That(disagreements, Is.Empty, message);
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace NUnit.Framework.Internal.Filters {
                     disagreements.Add(test.FullName);
             }
             var message = CaseErrorMessage("Match", andFilter, orFilter);
-            Assert.IsEmpty(disagreements, message);
+            Assert.That(disagreements, Is.Empty, message);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
@@ -16,14 +16,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         public void ExplicitMatchTest()
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
@@ -39,9 +39,9 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchesNothingExplicitly()
         {
-            Assert.False(TestFilter.Empty.IsExplicitMatch(_dummyFixture));
-            Assert.False(TestFilter.Empty.IsExplicitMatch(_anotherFixture));
-            Assert.False(TestFilter.Empty.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(TestFilter.Empty.IsExplicitMatch(_dummyFixture), Is.False);
+            Assert.That(TestFilter.Empty.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(TestFilter.Empty.IsExplicitMatch(_yetAnotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
@@ -16,14 +16,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         public void ExplicitMatchTest()
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
@@ -15,14 +15,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -40,9 +40,9 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -11,17 +11,17 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new IdFilter("Id-1"), new IdFilter("Id-2"));
 
-            Assert.True(InFilter.TryOptimize(filter, out var optimized));
+            Assert.That(InFilter.TryOptimize(filter, out var optimized), Is.True);
 
-            Assert.NotNull(optimized);
-            Assert.False(optimized.IsEmpty);
+            Assert.That(optimized, Is.Not.Null);
+            Assert.That(optimized.IsEmpty, Is.False);
 
-            Assert.True(optimized.Match(new TestDummy { Id = "Id-1" }));
-            Assert.True(optimized.Match(new TestDummy { Id = "Id-2" }));
+            Assert.That(optimized.Match(new TestDummy { Id = "Id-1" }), Is.True);
+            Assert.That(optimized.Match(new TestDummy { Id = "Id-2" }), Is.True);
 
-            Assert.False(optimized.Match(new TestDummy { Id = "id-1" }));
-            Assert.False(optimized.Match(new TestDummy { Id = "Id-" }));
-            Assert.False(optimized.Match(new TestDummy { Id = "" }));
+            Assert.That(optimized.Match(new TestDummy { Id = "id-1" }), Is.False);
+            Assert.That(optimized.Match(new TestDummy { Id = "Id-" }), Is.False);
+            Assert.That(optimized.Match(new TestDummy { Id = "" }), Is.False);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
 
-            Assert.False(InFilter.TryOptimize(filter, out _));
+            Assert.That(InFilter.TryOptimize(filter, out _), Is.False);
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new TestFilter[] {});
 
-            Assert.False(InFilter.TryOptimize(filter, out _));
+            Assert.That(InFilter.TryOptimize(filter, out _), Is.False);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX, true), new FullNameFilter(ANOTHER_CLASS_REGEX, true));
 
-            Assert.False(InFilter.TryOptimize(filter, out _));
+            Assert.That(InFilter.TryOptimize(filter, out _), Is.False);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX, true), new FullNameFilter("Dummy", false));
 
-            Assert.False(InFilter.TryOptimize(filter, out _));
+            Assert.That(InFilter.TryOptimize(filter, out _), Is.False);
         }
         
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal.Filters
             foreach (var orFilter in orFilters)
             {
                 InFilter.TryOptimize(orFilter, out var inFilter);
-                Assert.NotNull(inFilter);
+                Assert.That(inFilter, Is.Not.Null);
 
                 var orFilterXml = orFilter.ToXml(true).OuterXml;
                 var inFilterXml = inFilter.ToXml(true).OuterXml;

--- a/src/NUnitFramework/tests/Internal/Filters/MethodNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MethodNameFilterTests.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
@@ -35,16 +35,16 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(_filter.Pass(_anotherFixture));
             Assert.That(_filter.Pass(_anotherFixture.Tests[0]));
-            Assert.False(_filter.Pass(_yetAnotherFixture));
+            Assert.That(_filter.Pass(_yetAnotherFixture), Is.False);
         }
 
         public void ExplicitMatch_SingleName()
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MockTestFilter.cs
@@ -78,8 +78,8 @@ namespace NUnit.Framework.Internal.Filters
 
         private bool AssertAndGetEquality(ITest test, MatchFunction calledFunction)
         {
-            Assert.AreSame(_expectedTest, test);
-            Assert.AreEqual(_expectedFunctionToBeCalled, calledFunction);
+            Assert.That(test, Is.SameAs(_expectedTest));
+            Assert.That(calledFunction, Is.EqualTo(_expectedFunctionToBeCalled));
             NumberOfMatchCalls += 1;
             return _matchFunctionResult;
         }

--- a/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
@@ -14,14 +14,14 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.IsExplicitMatch(_dummyFixture));
 
-            Assert.False(filter.Match(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
 
-            Assert.False(filter.Match(_yetAnotherFixture));
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
 
-            Assert.False(filter.Match(_explicitFixture));
-            Assert.False(filter.IsExplicitMatch(_explicitFixture));
+            Assert.That(filter.Match(_explicitFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
         }
 
         [Test]
@@ -30,16 +30,16 @@ namespace NUnit.Framework.Internal.Filters
             var filter = new NotFilter(new CategoryFilter("NotDummy"));
 
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture));
+            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
 
             Assert.That(filter.Match(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
 
             Assert.That(filter.Match(_yetAnotherFixture));
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
 
             Assert.That(filter.Match(_explicitFixture));
-            Assert.False(filter.IsExplicitMatch(_explicitFixture));
+            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
         }
 
         [Test]
@@ -52,16 +52,16 @@ namespace NUnit.Framework.Internal.Filters
                     new PropertyFilter("Priority", "Low")));
 
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture));
+            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
 
             Assert.That(filter.Match(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
 
-            Assert.False(filter.Match(_yetAnotherFixture));
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
 
-            Assert.False(filter.Match(_explicitFixture));
-            Assert.False(filter.IsExplicitMatch(_explicitFixture));
+            Assert.That(filter.Match(_explicitFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
         }
 
         [Test]
@@ -75,13 +75,13 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.IsExplicitMatch(_dummyFixture));
 
             Assert.That(filter.Match(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
 
             Assert.That(filter.Match(_yetAnotherFixture));
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
 
             Assert.That(filter.Match(_explicitFixture));
-            Assert.False(filter.IsExplicitMatch(_explicitFixture));
+            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
         }
 
         [Test]
@@ -93,16 +93,16 @@ namespace NUnit.Framework.Internal.Filters
                         new NotFilter(new CategoryFilter("Dummy")))));
 
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture));
+            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
 
-            Assert.False(filter.Match(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
 
-            Assert.False(filter.Match(_yetAnotherFixture));
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
 
-            Assert.False(filter.Match(_explicitFixture));
-            Assert.False(filter.IsExplicitMatch(_explicitFixture));
+            Assert.That(filter.Match(_explicitFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
         }
 
         [Test]
@@ -115,18 +115,18 @@ namespace NUnit.Framework.Internal.Filters
                     new MethodNameFilter("Test1")));
 
             Assert.That(filter.Pass(_topLevelSuite));
-            Assert.False(filter.Match(_topLevelSuite));
+            Assert.That(filter.Match(_topLevelSuite), Is.False);
 
             Assert.That(filter.Pass(_fixtureWithMultipleTests));
-            Assert.False(filter.Match(_fixtureWithMultipleTests));
+            Assert.That(filter.Match(_fixtureWithMultipleTests), Is.False);
 
             var test1 = _fixtureWithMultipleTests.Tests[0];
-            Assert.False(filter.Pass(test1));
-            Assert.False(filter.Match(test1));
+            Assert.That(filter.Pass(test1), Is.False);
+            Assert.That(filter.Match(test1), Is.False);
 
             var test2 = _fixtureWithMultipleTests.Tests[1];
             Assert.That(filter.Pass(test2));
-            Assert.False(filter.IsExplicitMatch(test2));
+            Assert.That(filter.IsExplicitMatch(test2), Is.False);
             Assert.That(filter.Match(test2));
         }
 
@@ -146,12 +146,12 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_fixtureWithMultipleTests));
 
             var test1 = _fixtureWithMultipleTests.Tests[0];
-            Assert.False(filter.Pass(test1));
-            Assert.False(filter.Match(test1));
+            Assert.That(filter.Pass(test1), Is.False);
+            Assert.That(filter.Match(test1), Is.False);
 
             var test2 = _fixtureWithMultipleTests.Tests[1];
             Assert.That(filter.Pass(test2));
-            Assert.False(filter.IsExplicitMatch(test2));
+            Assert.That(filter.IsExplicitMatch(test2), Is.False);
             Assert.That(filter.Match(test2));
         }
     }

--- a/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/Filters/NotFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/NotFilterTests.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.False(filter.IsEmpty);
+            Assert.That(filter.IsEmpty, Is.False);
         }
 
         [Test]
@@ -17,15 +17,15 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.True(filter.Match(_topLevelSuite));
-            Assert.False(filter.Match(_dummyFixture));
-            Assert.True(filter.Match(_dummyFixture.Tests[0]));
+            Assert.That(filter.Match(_topLevelSuite), Is.True);
+            Assert.That(filter.Match(_dummyFixture), Is.False);
+            Assert.That(filter.Match(_dummyFixture.Tests[0]), Is.True);
 
-            Assert.True(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.True);
 
-            Assert.True (filter.Match (_fixtureWithMultipleTests));
-            Assert.True (filter.Match (_fixtureWithMultipleTests.Tests[0]));
-            Assert.False (filter.Match (_fixtureWithMultipleTests.Tests[1]));
+            Assert.That(filter.Match (_fixtureWithMultipleTests), Is.True);
+            Assert.That(filter.Match (_fixtureWithMultipleTests.Tests[0]), Is.True);
+            Assert.That(filter.Match (_fixtureWithMultipleTests.Tests[1]), Is.False);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.True(filter.Pass(_topLevelSuite));
-            Assert.False(filter.Pass(_dummyFixture));
-            Assert.False(filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(filter.Pass(_topLevelSuite), Is.True);
+            Assert.That(filter.Pass(_dummyFixture), Is.False);
+            Assert.That(filter.Pass(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.True(filter.Pass(_anotherFixture));
-            Assert.True(filter.Pass(_anotherFixture.Tests[0]));
+            Assert.That(filter.Pass(_anotherFixture), Is.True);
+            Assert.That(filter.Pass(_anotherFixture.Tests[0]), Is.True);
 
-            Assert.True (filter.Pass (_fixtureWithMultipleTests));
-            Assert.True (filter.Pass (_fixtureWithMultipleTests.Tests[0]));
-            Assert.False (filter.Pass (_fixtureWithMultipleTests.Tests[1]));
+            Assert.That(filter.Pass (_fixtureWithMultipleTests), Is.True);
+            Assert.That(filter.Pass (_fixtureWithMultipleTests.Tests[0]), Is.True);
+            Assert.That(filter.Pass (_fixtureWithMultipleTests.Tests[1]), Is.False);
         }
 
         [Test]
@@ -50,12 +50,12 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.False (filter.IsExplicitMatch (_topLevelSuite));
-            Assert.False (filter.IsExplicitMatch (_dummyFixture));
-            Assert.False (filter.IsExplicitMatch (_dummyFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch (_topLevelSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch (_dummyFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch (_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False (filter.IsExplicitMatch (_anotherFixture));
-            Assert.False (filter.IsExplicitMatch (_anotherFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch (_anotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch (_anotherFixture.Tests[0]), Is.False);
         }
 
         [Test]
@@ -65,8 +65,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><not><cat>Dummy</cat></not></filter>");
 
             Assert.That(filter, Is.TypeOf<NotFilter>());
-            Assert.False(filter.Match(_dummyFixture));
-            Assert.True(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_dummyFixture), Is.False);
+            Assert.That(filter.Match(_anotherFixture), Is.True);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new CategoryFilter("Another"));
 
-            Assert.False(filter.IsEmpty);
+            Assert.That(filter.IsEmpty, Is.False);
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter("Dummy"), new FullNameFilter("Another"));
 
-            Assert.False(filter.IsEmpty);
+            Assert.That(filter.IsEmpty, Is.False);
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
 
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
 
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -50,9 +50,9 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new TestFilter[] {});
 
-            Assert.False(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_dummyFixture), Is.False);
+            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
 
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Match(_dummyFixture));
             Assert.That(filter.Match(_anotherFixture));
 
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Pass(_anotherFixture));
             Assert.That(filter.Pass(_anotherFixture.Tests[0]));
 
-            Assert.False(filter.Pass(_yetAnotherFixture));
+            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Pass(_anotherFixture));
             Assert.That(filter.Pass(_anotherFixture.Tests[0]));
 
-            Assert.False(filter.Pass(_yetAnotherFixture));
+            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter.Pass(_anotherFixture));
             Assert.That(filter.Pass(_anotherFixture.Tests[0]));
 
-            Assert.False(filter.Pass(_yetAnotherFixture));
+            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -126,11 +126,11 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
             Assert.That(filter.IsExplicitMatch(_anotherFixture));
-            Assert.False(filter.IsExplicitMatch(_anotherFixture.Tests[0]));
+            Assert.That(filter.IsExplicitMatch(_anotherFixture.Tests[0]), Is.False);
 
-            Assert.False(filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
         }
 
         /// <summary>
@@ -172,14 +172,14 @@ namespace NUnit.Framework.Internal.Filters
             foreach (var inputBool in inputBooleans)
             {
                 var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
-                Assert.AreEqual(inputBool, ExecuteMatchFunction(strictFilter, matchFunction));
+                Assert.That(ExecuteMatchFunction(strictFilter, matchFunction), Is.EqualTo(inputBool));
 
                 filters.Add(strictFilter);
             }
 
             var filter = new OrFilter(filters.ToArray());
             bool calculatedResult = ExecuteMatchFunction(filter, matchFunction);
-            Assert.AreEqual(expectedResult, calculatedResult);
+            Assert.That(calculatedResult, Is.EqualTo(expectedResult));
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Internal/Filters/PropertyFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/PropertyFilterTests.cs
@@ -16,15 +16,15 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
-            Assert.False(_filter.Match(_yetAnotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
+            Assert.That(_filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -34,8 +34,8 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
-            Assert.False(_filter.Pass(_yetAnotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
+            Assert.That(_filter.Pass(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -43,10 +43,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
-            Assert.False(_filter.IsExplicitMatch(_yetAnotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<ClassNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<ClassNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(filter, Is.TypeOf<MethodNameFilter>());
             Assert.That(filter.Match(_dummyFixture.Tests[0]));
             Assert.That(filter.Match(_anotherFixture.Tests[0]));
-            Assert.False(filter.Match(_fixtureWithMultipleTests.Tests[0]));
+            Assert.That(filter.Match(_fixtureWithMultipleTests.Tests[0]), Is.False);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<TestNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<TestNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<FullNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<FullNameFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_specialFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
             Assert.That(filter.Match(_specialFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -252,8 +252,8 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<PropertyFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -271,8 +271,8 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<PropertyFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
-            Assert.False(filter.Match(_yetAnotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace NUnit.Framework.Internal.Filters
 
             Assert.That(filter, Is.TypeOf<IdFilter>());
             Assert.That(filter.Match(_dummyFixture));
-            Assert.False(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/Filters/TestNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestNameFilterTests.cs
@@ -16,14 +16,14 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            Assert.False(_filter.IsEmpty);
+            Assert.That(_filter.IsEmpty, Is.False);
         }
 
         [Test]
         public void MatchTest()
         {
             Assert.That(_filter.Match(_dummyFixture));
-            Assert.False(_filter.Match(_anotherFixture));
+            Assert.That(_filter.Match(_anotherFixture), Is.False);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Internal.Filters
             Assert.That(_filter.Pass(_dummyFixture));
             Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
 
-            Assert.False(_filter.Pass(_anotherFixture));
+            Assert.That(_filter.Pass(_anotherFixture), Is.False);
         }
 
         public void ExplicitMatchTest()
         {
             Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
             Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.False(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
+            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
 
-            Assert.False(_filter.IsExplicitMatch(_anotherFixture));
+            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/GenericTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestFixtureTests.cs
@@ -17,15 +17,20 @@ namespace NUnit.Framework.Internal
             list.Add(1);
             list.Add(2);
             list.Add(3);
-            Assert.AreEqual(3, list.Count);
+            Assert.That(list, Has.Count.EqualTo(3));
         }
     }
 
+    // Deja-vu: Same test as TypeParameterUsedWithTestMethod
     [TestFixture(typeof(double))]
     public class GenericTestFixture_Numeric<T>
     {
+        // TODO: NUnit.Analyzer doesn't handle generics.
+        // It would need to have to check against the TestFixture parameter attribute.
+#pragma warning disable NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         [TestCase(5)]
         [TestCase(1.23)]
+#pragma warning restore NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         public void TestMyArgType(T x)
         {
             Assert.That(x, Is.TypeOf(typeof(T)));

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -10,23 +10,30 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     class GenericTestMethodTests
     {
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
         [TestCase(5, 2, "ABC")]
         [TestCase(5.0, 2.0, "ABC")]
         [TestCase(5, 2.0, "ABC")]
         [TestCase(5.0, 2L, "ABC")]
         public void TestCase_OneTypeParameterOnTwoArgs<T>(T x, T y, string label)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
-            Assert.AreEqual("ABC", label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+                Assert.That(label, Is.EqualTo("ABC"));
+            });
         }
 
         [Test]
         public void TestCase_IncompatibleArgsAreNotRunnable()
         {
             var result = TestBuilder.RunTestFixture(typeof(IncompatibleGenericTestCaseData));
-            Assert.That(result.PassCount, Is.EqualTo(2), "PassCount");
-            Assert.That(result.FailCount, Is.EqualTo(2), "FailCount");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.PassCount, Is.EqualTo(2), "PassCount");
+                Assert.That(result.FailCount, Is.EqualTo(2), "FailCount");
+            });
 
             int invalid = 0;
             // Examine grandchildren - child is parameterized method suite
@@ -44,9 +51,12 @@ namespace NUnit.Framework.Internal
         [TestCase(5.0, 2L, "ABC")]
         public void TestCase_TwoTypeParameters<T1, T2>(T1 x, T2 y, string label)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
-            Assert.AreEqual("ABC", label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+                Assert.That(label, Is.EqualTo("ABC"));
+            });
         }
 
         [TestCase(5, 2, "ABC")]
@@ -55,25 +65,34 @@ namespace NUnit.Framework.Internal
         [TestCase(5.0, 2L, "ABC")]
         public void TestCase_TwoTypeParameters_Reversed<T1, T2>(T2 x, T1 y, string label)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
-            Assert.AreEqual("ABC", label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+                Assert.That(label, Is.EqualTo("ABC"));
+            });
         }
 
         [TestCaseSource(nameof(Source))]
         public void TestCaseSource_OneTypeParameterOnTwoArgs<T>(T x, T y, string label)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
-            Assert.AreEqual("ABC", label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+                Assert.That(label, Is.EqualTo("ABC"));
+            });
         }
 
         [Test]
         public void TestCaseSource_IncompatibleArgsAreNotRunnable()
         {
             var result = TestBuilder.RunTestFixture(typeof(IncompatibleGenericTestCaseSourceData));
-            Assert.That(result.PassCount, Is.EqualTo(2), "PassCount");
-            Assert.That(result.FailCount, Is.EqualTo(2), "FailCount");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.PassCount, Is.EqualTo(2), "PassCount");
+                Assert.That(result.FailCount, Is.EqualTo(2), "FailCount");
+            });
 
             int invalid = 0;
             // Examine grandchildren - child is parameterized method suite
@@ -88,9 +107,12 @@ namespace NUnit.Framework.Internal
         [TestCaseSource(nameof(Source))]
         public void TestCaseSource_TwoTypeParameters<T1, T2>(T1 x, T2 y, string label)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
-            Assert.AreEqual("ABC", label);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+                Assert.That(label, Is.EqualTo("ABC"));
+            });
         }
 
         [Test]
@@ -98,8 +120,11 @@ namespace NUnit.Framework.Internal
             [Values(5, 5.0)] T x,
             [Values(2.0, 2)] T y)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -107,8 +132,11 @@ namespace NUnit.Framework.Internal
             [Values(5, 5.0)] T1 x,
             [Values(2.0, 2)] T2 y)
         {
-            Assert.AreEqual(5, x);
-            Assert.AreEqual(2, y);
+            Assert.Multiple(() =>
+            {
+                Assert.That(x, Is.EqualTo(5));
+                Assert.That(y, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -143,5 +171,6 @@ namespace NUnit.Framework.Internal
 
         //static ITestCaseData[] SequenceCases = {
         //    new TestCaseData(new List<int> { 1, 2 }, new List<int> { 1, 2 }) };
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
     }
 }

--- a/src/NUnitFramework/tests/Internal/NamespaceTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTests.cs
@@ -23,8 +23,8 @@ namespace NUnit.Framework.Internal
             {
                 foreach (var type in exportedTypes.Except(exportedTypesWhitelist))
                 {
-                    Assert.IsFalse(
-                        type.Namespace.StartsWith("System", StringComparison.OrdinalIgnoreCase),
+                    Assert.That(
+                        type.Namespace.StartsWith("System", StringComparison.OrdinalIgnoreCase), Is.False,
                         $"Type {type.FullName} is publicly visible in the System namespace but should not be.");
                 }
             });

--- a/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Internal.Builders
         public void InitialTreeState()
         {
             Assert.That(_builder.RootSuite, Is.SameAs(_testAssembly));
-            Assert.That(_builder.RootSuite.Tests.Count, Is.Zero);
+            Assert.That(_builder.RootSuite.Tests, Is.Empty);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal
                 else if ( didPass && !shouldPass )
                     Assert.Fail( "False positive on {0}", testPlatform );
                 else if ( !shouldPass && !didPass )
-                    Assert.AreEqual( "Only supported on " + testPlatform, helper.Reason );
+                    Assert.That( helper.Reason, Is.EqualTo("Only supported on " + testPlatform));
             }
         }
 
@@ -355,27 +355,27 @@ namespace NUnit.Framework.Internal
         [Test]
         public void DetectExactVersion()
         {
-            Assert.IsTrue( winXPHelper.IsPlatformSupported( "net-1.1.4322" ) );
-            Assert.IsTrue( winXPHelper.IsPlatformSupported( "net-1.1.4322.0" ) );
-            Assert.IsFalse( winXPHelper.IsPlatformSupported( "net-1.1.4323.0" ) );
-            Assert.IsFalse( winXPHelper.IsPlatformSupported( "net-1.1.4322.1" ) );
+            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322" ), Is.True);
+            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322.0" ), Is.True);
+            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4323.0" ), Is.False);
+            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322.1" ), Is.False);
         }
 
         [Test]
         public void ArrayOfPlatforms()
         {
             string[] platforms = new[] { "NT4", "Win2K", "WinXP" };
-            Assert.IsTrue( winXPHelper.IsPlatformSupported( platforms ) );
-            Assert.IsFalse( win95Helper.IsPlatformSupported( platforms ) );
+            Assert.That( winXPHelper.IsPlatformSupported( platforms ), Is.True);
+            Assert.That( win95Helper.IsPlatformSupported( platforms ), Is.False);
         }
 
         [Test]
         public void PlatformAttribute_Include()
         {
             PlatformAttribute attr = new PlatformAttribute( "Win2K,WinXP,NT4" );
-            Assert.IsTrue( winXPHelper.IsPlatformSupported( attr ) );
-            Assert.IsFalse( win95Helper.IsPlatformSupported( attr ) );
-            Assert.AreEqual("Only supported on Win2K,WinXP,NT4", win95Helper.Reason);
+            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.True);
+            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That(win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
         }
 
         [Test]
@@ -383,9 +383,9 @@ namespace NUnit.Framework.Internal
         {
             PlatformAttribute attr = new PlatformAttribute();
             attr.Exclude = "Win2K,WinXP,NT4";
-            Assert.IsFalse( winXPHelper.IsPlatformSupported( attr ) );
-            Assert.AreEqual( "Not supported on Win2K,WinXP,NT4", winXPHelper.Reason );
-            Assert.IsTrue( win95Helper.IsPlatformSupported( attr ) );
+            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( winXPHelper.Reason, Is.EqualTo("Not supported on Win2K,WinXP,NT4"));
+            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.True);
         }
 
         [Test]
@@ -393,14 +393,14 @@ namespace NUnit.Framework.Internal
         {
             PlatformAttribute attr = new PlatformAttribute( "Win2K,WinXP,NT4" );
             attr.Exclude = "Mono";
-            Assert.IsFalse( win95Helper.IsPlatformSupported( attr ) );
-            Assert.AreEqual( "Only supported on Win2K,WinXP,NT4", win95Helper.Reason );
-            Assert.IsTrue( winXPHelper.IsPlatformSupported( attr ) );
+            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
+            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.True);
             attr.Exclude = "Net";
-            Assert.IsFalse( win95Helper.IsPlatformSupported( attr ) );
-            Assert.AreEqual( "Only supported on Win2K,WinXP,NT4", win95Helper.Reason );
-            Assert.IsFalse( winXPHelper.IsPlatformSupported( attr ) );
-            Assert.AreEqual( "Not supported on Net", winXPHelper.Reason );
+            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
+            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( winXPHelper.Reason, Is.EqualTo("Not supported on Net"));
         }
 
         [Test]
@@ -423,7 +423,7 @@ namespace NUnit.Framework.Internal
             // do not cause an error and return consistent results.
             bool is32BitProcess = helper.IsPlatformSupported(attr32);
             bool is64BitProcess = helper.IsPlatformSupported(attr64);
-            Assert.False(is32BitProcess & is64BitProcess, "Process cannot be both 32 and 64 bit");
+            Assert.That(is32BitProcess & is64BitProcess, Is.False, "Process cannot be both 32 and 64 bit");
             Assert.That(is64BitProcess, Is.EqualTo(Environment.Is64BitProcess));
         }
 

--- a/src/NUnitFramework/tests/Internal/PropertyBagAdapterTests.cs
+++ b/src/NUnitFramework/tests/Internal/PropertyBagAdapterTests.cs
@@ -26,17 +26,17 @@ namespace NUnit.Framework.Internal
         [Test]
         public void PropertyBagAdapter_Get_CanAccessKeysFromSourceIPropertyBag()
         {
-            Assert.AreEqual("val1", _adapter.Get("key"));
-            Assert.AreEqual(42, _adapter.Get("meaningOfLife"));
-            Assert.AreEqual(null, _adapter.Get("nonExistantKey"));
+            Assert.That(_adapter.Get("key"), Is.EqualTo("val1"));
+            Assert.That(_adapter.Get("meaningOfLife"), Is.EqualTo(42));
+            Assert.That(_adapter.Get("nonExistantKey"), Is.EqualTo(null));
         }
 
         [Test]
         public void PropertyBagAdapter_ContainsKeys()
         {
-            Assert.IsTrue(_adapter.ContainsKey("key"));
-            Assert.IsTrue(_adapter.ContainsKey("meaningOfLife"));
-            Assert.IsFalse(_adapter.ContainsKey("nonExistantKey"));
+            Assert.That(_adapter.ContainsKey("key"), Is.True);
+            Assert.That(_adapter.ContainsKey("meaningOfLife"), Is.True);
+            Assert.That(_adapter.ContainsKey("nonExistantKey"), Is.False);
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Internal
             var enumerable = _adapter["key"];
 
             var asList = new List<object>(enumerable);
-            Assert.AreEqual(2, asList.Count);
+            Assert.That(asList, Has.Count.EqualTo(2));
             CollectionAssert.Contains(asList, "val1");
             CollectionAssert.Contains(asList, "val2");
         }
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void PropertyBagAdapter_Count()
         {
-            Assert.AreEqual(2, _adapter.Count("key"));
+            Assert.That(_adapter.Count("key"), Is.EqualTo(2));
         }
 
         [Test]
@@ -70,10 +70,10 @@ namespace NUnit.Framework.Internal
         {
             _source.Add("newKey", "newVal");
 
-            Assert.IsTrue(_adapter.ContainsKey("newKey"));
-            Assert.AreEqual("newVal", _adapter.Get("newKey"));
+            Assert.That(_adapter.ContainsKey("newKey"), Is.True);
+            Assert.That(_adapter.Get("newKey"), Is.EqualTo("newVal"));
             CollectionAssert.AreEquivalent(new[] { "newVal" }, _adapter["newKey"]);
-            Assert.AreEqual(1, _adapter.Count("newKey"));
+            Assert.That(_adapter.Count("newKey"), Is.EqualTo(1));
             CollectionAssert.AreEquivalent(new[] { "key", "meaningOfLife", "newKey" }, _adapter.Keys);
         }
     }

--- a/src/NUnitFramework/tests/Internal/PropertyBagTests.cs
+++ b/src/NUnitFramework/tests/Internal/PropertyBagTests.cs
@@ -22,10 +22,10 @@ namespace NUnit.Framework.Internal
         [Test]
         public void IndexGetsListOfValues()
         {
-            Assert.That(bag["Answer"].Count, Is.EqualTo(1));
+            Assert.That(bag["Answer"], Has.Count.EqualTo(1));
             Assert.That(bag["Answer"], Contains.Item(42));
 
-            Assert.That(bag["Tag"].Count, Is.EqualTo(2));
+            Assert.That(bag["Tag"], Has.Count.EqualTo(2));
             Assert.That(bag["Tag"], Contains.Item("bug"));
             Assert.That(bag["Tag"], Contains.Item("easy"));
         }
@@ -33,14 +33,14 @@ namespace NUnit.Framework.Internal
         [Test]
         public void IndexGetsEmptyListIfNameIsNotPresent()
         {
-            Assert.That(bag["Level"].Count, Is.EqualTo(0));
+            Assert.That(bag["Level"], Is.Empty);
         }
 
         [Test]
         public void IndexSetsListOfValues()
         {
             bag["Zip"] = new[] {"junk", "more junk"};
-            Assert.That(bag["Zip"].Count, Is.EqualTo(2));
+            Assert.That(bag["Zip"], Has.Count.EqualTo(2));
             Assert.That(bag["Zip"], Contains.Item("junk"));
             Assert.That(bag["Zip"], Contains.Item("more junk"));
         }
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void AllKeysAreListed()
         {
-            Assert.That(bag.Keys.Count, Is.EqualTo(2));
+            Assert.That(bag.Keys, Has.Count.EqualTo(2));
             Assert.That(bag.Keys, Has.Member("Answer"));
             Assert.That(bag.Keys, Has.Member("Tag"));
         }
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Internal
         {
             Assert.That(bag.ContainsKey("Answer"));
             Assert.That(bag.ContainsKey("Tag"));
-            Assert.False(bag.ContainsKey("Target"));
+            Assert.That(bag.ContainsKey("Target"), Is.False);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Internal
         public void SetAddsNewSingleValue()
         {
             bag.Set("Zip", "ZAP");
-            Assert.That(bag["Zip"].Count, Is.EqualTo(1));
+            Assert.That(bag["Zip"], Has.Count.EqualTo(1));
             Assert.That(bag["Zip"], Has.Member("ZAP"));
             Assert.That(bag.Get("Zip"), Is.EqualTo("ZAP"));
         }
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
         public void SetReplacesOldValues()
         {
             bag.Set("Tag", "ZAPPED");
-            Assert.That(bag["Tag"].Count, Is.EqualTo(1));
+            Assert.That(bag["Tag"], Has.Count.EqualTo(1));
             Assert.That(bag.Get("Tag"), Is.EqualTo("ZAPPED"));
         }
 
@@ -109,7 +109,7 @@ namespace NUnit.Framework.Internal
         public void TestNullPropertyValueIsntAdded()
         {
             Assert.Throws<ArgumentNullException>(() => bag.Add("dontAddMe", null));
-            Assert.IsFalse(bag.ContainsKey("dontAddMe"));
+            Assert.That(bag.ContainsKey("dontAddMe"), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/RandomizerTests.cs
+++ b/src/NUnitFramework/tests/Internal/RandomizerTests.cs
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Internal
         public void RandomULongWithMaximum()
         {
             ulong val = _randomizer.NextULong(1066UL);
-            Assert.That(val < 1066UL, "Out of range");
+            Assert.That(val, Is.LessThan(1066UL), "Out of range");
         }
 
         [Test]
@@ -427,13 +427,14 @@ namespace NUnit.Framework.Internal
         public void RandomBoolWithProbabilityZeroIsAlwaysFalse()
         {
             for (int i = 0; i < 10; i++)
-                Assert.False(_randomizer.NextBool(0.0));
+                Assert.That(_randomizer.NextBool(0.0), Is.False);
         }
 
+        [Test]
         public void RandomBoolWithProbabilityOneIsAlwaysTrue()
         {
             for (int i = 0; i < 10; i++)
-                Assert.True(_randomizer.NextBool(1.0));
+                Assert.That(_randomizer.NextBool(1.0), Is.True);
         }
 
         #endregion
@@ -534,32 +535,6 @@ namespace NUnit.Framework.Internal
         public void RandomFloatsInRangeAreUnique()
         {
             UniqueValues.Check(() => _randomizer.NextFloat(0.5f, 1.5f), 10, 100);
-        }
-
-        /// <summary>
-        /// Return an array of random floats between 0.0 and 1.0.
-        /// </summary>
-        public float[] GetFloats(int count)
-        {
-            float[] floats = new float[count];
-
-            for (int index = 0; index < count; index++)
-                floats[index] = _randomizer.NextFloat();
-
-            return floats;
-        }
-
-        /// <summary>
-        /// Return an array of random floats with values in a specified range.
-        /// </summary>
-        public float[] GetFloats(float min, float max, int count)
-        {
-            float[] floats = new float[count];
-
-            for (int index = 0; index < count; index++)
-                floats[index] = _randomizer.NextFloat(min, max);
-
-            return floats;
         }
 
         #endregion
@@ -747,13 +722,13 @@ namespace NUnit.Framework.Internal
             }
 
             static readonly MethodInfo testMethod1 =
-                typeof(Repeatability).GetMethod("TestMethod1", BindingFlags.NonPublic | BindingFlags.Static);
+                typeof(Repeatability).GetMethod(nameof(TestMethod1), BindingFlags.NonPublic | BindingFlags.Static);
             private static void TestMethod1(int x, int y)
             {
             }
 
             static readonly MethodInfo testMethod2 =
-                typeof(Repeatability).GetMethod("TestMethod2", BindingFlags.NonPublic | BindingFlags.Static);
+                typeof(Repeatability).GetMethod(nameof(TestMethod2), BindingFlags.NonPublic | BindingFlags.Static);
             private static void TestMethod2(int x, int y)
             {
             }

--- a/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/RealAsyncSetupTeardownTests.cs
@@ -27,8 +27,11 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestCurrentFixtureInitialization()
         {
-            Assert.That(_initializedOnce, Is.Not.Null);
-            Assert.That(_initializedEveryTime, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_initializedOnce, Is.Not.Null);
+                Assert.That(_initializedEveryTime, Is.Not.Null);
+            });
 
             _initializedEveryTime = null;
         }

--- a/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
@@ -32,13 +32,13 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResult_AssertionResults()
         {
-            Assert.AreEqual(_expectedAssertions, _testResult.AssertionResults);
+            Assert.That(_testResult.AssertionResults, Is.EqualTo(_expectedAssertions));
         }
 
         [Test]
         public void SuiteResult_AssertionResults()
         {
-            Assert.IsEmpty(_suiteResult.AssertionResults);
+            Assert.That(_suiteResult.AssertionResults, Is.Empty);
         }
 
         [Test]
@@ -48,35 +48,35 @@ namespace NUnit.Framework.Internal.Results
 
             if (_expectedAssertions.Count == 0)
             {
-                Assert.Null(assertionResults, "No <assertions> element expected");
+                Assert.That(assertionResults, Is.Null, "No <assertions> element expected");
                 return;
             }
 
-            Assert.NotNull(assertionResults, "Expected <assertions> element");
+            Assert.That(assertionResults, Is.Not.Null, "Expected <assertions> element");
 
             var assertionNodes = assertionResults.SelectNodes("assertion");
-            Assert.NotNull(assertionNodes, "Empty <assertions> element");
+            Assert.That(assertionNodes, Is.Not.Null, "Empty <assertions> element");
 
-            Assert.AreEqual(_expectedAssertions.Count, assertionNodes.Count, "Wrong number of <assertion> elements");
+            Assert.That(assertionNodes, Has.Count.EqualTo(_expectedAssertions.Count), "Wrong number of <assertion> elements");
 
             for (int index = 0; index < _expectedAssertions.Count; index++)
             {
                 AssertionResult expectedAssertion = _expectedAssertions[index];
                 TNode assertionNode = assertionNodes[index];
 
-                Assert.AreEqual(expectedAssertion.Status.ToString(), assertionNode.Attributes["result"]);
+                Assert.That(assertionNode.Attributes["result"], Is.EqualTo(expectedAssertion.Status.ToString()));
 
                 if (expectedAssertion.Message != null)
                 {
                     TNode messageNode = assertionNode.SelectSingleNode("message");
-                    Assert.NotNull(messageNode);
+                    Assert.That(messageNode, Is.Not.Null);
                     Assert.That(messageNode.Value, Is.EqualTo(expectedAssertion.Message));
                 }
 
                 if (expectedAssertion.StackTrace != null)
                 {
                     TNode stackNode = assertionNode.SelectSingleNode("stack-trace");
-                    Assert.NotNull(stackNode);
+                    Assert.That(stackNode, Is.Not.Null);
                     Assert.That(stackNode.Value, Is.EqualTo(expectedAssertion.StackTrace));
                 }
             }
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal.Results
         public void SuiteResultXml_AssertionResults()
         {
             TNode suiteNode = _suiteResult.ToXml(true);
-            Assert.Null(suiteNode.SelectSingleNode("assertions"));
+            Assert.That(suiteNode.SelectSingleNode("assertions"), Is.Null);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
@@ -113,27 +113,33 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsFailure()
         {
-            Assert.AreEqual(ResultState.Failure, _testResult.ResultState);
-            Assert.AreEqual(TestStatus.Failed, _testResult.ResultState.Status);
-            Assert.AreEqual(_failureReason, _testResult.Message);
-            Assert.AreEqual(_stackTrace, _testResult.StackTrace);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Failure));
+                Assert.That(_testResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(_testResult.Message, Is.EqualTo(_failureReason));
+                Assert.That(_testResult.StackTrace, Is.EqualTo(_stackTrace));
+            });
         }
 
         [Test]
         public void SuiteResultIsFailure()
         {
-            Assert.AreEqual(ResultState.ChildFailure, _suiteResult.ResultState);
-            Assert.AreEqual(TestStatus.Failed, _suiteResult.ResultState.Status);
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE, _suiteResult.Message);
-            Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-            Assert.That(_suiteResult.StackTrace, Is.Null);
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(0, _suiteResult.PassCount);
-            Assert.AreEqual(1, _suiteResult.FailCount);
-            Assert.AreEqual(0, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(0, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(3, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(_suiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(_suiteResult.StackTrace, Is.Null);
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(3));
+            });
         }
 
         [Test]
@@ -141,9 +147,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Failed", testNode.Attributes["result"]);
-            Assert.AreEqual(null, testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Failed"));
+                Assert.That(testNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(testNode.Attributes["site"], Is.EqualTo(null));
+            });
 
             var failureNode = _xmlFailureNodeValidation(testNode);
             _xmlMessageNodeValidation(failureNode);
@@ -170,26 +179,31 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Failed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual("Child", suiteNode.Attributes["site"]);
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Failed"));
+                Assert.That(suiteNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(suiteNode.Attributes["site"], Is.EqualTo("Child"));
+            });
             TNode failureNode = suiteNode.SelectSingleNode("failure");
-            Assert.NotNull(failureNode, "No <failure> element found");
+            Assert.That(failureNode, Is.Not.Null, "No <failure> element found");
 
             TNode messageNode = failureNode.SelectSingleNode("message");
-            Assert.NotNull(messageNode, "No <message> element found");
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE, messageNode.Value);
+            Assert.That(messageNode, Is.Not.Null, "No <message> element found");
+            Assert.That(messageNode.Value, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
 
             TNode stacktraceNode = failureNode.SelectSingleNode("stacktrace");
-            Assert.Null(stacktraceNode, "Unexpected <stack-trace> element found");
+            Assert.That(stacktraceNode, Is.Null, "Unexpected <stack-trace> element found");
 
-            Assert.AreEqual("0", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("1", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("3", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("3"));
+            });
         }
 
         protected static TNode FailureNodeExistsAndIsNotNull(TNode testNode)

--- a/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
@@ -44,8 +44,8 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResult_Identification()
         {
-            Assert.AreEqual(_test.Name, _testResult.Name);
-            Assert.AreEqual(_test.FullName, _testResult.FullName);
+            Assert.That(_testResult.Name, Is.EqualTo(_test.Name));
+            Assert.That(_testResult.FullName, Is.EqualTo(_test.FullName));
         }
 
         [Test]
@@ -59,9 +59,9 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResult_Duration()
         {
-            Assert.AreEqual(EXPECTED_START, _testResult.StartTime);
-            Assert.AreEqual(EXPECTED_END, _testResult.EndTime);
-            Assert.AreEqual(EXPECTED_DURATION, _testResult.Duration);
+            Assert.That(_testResult.StartTime, Is.EqualTo(EXPECTED_START));
+            Assert.That(_testResult.EndTime, Is.EqualTo(EXPECTED_END));
+            Assert.That(_testResult.Duration, Is.EqualTo(EXPECTED_DURATION));
         }
 
         [Test]
@@ -76,8 +76,8 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResult_Identification()
         {
-            Assert.AreEqual(_suite.Name, _suiteResult.Name);
-            Assert.AreEqual(_suite.FullName, _suiteResult.FullName);
+            Assert.That(_suiteResult.Name, Is.EqualTo(_suite.Name));
+            Assert.That(_suiteResult.FullName, Is.EqualTo(_suite.FullName));
         }
 
         [Test]
@@ -91,9 +91,9 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResult_Duration()
         {
-            Assert.AreEqual(EXPECTED_START, _suiteResult.StartTime);
-            Assert.AreEqual(EXPECTED_END, _suiteResult.EndTime);
-            Assert.AreEqual(EXPECTED_DURATION, _suiteResult.Duration);
+            Assert.That(_suiteResult.StartTime, Is.EqualTo(EXPECTED_START));
+            Assert.That(_suiteResult.EndTime, Is.EqualTo(EXPECTED_END));
+            Assert.That(_suiteResult.Duration, Is.EqualTo(EXPECTED_DURATION));
         }
 
         [Test]
@@ -110,10 +110,13 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.NotNull(testNode.Attributes["id"]);
-            Assert.AreEqual("test-case", testNode.Name);
-            Assert.AreEqual(_testResult.Name, testNode.Attributes["name"]);
-            Assert.AreEqual(_testResult.FullName, testNode.Attributes["fullname"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["id"], Is.Not.Null);
+                Assert.That(testNode.Name, Is.EqualTo("test-case"));
+                Assert.That(testNode.Attributes["name"], Is.EqualTo(_testResult.Name));
+                Assert.That(testNode.Attributes["fullname"], Is.EqualTo(_testResult.FullName));
+            });
         }
 
         [Test]
@@ -121,9 +124,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual(TEST_DESCRIPTION, testNode.SelectSingleNode("properties/property[@name='Description']").Attributes["value"]);
-            Assert.AreEqual(TEST_CATEGORY, testNode.SelectSingleNode("properties/property[@name='Category']").Attributes["value"]);
-            Assert.AreEqual(TEST_PRIORITY, testNode.SelectSingleNode("properties/property[@name='Priority']").Attributes["value"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.SelectSingleNode("properties/property[@name='Description']").Attributes["value"], Is.EqualTo(TEST_DESCRIPTION));
+                Assert.That(testNode.SelectSingleNode("properties/property[@name='Category']").Attributes["value"], Is.EqualTo(TEST_CATEGORY));
+                Assert.That(testNode.SelectSingleNode("properties/property[@name='Priority']").Attributes["value"], Is.EqualTo(TEST_PRIORITY));
+            });
         }
 
         [Test]
@@ -131,7 +137,7 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual(0, testNode.SelectNodes("test-case").Count);
+            Assert.That(testNode.SelectNodes("test-case"), Is.Empty);
         }
 
         [Test]
@@ -139,9 +145,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual(EXPECTED_START.ToString("o"), testNode.Attributes["start-time"]);
-            Assert.AreEqual(EXPECTED_END.ToString("o"), testNode.Attributes["end-time"]);
-            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture), testNode.Attributes["duration"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["start-time"], Is.EqualTo(EXPECTED_START.ToString("o")));
+                Assert.That(testNode.Attributes["end-time"], Is.EqualTo(EXPECTED_END.ToString("o")));
+                Assert.That(testNode.Attributes["duration"], Is.EqualTo(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture)));
+            });
         }
 
         [Test]
@@ -149,10 +158,13 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.NotNull(suiteNode.Attributes["id"]);
-            Assert.AreEqual("test-suite", suiteNode.Name);
-            Assert.AreEqual(_suiteResult.Name, suiteNode.Attributes["name"]);
-            Assert.AreEqual(_suiteResult.FullName, suiteNode.Attributes["fullname"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["id"], Is.Not.Null);
+                Assert.That(suiteNode.Name, Is.EqualTo("test-suite"));
+                Assert.That(suiteNode.Attributes["name"], Is.EqualTo(_suiteResult.Name));
+                Assert.That(suiteNode.Attributes["fullname"], Is.EqualTo(_suiteResult.FullName));
+            });
         }
 
         [Test]
@@ -160,9 +172,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual(SUITE_DESCRIPTION, suiteNode.SelectSingleNode("properties/property[@name='Description']").Attributes["value"]);
-            Assert.AreEqual(SUITE_CATEGORY, suiteNode.SelectSingleNode("properties/property[@name='Category']").Attributes["value"]);
-            Assert.AreEqual(SUITE_LEVEL.ToString(), suiteNode.SelectSingleNode("properties/property[@name='Level']").Attributes["value"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.SelectSingleNode("properties/property[@name='Description']").Attributes["value"], Is.EqualTo(SUITE_DESCRIPTION));
+                Assert.That(suiteNode.SelectSingleNode("properties/property[@name='Category']").Attributes["value"], Is.EqualTo(SUITE_CATEGORY));
+                Assert.That(suiteNode.SelectSingleNode("properties/property[@name='Level']").Attributes["value"], Is.EqualTo(SUITE_LEVEL.ToString()));
+            });
         }
 
         [Test]
@@ -170,7 +185,7 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual(_suiteResult.Children.Count(), suiteNode.SelectNodes("test-case").Count);
+            Assert.That(suiteNode.SelectNodes("test-case"), Has.Count.EqualTo(_suiteResult.Children.Count()));
         }
 
         [Test]
@@ -178,9 +193,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual(EXPECTED_START.ToString("o"), suiteNode.Attributes["start-time"]);
-            Assert.AreEqual(EXPECTED_END.ToString("o"), suiteNode.Attributes["end-time"]);
-            Assert.AreEqual(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture), suiteNode.Attributes["duration"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["start-time"], Is.EqualTo(EXPECTED_START.ToString("o")));
+                Assert.That(suiteNode.Attributes["end-time"], Is.EqualTo(EXPECTED_END.ToString("o")));
+                Assert.That(suiteNode.Attributes["duration"], Is.EqualTo(EXPECTED_DURATION.ToString("0.000000", CultureInfo.InvariantCulture)));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -54,22 +54,28 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsIgnored()
         {
-            Assert.AreEqual(ResultState.Ignored, _testResult.ResultState);
-            Assert.AreEqual(_ignoreReason, _testResult.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Ignored));
+                Assert.That(_testResult.Message, Is.EqualTo(_ignoreReason));
+            });
         }
 
         [Test]
         public void SuiteResultIsIgnored()
         {
-            Assert.AreEqual(ResultState.ChildIgnored, _suiteResult.ResultState);
-            Assert.AreEqual(TestResult.CHILD_IGNORE_MESSAGE, _suiteResult.Message);
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(0, _suiteResult.PassCount);
-            Assert.AreEqual(0, _suiteResult.FailCount);
-            Assert.AreEqual(0, _suiteResult.WarningCount);
-            Assert.AreEqual(1, _suiteResult.SkipCount);
-            Assert.AreEqual(0, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(0, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildIgnored));
+                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_IGNORE_MESSAGE));
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -77,10 +83,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Skipped", testNode.Attributes["result"]);
-            Assert.AreEqual("Ignored", testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Skipped"));
+                Assert.That(testNode.Attributes["label"], Is.EqualTo("Ignored"));
+                Assert.That(testNode.Attributes["site"], Is.EqualTo(null));
+            });
             _xmlReasonNodeValidation(testNode);
         }
 
@@ -89,15 +97,18 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Skipped", suiteNode.Attributes["result"]);
-            Assert.AreEqual("Ignored", suiteNode.Attributes["label"]);
-            Assert.AreEqual("Child", suiteNode.Attributes["site"]);
-            Assert.AreEqual("0", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("1", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Skipped"));
+                Assert.That(suiteNode.Attributes["label"], Is.EqualTo("Ignored"));
+                Assert.That(suiteNode.Attributes["site"], Is.EqualTo("Child"));
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("0"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -54,22 +54,28 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsInconclusive()
         {
-            Assert.AreEqual(ResultState.Inconclusive, _testResult.ResultState);
-            Assert.AreEqual(_inconclusiveReason, _testResult.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
+                Assert.That(_testResult.Message, Is.EqualTo(_inconclusiveReason));
+            });
         }
 
         [Test]
         public void SuiteResultIsInconclusive()
         {
-            Assert.AreEqual(ResultState.Inconclusive, _suiteResult.ResultState);
-            Assert.Null(_suiteResult.Message);
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(0, _suiteResult.PassCount);
-            Assert.AreEqual(0, _suiteResult.FailCount);
-            Assert.AreEqual(0, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(1, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(0, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
+                Assert.That(_suiteResult.Message, Is.Null);
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -77,10 +83,12 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Inconclusive", testNode.Attributes["result"]);
-            Assert.IsNull(testNode.Attributes["label"]);
-            Assert.IsNull(testNode.Attributes["site"]);
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Inconclusive"));
+                Assert.That(testNode.Attributes["label"], Is.Null);
+                Assert.That(testNode.Attributes["site"], Is.Null);
+            });
             _xmlReasonNodeValidation(testNode);
         }
 
@@ -89,14 +97,17 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Inconclusive", suiteNode.Attributes["result"]);
-            Assert.IsNull(suiteNode.Attributes["label"]);
-            Assert.AreEqual("0", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("1", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Inconclusive"));
+                Assert.That(suiteNode.Attributes["label"], Is.Null);
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("0"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultMixedResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultMixedResultTests.cs
@@ -33,18 +33,21 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultIsFailure()
         {
-            Assert.AreEqual(ResultState.ChildFailure, _suiteResult.ResultState);
-            Assert.AreEqual(TestStatus.Failed, _suiteResult.ResultState.Status);
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE, _suiteResult.Message);
-            Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-            Assert.Null(_suiteResult.StackTrace, "There should be no stacktrace");
-            Assert.AreEqual(5, _suiteResult.TotalCount);
-            Assert.AreEqual(2, _suiteResult.PassCount);
-            Assert.AreEqual(1, _suiteResult.FailCount);
-            Assert.AreEqual(1, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(1, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(6, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(_suiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(_suiteResult.StackTrace, Is.Null, "There should be no stacktrace");
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(5));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(2));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(6));
+            });
         }
 
         [Test]
@@ -52,23 +55,27 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Failed", suiteNode.Attributes["result"]);
+            Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Failed"));
             TNode failureNode = suiteNode.SelectSingleNode("failure");
-            Assert.NotNull(failureNode, "No failure element found");
+            Assert.That(failureNode, Is.Not.Null, "No failure element found");
 
             TNode messageNode = failureNode.SelectSingleNode("message");
-            Assert.NotNull(messageNode, "No message element found");
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE, messageNode.Value);
+            Assert.That(messageNode, Is.Not.Null, "No message element found");
+            Assert.That(messageNode.Value, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
 
             TNode stacktraceNode = failureNode.SelectSingleNode("stacktrace");
-            Assert.Null(stacktraceNode, "There should be no stacktrace");
-            Assert.AreEqual("5", suiteNode.Attributes["total"]);
-            Assert.AreEqual("2", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("1", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("1", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("1", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("6", suiteNode.Attributes["asserts"]);
+            Assert.That(stacktraceNode, Is.Null, "There should be no stacktrace");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["total"], Is.EqualTo("5"));
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("2"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("6"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultNotRunnableTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultNotRunnableTests.cs
@@ -16,23 +16,29 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsNotRunnable()
         {
-            Assert.AreEqual(ResultState.NotRunnable, _testResult.ResultState);
-            Assert.AreEqual("bad test", _testResult.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.NotRunnable));
+                Assert.That(_testResult.Message, Is.EqualTo("bad test"));
+            });
         }
 
         [Test]
         public void SuiteResultIsFailure()
         {
-            Assert.AreEqual(ResultState.ChildFailure, _suiteResult.ResultState);
-            Assert.AreEqual(TestResult.CHILD_ERRORS_MESSAGE, _suiteResult.Message);
-            Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(0, _suiteResult.PassCount);
-            Assert.AreEqual(1, _suiteResult.FailCount);
-            Assert.AreEqual(0, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(0, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(0, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -40,14 +46,18 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Failed", testNode.Attributes["result"]);
-            Assert.AreEqual("Invalid", testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Failed"));
+                Assert.That(testNode.Attributes["label"], Is.EqualTo("Invalid"));
+                Assert.That(testNode.Attributes["site"], Is.EqualTo(null));
+            });
+
             TNode failure = testNode.SelectSingleNode("failure");
-            Assert.NotNull(failure);
-            Assert.NotNull(failure.SelectSingleNode("message"));
-            Assert.AreEqual("bad test", failure.SelectSingleNode("message").Value);
-            Assert.Null(failure.SelectSingleNode("stack-trace"));
+            Assert.That(failure, Is.Not.Null);
+            Assert.That(failure.SelectSingleNode("message"), Is.Not.Null);
+            Assert.That(failure.SelectSingleNode("message").Value, Is.EqualTo("bad test"));
+            Assert.That(failure.SelectSingleNode("stack-trace"), Is.Null);
         }
 
         [Test]
@@ -55,15 +65,18 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Failed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual("Child", suiteNode.Attributes["site"]);
-            Assert.AreEqual("0", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("1", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Failed"));
+                Assert.That(suiteNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(suiteNode.Attributes["site"], Is.EqualTo("Child"));
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("0"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultOutputTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultOutputTests.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Internal.Results
             _result.OutWriter.WriteLine(SOME_TEXT);
 
             var outputNode = _result.ToXml(false).SelectSingleNode("output");
-            Assert.NotNull(outputNode, "No output node found in XML");
+            Assert.That(outputNode, Is.Not.Null, "No output node found in XML");
             Assert.That(outputNode.Value, Is.EqualTo(SOME_TEXT + NL));
         }
 
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Internal.Results
             _result.OutWriter.WriteLine("Last line!");
 
             var outputNode = _result.ToXml(false).SelectSingleNode("output");
-            Assert.NotNull(outputNode, "No output node found in XML");
+            Assert.That(outputNode, Is.Not.Null, "No output node found in XML");
             Assert.That(outputNode.Value, Is.EqualTo(SOME_TEXT + NL +
                 "More text written in segments." + NL + "Last line!" + NL));
         }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
@@ -58,21 +58,27 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsSuccess()
         {
-            Assert.True(_testResult.ResultState == ResultState.Success);
-            Assert.AreEqual(_successMessage, _testResult.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Success));
+                Assert.That(_testResult.Message, Is.EqualTo(_successMessage));
+            });
         }
 
         [Test]
         public void SuiteResultIsSuccess()
         {
-            Assert.True(_suiteResult.ResultState == ResultState.Success);
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(1, _suiteResult.PassCount);
-            Assert.AreEqual(0, _suiteResult.FailCount);
-            Assert.AreEqual(0, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(0, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(2, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.Success));
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -80,10 +86,13 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Passed", testNode.Attributes["result"]);
-            Assert.AreEqual(null, testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
-            Assert.AreEqual("2", testNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Passed"));
+                Assert.That(testNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(testNode.Attributes["site"], Is.EqualTo(null));
+                Assert.That(testNode.Attributes["asserts"], Is.EqualTo("2"));
+            });
 
             _xmlReasonNodeValidation(testNode);
         }
@@ -93,16 +102,19 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Passed", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual(null, suiteNode.Attributes["site"]);
-            Assert.AreEqual("1", suiteNode.Attributes["total"]);
-            Assert.AreEqual("1", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("2", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Passed"));
+                Assert.That(suiteNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(suiteNode.Attributes["site"], Is.EqualTo(null));
+                Assert.That(suiteNode.Attributes["total"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("2"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -30,16 +30,16 @@ namespace NUnit.Framework.Internal.Results
         protected static void ReasonNodeExpectedValidation(TNode testNode, string reasonMessage)
         {
             TNode reason = testNode.SelectSingleNode("reason");
-            Assert.NotNull(reason);
-            Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual(reasonMessage, reason.SelectSingleNode("message").Value);
-            Assert.Null(reason.SelectSingleNode("stack-trace"));
+            Assert.That(reason, Is.Not.Null);
+            Assert.That(reason.SelectSingleNode("message"), Is.Not.Null);
+            Assert.That(reason.SelectSingleNode("message").Value, Is.EqualTo(reasonMessage));
+            Assert.That(reason.SelectSingleNode("stack-trace"), Is.Null);
         }
 
         protected static void NoReasonNodeExpectedValidation(TNode testNode)
         {
             TNode reason = testNode.SelectSingleNode("reason");
-            Assert.IsNull(reason, "This test expects no reason element to be present in the XML representation.");
+            Assert.That(reason, Is.Null, "This test expects no reason element to be present in the XML representation.");
         }
 
         #region Nested DummySuite

--- a/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
@@ -16,22 +16,28 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultIsWarning()
         {
-            Assert.AreEqual(ResultState.Warning, _testResult.ResultState);
-            Assert.AreEqual("Warning message", _testResult.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Warning));
+                Assert.That(_testResult.Message, Is.EqualTo("Warning message"));
+            });
         }
 
         [Test]
         public void SuiteResultIsWarning()
         {
-            Assert.AreEqual(ResultState.ChildWarning, _suiteResult.ResultState);
-            Assert.AreEqual(TestResult.CHILD_WARNINGS_MESSAGE, _suiteResult.Message);
-            Assert.AreEqual(1, _suiteResult.TotalCount);
-            Assert.AreEqual(0, _suiteResult.PassCount);
-            Assert.AreEqual(0, _suiteResult.FailCount);
-            Assert.AreEqual(1, _suiteResult.WarningCount);
-            Assert.AreEqual(0, _suiteResult.SkipCount);
-            Assert.AreEqual(0, _suiteResult.InconclusiveCount);
-            Assert.AreEqual(0, _suiteResult.AssertCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildWarning));
+                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_WARNINGS_MESSAGE));
+                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.WarningCount, Is.EqualTo(1));
+                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -39,15 +45,18 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode testNode = _testResult.ToXml(true);
 
-            Assert.AreEqual("Warning", testNode.Attributes["result"]);
-            Assert.AreEqual(null, testNode.Attributes["label"]);
-            Assert.AreEqual(null, testNode.Attributes["site"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(testNode.Attributes["result"], Is.EqualTo("Warning"));
+                Assert.That(testNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(testNode.Attributes["site"], Is.EqualTo(null));
+            });
 
             TNode reason = testNode.SelectSingleNode("reason");
-            Assert.NotNull(reason);
-            Assert.NotNull(reason.SelectSingleNode("message"));
-            Assert.AreEqual("Warning message", reason.SelectSingleNode("message").Value);
-            Assert.Null(reason.SelectSingleNode("stack-trace"));
+            Assert.That(reason, Is.Not.Null);
+            Assert.That(reason.SelectSingleNode("message"), Is.Not.Null);
+            Assert.That(reason.SelectSingleNode("message").Value, Is.EqualTo("Warning message"));
+            Assert.That(reason.SelectSingleNode("stack-trace"), Is.Null);
         }
 
         [Test]
@@ -55,15 +64,18 @@ namespace NUnit.Framework.Internal.Results
         {
             TNode suiteNode = _suiteResult.ToXml(true);
 
-            Assert.AreEqual("Warning", suiteNode.Attributes["result"]);
-            Assert.AreEqual(null, suiteNode.Attributes["label"]);
-            Assert.AreEqual("Child", suiteNode.Attributes["site"]);
-            Assert.AreEqual("0", suiteNode.Attributes["passed"]);
-            Assert.AreEqual("0", suiteNode.Attributes["failed"]);
-            Assert.AreEqual("1", suiteNode.Attributes["warnings"]);
-            Assert.AreEqual("0", suiteNode.Attributes["skipped"]);
-            Assert.AreEqual("0", suiteNode.Attributes["inconclusive"]);
-            Assert.AreEqual("0", suiteNode.Attributes["asserts"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Warning"));
+                Assert.That(suiteNode.Attributes["label"], Is.EqualTo(null));
+                Assert.That(suiteNode.Attributes["site"], Is.EqualTo("Child"));
+                Assert.That(suiteNode.Attributes["passed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["failed"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["warnings"], Is.EqualTo("1"));
+                Assert.That(suiteNode.Attributes["skipped"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["inconclusive"], Is.EqualTo("0"));
+                Assert.That(suiteNode.Attributes["asserts"], Is.EqualTo("0"));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -20,9 +20,11 @@ namespace NUnit.Framework.Internal
         public void CanGetCurrentFramework()
         {
             RuntimeFramework framework = RuntimeFramework.CurrentFramework;
-
-            Assert.That(framework.Runtime, Is.EqualTo(currentRuntime), "#1");
-            Assert.That(framework.ClrVersion, Is.EqualTo(Environment.Version), "#2");
+            Assert.Multiple(() =>
+            {
+                Assert.That(framework.Runtime, Is.EqualTo(currentRuntime), "#1");
+                Assert.That(framework.ClrVersion, Is.EqualTo(Environment.Version), "#2");
+            });
         }
 
         [Test]
@@ -43,16 +45,19 @@ namespace NUnit.Framework.Internal
 #else
             isNetCore = false;
 #endif
-            Assert.AreEqual(isNetCore, platformHelper.IsPlatformSupported("netcore"));
+            Assert.That(platformHelper.IsPlatformSupported("netcore"), Is.EqualTo(isNetCore));
         }
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanCreateUsingFrameworkVersion(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.Runtime, data.FrameworkVersion);
-            Assert.AreEqual(data.Runtime, framework.Runtime, "#1");
-            Assert.AreEqual(data.FrameworkVersion, framework.FrameworkVersion, "#2");
-            Assert.AreEqual(data.ClrVersion, framework.ClrVersion, "#3");
+            Assert.Multiple(() =>
+            {
+                Assert.That(framework.Runtime, Is.EqualTo(data.Runtime), "#1");
+                Assert.That(framework.FrameworkVersion, Is.EqualTo(data.FrameworkVersion), "#2");
+                Assert.That(framework.ClrVersion, Is.EqualTo(data.ClrVersion), "#3");
+            });
         }
 
         [TestCaseSource(nameof(frameworkData))]
@@ -64,25 +69,34 @@ namespace NUnit.Framework.Internal
             Assume.That(data.Runtime != RuntimeType.NetCore, "#0");
 
             RuntimeFramework framework = new RuntimeFramework(data.Runtime, data.ClrVersion);
-            Assert.AreEqual(data.Runtime, framework.Runtime, "#1");
-            Assert.AreEqual(data.FrameworkVersion, framework.FrameworkVersion, "#2");
-            Assert.AreEqual(data.ClrVersion, framework.ClrVersion, "#3");
+            Assert.Multiple(() =>
+            {
+                Assert.That(framework.Runtime, Is.EqualTo(data.Runtime), "#1");
+                Assert.That(framework.FrameworkVersion, Is.EqualTo(data.FrameworkVersion), "#2");
+                Assert.That(framework.ClrVersion, Is.EqualTo(data.ClrVersion), "#3");
+            });
         }
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanParseRuntimeFramework(FrameworkData data)
         {
             RuntimeFramework framework = RuntimeFramework.Parse(data.Representation);
-            Assert.AreEqual(data.Runtime, framework.Runtime, "#1");
-            Assert.AreEqual(data.ClrVersion, framework.ClrVersion, "#2");
+            Assert.Multiple(() =>
+            {
+                Assert.That(framework.Runtime, Is.EqualTo(data.Runtime), "#1");
+                Assert.That(framework.ClrVersion, Is.EqualTo(data.ClrVersion), "#2");
+            });
         }
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanDisplayFrameworkAsString(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.Runtime, data.FrameworkVersion);
-            Assert.AreEqual(data.Representation, framework.ToString(), "#1");
-            Assert.AreEqual(data.DisplayName, framework.DisplayName, "#2");
+            Assert.Multiple(() =>
+            {
+                Assert.That(framework.ToString(), Is.EqualTo(data.Representation), "#1");
+                Assert.That(framework.DisplayName, Is.EqualTo(data.DisplayName), "#2");
+            });
         }
 
         [TestCaseSource(nameof(matchData))]

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -56,31 +56,41 @@ namespace NUnit.Framework.Internal
         public void NamespaceSetUpFixtureReplacesNamespaceNodeInTree()
         {
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace1";
-            IDictionary<string, object> options = new Dictionary<string, object>();
-            options["LOAD"] = new[] { nameSpace };
+            IDictionary<string, object> options = new Dictionary<string, object>
+            {
+                ["LOAD"] = new[] { nameSpace }
+            };
             ITest suite = builder.Build(ASSEMBLY_PATH, options);
 
-            Assert.IsNotNull(suite);
-
-            Assert.AreEqual(ASSEMBLY_PATH, suite.FullName);
-            Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
+            Assert.That(suite, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.FullName, Is.EqualTo(ASSEMBLY_PATH));
+                Assert.That(suite.Tests, Has.Count.EqualTo(1), "Error in top level test count");
+            });
 
             string[] nameSpaceBits = ("[default namespace]." + nameSpace).Split('.');
             for (int i = 0; i < nameSpaceBits.Length; i++)
             {
                 suite = suite.Tests[0] as TestSuite;
-                Assert.AreEqual(nameSpaceBits[i], suite.Name);
-                Assert.AreEqual(1, suite.Tests.Count);
-                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(suite.Name, Is.EqualTo(nameSpaceBits[i]));
+                    Assert.That(suite.Tests, Has.Count.EqualTo(1));
+                    Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                });
             }
 
             Assert.That(suite, Is.InstanceOf<SetUpFixture>());
 
             suite = suite.Tests[0] as TestSuite;
-            Assert.AreEqual("SomeFixture", suite.Name);
-            Assert.AreEqual(1, suite.Tests.Count);
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Name, Is.EqualTo("SomeFixture"));
+                Assert.That(suite.Tests, Has.Count.EqualTo(1));
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+            });
         }
 
         /// <summary>
@@ -97,38 +107,48 @@ namespace NUnit.Framework.Internal
             Assert.That(setupFixture, Is.TypeOf<SetUpFixture>());
 
             var testFixture = TestFinder.Find("SomeFixture", (SetUpFixture)setupFixture, false);
-            Assert.NotNull(testFixture);
-            Assert.AreEqual(1, testFixture.Tests.Count);
+            Assert.That(testFixture, Is.Not.Null);
+            Assert.That(testFixture.Tests, Has.Count.EqualTo(1));
         }
 
         [Test]
         public void InvalidAssemblySetUpFixtureIsLoadedCorrectly()
         {
             string nameSpace = "NUnit.TestData.SetupFixture.Namespace6";
-            IDictionary<string, object> options = new Dictionary<string, object>();
-            options["LOAD"] = new[] { nameSpace };
+            IDictionary<string, object> options = new Dictionary<string, object>
+            {
+                ["LOAD"] = new[] { nameSpace }
+            };
             ITest suite = builder.Build(ASSEMBLY_PATH, options);
 
-            Assert.IsNotNull(suite);
-
-            Assert.AreEqual(ASSEMBLY_PATH, suite.FullName);
-            Assert.AreEqual(1, suite.Tests.Count, "Error in top level test count");
-            Assert.AreEqual(RunState.Runnable, suite.RunState);
+            Assert.That(suite, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.FullName, Is.EqualTo(ASSEMBLY_PATH));
+                Assert.That(suite.Tests, Has.Count.EqualTo(1), "Error in top level test count");
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            });
 
             string[] nameSpaceBits = ("[default namespace]." + nameSpace).Split('.');
             for (int i = 0; i < nameSpaceBits.Length; i++)
             {
                 suite = suite.Tests[0] as TestSuite;
-                Assert.AreEqual(nameSpaceBits[i], suite.Name);
-                Assert.AreEqual(1, suite.Tests.Count);
-                Assert.That(suite.RunState, Is.EqualTo(i < nameSpaceBits.Length - 1 ? RunState.Runnable : RunState.NotRunnable));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(suite.Name, Is.EqualTo(nameSpaceBits[i]));
+                    Assert.That(suite.Tests, Has.Count.EqualTo(1));
+                    Assert.That(suite.RunState, Is.EqualTo(i < nameSpaceBits.Length - 1 ? RunState.Runnable : RunState.NotRunnable));
+                });
             }
 
             suite = suite.Tests[0] as TestSuite;
-            Assert.AreEqual("SomeFixture", suite.Name);
-            Assert.AreEqual(1, suite.Tests.Count);
-            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
-            Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.Name, Is.EqualTo("SomeFixture"));
+                Assert.That(suite.Tests, Has.Count.EqualTo(1));
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+            });
         }
 
         #endregion
@@ -281,11 +301,14 @@ namespace NUnit.Framework.Internal
         public void AssemblySetupFixtureWrapsExecutionOfTest()
         {
             ITestResult result = RunTests(null, new Filters.FullNameFilter("SomeFixture"));
-            Assert.AreEqual(1, result.PassCount);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-            TestUtilities.SimpleEventRecorder.Verify("Assembly.OneTimeSetUp",
-                                                     "NoNamespaceTest",
-                                                     "Assembly.OneTimeTearDown");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.PassCount, Is.EqualTo(1));
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            });
+            SimpleEventRecorder.Verify("Assembly.OneTimeSetUp",
+                                       "NoNamespaceTest",
+                                       "Assembly.OneTimeTearDown");
         }
         #endregion NoNamespaceSetupFixture
     }

--- a/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
@@ -17,8 +17,8 @@ namespace NUnit.Framework.Internal
             SetUpAndTearDownCounterFixture fixture = new SetUpAndTearDownCounterFixture();
             TestBuilder.RunTestFixture( fixture );
 
-            Assert.AreEqual(3, fixture.SetUpCounter);
-            Assert.AreEqual(3, fixture.TearDownCounter);
+            Assert.That(fixture.SetUpCounter, Is.EqualTo(3));
+            Assert.That(fixture.TearDownCounter, Is.EqualTo(3));
         }
 
 
@@ -28,8 +28,8 @@ namespace NUnit.Framework.Internal
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             TestBuilder.RunTestFixture( fixture );
 
-            Assert.IsTrue(fixture.WasSetUpCalled);
-            Assert.IsTrue(fixture.WasTearDownCalled);
+            Assert.That(fixture.WasSetUpCalled, Is.True);
+            Assert.That(fixture.WasTearDownCalled, Is.True);
         }
 
         [Test]
@@ -38,8 +38,8 @@ namespace NUnit.Framework.Internal
             InheritSetUpAndTearDown fixture = new InheritSetUpAndTearDown();
             TestBuilder.RunTestFixture( fixture );
 
-            Assert.IsTrue(fixture.WasSetUpCalled);
-            Assert.IsTrue(fixture.WasTearDownCalled);
+            Assert.That(fixture.WasSetUpCalled, Is.True);
+            Assert.That(fixture.WasTearDownCalled, Is.True);
         }
 
         [Test]
@@ -48,10 +48,10 @@ namespace NUnit.Framework.Internal
             DefineInheritSetUpAndTearDown fixture = new DefineInheritSetUpAndTearDown();
             TestBuilder.RunTestFixture( fixture );
 
-            Assert.IsFalse(fixture.WasSetUpCalled);
-            Assert.IsFalse(fixture.WasTearDownCalled);
-            Assert.IsTrue(fixture.DerivedSetUpCalled);
-            Assert.IsTrue(fixture.DerivedTearDownCalled);
+            Assert.That(fixture.WasSetUpCalled, Is.False);
+            Assert.That(fixture.WasTearDownCalled, Is.False);
+            Assert.That(fixture.DerivedSetUpCalled, Is.True);
+            Assert.That(fixture.DerivedTearDownCalled, Is.True);
         }
 
         [Test]
@@ -60,11 +60,11 @@ namespace NUnit.Framework.Internal
             MultipleSetUpTearDownFixture fixture = new MultipleSetUpTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.IsTrue(fixture.WasSetUp1Called, "SetUp1");
-            Assert.IsTrue(fixture.WasSetUp2Called, "SetUp2");
-            Assert.IsTrue(fixture.WasSetUp3Called, "SetUp3");
-            Assert.IsTrue(fixture.WasTearDown1Called, "TearDown1");
-            Assert.IsTrue(fixture.WasTearDown2Called, "TearDown2");
+            Assert.That(fixture.WasSetUp1Called, Is.True, "SetUp1");
+            Assert.That(fixture.WasSetUp2Called, Is.True, "SetUp2");
+            Assert.That(fixture.WasSetUp3Called, Is.True, "SetUp3");
+            Assert.That(fixture.WasTearDown1Called, Is.True, "TearDown1");
+            Assert.That(fixture.WasTearDown2Called, Is.True, "TearDown2");
         }
 
         [Test]
@@ -73,12 +73,12 @@ namespace NUnit.Framework.Internal
             DerivedClassWithSeparateSetUp fixture = new DerivedClassWithSeparateSetUp();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.IsTrue(fixture.WasSetUpCalled, "Base SetUp Called");
-            Assert.IsTrue(fixture.WasTearDownCalled, "Base TearDown Called");
-            Assert.IsTrue(fixture.WasDerivedSetUpCalled, "Derived SetUp Called");
-            Assert.IsTrue(fixture.WasDerivedTearDownCalled, "Derived TearDown Called");
-            Assert.IsTrue(fixture.WasBaseSetUpCalledFirst, "SetUp Order");
-            Assert.IsTrue(fixture.WasBaseTearDownCalledLast, "TearDown Order");
+            Assert.That(fixture.WasSetUpCalled, Is.True, "Base SetUp Called");
+            Assert.That(fixture.WasTearDownCalled, Is.True, "Base TearDown Called");
+            Assert.That(fixture.WasDerivedSetUpCalled, Is.True, "Derived SetUp Called");
+            Assert.That(fixture.WasDerivedTearDownCalled, Is.True, "Derived TearDown Called");
+            Assert.That(fixture.WasBaseSetUpCalledFirst, Is.True, "SetUp Order");
+            Assert.That(fixture.WasBaseTearDownCalledLast, Is.True, "TearDown Order");
         }
 
         [Test]
@@ -88,10 +88,10 @@ namespace NUnit.Framework.Internal
             fixture.ThrowInBaseSetUp = true;
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.IsTrue(fixture.WasSetUpCalled, "Base SetUp Called");
-            Assert.IsTrue(fixture.WasTearDownCalled, "Base TearDown Called");
-            Assert.IsFalse(fixture.WasDerivedSetUpCalled, "Derived SetUp Called");
-            Assert.IsFalse(fixture.WasDerivedTearDownCalled, "Derived TearDown Called");
+            Assert.That(fixture.WasSetUpCalled, Is.True, "Base SetUp Called");
+            Assert.That(fixture.WasTearDownCalled, Is.True, "Base TearDown Called");
+            Assert.That(fixture.WasDerivedSetUpCalled, Is.False, "Derived SetUp Called");
+            Assert.That(fixture.WasDerivedTearDownCalled, Is.False, "Derived TearDown Called");
         }
 
         [Test]
@@ -101,11 +101,11 @@ namespace NUnit.Framework.Internal
             SetupAndTearDownExceptionFixture fixture = new SetupAndTearDownExceptionFixture();
             fixture.SetupException = e;
             ITestResult suiteResult = TestBuilder.RunTestFixture(fixture);
-            Assert.IsTrue(suiteResult.HasChildren, "Fixture test should have child result.");
+            Assert.That(suiteResult.HasChildren, Is.True, "Fixture test should have child result.");
             ITestResult result = suiteResult.Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Error, result.ResultState, "Test should be in error state");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "Test should be in error state");
             string expected = $"{e.GetType().FullName} : {e.Message}";
-            Assert.AreEqual(expected, result.Message);
+            Assert.That(result.Message, Is.EqualTo(expected));
 
             PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
             {
@@ -122,9 +122,9 @@ namespace NUnit.Framework.Internal
             ITestResult suiteResult = TestBuilder.RunTestFixture(fixture);
             Assert.That(suiteResult.HasChildren, "Fixture test should have child result.");
             ITestResult result = suiteResult.Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Error, result.ResultState, "Test should be in error state");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "Test should be in error state");
             string expected = $"TearDown : {e.GetType().FullName} : {e.Message}";
-            Assert.AreEqual(expected, result.Message);
+            Assert.That(result.Message, Is.EqualTo(expected));
             Assert.That(result.StackTrace, Does.StartWith("--TearDown"));
 
             PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
@@ -144,10 +144,10 @@ namespace NUnit.Framework.Internal
             ITestResult suiteResult = TestBuilder.RunTestFixture(fixture);
             Assert.That(suiteResult.HasChildren, "Fixture test should have child result.");
             ITestResult result = suiteResult.Children.ToArray()[0];
-            Assert.AreEqual(ResultState.Error, result.ResultState, "Test should be in error state");
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "Test should be in error state");
             string expected = $"{e1.GetType().FullName} : {e1.Message}" + Environment.NewLine
                                                                         + $"TearDown : {e2.GetType().FullName} : {e2.Message}";
-            Assert.AreEqual(expected, result.Message);
+            Assert.That(result.Message, Is.EqualTo(expected));
             Assert.That(result.StackTrace, Does.Contain("--TearDown"));
 
             PlatformInconsistency.MonoMethodInfoInvokeLosesStackTrace.SkipOnAffectedPlatform(() =>
@@ -181,7 +181,7 @@ namespace NUnit.Framework.Internal
             [Test]
             public override void AssertCount()
             {
-                Assert.AreEqual(2, SetupCount);
+                Assert.That(SetupCount, Is.EqualTo(2));
             }
         }
     }

--- a/src/NUnitFramework/tests/Internal/StringTokenEnumeratorTests.cs
+++ b/src/NUnitFramework/tests/Internal/StringTokenEnumeratorTests.cs
@@ -11,25 +11,25 @@ namespace NUnit.Framework.Internal
         public void Empty()
         {
             var tokens = Enumerate("", ',');
-            Assert.AreEqual(0, tokens.Count);
+            Assert.That(tokens, Is.Empty);
         }
 
         [Test]
         public void Whitespace()
         {
             var tokens = Enumerate("  ", ',');
-            Assert.AreEqual(1, tokens.Count);
-            Assert.AreEqual("  ", tokens[0]);
+            Assert.That(tokens, Has.Count.EqualTo(1));
+            Assert.That(tokens[0], Is.EqualTo("  "));
         }
 
         [Test]
         public void Tokens()
         {
             var tokens = Enumerate("a,b,c", ',');
-            Assert.AreEqual(3, tokens.Count);
-            Assert.AreEqual("a", tokens[0]);
-            Assert.AreEqual("b", tokens[1]);
-            Assert.AreEqual("c", tokens[2]);
+            Assert.That(tokens, Has.Count.EqualTo(3));
+            Assert.That(tokens[0], Is.EqualTo("a"));
+            Assert.That(tokens[1], Is.EqualTo("b"));
+            Assert.That(tokens[2], Is.EqualTo("c"));
         }
 
         [TestCase("aaa,,cccdd", ',', false)]

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Diagnostics;
+#if NETFRAMEWORK
 using System.Reflection;
+#endif
 using System.Threading;
 using System.Globalization;
 using System.IO;
@@ -93,7 +95,7 @@ namespace NUnit.Framework.Internal
         {
             var context = TestExecutionContext.CurrentContext;
             await YieldAsync();
-            Assert.AreSame(context, TestExecutionContext.CurrentContext);
+            Assert.That(TestExecutionContext.CurrentContext, Is.SameAs(context));
         }
 
         [Test]
@@ -102,9 +104,9 @@ namespace NUnit.Framework.Internal
             var expected = TestExecutionContext.CurrentContext;
             var parallelResult = await WhenAllAsync(YieldAndReturnContext(), YieldAndReturnContext());
 
-            Assert.AreSame(expected, TestExecutionContext.CurrentContext);
-            Assert.AreSame(expected, parallelResult[0]);
-            Assert.AreSame(expected, parallelResult[1]);
+            Assert.That(TestExecutionContext.CurrentContext, Is.SameAs(expected));
+            Assert.That(parallelResult[0], Is.SameAs(expected));
+            Assert.That(parallelResult[1], Is.SameAs(expected));
         }
 
         [Test]
@@ -227,7 +229,7 @@ namespace NUnit.Framework.Internal
         [TestCase(123, "abc")]
         public void TestCanAccessItsOwnArguments(int i, string s)
         {
-            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {123, "abc"}));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {i, s}));
         }
 
         [Test]
@@ -278,9 +280,9 @@ namespace NUnit.Framework.Internal
         [TestCase(123, "abc")]
         public async Task AsyncTestCanAccessItsOwnArguments(int i, string s)
         {
-            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {123, "abc"}));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {i, s}));
             await YieldAsync();
-            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {123, "abc"}));
+            Assert.That(TestExecutionContext.CurrentContext.CurrentTest.Arguments, Is.EqualTo(new object[] {i, s}));
         }
 
         [Test]
@@ -718,17 +720,17 @@ namespace NUnit.Framework.Internal
                 CultureInfo otherCulture =
                     new CultureInfo(originalCulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
                 context.CurrentCulture = otherCulture;
-                Assert.AreEqual(otherCulture, CultureInfo.CurrentCulture, "Culture was not set");
-                Assert.AreEqual(otherCulture, context.CurrentCulture, "Culture not in new context");
-                Assert.AreEqual(_setupContext.CurrentCulture, originalCulture, "Original context should not change");
+                Assert.That(CultureInfo.CurrentCulture, Is.EqualTo(otherCulture), "Culture was not set");
+                Assert.That(context.CurrentCulture, Is.EqualTo(otherCulture), "Culture not in new context");
+                Assert.That(originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.AreEqual(CultureInfo.CurrentCulture, originalCulture, "Culture was not restored");
-            Assert.AreEqual(_setupContext.CurrentCulture, originalCulture, "Culture not in final context");
+            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture was not restored");
+            Assert.That(originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Culture not in final context");
         }
 
         [Test]
@@ -741,17 +743,17 @@ namespace NUnit.Framework.Internal
                 CultureInfo otherCulture =
                     new CultureInfo(originalUICulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
                 context.CurrentUICulture = otherCulture;
-                Assert.AreEqual(otherCulture, CultureInfo.CurrentUICulture, "UICulture was not set");
-                Assert.AreEqual(otherCulture, context.CurrentUICulture, "UICulture not in new context");
-                Assert.AreEqual(_setupContext.CurrentUICulture, originalUICulture, "Original context should not change");
+                Assert.That(CultureInfo.CurrentUICulture, Is.EqualTo(otherCulture), "UICulture was not set");
+                Assert.That(context.CurrentUICulture, Is.EqualTo(otherCulture), "UICulture not in new context");
+                Assert.That(originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.AreEqual(CultureInfo.CurrentUICulture, originalUICulture, "UICulture was not restored");
-            Assert.AreEqual(_setupContext.CurrentUICulture, originalUICulture, "UICulture not in final context");
+            Assert.That(originalUICulture, Is.EqualTo(CultureInfo.CurrentUICulture), "UICulture was not restored");
+            Assert.That(originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "UICulture not in final context");
         }
 
 #endregion
@@ -785,17 +787,17 @@ namespace NUnit.Framework.Internal
             {
                 GenericIdentity identity = new GenericIdentity("foo");
                 context.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
-                Assert.AreEqual("foo", Thread.CurrentPrincipal.Identity.Name, "Principal was not set");
-                Assert.AreEqual("foo", context.CurrentPrincipal.Identity.Name, "Principal not in new context");
-                Assert.AreEqual(_setupContext.CurrentPrincipal, originalPrincipal, "Original context should not change");
+                Assert.That(Thread.CurrentPrincipal.Identity.Name, Is.EqualTo("foo"), "Principal was not set");
+                Assert.That(context.CurrentPrincipal.Identity.Name, Is.EqualTo("foo"), "Principal not in new context");
+                Assert.That(originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.AreEqual(Thread.CurrentPrincipal, originalPrincipal, "Principal was not restored");
-            Assert.AreEqual(_setupContext.CurrentPrincipal, originalPrincipal, "Principal not in final context");
+            Assert.That(originalPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Principal was not restored");
+            Assert.That(originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Principal not in final context");
         }
 
 #endregion
@@ -833,7 +835,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void SingleThreadedDefaultsToFalse()
         {
-            Assert.False(new TestExecutionContext().IsSingleThreaded);
+            Assert.That(new TestExecutionContext().IsSingleThreaded, Is.False);
         }
 
         [Test]
@@ -841,7 +843,7 @@ namespace NUnit.Framework.Internal
         {
             var parent = new TestExecutionContext();
             parent.IsSingleThreaded = true;
-            Assert.True(new TestExecutionContext(parent).IsSingleThreaded);
+            Assert.That(new TestExecutionContext(parent).IsSingleThreaded, Is.True);
         }
 
 #endregion
@@ -899,7 +901,7 @@ namespace NUnit.Framework.Internal
 
             var obj = domain.CreateInstanceAndUnwrap("nunit.framework.tests", "NUnit.Framework.Internal.TestExecutionContextTests+TestClass");
 
-            Assert.NotNull(obj);
+            Assert.That(obj, Is.Not.Null);
         }
 
         [Serializable]

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -25,8 +25,8 @@ namespace NUnit.Framework.Internal
         private static void CanConstructFrom(Type fixtureType, string expectedName)
         {
             TestSuite fixture = TestBuilder.MakeFixture(fixtureType);
-            Assert.AreEqual(expectedName, fixture.Name);
-            Assert.AreEqual(fixtureType.FullName, fixture.FullName);
+            Assert.That(fixture.Name, Is.EqualTo(expectedName));
+            Assert.That(fixture.FullName, Is.EqualTo(fixtureType.FullName));
         }
 
         private static Type GetTestDataType(string typeName)
@@ -54,6 +54,7 @@ namespace NUnit.Framework.Internal
             CanConstructFrom(typeof(OuterClass.NestedTestFixture.DoublyNestedTestFixture), "OuterClass+NestedTestFixture+DoublyNestedTestFixture");
         }
 
+        [Test]
         public void ConstructFromTypeWithoutTestFixtureAttributeContainingTest()
         {
             CanConstructFrom(typeof(FixtureWithoutTestFixtureAttributeContainingTest));
@@ -107,7 +108,7 @@ namespace NUnit.Framework.Internal
         public void CapturesArgumentsForConstructorWithMultipleArgsSupplied()
         {
             var fixture = TestBuilder.MakeFixture(typeof(FixtureWithMultipleArgsSupplied));
-            Assert.True(fixture.HasChildren);
+            Assert.That(fixture.HasChildren, Is.True);
 
             var expectedArgumentSeries = new[]
             {
@@ -143,40 +144,39 @@ namespace NUnit.Framework.Internal
         public void FixtureUsingIgnoreAttributeIsIgnored()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreAttribute));
-            Assert.AreEqual(RunState.Ignored, suite.RunState);
-            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Ignored));
+            Assert.That(suite.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("testing ignore a fixture"));
         }
 
         [Test]
         public void FixtureWithNestedIgnoreAttributeIsIgnored() {
             TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreAttribute.SubFixture));
-            Assert.AreEqual(RunState.Ignored, suite.RunState);
-            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Ignored));
+            Assert.That(suite.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("testing ignore a fixture"));
         }
 
         [Test]
         public void FixtureUsingIgnorePropertyIsIgnored()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreProperty));
-            Assert.AreEqual(RunState.Ignored, suite.RunState);
-            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Ignored));
+            Assert.That(suite.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("testing ignore a fixture"));
         }
 
         [Test]
         public void FixtureUsingIgnoreReasonPropertyIsIgnored()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureUsingIgnoreReasonProperty));
-            Assert.AreEqual(RunState.Ignored, suite.RunState);
-            Assert.AreEqual("testing ignore a fixture", suite.Properties.Get(PropertyNames.SkipReason));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Ignored));
+            Assert.That(suite.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("testing ignore a fixture"));
         }
 
         [Test]
         public void FixtureWithParallelizableOnOneTimeSetUpIsInvalid()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureWithParallelizableOnOneTimeSetUp));
-            Assert.AreEqual(RunState.NotRunnable, suite.RunState);
-            Assert.AreEqual("ParallelizableAttribute is only allowed on test methods and fixtures",
-                suite.Properties.Get(PropertyNames.SkipReason));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.NotRunnable));
+            Assert.That(suite.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("ParallelizableAttribute is only allowed on test methods and fixtures"));
         }
 
         //		[Test]
@@ -208,7 +208,7 @@ namespace NUnit.Framework.Internal
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(DoubleDerivedClassWithTwoInheritedAttributes));
             Assert.That(suite, Is.TypeOf(typeof(TestFixture)));
-            Assert.That(suite.Tests.Count, Is.EqualTo(0));
+            Assert.That(suite.Tests, Is.Empty);
         }
 
         [Test]
@@ -248,7 +248,7 @@ namespace NUnit.Framework.Internal
             // GetTestDataType("NUnit.TestData.TestFixtureData.GenericFixtureWithProperArgsProvided`1"));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(2));
+            Assert.That(suite.Tests, Has.Count.EqualTo(2));
         }
 
 //        [Test]
@@ -288,7 +288,7 @@ namespace NUnit.Framework.Internal
             // GetTestDataType("NUnit.TestData.TestFixtureData.GenericFixtureDerivedFromAbstractFixtureWithArgsProvided`1"));
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             Assert.That(suite is ParameterizedFixtureSuite);
-            Assert.That(suite.Tests.Count, Is.EqualTo(2));
+            Assert.That(suite.Tests, Has.Count.EqualTo(2));
         }
 
         #region SetUp Signature

--- a/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
@@ -41,11 +41,14 @@ namespace NUnit.Framework.Internal
         public void TestMethodHasAttributesAppliedCorrectlyEvenIfNotRunnable()
         {
             var test = TestBuilder.MakeTestCase(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvidedAndExtraAttributes));
-            // NOTE: IgnoreAttribute has no effect, either on RunState or on the reason
-            Assert.That(test.RunState == RunState.NotRunnable);
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("No arguments were provided"));
-            Assert.That(test.Properties.Get(PropertyNames.Description), Is.EqualTo("My test"));
-            Assert.That(test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(47));
+            Assert.Multiple(() =>
+            {
+                // NOTE: IgnoreAttribute has no effect, either on RunState or on the reason
+                Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+                Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("No arguments were provided"));
+                Assert.That(test.Properties.Get(PropertyNames.Description), Is.EqualTo("My test"));
+                Assert.That(test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(47));
+            });
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestProgressReporterTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var startReport = _listener.Reports.FirstOrDefault();
-            Assert.NotNull(startReport);
+            Assert.That(startReport, Is.Not.Null);
             Assert.That(startReport, Does.StartWith("<start-suite"));
             Assert.That(startReport, Contains.Substring("type=\"Assembly\""));
 
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var startReport = _listener.Reports.FirstOrDefault();
-            Assert.NotNull(startReport);
+            Assert.That(startReport, Is.Not.Null);
             Assert.That(startReport, Does.StartWith("<start-suite"));
             Assert.That(startReport, Contains.Substring($"framework-version=\"{typeof(TestProgressReporter).Assembly.GetName().Version}\""));
         }
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var endReport = _listener.Reports.LastOrDefault();
-            Assert.NotNull(endReport);
+            Assert.That(endReport, Is.Not.Null);
             Assert.That(endReport, Does.StartWith("<test-suite"));
             Assert.That(endReport, Contains.Substring("type=\"Assembly\""));
 
@@ -81,8 +81,8 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var startReport = _listener.Reports.FirstOrDefault();
-            Assert.NotNull(startReport);
-            StringAssert.StartsWith("<start-suite", startReport);
+            Assert.That(startReport, Is.Not.Null);
+            Assert.That(startReport, Does.StartWith("<start-suite"));
             Assert.That(startReport, Contains.Substring("type=\"TestFixture\""));
         }
 
@@ -95,8 +95,8 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var startReport = _listener.Reports.FirstOrDefault();
-            Assert.NotNull(startReport);
-            StringAssert.StartsWith("<start-test", startReport);
+            Assert.That(startReport, Is.Not.Null);
+            Assert.That(startReport, Does.StartWith("<start-test"));
         }
 
         [Test]
@@ -108,13 +108,13 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var startReport = _listener.Reports.FirstOrDefault();
-            Assert.NotNull(startReport);
-            StringAssert.StartsWith("<start-test", startReport);
-            StringAssert.Contains($"id=\"{work.Test.Id}\"", startReport);
-            StringAssert.Contains($"parentId=\"{work.Test.Parent?.Id}\"", startReport);
-            StringAssert.Contains($"name=\"{work.Test.Name}\"", startReport);
-            StringAssert.Contains($"fullname=\"{work.Test.FullName}\"", startReport);
-            StringAssert.Contains($"type=\"{work.Test.TestType}\"", startReport);
+            Assert.That(startReport, Is.Not.Null);
+            Assert.That(startReport, Does.StartWith("<start-test"));
+            Assert.That(startReport, Contains.Substring($"id=\"{work.Test.Id}\""));
+            Assert.That(startReport, Contains.Substring($"parentId=\"{work.Test.Parent?.Id}\""));
+            Assert.That(startReport, Contains.Substring($"name=\"{work.Test.Name}\""));
+            Assert.That(startReport, Contains.Substring($"fullname=\"{work.Test.FullName}\""));
+            Assert.That(startReport, Contains.Substring($"type=\"{work.Test.TestType}\""));
         }
 
         [Test]
@@ -126,9 +126,9 @@ namespace NUnit.Framework.Internal
             TestBuilder.ExecuteWorkItem(work);
 
             var endReport = _listener.Reports.LastOrDefault();
-            Assert.NotNull(endReport);
-            StringAssert.DoesNotStartWith("<start", endReport);
-            StringAssert.Contains($"parentId=\"{work.Test.Parent?.Id}\"", endReport);
+            Assert.That(endReport, Is.Not.Null);
+            Assert.That(endReport, Does.Not.StartWith("<start"));
+            Assert.That(endReport, Contains.Substring($"parentId=\"{work.Test.Parent?.Id}\""));
         }
 
         #region Nested ReportCollector Class

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Internal
 
         private void CheckXmlForTest(Test test, TNode topNode, bool recursive)
         {
-            Assert.NotNull(topNode);
+            Assert.That(topNode, Is.Not.Null);
 
             //if (test is TestSuite)
             //{
@@ -128,12 +128,12 @@ namespace NUnit.Framework.Internal
             Assert.That(topNode.Attributes["fullname"], Is.EqualTo(test.FullName));
             if (test.TypeInfo != null)
             {
-                Assert.NotNull(test.ClassName);
+                Assert.That(test.ClassName, Is.Not.Null);
                 Assert.That(topNode.Attributes["classname"], Is.EqualTo(test.ClassName));
             }
             if (test is TestMethod)
             {
-                Assert.NotNull(test.MethodName);
+                Assert.That(test.MethodName, Is.Not.Null);
                 Assert.That(topNode.Attributes["methodname"], Is.EqualTo(test.MethodName));
             }
             Assert.That(topNode.Attributes["runstate"], Is.EqualTo(test.RunState.ToString()));
@@ -146,7 +146,7 @@ namespace NUnit.Framework.Internal
                         expectedProps.Add(key + "=" + value);
 
                 TNode propsNode = topNode.SelectSingleNode("properties");
-                Assert.NotNull(propsNode);
+                Assert.That(propsNode, Is.Not.Null);
 
                 var actualProps = new List<string>();
                 foreach (TNode node in propsNode.ChildNodes)
@@ -167,7 +167,7 @@ namespace NUnit.Framework.Internal
                     {
                         string xpathQuery = $"{child.XmlElementName}[@id={child.Id}]";
                         TNode childNode = topNode.SelectSingleNode(xpathQuery);
-                        Assert.NotNull(childNode, "Expected node for test with ID={0}, Name={1}", child.Id, child.Name);
+                        Assert.That(childNode, Is.Not.Null, "Expected node for test with ID={0}, Name={1}", child.Id, child.Name);
 
                         CheckXmlForTest(child, childNode, recursive);
                     }

--- a/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
@@ -365,7 +365,7 @@ namespace NUnit.Framework.Internal
         {
             var notGeneric = new DifferingNamespace1.Dummy(1);
 
-            Assert.False(_differenceGetter.IsTypeGeneric(notGeneric.GetType()));
+            Assert.That(_differenceGetter.IsTypeGeneric(notGeneric.GetType()), Is.False);
 
             var generic = new DifferingNamespace1.DummyGeneric<DifferingNamespace1.Dummy>(new DifferingNamespace1.Dummy(1));
 
@@ -381,7 +381,7 @@ namespace NUnit.Framework.Internal
 
             var actual = _differenceGetter.GetGenericTypeName(generic);
 
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -401,7 +401,7 @@ namespace NUnit.Framework.Internal
                 "KeyValuePair`2",
                 new List<string>() { "String", "Int32" });
 
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         private void TestShortenTypeNames(object objA, object objB, string shortenedA, string shortenedB)
@@ -409,8 +409,8 @@ namespace NUnit.Framework.Internal
 
             _differenceGetter.ShortenTypeNames(objA.GetType(), objB.GetType(), out var actualA, out var actualB);
 
-            Assert.AreEqual(shortenedA, actualA);
-            Assert.AreEqual(shortenedB, actualB);
+            Assert.That(actualA, Is.EqualTo(shortenedA));
+            Assert.That(actualB, Is.EqualTo(shortenedB));
         }
 
         [Test]
@@ -428,8 +428,8 @@ namespace NUnit.Framework.Internal
 
             _differenceGetter.GetShortenedGenericTypes(objA.GetType(), objB.GetType(), out var actualA, out var actualB);
 
-            Assert.AreEqual(shortenedA, actualA);
-            Assert.AreEqual(shortenedB, actualB);
+            Assert.That(actualA, Is.EqualTo(shortenedA));
+            Assert.That(actualB, Is.EqualTo(shortenedB));
         }
 
         [Test]
@@ -452,7 +452,7 @@ namespace NUnit.Framework.Internal
         {
             string actual = _differenceGetter.FullyShortenTypeName(type);
 
-            Assert.AreEqual(expectedOutput, actual);
+            Assert.That(actual, Is.EqualTo(expectedOutput));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TypeParameterUsedWithTestMethod.cs
+++ b/src/NUnitFramework/tests/Internal/TypeParameterUsedWithTestMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 namespace NUnit.Framework.Internal
 {
@@ -6,8 +6,12 @@ namespace NUnit.Framework.Internal
     [TestFixture(typeof(double))]
     public class TypeParameterUsedWithTestMethod<T>
     {
+        // TODO: NUnit.Analyzer doesn't handle generics.
+        // It would need to have to check against the TestFixture parameter attribute.
+#pragma warning disable NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         [TestCase(5)]
         [TestCase(1.23)]
+#pragma warning restore NUnit1001 // The individual arguments provided by a TestCaseAttribute must match the type of the corresponding parameter of the method
         public void TestMyArgType(T x)
         {
             Assert.That(x, Is.TypeOf(typeof(T)));

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -23,8 +23,11 @@ namespace NUnit.Framework.Internal
 
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsWithInnerException));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual(expectedMessage, result.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo(expectedMessage));
+            });
         }
 
         [Test]
@@ -37,8 +40,11 @@ namespace NUnit.Framework.Internal
 
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsWithNestedInnerException));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual(expectedMessage, result.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo(expectedMessage));
+            });
         }
 
         [Test]
@@ -51,9 +57,12 @@ namespace NUnit.Framework.Internal
 
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsWithAggregateException));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
-            Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
+                Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+            });
         }
 
         [Test]
@@ -66,9 +75,12 @@ namespace NUnit.Framework.Internal
 
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsWithAggregateExceptionContainingNestedInnerException));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
-            Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
+                Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+            });
         }
 
         [Test]
@@ -76,9 +88,12 @@ namespace NUnit.Framework.Internal
         {
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsWithBadStackTrace));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual("NUnit.TestData.UnexpectedExceptionFixture.ExceptionWithBadStackTrace : thrown by me", result.Message);
-            Assert.AreEqual("InvalidOperationException was thrown by the Exception.StackTrace property.", result.StackTrace);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo("NUnit.TestData.UnexpectedExceptionFixture.ExceptionWithBadStackTrace : thrown by me"));
+                Assert.That(result.StackTrace, Is.EqualTo("InvalidOperationException was thrown by the Exception.StackTrace property."));
+            });
         }
 
         [Test]
@@ -86,8 +101,11 @@ namespace NUnit.Framework.Internal
         {
             ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsCustomException));
 
-            Assert.AreEqual(ResultState.Error, result.ResultState);
-            Assert.AreEqual("NUnit.TestData.UnexpectedExceptionFixture.CustomException : message", result.Message);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo("NUnit.TestData.UnexpectedExceptionFixture.CustomException : message"));
+            });
         }
 
         [Test]
@@ -175,9 +193,11 @@ namespace NUnit.Framework.Internal
                 + "RecursivelyThrowingException was thrown by the Exception.StackTrace property."));
         }
 
+#pragma warning disable NUnit1028 // The non-test method is public
         public void DummyMethod()
         {
         }
+#pragma warning restore NUnit1028 // The non-test method is public
 
 #pragma warning disable SYSLIB0032
         [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]

--- a/src/NUnitFramework/tests/Internal/UnhandledExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnhandledExceptionTests.cs
@@ -18,19 +18,19 @@ namespace NUnit.Framework.Tests
         [NUnit.Framework.Test]
         public void Normal()
         {
-            testDummy("Normal", false);
+            TestDummy("Normal", false);
         }
 
-        private static void testDummy(string dummyName, bool shouldPass)
+        private static void TestDummy(string dummyName, bool shouldPass)
         {
             Type fixtureType = typeof(NUnit.TestData.UnhandledExceptionData.UnhandledExceptions);
             ITestResult result = TestBuilder.RunTestCase(fixtureType, dummyName);
             if (shouldPass)
-                Assert.IsTrue(result.ResultState == ResultState.Success, "{0} test should have passed", dummyName);
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Success), "{0} test should have passed", dummyName);
             else
             {
-                Assert.IsTrue(result.ResultState == ResultState.Failure, "{0} test should have failed", dummyName);
-                Assert.AreEqual("System.ApplicationException : Test exception", result.Message);
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure), "{0} test should have failed", dummyName);
+                Assert.That(result.Message, Is.EqualTo("System.ApplicationException : Test exception"));
             }
         }
         #endregion Normal
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Tests
         public void ThreadedAndWait()
         {
             // TODO: Make this fail
-            testDummy("ThreadedAndWait", true);
+            TestDummy("ThreadedAndWait", true);
         }
         #endregion ThreadedAndWait
 
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests
         public void ThreadedAndForget()
         {
             // TODO: Make this fail
-            testDummy("ThreadedAndForget", true);
+            TestDummy("ThreadedAndForget", true);
         }
         #endregion ThreadedAndForget
 
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Tests
         [NUnit.Framework.Test]
         public void ThreadedAssert()
         {
-            testDummy("ThreadedAssert", true);
+            TestDummy("ThreadedAssert", true);
         }
         #endregion
     }

--- a/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal.Execution
 
             if (alive > 0)
                 foreach (var worker in workers)
-                    Assert.False(worker.IsAlive, "Worker thread {0} did not stop", worker.Name);
+                    Assert.That(worker.IsAlive, Is.False, "Worker thread {0} did not stop", worker.Name);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/WorkShiftTests.cs
+++ b/src/NUnitFramework/tests/Internal/WorkShiftTests.cs
@@ -18,15 +18,15 @@ namespace NUnit.Framework.Internal.Execution
         [Test]
         public void InitialState()
         {
-            Assert.False(_shift.IsActive, "Should not be active");
-            Assert.That(_shift.Queues.Count, Is.EqualTo(0));
+            Assert.That(_shift.IsActive, Is.False, "Should not be active");
+            Assert.That(_shift.Queues, Is.Empty);
         }
 
         [Test]
         public void StartShift()
         {
             _shift.Start();
-            Assert.True(_shift.IsActive, "Should be active");
+            Assert.That(_shift.IsActive, Is.True, "Should be active");
         }
 
         private static WorkItemQueue CreateQueue(string name)
@@ -38,8 +38,8 @@ namespace NUnit.Framework.Internal.Execution
         public void AddQueue()
         {
             _shift.AddQueue(CreateQueue("test"));
-            Assert.False(_shift.IsActive, "Should not be active");
-            Assert.That(_shift.Queues.Count, Is.EqualTo(1));
+            Assert.That(_shift.IsActive, Is.False, "Should not be active");
+            Assert.That(_shift.Queues, Has.Count.EqualTo(1));
             Assert.That(_shift.Queues[0].State, Is.EqualTo(WorkItemQueueState.Paused));
         }
 
@@ -48,8 +48,8 @@ namespace NUnit.Framework.Internal.Execution
         {
             _shift.AddQueue(CreateQueue("test"));
             _shift.Start();
-            Assert.True(_shift.IsActive, "Should be active");
-            Assert.That(_shift.Queues.Count, Is.EqualTo(1));
+            Assert.That(_shift.IsActive, Is.True, "Should be active");
+            Assert.That(_shift.Queues, Has.Count.EqualTo(1));
             Assert.That(_shift.Queues[0].State, Is.EqualTo(WorkItemQueueState.Running));
         }
 
@@ -58,8 +58,8 @@ namespace NUnit.Framework.Internal.Execution
         {
             _shift.Start();
             _shift.AddQueue(CreateQueue("test"));
-            Assert.True(_shift.IsActive, "Should be active");
-            Assert.That(_shift.Queues.Count, Is.EqualTo(1));
+            Assert.That(_shift.IsActive, Is.True, "Should be active");
+            Assert.That(_shift.Queues, Has.Count.EqualTo(1));
             Assert.That(_shift.Queues[0].State, Is.EqualTo(WorkItemQueueState.Running));
         }
 
@@ -69,8 +69,8 @@ namespace NUnit.Framework.Internal.Execution
             _shift.AddQueue(CreateQueue("test"));
             _shift.Start();
             _shift.AddQueue(CreateQueue("test"));
-            Assert.True(_shift.IsActive, "Should be active");
-            Assert.That(_shift.Queues.Count, Is.EqualTo(2));
+            Assert.That(_shift.IsActive, Is.True, "Should be active");
+            Assert.That(_shift.Queues, Has.Count.EqualTo(2));
             Assert.That(_shift.Queues[0].State, Is.EqualTo(WorkItemQueueState.Running));
             Assert.That(_shift.Queues[1].State, Is.EqualTo(WorkItemQueueState.Running));
         }
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Internal.Execution
         {
             var q = CreateQueue("test");
             _shift.AddQueue(q);
-            Assert.False(_shift.HasWork, "Should not have work initially");
+            Assert.That(_shift.HasWork, Is.False, "Should not have work initially");
             q.Enqueue(Fakes.GetWorkItem(this, "Test1"));
             Assert.That(_shift.HasWork, "Should have work after enqueue");
             _shift.Start();

--- a/src/NUnitFramework/tests/SendMessageTests.cs
+++ b/src/NUnitFramework/tests/SendMessageTests.cs
@@ -22,6 +22,7 @@ namespace NUnit.Framework
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Output, Is.EqualTo(""));
 
+            Assert.That(_testMessage, Is.Not.Null);
             Assert.That(_testMessage.Destination, Is.EqualTo(SOME_DESTINATION));
             Assert.That(_testMessage.Message, Is.EqualTo(SOME_MESSAGE));
             Assert.That(_testMessage.TestId, Is.EqualTo(result.Test.Id));
@@ -29,24 +30,24 @@ namespace NUnit.Framework
 
         #region ITestListener Implementation
 
-        public void TestStarted(ITest test)
+        void ITestListener.TestStarted(ITest test)
         {
         }
 
-        public void TestFinished(ITestResult result)
+        void ITestListener.TestFinished(ITestResult result)
         {
         }
 
         TestOutput _testOutput;
 
-        public void TestOutput(TestOutput output)
+        void ITestListener.TestOutput(TestOutput output)
         {
             _testOutput = output;
         }
 
         TestMessage _testMessage;
 
-        public void SendMessage(TestMessage message)
+        void ITestListener.SendMessage(TestMessage message)
         {
             _testMessage = message;
         }

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -52,69 +52,83 @@ namespace NUnit.Framework.Syntax
             Assert.That(i3, Is.EqualTo(d3));
             Assert.That(2 + 2, Is.Not.EqualTo(5));
             Assert.That(i3, Is.Not.EqualTo(iunequal));
-            List<string> list = new List<string>();
-            list.Add("foo");
-            list.Add("bar");
+            List<string> list = new List<string>
+            {
+                "foo",
+                "bar"
+            };
             Assert.That(list, Is.EqualTo(new[] { "foo", "bar" }));
         }
 
         [Test]
         public void EqualityTestsWithTolerance()
         {
-            Assert.That(4.99d, Is.EqualTo(5.0d).Within(0.05d));
-            Assert.That(4.0d, Is.Not.EqualTo(5.0d).Within(0.5d));
-            Assert.That(4.99f, Is.EqualTo(5.0f).Within(0.05f));
-            Assert.That(4.99m, Is.EqualTo(5.0m).Within(0.05m));
-            Assert.That(3999999999u, Is.EqualTo(4000000000u).Within(5u));
-            Assert.That(499, Is.EqualTo(500).Within(5));
-            Assert.That(4999999999L, Is.EqualTo(5000000000L).Within(5L));
-            Assert.That(5999999999ul, Is.EqualTo(6000000000ul).Within(5ul));
+            Assert.Multiple(() =>
+            {
+                Assert.That(4.99d, Is.EqualTo(5.0d).Within(0.05d));
+                Assert.That(4.0d, Is.Not.EqualTo(5.0d).Within(0.5d));
+                Assert.That(4.99f, Is.EqualTo(5.0f).Within(0.05f));
+                Assert.That(4.99m, Is.EqualTo(5.0m).Within(0.05m));
+                Assert.That(3999999999u, Is.EqualTo(4000000000u).Within(5u));
+                Assert.That(499, Is.EqualTo(500).Within(5));
+                Assert.That(4999999999L, Is.EqualTo(5000000000L).Within(5L));
+                Assert.That(5999999999ul, Is.EqualTo(6000000000ul).Within(5ul));
+            });
         }
 
         [Test]
         public void EqualityTestsWithTolerance_MixedFloatAndDouble()
         {
-            // Bug Fix 1743844
-            Assert.That(2.20492d, Is.EqualTo(2.2d).Within(0.01f),
-                "Double actual, Double expected, Single tolerance");
-            Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01d),
-                "Double actual, Single expected, Double tolerance");
-            Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01f),
-                "Double actual, Single expected, Single tolerance");
-            Assert.That(2.20492f, Is.EqualTo(2.2f).Within(0.01d),
-                "Single actual, Single expected, Double tolerance");
-            Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01d),
-                "Single actual, Double expected, Double tolerance");
-            Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01f),
-                "Single actual, Double expected, Single tolerance");
+            Assert.Multiple(() =>
+            {
+                // Bug Fix 1743844
+                Assert.That(2.20492d, Is.EqualTo(2.2d).Within(0.01f),
+                    "Double actual, Double expected, Single tolerance");
+                Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01d),
+                    "Double actual, Single expected, Double tolerance");
+                Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01f),
+                    "Double actual, Single expected, Single tolerance");
+                Assert.That(2.20492f, Is.EqualTo(2.2f).Within(0.01d),
+                    "Single actual, Single expected, Double tolerance");
+                Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01d),
+                    "Single actual, Double expected, Double tolerance");
+                Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01f),
+                    "Single actual, Double expected, Single tolerance");
+            });
         }
 
         [Test]
         public void EqualityTestsWithTolerance_MixingTypesGenerally()
         {
-            // Extending tolerance to all numeric types
-            Assert.That(202d, Is.EqualTo(200d).Within(2),
-                "Double actual, Double expected, int tolerance");
-            Assert.That(4.87m, Is.EqualTo(5).Within(.25),
-                "Decimal actual, int expected, Double tolerance");
-            Assert.That(4.87m, Is.EqualTo(5ul).Within(1),
-                "Decimal actual, ulong expected, int tolerance");
-            Assert.That(487, Is.EqualTo(500).Within(25),
-                "int actual, int expected, int tolerance");
-            Assert.That(487u, Is.EqualTo(500).Within(25),
-                "uint actual, int expected, int tolerance");
-            Assert.That(487L, Is.EqualTo(500).Within(25),
-                "long actual, int expected, int tolerance");
-            Assert.That(487ul, Is.EqualTo(500).Within(25),
-                "ulong actual, int expected, int tolerance");
+            Assert.Multiple(() =>
+            {
+                // Extending tolerance to all numeric types
+                Assert.That(202d, Is.EqualTo(200d).Within(2),
+                    "Double actual, Double expected, int tolerance");
+                Assert.That(4.87m, Is.EqualTo(5).Within(.25),
+                    "Decimal actual, int expected, Double tolerance");
+                Assert.That(4.87m, Is.EqualTo(5ul).Within(1),
+                    "Decimal actual, ulong expected, int tolerance");
+                Assert.That(487, Is.EqualTo(500).Within(25),
+                    "int actual, int expected, int tolerance");
+                Assert.That(487u, Is.EqualTo(500).Within(25),
+                    "uint actual, int expected, int tolerance");
+                Assert.That(487L, Is.EqualTo(500).Within(25),
+                    "long actual, int expected, int tolerance");
+                Assert.That(487ul, Is.EqualTo(500).Within(25),
+                    "ulong actual, int expected, int tolerance");
+            });
         }
 
         [Test, DefaultFloatingPointTolerance(0.05)]
         public void EqualityTestsUsingDefaultFloatingPointTolerance()
         {
-            Assert.That(4.99d, Is.EqualTo(5.0d));
-            Assert.That(4.0d, Is.Not.EqualTo(5.0d));
-            Assert.That(4.99f, Is.EqualTo(5.0f));
+            Assert.Multiple(() =>
+            {
+                Assert.That(4.99d, Is.EqualTo(5.0d));
+                Assert.That(4.0d, Is.Not.EqualTo(5.0d));
+                Assert.That(4.99f, Is.EqualTo(5.0f));
+            });
         }
     }
 }

--- a/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
@@ -14,81 +14,72 @@ namespace NUnit.Framework.Syntax
         public void ThrowsException()
         {
             IResolveConstraint expr = Throws.Exception;
-            Assert.AreEqual(
-                "<throwsexception>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo("<throwsexception>"));
         }
 
         [Test]
         public void ThrowsExceptionWithConstraint()
         {
             IResolveConstraint expr = Throws.Exception.With.Property("ParamName").EqualTo("myParam");
-            Assert.AreEqual(
-                @"<throws <property ParamName <equal ""myParam"">>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <property ParamName <equal ""myParam"">>>"));
         }
 
         [Test]
         public void ThrowsExceptionTypeOf()
         {
             IResolveConstraint expr = Throws.Exception.TypeOf(typeof(ArgumentException));
-            Assert.AreEqual(
-                "<throws <typeof System.ArgumentException>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo("<throws <typeof System.ArgumentException>>"));
         }
 
         [Test]
         public void ThrowsTypeOf()
         {
             IResolveConstraint expr = Throws.TypeOf(typeof(ArgumentException));
-            Assert.AreEqual(
-                "<throws <typeof System.ArgumentException>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo("<throws <typeof System.ArgumentException>>"));
         }
 
         [Test]
         public void ThrowsTypeOfAndConstraint()
         {
             IResolveConstraint expr = Throws.TypeOf(typeof(ArgumentException)).And.Property("ParamName").EqualTo("myParam");
-            Assert.AreEqual(
-                @"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
         }
 
         [Test]
         public void ThrowsExceptionTypeOfAndConstraint()
         {
             IResolveConstraint expr = Throws.Exception.TypeOf(typeof(ArgumentException)).And.Property("ParamName").EqualTo("myParam");
-            Assert.AreEqual(
-                @"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
         }
 
         [Test]
         public void ThrowsTypeOfWithConstraint()
         {
             IResolveConstraint expr = Throws.TypeOf(typeof(ArgumentException)).With.Property("ParamName").EqualTo("myParam");
-            Assert.AreEqual(
-                @"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
         }
 
         [Test]
         public void ThrowsInstanceOf()
         {
             IResolveConstraint expr = Throws.InstanceOf(typeof(ArgumentException));
-            Assert.AreEqual(
-                "<throws <instanceof System.ArgumentException>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo("<throws <instanceof System.ArgumentException>>"));
         }
 
         [Test]
         public void ThrowsExceptionInstanceOf()
         {
             IResolveConstraint expr = Throws.Exception.InstanceOf(typeof(ArgumentException));
-            Assert.AreEqual(
-                "<throws <instanceof System.ArgumentException>>",
-                expr.Resolve().ToString());
+            Assert.That(
+                expr.Resolve().ToString(), Is.EqualTo("<throws <instanceof System.ArgumentException>>"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework
         public void TestCanAccessWorkDirectory()
         {
             string workDirectory = TestContext.CurrentContext.WorkDirectory;
-            Assert.NotNull(workDirectory);
+            Assert.That(workDirectory, Is.Not.Null);
             Assert.That(Directory.Exists(workDirectory), $"Directory {workDirectory} does not exist");
         }
 
@@ -225,7 +225,7 @@ namespace NUnit.Framework
 
             // These are counted as asserts
             Assert.That(context.AssertCount, Is.EqualTo(0));
-            Assert.AreEqual(4, 2 + 2);
+            Assert.That(2 + 2, Is.EqualTo(4));
             Warn.Unless(2 + 2, Is.EqualTo(4));
 
             // This one is counted below
@@ -307,13 +307,16 @@ namespace NUnit.Framework
         {
             var fixture = new TestTestContextInOneTimeTearDown();
             TestBuilder.RunTestFixture(fixture);
-            Assert.That(fixture.PassCount, Is.EqualTo(2));
-            Assert.That(fixture.FailCount, Is.EqualTo(1));
-            Assert.That(fixture.WarningCount, Is.EqualTo(0));
-            Assert.That(fixture.SkipCount, Is.EqualTo(3));
-            Assert.That(fixture.InconclusiveCount, Is.EqualTo(4));
-            Assert.That(fixture.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
-            Assert.That(fixture.StackTrace, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.PassCount, Is.EqualTo(2));
+                Assert.That(fixture.FailCount, Is.EqualTo(1));
+                Assert.That(fixture.WarningCount, Is.EqualTo(0));
+                Assert.That(fixture.SkipCount, Is.EqualTo(3));
+                Assert.That(fixture.InconclusiveCount, Is.EqualTo(4));
+                Assert.That(fixture.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(fixture.StackTrace, Is.Null);
+            });
         }
 
         #endregion
@@ -325,7 +328,7 @@ namespace NUnit.Framework
         {
             var expected = TestContext.Out;
             await YieldAsync();
-            Assert.AreEqual(expected, TestContext.Out);
+            Assert.That(TestContext.Out, Is.EqualTo(expected));
         }
 
         [Test]
@@ -344,7 +347,7 @@ namespace NUnit.Framework
             {
                 isTestContextOutAvailable = TestContext.Out != null;
             }).Wait();
-            Assert.True(isTestContextOutAvailable);
+            Assert.That(isTestContextOutAvailable, Is.True);
         }
 
         private async Task YieldAsync()

--- a/src/NUnitFramework/tests/TestParametersTests.cs
+++ b/src/NUnitFramework/tests/TestParametersTests.cs
@@ -25,19 +25,19 @@ namespace NUnit.Framework
         [Test]
         public void Initially_ValuesAreNull()
         {
-            Assert.Null(_parameters["ABC"]);
+            Assert.That(_parameters["ABC"], Is.Null);
         }
 
         [Test]
         public void Initially_ExistsIsFalse()
         {
-            Assert.False(_parameters.Exists("ABC"));
+            Assert.That(_parameters.Exists("ABC"), Is.False);
         }
 
         [Test]
         public void Initially_NamesAreEmpty()
         {
-            Assert.That(_parameters.Names.Count, Is.EqualTo(0));
+            Assert.That(_parameters.Names, Is.Empty);
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/TestAssert.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestAssert.cs
@@ -13,16 +13,16 @@ namespace NUnit.TestUtilities
         #region IsRunnable
         public static void IsRunnable(Test test)
         {
-            Assert.AreEqual(RunState.Runnable, test.RunState);
+            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         public static void IsRunnable(Type type)
         {
             TestSuite suite = TestBuilder.MakeFixture(type);
-            Assert.NotNull(suite, "Unable to construct fixture");
-            Assert.AreEqual(RunState.Runnable, suite.RunState);
+            Assert.That(suite, Is.Not.Null, "Unable to construct fixture");
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             ITestResult result = TestBuilder.RunTest(suite, null);
-            Assert.AreEqual(ResultState.Success, result.ResultState);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
         }
 
         public static void IsRunnable(Type type, string name)
@@ -45,7 +45,7 @@ namespace NUnit.TestUtilities
         #region IsNotRunnable
         public static void IsNotRunnable(Test test)
         {
-            Assert.AreEqual(RunState.NotRunnable, test.RunState);
+            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
             //ITestResult result = TestBuilder.RunTest(test, null);
             //Assert.AreEqual(TestStatus.Failed, result.ResultState.Status);
             //Assert.AreEqual("Invalid", result.ResultState.Label);
@@ -54,7 +54,7 @@ namespace NUnit.TestUtilities
         public static void IsNotRunnable(Type type)
         {
             TestSuite fixture = TestBuilder.MakeFixture(type);
-            Assert.NotNull(fixture, "Unable to construct fixture");
+            Assert.That(fixture, Is.Not.Null, "Unable to construct fixture");
             IsNotRunnable(fixture);
         }
 

--- a/src/NUnitFramework/tests/TestUtilities/UniqueValues.cs
+++ b/src/NUnitFramework/tests/TestUtilities/UniqueValues.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Collections;
 using System.Collections.Generic;
@@ -48,20 +48,6 @@ namespace NUnit.TestUtilities
             foreach (object o1 in actual)
                 if (!list.Contains(o1))
                     list.Add(o1);
-
-            return list.Count;
-        }
-
-        private static int CountUniqueValues<T>(ActualValueDelegate<T> del, int count)
-        {
-            var list = new List<T>();
-
-            while (count-- > 0)
-            {
-                T item = del();
-                if (!list.Contains(item))
-                    list.Add(item);
-            }
 
             return list.Count;
         }

--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Output, Is.EqualTo(""));
 
-            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput, Is.Not.Null, "No output received");
             Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT));
             Assert.That(_testOutput.Stream, Is.EqualTo("Error"));
         }
@@ -57,7 +57,7 @@ namespace NUnit.Framework
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Output, Is.EqualTo(""));
 
-            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput, Is.Not.Null, "No output received");
             Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT + Environment.NewLine));
             Assert.That(_testOutput.Stream, Is.EqualTo("Error"));
         }
@@ -84,7 +84,7 @@ namespace NUnit.Framework
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Output, Is.EqualTo(""));
 
-            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput, Is.Not.Null, "No output received");
             Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT + Environment.NewLine));
             Assert.That(_testOutput.Stream, Is.EqualTo("Error"));
         }
@@ -100,7 +100,7 @@ namespace NUnit.Framework
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
             Assert.That(result.Output, Is.EqualTo(""));
 
-            Assert.NotNull(_testOutput, "No output received");
+            Assert.That(_testOutput, Is.Not.Null, "No output received");
             Assert.That(_testOutput.Text, Is.EqualTo(ERROR_TEXT + Environment.NewLine));
             Assert.That(_testOutput.Stream, Is.EqualTo("Progress"));
         }
@@ -128,22 +128,22 @@ namespace NUnit.Framework
 
         #region ITestListener Implementation
 
-        public void TestStarted(ITest test)
+        void ITestListener.TestStarted(ITest test)
         {
         }
 
-        public void TestFinished(ITestResult result)
+        void ITestListener.TestFinished(ITestResult result)
         {
         }
 
         TestOutput _testOutput;
 
-        public void TestOutput(TestOutput output)
+        void ITestListener.TestOutput(TestOutput output)
         {
             _testOutput = output;
         }
 
-        public void SendMessage(TestMessage message)
+        void ITestListener.SendMessage(TestMessage message)
         {
             
         }

--- a/src/NUnitFramework/tests/WorkItemTests.cs
+++ b/src/NUnitFramework/tests/WorkItemTests.cs
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Internal.Execution
             Assert.That(wrapped.TargetApartment, Is.EqualTo(expected));
         }
 
-        public static IEnumerable<TestCaseData> GetTargetApartmentTestData()
+        private static IEnumerable<TestCaseData> GetTargetApartmentTestData()
         {
             yield return new TestCaseData(CreateFakeTests(ApartmentState.Unknown, ApartmentState.Unknown, ApartmentState.Unknown), ApartmentState.Unknown);
             yield return new TestCaseData(CreateFakeTests(ApartmentState.Unknown, ApartmentState.Unknown, ApartmentState.STA), ApartmentState.STA);

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0-alpha.4" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple" version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #4364 
Fixes #4365 

Convert appropriate classic Assert to Constraints except in the area explicitly testing those classic Assertions.
