### PR TITLE
WIP: Try to convert int to uint in testcase parameters

### DIFF
--- a/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
+++ b/src/NUnitFramework/framework/Internal/ParamAttributeTypeConversions.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal
             var underlyingTargetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
 
             if (underlyingTargetType == typeof(short) || underlyingTargetType == typeof(byte) || underlyingTargetType == typeof(sbyte)
-                || underlyingTargetType == typeof(long) || underlyingTargetType == typeof(double))
+                || underlyingTargetType == typeof(long) || underlyingTargetType == typeof(double) || underlyingTargetType == typeof(uint))
             {
                 convert = value is int;
             }

--- a/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Attributes
         };
 
         // See XML docs for the ParamAttributeTypeConversions class.
-        private static readonly Type[] Int32RangeConvertibleToParameterTypes = { typeof(int), typeof(sbyte), typeof(byte), typeof(short), typeof(decimal), typeof(long), typeof(double) };
+        private static readonly Type[] Int32RangeConvertibleToParameterTypes = { typeof(int), typeof(sbyte), typeof(byte), typeof(short), typeof(decimal), typeof(long), typeof(double), typeof(uint) };
         private static readonly Type[] UInt32RangeConvertibleToParameterTypes = { typeof(uint) };
         private static readonly Type[] Int64RangeConvertibleToParameterTypes = { typeof(long) };
         private static readonly Type[] UInt64RangeConvertibleToParameterTypes = { typeof(ulong) };

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -73,6 +73,14 @@ namespace NUnit.Framework.Attributes
             return (sbyte)(x + y);
         }
 
+        [TestCase(0x00FFFFFF, ExpectedResult = 0x00FFFFFF)]
+        public uint CanConvertIntToUInt(uint stopColor)
+        {
+            // Ensure that parameter type conversions are in sync with equality type conversions
+            Assert.That(0x00FFFFFF, Is.EqualTo(stopColor));
+            return stopColor;
+        }
+
         [TestCase(nameof(TestCaseAttributeFixture.MethodCausesConversionOverflow), RunState.NotRunnable)]
         [TestCase(nameof(TestCaseAttributeFixture.VoidTestCaseWithExpectedResult), RunState.NotRunnable)]
         [TestCase(nameof(TestCaseAttributeFixture.TestCaseWithNullableReturnValueAndNullExpectedResult), RunState.Runnable)]


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/2783

We noticed that passing an `int` in a `TestCase` into a `uint` would fail. This was originally by design as:

> WRT TestCaseAttribute args, we compromised but we only step in if you have a target Type that cannot be expressed as an attribute argument

However it was noticed that this was inconsistent with how we do equality conversions. Equality conversions do allow for implicit `int` -> `uint` conversions.

> A thought: maybe we should do all the conversions that we already do on numerics (e.g. for equality). That would probably feel more consistent. If so, we should do them where they will work for all data attributes rather than just for TestCaseAttribute.

> Since we are already converting int to uint when comparing for equality, that answers my question since I think we should make all type conversions use the same logic. And we wouldn't want to remove that feature when unifying.