### PR TITLE
Change Guard methods to be inlineable

### DIFF
--- a/src/NUnitFramework/framework/Guard.cs
+++ b/src/NUnitFramework/framework/Guard.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
@@ -20,8 +21,12 @@ namespace NUnit.Framework
         /// <param name="name">The name of the argument</param>
         public static void ArgumentNotNull([NotNull] object? value, string name)
         {
-            if (value == null)
-                throw new ArgumentNullException(name, "Argument " + name + " must not be null");
+            if (value is null)
+                ThrowArgumentNullException(name);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowArgumentNullException(string name) => throw new ArgumentNullException(name, "Argument " + name + " must not be null");
         }
 
         /// <summary>
@@ -34,8 +39,13 @@ namespace NUnit.Framework
             ArgumentNotNull(value, name);
 
             if (value == string.Empty)
-                throw new ArgumentException("Argument " + name +" must not be the empty string", name);
+                ThrowArgumentNotNullOrEmpty(name);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowArgumentNotNullOrEmpty(string name) => throw new ArgumentException("Argument " + name + " must not be the empty string", name);
         }
+
 
         /// <summary>
         /// Throws an ArgumentOutOfRangeException if the specified condition is not met.
@@ -46,7 +56,11 @@ namespace NUnit.Framework
         public static void ArgumentInRange([DoesNotReturnIf(false)] bool condition, string message, string paramName)
         {
             if (!condition)
-                throw new ArgumentOutOfRangeException(paramName, message);
+                ThrowArgumentOutOfRangeException(message, paramName);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowArgumentOutOfRangeException(string message, string paramName) => throw new ArgumentOutOfRangeException(paramName, message);
         }
 
         /// <summary>
@@ -58,8 +72,13 @@ namespace NUnit.Framework
         public static void ArgumentValid([DoesNotReturnIf(false)] bool condition, string message, string paramName)
         {
             if (!condition)
-                throw new ArgumentException(message, paramName);
+                ThrowArgumentException(message, paramName);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowArgumentException(string message, string paramName) => throw new ArgumentException(message, paramName);
         }
+
 
         /// <summary>
         /// Throws an InvalidOperationException if the specified condition is not met.
@@ -69,7 +88,11 @@ namespace NUnit.Framework
         public static void OperationValid([DoesNotReturnIf(false)] bool condition, string message)
         {
             if (!condition)
-                throw new InvalidOperationException(message);
+                ThrowInvalidOperationException(message);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowInvalidOperationException(string message) => throw new InvalidOperationException(message);
         }
 
         /// <summary>
@@ -88,7 +111,11 @@ namespace NUnit.Framework
             if (method.ReturnType != typeof(void)) return;
             if (!AsyncToSyncAdapter.IsAsyncOperation(method)) return;
 
-            throw new ArgumentException("Async void methods are not supported. Please use 'async Task' instead.", paramName);
+            ThrowArgumentNotAsyncVoid(paramName);
+
+            [DoesNotReturn]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowArgumentNotAsyncVoid(string paramName) => throw new ArgumentException("Async void methods are not supported. Please use 'async Task' instead.", paramName);
         }
     }
 }


### PR DESCRIPTION
This PR changes Guard API to have methods that can be inlined to call site by not throwing exception in the actual Guard method. This follows [the throw helper pattern](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/diagnostics/throwhelper#technical-details) that is also used in BCL. So basically constructors using Guard can also become inlineable improving performance. I made them local functions as each method had quite tailored error message.

Low-level C# for those interested in how the output will look like:

```c#
namespace NUnit.Framework
{
  [NullableContext(1)]
  [Nullable(0)]
  internal static class Guard
  {
    public static void ArgumentNotNull([Nullable(2), NotNull] object value, string name)
    {
      if (value != null)
        return;
      Guard.<ArgumentNotNull>g__ThrowArgumentNullException|0_0(name);
    }

    public static void ArgumentNotNullOrEmpty([Nullable(2), NotNull] string value, string name)
    {
      Guard.ArgumentNotNull((object) value, name);
      if (!string.op_Equality(value, string.Empty))
        return;
      Guard.<ArgumentNotNullOrEmpty>g__ThrowArgumentNotNullOrEmpty|1_0(name);
    }

    public static void ArgumentInRange([DoesNotReturnIf(false)] bool condition, string message, string paramName)
    {
      if (condition)
        return;
      Guard.<ArgumentInRange>g__ThrowArgumentOutOfRangeException|2_0(message, paramName);
    }

    public static void ArgumentValid([DoesNotReturnIf(false)] bool condition, string message, string paramName)
    {
      if (condition)
        return;
      Guard.<ArgumentValid>g__ThrowArgumentException|3_0(message, paramName);
    }

    public static void OperationValid([DoesNotReturnIf(false)] bool condition, string message)
    {
      if (condition)
        return;
      Guard.<OperationValid>g__ThrowInvalidOperationException|4_0(message);
    }

    public static void ArgumentNotAsyncVoid(Delegate @delegate, string paramName)
    {
      Guard.ArgumentNotAsyncVoid(@delegate.GetMethodInfo(), paramName);
    }

    public static void ArgumentNotAsyncVoid(MethodInfo method, string paramName)
    {
      if (Type.op_Inequality(method.ReturnType, typeof (void)) || !AsyncToSyncAdapter.IsAsyncOperation(method))
        return;
      Guard.<ArgumentNotAsyncVoid>g__ThrowArgumentNotAsyncVoid|6_0(paramName);
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <ArgumentNotNull>g__ThrowArgumentNullException|0_0(string name)
    {
      throw new ArgumentNullException(name, string.Concat("Argument ", name, " must not be null"));
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <ArgumentNotNullOrEmpty>g__ThrowArgumentNotNullOrEmpty|1_0(string name)
    {
      throw new ArgumentException(string.Concat("Argument ", name, " must not be the empty string"), name);
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <ArgumentInRange>g__ThrowArgumentOutOfRangeException|2_0(
      string message,
      string paramName)
    {
      throw new ArgumentOutOfRangeException(paramName, message);
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <ArgumentValid>g__ThrowArgumentException|3_0(
      string message,
      string paramName)
    {
      throw new ArgumentException(message, paramName);
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <OperationValid>g__ThrowInvalidOperationException|4_0(string message)
    {
      throw new InvalidOperationException(message);
    }

    [CompilerGenerated]
    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    internal static void <ArgumentNotAsyncVoid>g__ThrowArgumentNotAsyncVoid|6_0(string paramName)
    {
      throw new ArgumentException("Async void methods are not supported. Please use 'async Task' instead.", paramName);
    }
  }
}
```