### PR TITLE
adding better error message for missing generic parameter

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -203,9 +203,9 @@ namespace NUnit.Framework.Internal.Builders
             if (argsProvided > maxArgsNeeded)
                 return MarkAsNotRunnable(testMethod, $"Too many arguments provided, provide at most {maxArgsNeeded} arguments.");
 
-            if (testMethod.Method.IsGenericMethodDefinition && arglist != null)
+            if (testMethod.Method.IsGenericMethodDefinition)
             {
-                if (!new GenericMethodHelper(testMethod.Method.MethodInfo).TryGetTypeArguments(arglist, out var typeArguments))
+                if (arglist == null || !new GenericMethodHelper(testMethod.Method.MethodInfo).TryGetTypeArguments(arglist, out var typeArguments))
                     return MarkAsNotRunnable(testMethod, "Unable to determine type arguments for method");
 
                 testMethod.Method = testMethod.Method.MakeGenericMethod(typeArguments);

--- a/src/NUnitFramework/testdata/GenericTestMethodData.cs
+++ b/src/NUnitFramework/testdata/GenericTestMethodData.cs
@@ -41,4 +41,25 @@ namespace NUnit.TestData
         {
         }
     }
+
+    public class NotRunnableGenericData
+    {
+        [Test]
+        public void TestWithGeneric_ReturningVoid_ThatIsUnRunnable<T>()
+        {
+        }
+
+        [TestCase(ExpectedResult = default)]
+        public T TestWithGeneric_ReturningGenericType_ThatIsUnRunnable<T>()
+        {
+            return default;
+        }
+
+        [TestCase(1)]
+        public void TestWithGeneric_PassingInGenericParameter_ThatIsRunnable<T>(T parameter)
+        {
+            Assert.That(parameter, Is.EqualTo(1));
+
+        }
+    }
 }

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -156,6 +156,24 @@ namespace NUnit.Framework.Internal
             Assert.That(invalid, Is.EqualTo(2), "Invalid count");
         }
 
+        [Test]
+        public void TestCase_MissingGenericArgumentAreNotRunnable()
+        {
+            //Need to use full fixture, since targeting one test at the time crashed during buildup and not in the framework
+            ITestResult result = TestBuilder.RunTestFixture(typeof(NotRunnableGenericData));
+            Assert.That(result.PassCount, Is.EqualTo(1), "PassCount");
+            Assert.That(result.TotalCount, Is.EqualTo(3), "TotalCount");
+
+            var voidTest = result.Children.Single(c => c.Name == nameof(NotRunnableGenericData.TestWithGeneric_ReturningVoid_ThatIsUnRunnable) + "<T>");
+            Assert.That(voidTest.ResultState, Is.EqualTo(ResultState.NotRunnable));
+
+            var returnTest = result.Children.Single(c => c.Name == nameof(NotRunnableGenericData.TestWithGeneric_ReturningGenericType_ThatIsUnRunnable));
+            Assert.That(returnTest.Children.First().ResultState, Is.EqualTo(ResultState.NotRunnable));
+
+            var validTest = result.Children.Single(c => c.Name == nameof(NotRunnableGenericData.TestWithGeneric_PassingInGenericParameter_ThatIsRunnable));
+            Assert.That(validTest.ResultState, Is.EqualTo(ResultState.Success));
+        }
+
         private static readonly object[] Source = new object[] {
             new object[] { 5, 2, "ABC" },
             new object[] { 5.0, 2.0, "ABC" },


### PR DESCRIPTION
fixes #3215

got full file conflicts if I tried reusing the branch and pushing it on top of master from prev PR, so started over

adding tests for generic methods that cannot resolve type
not the best unittest, but had to use a the runfixture method to get the buildup happening and "crashing" in the correct place