### PR TITLE
Use consistent field names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,6 +50,8 @@ csharp_indent_block_contents = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 
+csharp_prefer_braces = when_multiline
+
 # https://github.com/nunit/docs/wiki/Coding-Standards#naming
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
@@ -144,6 +146,9 @@ dotnet_diagnostic.IDE0003.severity = warning
 
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = error
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = warning
 
 # IDE0044: Add readonly modifier
 dotnet_diagnostic.IDE0044.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -145,6 +145,9 @@ dotnet_diagnostic.IDE0003.severity = warning
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = error
 
+# IDE0044: Add readonly modifier
+dotnet_diagnostic.IDE0044.severity = warning
+
 # IDE1006: Naming Styles
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -139,6 +139,9 @@ dotnet_diagnostic.CS3016.severity = none
 # IDE Analysis
 ############################################################################################
 
+# IDE0003: Remove qualification
+dotnet_diagnostic.IDE0003.severity = warning
+
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = error
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -61,52 +61,45 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
-# Required
 dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
 dotnet_naming_rule.namespaces_types_and_non_field_members.severity = error
 dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
 dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
 
-# Required
 dotnet_naming_symbols.visible_fields.applicable_kinds = field
 dotnet_naming_symbols.visible_fields.applicable_accessibilities = public, protected, protected_internal
 dotnet_naming_rule.visible_fields.severity = error
 dotnet_naming_rule.visible_fields.symbols = visible_fields
 dotnet_naming_rule.visible_fields.style = pascal_case
 
-# Defaults without diagnostics
 dotnet_naming_symbols.internal_fields.applicable_kinds = field
 dotnet_naming_symbols.internal_fields.applicable_accessibilities = internal
-dotnet_naming_rule.internal_fields.severity = none
+dotnet_naming_rule.internal_fields.severity = error
 dotnet_naming_rule.internal_fields.symbols = internal_fields
 dotnet_naming_rule.internal_fields.style = pascal_case
 
-# Defaults without diagnostics
 dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
 dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_rule.static_readonly_fields.severity = none
+dotnet_naming_rule.static_readonly_fields.severity = error
 dotnet_naming_rule.static_readonly_fields.symbols = static_readonly_fields
 dotnet_naming_rule.static_readonly_fields.style = pascal_case
 
-# Defaults without diagnostics
 dotnet_naming_symbols.constant_fields.applicable_kinds = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_rule.constant_fields.severity = none
+dotnet_naming_rule.constant_fields.severity = error
 dotnet_naming_rule.constant_fields.symbols = constant_fields
 dotnet_naming_rule.constant_fields.style = pascal_case
 
 dotnet_naming_style.underscore_camel_case.capitalization = camel_case
 dotnet_naming_style.underscore_camel_case.required_prefix = _
 
-# Required for newly added fields
 dotnet_naming_symbols.remaining_fields.applicable_kinds = field
-dotnet_naming_rule.remaining_fields.severity = suggestion
+dotnet_naming_rule.remaining_fields.severity = error
 dotnet_naming_rule.remaining_fields.symbols = remaining_fields
 dotnet_naming_rule.remaining_fields.style = underscore_camel_case
 
 dotnet_naming_style.camel_case.capitalization = camel_case
 
-# Required
 dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
 dotnet_naming_rule.parameters_and_locals.severity = error
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
@@ -148,6 +141,9 @@ dotnet_diagnostic.CS3016.severity = none
 
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = error
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = warning
 
 ##################################################################################
 # CSharpIsNull Analyzers

--- a/src/NUnitFramework/TestFile.cs
+++ b/src/NUnitFramework/TestFile.cs
@@ -23,7 +23,9 @@ namespace NUnit.TestUtilities
         public TestFile(string fileName, string contentSource, bool isContent)
         {
             if (Path.IsPathRooted(fileName))
+            {
                 _fileInfo = new FileInfo(fileName);
+            }
             else
             {
                 var tempPath = Path.GetTempPath();
@@ -90,10 +92,12 @@ namespace NUnit.TestUtilities
                     if (count == 0)
                         break;
                     foreach (char c in buffer)
+                    {
                         if (c == target)
                             return offset;
                         else
                             offset++;
+                    }
                 }
 
                 return -1L;
@@ -116,9 +120,13 @@ namespace NUnit.TestUtilities
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
+            {
                 if (disposing)
+                {
                     if (_fileInfo.Exists)
                         _fileInfo.Delete();
+                }
+            }
 
             _disposedValue = true;
         }

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/CompositeWorkItemBenchmark.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/CompositeWorkItemBenchmark.cs
@@ -45,12 +45,12 @@ public class CompositeWorkItemBenchmark
 }
 
 [SomeTestAttr]
-[TestFixtureSource(nameof(_fixtureArgs))]
+[TestFixtureSource(nameof(FixtureArgs))]
 public class TestWithTestActionAttribute
 {
-    private static object[] _fixtureArgs = Enumerable.Range(0, 100)
-                                                     .Select(a => new object[] { $"a{a:000}" })
-                                                     .ToArray();
+    private static readonly object[] FixtureArgs = Enumerable.Range(0, 100)
+                                                             .Select(a => new object[] { $"a{a:000}" })
+                                                             .ToArray();
 
     public TestWithTestActionAttribute(string arg) { }
 
@@ -61,7 +61,7 @@ public class TestWithTestActionAttribute
 [AttributeUsage(AttributeTargets.Class)]
 public class SomeTestAttrAttribute : Attribute, ITestAction
 {
-    private object _data = Enumerable.Range(0, 1000000).ToArray();
+    private readonly object _data = Enumerable.Range(0, 1000000).ToArray();
 
     public SomeTestAttrAttribute()
     {

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Api
     /// </summary>
     public class DefaultTestAssemblyBuilder : ITestAssemblyBuilder
     {
-        private static readonly Logger log = InternalTrace.GetLogger(typeof(DefaultTestAssemblyBuilder));
+        private static readonly Logger Log = InternalTrace.GetLogger(typeof(DefaultTestAssemblyBuilder));
 
         #region Instance Fields
 
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Api
         /// </returns>
         public ITest Build(Assembly assembly, IDictionary<string, object> options)
         {
-            log.Debug("Loading {0} in AppDomain {1}", assembly.FullName!, AppDomain.CurrentDomain.FriendlyName);
+            Log.Debug("Loading {0} in AppDomain {1}", assembly.FullName!, AppDomain.CurrentDomain.FriendlyName);
 
             string assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
             string suiteName = assemblyPath.Equals("<Unknown>")
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Api
         /// </returns>
         public ITest Build(string assemblyNameOrPath, IDictionary<string, object> options)
         {
-            log.Debug("Loading {0} in AppDomain {1}", assemblyNameOrPath, AppDomain.CurrentDomain.FriendlyName);
+            Log.Debug("Loading {0} in AppDomain {1}", assemblyNameOrPath, AppDomain.CurrentDomain.FriendlyName);
 
             TestSuite testAssembly;
 
@@ -165,11 +165,11 @@ namespace NUnit.Framework.Api
         private IList<Test> GetFixtures(Assembly assembly, PreFilter filter)
         {
             var fixtures = new List<Test>();
-            log.Debug("Examining assembly for test fixtures");
+            Log.Debug("Examining assembly for test fixtures");
 
             var testTypes = GetCandidateFixtureTypes(assembly, filter);
 
-            log.Debug("Found {0} classes to examine", testTypes.Count);
+            Log.Debug("Found {0} classes to examine", testTypes.Count);
             var timer = Stopwatch.StartNew();
             var testcases = 0;
             foreach (Type testType in testTypes)
@@ -191,7 +191,7 @@ namespace NUnit.Framework.Api
                 }
             }
 
-            log.Debug("Found {0} fixtures with {1} test cases in {2}ms", fixtures.Count, testcases, timer.ElapsedMilliseconds);
+            Log.Debug("Found {0} fixtures with {1} test cases in {2}ms", fixtures.Count, testcases, timer.ElapsedMilliseconds);
 
             return fixtures;
         }

--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -201,8 +201,10 @@ namespace NUnit.Framework.Api
             var result = new List<Type>();
 
             foreach (Type type in assembly.GetTypes())
+            {
                 if (filter.IsMatch(type))
                     result.Add(type);
+            }
 
             return result;
         }

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -49,8 +49,8 @@ namespace NUnit.Framework.Api
         {
             Initialize(assemblyNameOrPath, settings);
 
-            this.Builder = new DefaultTestAssemblyBuilder();
-            this.Runner = new NUnitTestAssemblyRunner(this.Builder);
+            Builder = new DefaultTestAssemblyBuilder();
+            Runner = new NUnitTestAssemblyRunner(Builder);
 
             Test.IdPrefix = idPrefix ?? string.Empty;
         }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -292,7 +292,9 @@ namespace NUnit.Framework.Api
 #if NETFRAMEWORK
             if (Settings.TryGetValue(FrameworkPackageSettings.PauseBeforeRun, out var pauseBeforeRun) &&
                 (bool)pauseBeforeRun)
+            {
                 PauseBeforeRun();
+            }
 #endif
 
             context.Dispatcher.Start(topLevelWorkItem);
@@ -326,11 +328,17 @@ namespace NUnit.Framework.Api
 
             if (Settings.TryGetValue(FrameworkPackageSettings.RunOnMainThread, out var runOnMainThread) &&
                 (bool)runOnMainThread)
+            {
                 context.Dispatcher = new MainThreadWorkItemDispatcher();
+            }
             else if (levelOfParallelism > 0)
+            {
                 context.Dispatcher = new ParallelWorkItemDispatcher(levelOfParallelism);
+            }
             else
+            {
                 context.Dispatcher = new SimpleWorkItemDispatcher();
+            }
 
             return context;
         }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -25,7 +25,7 @@ namespace NUnit.Framework.Api
     /// </summary>
     public class NUnitTestAssemblyRunner : ITestAssemblyRunner
     {
-        private static readonly Logger log = InternalTrace.GetLogger("DefaultTestAssemblyRunner");
+        private static readonly Logger Log = InternalTrace.GetLogger("DefaultTestAssemblyRunner");
 
         private readonly ITestAssemblyBuilder _builder;
         private readonly ManualResetEventSlim _runComplete = new ManualResetEventSlim();
@@ -194,7 +194,7 @@ namespace NUnit.Framework.Api
         /// </remarks>
         public void RunAsync(ITestListener listener, ITestFilter filter)
         {
-            log.Info("Running tests");
+            Log.Info("Running tests");
             if (LoadedTest is null)
                 throw new InvalidOperationException("Tests must be loaded before running them.");
 

--- a/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CategoryAttribute.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework
         /// <param name="name">The name of the category</param>
         public CategoryAttribute(string name)
         {
-            this.categoryName = name.Trim();
+            categoryName = name.Trim();
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace NUnit.Framework
         /// </summary>
         protected CategoryAttribute()
         {
-            this.categoryName = this.GetType().Name;
+            categoryName = GetType().Name;
             if ( categoryName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 categoryName = categoryName.Substring( 0, categoryName.Length - 9 );
         }
@@ -61,7 +61,7 @@ namespace NUnit.Framework
         /// <param name="test">The test to modify</param>
         public void ApplyToTest(Test test)
         {
-            test.Properties.Add(PropertyNames.Category, this.Name);
+            test.Properties.Add(PropertyNames.Category, Name);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -14,8 +14,8 @@ namespace NUnit.Framework
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
     public class CultureAttribute : IncludeExcludeAttribute, IApplyToTest
     {
-        private readonly CultureDetector cultureDetector = new CultureDetector();
-        private readonly CultureInfo currentCulture = CultureInfo.CurrentCulture;
+        private readonly CultureDetector _cultureDetector = new CultureDetector();
+        private readonly CultureInfo _currentCulture = CultureInfo.CurrentCulture;
 
         /// <summary>
         /// Constructor with no cultures specified, for use
@@ -56,13 +56,13 @@ namespace NUnit.Framework
         /// <returns>True, if the current culture is supported</returns>
         private bool IsCultureSupported([NotNullWhen(false)] out string? reason)
         {
-            if (Include is not null && !cultureDetector.IsCultureSupported(Include))
+            if (Include is not null && !_cultureDetector.IsCultureSupported(Include))
             {
                 reason = $"Only supported under culture {Include}";
                 return false;
             }
 
-            if (Exclude is not null && cultureDetector.IsCultureSupported(Exclude))
+            if (Exclude is not null && _cultureDetector.IsCultureSupported(Exclude))
             {
                 reason = $"Not supported under culture {Exclude}";
                 return false;
@@ -89,7 +89,7 @@ namespace NUnit.Framework
             }
             else
             {
-                if (currentCulture.Name == culture || currentCulture.TwoLetterISOLanguageName == culture)
+                if (_currentCulture.Name == culture || _currentCulture.TwoLetterISOLanguageName == culture)
                     return true;
             }
 

--- a/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/CultureAttribute.cs
@@ -105,8 +105,10 @@ namespace NUnit.Framework
         public bool IsCultureSupported(string[] cultures)
         {
             foreach (string culture in cultures)
+            {
                 if (IsCultureSupported(culture))
                     return true;
+            }
 
             return false;
         }

--- a/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework
         /// <param name="include">Comma-delimited list of included items</param>
         public IncludeExcludeAttribute(string? include)
         {
-            this._include = include;
+            _include = include;
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace NUnit.Framework
         /// </summary>
         public string? Include
         {
-            get => this._include;
+            get => _include;
             set => _include = value;
         }
 
@@ -44,8 +44,8 @@ namespace NUnit.Framework
         /// </summary>
         public string? Exclude
         {
-            get => this._exclude;
-            set => this._exclude = value;
+            get => _exclude;
+            set => _exclude = value;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IncludeExcludeAttribute.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework
     /// </summary>
     public abstract class IncludeExcludeAttribute : NUnitAttribute
     {
-        private string? include;
-        private string? exclude;
-        private string? reason;
+        private string? _include;
+        private string? _exclude;
+        private string? _reason;
 
         /// <summary>
         /// Constructor with no included items specified, for use
@@ -24,7 +24,7 @@ namespace NUnit.Framework
         /// <param name="include">Comma-delimited list of included items</param>
         public IncludeExcludeAttribute(string? include)
         {
-            this.include = include;
+            this._include = include;
         }
 
         /// <summary>
@@ -34,8 +34,8 @@ namespace NUnit.Framework
         /// </summary>
         public string? Include
         {
-            get => this.include;
-            set => include = value;
+            get => this._include;
+            set => _include = value;
         }
 
         /// <summary>
@@ -44,8 +44,8 @@ namespace NUnit.Framework
         /// </summary>
         public string? Exclude
         {
-            get => this.exclude;
-            set => this.exclude = value;
+            get => this._exclude;
+            set => this._exclude = value;
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace NUnit.Framework
         /// </summary>
         public string? Reason
         {
-            get => reason;
-            set => reason = value;
+            get => _reason;
+            set => _reason = value;
         }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/OSPlatformTranslator.cs
+++ b/src/NUnitFramework/framework/Attributes/OSPlatformTranslator.cs
@@ -12,8 +12,8 @@ namespace NUnit.Framework
     /// </summary>
     internal static class OSPlatformTranslator
     {
-        private static readonly Type? _osPlatformAttributeType = Type.GetType("System.Runtime.Versioning.OSPlatformAttribute, System.Runtime", false);
-        private static readonly PropertyInfo? _platformNameProperty = _osPlatformAttributeType?.GetProperty("PlatformName", typeof(string));
+        private static readonly Type? OsPlatformAttributeType = Type.GetType("System.Runtime.Versioning.OSPlatformAttribute, System.Runtime", false);
+        private static readonly PropertyInfo? PlatformNameProperty = OsPlatformAttributeType?.GetProperty("PlatformName", typeof(string));
 
         /// <summary>
         /// Converts one or more .NET 5+ OSPlatformAttributes into a single NUnit PlatformAttribute
@@ -25,9 +25,9 @@ namespace NUnit.Framework
             IApplyToTest[] applyToTestAttributes = provider.GetAttributes<IApplyToTest>(inherit: true);
 
             // OSPlatformAttribute is only available on NET5.O or greater
-            var osPlatformAttributes = _osPlatformAttributeType is null ?
+            var osPlatformAttributes = OsPlatformAttributeType is null ?
                 Array.Empty<Attribute>() :
-                (Attribute[])provider.GetCustomAttributes(_osPlatformAttributeType, inherit: true);
+                (Attribute[])provider.GetCustomAttributes(OsPlatformAttributeType, inherit: true);
 
             return Translate(osPlatformAttributes, applyToTestAttributes);
         }
@@ -63,7 +63,7 @@ namespace NUnit.Framework
             // Translate OSPlatformAttribute
             foreach (var osPlatformAttribute in osPlatformAttributes)
             {
-                string? platformName = (string?)_platformNameProperty?.GetValue(osPlatformAttribute);
+                string? platformName = (string?)PlatformNameProperty?.GetValue(osPlatformAttribute);
                 if (platformName is null)
                 {
                     // Invalid property, ignore

--- a/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PlatformAttribute.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited=false)]
     public class PlatformAttribute : IncludeExcludeAttribute, IApplyToTest
     {
-        private readonly PlatformHelper platformHelper = new PlatformHelper();
+        private readonly PlatformHelper _platformHelper = new PlatformHelper();
 
         /// <summary>
         /// Constructor with no platforms specified, for use
@@ -40,7 +40,7 @@ namespace NUnit.Framework
                 bool platformIsSupported = false;
                 try
                 {
-                    platformIsSupported = platformHelper.IsPlatformSupported(this);
+                    platformIsSupported = _platformHelper.IsPlatformSupported(this);
                 }
                 catch (InvalidPlatformException ex)
                 {
@@ -52,7 +52,7 @@ namespace NUnit.Framework
                 if (!platformIsSupported)
                 {
                     test.RunState = RunState.Skipped;
-                    test.Properties.Add(PropertyNames.SkipReason, platformHelper.Reason);
+                    test.Properties.Add(PropertyNames.SkipReason, _platformHelper.Reason);
                 }
             }
         }

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -80,8 +80,10 @@ namespace NUnit.Framework
         public virtual void ApplyToTest(Test test)
         {
             foreach (string key in Properties.Keys)
-                foreach(object value in Properties[key])
+            {
+                foreach (object value in Properties[key])
                     test.Properties.Add(key, value);
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Method|AttributeTargets.Assembly, AllowMultiple=true, Inherited=true)]
     public class PropertyAttribute : NUnitAttribute, IApplyToTest
     {
-        private readonly PropertyBag properties = new PropertyBag();
+        private readonly PropertyBag _properties = new PropertyBag();
 
         /// <summary>
         /// Construct a PropertyAttribute with a name and string value
@@ -21,7 +21,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, string propertyValue)
         {
-            this.properties.Add(propertyName, propertyValue);
+            this._properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, int propertyValue)
         {
-            this.properties.Add(propertyName, propertyValue);
+            this._properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, double propertyValue)
         {
-            this.properties.Add(propertyName, propertyValue);
+            this._properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -63,13 +63,13 @@ namespace NUnit.Framework
             string propertyName = this.GetType().Name;
             if ( propertyName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 propertyName = propertyName.Substring( 0, propertyName.Length - 9 );
-            this.properties.Add(propertyName, propertyValue);
+            this._properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
         /// Gets the property dictionary for this attribute
         /// </summary>
-        public IPropertyBag Properties => properties;
+        public IPropertyBag Properties => _properties;
 
         #region IApplyToTest Members
 

--- a/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/PropertyAttribute.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, string propertyValue)
         {
-            this._properties.Add(propertyName, propertyValue);
+            _properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, int propertyValue)
         {
-            this._properties.Add(propertyName, propertyValue);
+            _properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         /// <param name="propertyValue">The property value</param>
         public PropertyAttribute(string propertyName, double propertyValue)
         {
-            this._properties.Add(propertyName, propertyValue);
+            _properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>
@@ -60,10 +60,10 @@ namespace NUnit.Framework
         /// </summary>
         protected PropertyAttribute( object propertyValue )
         {
-            string propertyName = this.GetType().Name;
+            string propertyName = GetType().Name;
             if ( propertyName.EndsWith( "Attribute", StringComparison.Ordinal ) )
                 propertyName = propertyName.Substring( 0, propertyName.Length - 9 );
-            this._properties.Add(propertyName, propertyValue);
+            _properties.Add(propertyName, propertyValue);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -218,7 +218,7 @@ namespace NUnit.Framework
             private readonly int _count;
             private readonly bool _inRange;
 
-            private readonly List<T> previousValues = new List<T>();
+            private readonly List<T> _previousValues = new List<T>();
 
             protected RandomDataSource(int count) : base(typeof(T))
             {
@@ -257,9 +257,9 @@ namespace NUnit.Framework
                             next = _inRange
                                 ? GetNext(randomizer, _min!, _max!)
                                 : GetNext(randomizer);
-                        } while (previousValues.Contains(next));
+                        } while (_previousValues.Contains(next));
 
-                        previousValues.Add(next);
+                        _previousValues.Add(next);
 
                         yield return next;
                     }
@@ -614,7 +614,7 @@ namespace NUnit.Framework
         {
             private readonly int _count;
 
-            private readonly List<object> previousValues = new List<object>();
+            private readonly List<object> _previousValues = new List<object>();
 
             public EnumDataSource(int count) : base(typeof(Enum))
             {
@@ -641,9 +641,9 @@ namespace NUnit.Framework
                         do
                         {
                             next = randomizer.NextEnum(parameter.ParameterType);
-                        } while (previousValues.Contains(next));
+                        } while (_previousValues.Contains(next));
 
-                        previousValues.Add(next);
+                        _previousValues.Add(next);
 
                         yield return next;
                     }

--- a/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RandomAttribute.cs
@@ -264,9 +264,11 @@ namespace NUnit.Framework
                         yield return next;
                     }
                     else
+                    {
                         yield return _inRange
                             ? GetNext(randomizer, _min!, _max!)
                             : GetNext(randomizer);
+                    }
                 }
             }
 
@@ -648,7 +650,9 @@ namespace NUnit.Framework
                         yield return next;
                     }
                     else
+                    {
                         yield return randomizer.NextEnum(parameter.ParameterType);
+                    }
                 }
             }
         }

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -62,7 +62,7 @@ namespace NUnit.Framework
             public RepeatedTestCommand(TestCommand innerCommand, int repeatCount)
                 : base(innerCommand)
             {
-                this._repeatCount = repeatCount;
+                _repeatCount = repeatCount;
             }
 
             /// <summary>

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework
         /// </summary>
         public class RepeatedTestCommand : DelegatingTestCommand
         {
-            private readonly int repeatCount;
+            private readonly int _repeatCount;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="RepeatedTestCommand"/> class.
@@ -62,7 +62,7 @@ namespace NUnit.Framework
             public RepeatedTestCommand(TestCommand innerCommand, int repeatCount)
                 : base(innerCommand)
             {
-                this.repeatCount = repeatCount;
+                this._repeatCount = repeatCount;
             }
 
             /// <summary>
@@ -72,7 +72,7 @@ namespace NUnit.Framework
             /// <returns>A TestResult</returns>
             public override TestResult Execute(TestExecutionContext context)
             {
-                int count = repeatCount;
+                int count = _repeatCount;
 
                 while (count-- > 0)
                 {

--- a/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiresThreadAttribute.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework
         {
             Guard.ArgumentValid(apartment != ApartmentState.Unknown, "must be STA or MTA", nameof(apartment));
 
-            this.Properties.Add(PropertyNames.ApartmentState, apartment);
+            Properties.Add(PropertyNames.ApartmentState, apartment);
         }
 
         void IApplyToTest.ApplyToTest(Test test)

--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -66,11 +66,13 @@ namespace NUnit.Framework
             };
 
             foreach (Type invalidType in invalidAttributes)
+            {
                 if (typeInfo.HasMethodWithAttribute(invalidType))
                 {
                     reason = invalidType.Name + " attribute not allowed in a SetUpFixture";
                     return false;
                 }
+            }
 
             return true;
         }

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -278,7 +278,9 @@ namespace NUnit.Framework
                     Properties.Set(PropertyNames.IgnoreUntilDate, _untilDate.Value.ToString("u"));
                 }
                 else
+                {
                     RunState = RunState.NotRunnable;
+                }
             }
         }
 
@@ -351,7 +353,9 @@ namespace NUnit.Framework
                     for (var i = parms.Arguments.Length; i < parameters.Length; i++)
                     {
                         if (parameters[i].IsOptional)
+                        {
                             newArgList[i] = Type.Missing;
+                        }
                         else
                         {
                             if (i < parms.Arguments.Length)

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -278,7 +278,7 @@ namespace NUnit.Framework
                     Properties.Set(PropertyNames.IgnoreUntilDate, _untilDate.Value.ToString("u"));
                 }
                 else
-                    this.RunState = RunState.NotRunnable;
+                    RunState = RunState.NotRunnable;
             }
         }
 

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -196,8 +196,10 @@ namespace NUnit.Framework
                         }
 
                         if (Category is not null)
+                        {
                             foreach (string cat in Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
+                        }
 
                         data.Add(parms);
                     }
@@ -234,10 +236,12 @@ namespace NUnit.Framework
 
                 var field = member as FieldInfo;
                 if (field is not null)
+                {
                     return field.IsStatic
                         ? (MethodParams is null ? (IEnumerable?)field.GetValue(null)
                                                 : ReturnErrorAsParameter(ParamGivenToField))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
+                }
 
                 var property = member as PropertyInfo;
                 if (property is not null)
@@ -251,11 +255,13 @@ namespace NUnit.Framework
 
                 var m = member as MethodInfo;
                 if (m is not null)
+                {
                     return m.IsStatic
                         ? (MethodParams is null || m.GetParameters().Length == MethodParams.Length
                             ? m.InvokeMaybeAwait<IEnumerable?>(MethodParams)
                             : ReturnErrorAsParameter(NumberOfArgsDoesNotMatch))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
+                }
             }
 
             return null;

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework
         /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestCaseSourceAttribute(string sourceName)
         {
-            this.SourceName = sourceName;
+            SourceName = sourceName;
         }
 
         /// <summary>
@@ -46,9 +46,9 @@ namespace NUnit.Framework
         ///                     If the source name is a field or property has no effect.</param>
         public TestCaseSourceAttribute(Type sourceType, string sourceName, object?[]? methodParams)
         {
-            this.MethodParams = methodParams;
-            this.SourceType = sourceType;
-            this.SourceName = sourceName;
+            MethodParams = methodParams;
+            SourceType = sourceType;
+            SourceName = sourceName;
         }
         /// <summary>
         /// Construct with a Type and name
@@ -57,8 +57,8 @@ namespace NUnit.Framework
         /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestCaseSourceAttribute(Type sourceType, string sourceName)
         {
-            this.SourceType = sourceType;
-            this.SourceName = sourceName;
+            SourceType = sourceType;
+            SourceName = sourceName;
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace NUnit.Framework
         ///                     If the source name is a field or property has no effect.</param>
         public TestCaseSourceAttribute(string sourceName, object?[]? methodParams)
         {
-            this.MethodParams = methodParams;
-            this.SourceName = sourceName;
+            MethodParams = methodParams;
+            SourceName = sourceName;
         }
         /// <summary>
         /// Construct with a Type
@@ -78,7 +78,7 @@ namespace NUnit.Framework
         /// <param name="sourceType">The type that will provide data</param>
         public TestCaseSourceAttribute(Type sourceType)
         {
-            this.SourceType = sourceType;
+            SourceType = sourceType;
         }
 
         #endregion
@@ -195,8 +195,8 @@ namespace NUnit.Framework
                             parms = new TestCaseParameters(args);
                         }
 
-                        if (this.Category is not null)
-                            foreach (string cat in this.Category.Tokenize(','))
+                        if (Category is not null)
+                            foreach (string cat in Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
 
                         data.Add(parms);

--- a/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureAttribute.cs
@@ -143,11 +143,11 @@ namespace NUnit.Framework
         [DisallowNull]
         public string? Reason
         {
-            get => this.Properties.Get(PropertyNames.SkipReason) as string;
+            get => Properties.Get(PropertyNames.SkipReason) as string;
             set
             {
                 Guard.ArgumentNotNull(value, nameof(value));
-                this.Properties.Set(PropertyNames.SkipReason, value);
+                Properties.Set(PropertyNames.SkipReason, value);
             }
         }
 
@@ -226,7 +226,7 @@ namespace NUnit.Framework
         /// </summary>
         public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
         {
-            return this.BuildFrom(typeInfo, PreFilter.Empty);
+            return BuildFrom(typeInfo, PreFilter.Empty);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -155,8 +155,10 @@ namespace NUnit.Framework
                         }
 
                         if (Category is not null)
+                        {
                             foreach (string cat in Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
+                        }
 
                         data.Add(parms);
                     }
@@ -186,9 +188,11 @@ namespace NUnit.Framework
 
                 var field = member as FieldInfo;
                 if (field is not null)
+                {
                     return field.IsStatic
                         ? (IEnumerable?)field.GetValue(null)
                         : SourceMustBeStaticError();
+                }
 
                 var property = member as PropertyInfo;
                 if (property is not null)
@@ -201,9 +205,11 @@ namespace NUnit.Framework
 
                 var m = member as MethodInfo;
                 if (m is not null)
+                {
                     return m.IsStatic
                         ? m.InvokeMaybeAwait<IEnumerable?>()
                         : SourceMustBeStaticError();
+                }
             }
 
             return null;

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSourceAttribute.cs
@@ -32,7 +32,7 @@ namespace NUnit.Framework
         /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestFixtureSourceAttribute(string sourceName)
         {
-            this.SourceName = sourceName;
+            SourceName = sourceName;
         }
 
         /// <summary>
@@ -42,8 +42,8 @@ namespace NUnit.Framework
         /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
         public TestFixtureSourceAttribute(Type sourceType, string sourceName)
         {
-            this.SourceType = sourceType;
-            this.SourceName = sourceName;
+            SourceType = sourceType;
+            SourceName = sourceName;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace NUnit.Framework
         /// <param name="sourceType">The type that will provide data</param>
         public TestFixtureSourceAttribute(Type sourceType)
         {
-            this.SourceType = sourceType;
+            SourceType = sourceType;
         }
 
         #endregion
@@ -154,8 +154,8 @@ namespace NUnit.Framework
                             parms = new TestFixtureParameters(args);
                         }
 
-                        if (this.Category is not null)
-                            foreach (string cat in this.Category.Tokenize(','))
+                        if (Category is not null)
+                            foreach (string cat in Category.Tokenize(','))
                                 parms.Properties.Add(PropertyNames.Category, cat);
 
                         data.Add(parms);

--- a/src/NUnitFramework/framework/Constraints/AndConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AndConstraint.cs
@@ -48,14 +48,14 @@ namespace NUnit.Framework.Constraints
 
         private class AndConstraintResult : ConstraintResult
         {
-            private readonly ConstraintResult leftResult;
-            private readonly ConstraintResult rightResult;
+            private readonly ConstraintResult _leftResult;
+            private readonly ConstraintResult _rightResult;
 
             public AndConstraintResult(AndConstraint constraint, object? actual, ConstraintResult leftResult, ConstraintResult rightResult)
                 : base(constraint, actual, leftResult.IsSuccess && rightResult.IsSuccess)
             {
-                this.leftResult = leftResult;
-                this.rightResult = rightResult;
+                this._leftResult = leftResult;
+                this._rightResult = rightResult;
             }
 
             /// <summary>
@@ -69,20 +69,20 @@ namespace NUnit.Framework.Constraints
             {
                 if (this.IsSuccess)
                     base.WriteActualValueTo(writer);
-                else if (!leftResult.IsSuccess)
-                    leftResult.WriteActualValueTo(writer);
+                else if (!_leftResult.IsSuccess)
+                    _leftResult.WriteActualValueTo(writer);
                 else
-                    rightResult.WriteActualValueTo(writer);
+                    _rightResult.WriteActualValueTo(writer);
             }
 
             public override void WriteAdditionalLinesTo(MessageWriter writer)
             {
                 if (this.IsSuccess)
                     base.WriteAdditionalLinesTo(writer);
-                else if (!leftResult.IsSuccess)
-                    leftResult.WriteAdditionalLinesTo(writer);
+                else if (!_leftResult.IsSuccess)
+                    _leftResult.WriteAdditionalLinesTo(writer);
                 else
-                    rightResult.WriteAdditionalLinesTo(writer);
+                    _rightResult.WriteAdditionalLinesTo(writer);
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/AndConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AndConstraint.cs
@@ -54,8 +54,8 @@ namespace NUnit.Framework.Constraints
             public AndConstraintResult(AndConstraint constraint, object? actual, ConstraintResult leftResult, ConstraintResult rightResult)
                 : base(constraint, actual, leftResult.IsSuccess && rightResult.IsSuccess)
             {
-                this._leftResult = leftResult;
-                this._rightResult = rightResult;
+                _leftResult = leftResult;
+                _rightResult = rightResult;
             }
 
             /// <summary>
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Constraints
             /// <param name="writer">The writer on which the actual value is displayed</param>
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                if (this.IsSuccess)
+                if (IsSuccess)
                     base.WriteActualValueTo(writer);
                 else if (!_leftResult.IsSuccess)
                     _leftResult.WriteActualValueTo(writer);
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Constraints
 
             public override void WriteAdditionalLinesTo(MessageWriter writer)
             {
-                if (this.IsSuccess)
+                if (IsSuccess)
                     base.WriteAdditionalLinesTo(writer);
                 else if (!_leftResult.IsSuccess)
                     _leftResult.WriteAdditionalLinesTo(writer);

--- a/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class AttributeConstraint : PrefixConstraint
     {
-        private readonly Type expectedType;
+        private readonly Type _expectedType;
 
         /// <summary>
         /// Constructs an AttributeConstraint for a specified attribute
@@ -23,10 +23,10 @@ namespace NUnit.Framework.Constraints
         public AttributeConstraint(Type type, IConstraint baseConstraint)
             : base(baseConstraint, "attribute " + type.FullName)
         {
-            this.expectedType = type;
+            this._expectedType = type;
 
-            if (!typeof(Attribute).IsAssignableFrom(expectedType))
-                throw new ArgumentException($"Type {expectedType} is not an attribute", nameof(type));
+            if (!typeof(Attribute).IsAssignableFrom(_expectedType))
+                throw new ArgumentException($"Type {_expectedType} is not an attribute", nameof(type));
         }
 
         /// <summary>
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             Guard.ArgumentNotNull(actual, nameof(actual));
-            Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, expectedType, true);
+            Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, _expectedType, true);
             if (attrs.Length == 0)
-                throw new ArgumentException($"Attribute {expectedType} was not found", nameof(actual));
+                throw new ArgumentException($"Attribute {_expectedType} was not found", nameof(actual));
 
             Attribute attrFound = attrs[0];
             return BaseConstraint.ApplyTo(attrFound);
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return $"<attribute {expectedType} {BaseConstraint}>";
+            return $"<attribute {_expectedType} {BaseConstraint}>";
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeConstraint.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Constraints
         public AttributeConstraint(Type type, IConstraint baseConstraint)
             : base(baseConstraint, "attribute " + type.FullName)
         {
-            this._expectedType = type;
+            _expectedType = type;
 
             if (!typeof(Attribute).IsAssignableFrom(_expectedType))
                 throw new ArgumentException($"Type {_expectedType} is not an attribute", nameof(type));

--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Constraints
         public AttributeExistsConstraint(Type type)
             : base(type)
         {
-            this._expectedType = type;
+            _expectedType = type;
 
             if (!typeof(Attribute).IsAssignableFrom(_expectedType))
                 throw new ArgumentException($"Type {_expectedType} is not an attribute", nameof(type));

--- a/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AttributeExistsConstraint.cs
@@ -11,7 +11,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class AttributeExistsConstraint : Constraint
     {
-        private readonly Type expectedType;
+        private readonly Type _expectedType;
 
         /// <summary>
         /// Constructs an AttributeExistsConstraint for a specific attribute Type
@@ -20,17 +20,17 @@ namespace NUnit.Framework.Constraints
         public AttributeExistsConstraint(Type type)
             : base(type)
         {
-            this.expectedType = type;
+            this._expectedType = type;
 
-            if (!typeof(Attribute).IsAssignableFrom(expectedType))
-                throw new ArgumentException($"Type {expectedType} is not an attribute", nameof(type));
+            if (!typeof(Attribute).IsAssignableFrom(_expectedType))
+                throw new ArgumentException($"Type {_expectedType} is not an attribute", nameof(type));
         }
 
         /// <summary>
         /// The Description of what this constraint tests, for
         /// use in messages and in the ConstraintResult.
         /// </summary>
-        public override string Description => "type with attribute " + MsgUtils.FormatValue(expectedType);
+        public override string Description => "type with attribute " + MsgUtils.FormatValue(_expectedType);
 
         /// <summary>
         /// Tests whether the object provides the expected attribute.
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Constraints
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
             Guard.ArgumentNotNull(actual, nameof(actual));
-            Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, expectedType, true);
+            Attribute[] attrs = AttributeHelper.GetCustomAttributes(actual, _expectedType, true);
             ConstraintResult result = new ConstraintResult(this, actual);
             result.Status = attrs.Length > 0
                 ? ConstraintStatus.Success : ConstraintStatus.Failure;

--- a/src/NUnitFramework/framework/Constraints/BinaryConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinaryConstraint.cs
@@ -26,10 +26,10 @@ namespace NUnit.Framework.Constraints
             : base(left, right)
         {
             Guard.ArgumentNotNull(left, nameof(left));
-            this.Left = left;
+            Left = left;
 
             Guard.ArgumentNotNull(right, nameof(right));
-            this.Right = right;
+            Right = right;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class BinarySerializableConstraint : Constraint
     {
-        private readonly BinaryFormatter serializer = new BinaryFormatter();
+        private readonly BinaryFormatter _serializer = new BinaryFormatter();
 
         /// <summary>
         /// The Description of what this constraint tests, for
@@ -36,11 +36,11 @@ namespace NUnit.Framework.Constraints
 
             try
             {
-                serializer.Serialize(stream, actual);
+                _serializer.Serialize(stream, actual);
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                succeeded = serializer.Deserialize(stream) is not null;
+                succeeded = _serializer.Deserialize(stream) is not null;
             }
             catch (SerializationException)
             {

--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -209,14 +209,18 @@ namespace NUnit.Framework.Constraints
                             int comparisonResult = step.Comparer.Compare(previousValue, currentValue);
 
                             if (comparisonResult < 0)
+                            {
                                 if (step.Direction == OrderDirection.Descending)
                                     return false;
                                 else break;
+                            }
 
                             if (comparisonResult > 0)
+                            {
                                 if (step.Direction != OrderDirection.Descending)
                                     return false;
                                 else break;
+                            }
                         }
                     }
                     else

--- a/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
@@ -23,8 +23,10 @@ namespace NUnit.Framework.Constraints.Comparers
                 return false;
 
             for (int r = 1; r < rank; r++)
+            {
                 if (xArray.GetLength(r) != yArray.GetLength(r))
                     return false;
+            }
 
             return EnumerablesComparer.Equal(xArray, yArray, ref tolerance, state, equalityComparer);
         }

--- a/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
@@ -38,8 +38,10 @@ namespace NUnit.Framework.Constraints.Comparers
         public bool DidCompare(object x, object y)
         {
             foreach (var comparison in _comparisons)
+            {
                 if (ReferenceEquals(comparison.X, x) && ReferenceEquals(comparison.Y, y))
                     return true;
+            }
 
             return false;
         }

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -23,8 +23,10 @@ namespace NUnit.Framework.Constraints.Comparers
                 return false;
 
             foreach (object key in xDictionary.Keys)
+            {
                 if (!equalityComparer.AreEqual(xDictionary[key], yDictionary[key], ref tolerance, state.PushComparison(x, y)))
                     return false;
+            }
 
             return true;
         }

--- a/src/NUnitFramework/framework/Constraints/Comparers/KeyValuePairsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/KeyValuePairsComparer.cs
@@ -21,7 +21,9 @@ namespace NUnit.Framework.Constraints.Comparers
 
             if (xGenericTypeDefinition != typeof(KeyValuePair<,>) ||
                 yGenericTypeDefinition != typeof(KeyValuePair<,>))
+            {
                 return null;
+            }
 
             var keyTolerance = Tolerance.Exact;
             object? xKey = xType.GetProperty("Key")!.GetValue(x, null);

--- a/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             public ComparerAdapter(IComparer comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             /// <summary>
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             public ComparerAdapter(IComparer<T> comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             /// <summary>
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Constraints
             /// </summary>
             public ComparisonAdapterForComparison(Comparison<T> comparer)
             {
-                this._comparison = comparer;
+                _comparison = comparer;
             }
 
             /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonAdapter.cs
@@ -60,14 +60,14 @@ namespace NUnit.Framework.Constraints
 
         private class ComparerAdapter : ComparisonAdapter
         {
-            private readonly IComparer comparer;
+            private readonly IComparer _comparer;
 
             /// <summary>
             /// Construct a ComparisonAdapter for an <see cref="IComparer"/>
             /// </summary>
             public ComparerAdapter(IComparer comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             /// <summary>
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Constraints
             /// <returns></returns>
             public override int Compare(object? expected, object? actual)
             {
-                return comparer.Compare(expected, actual);
+                return _comparer.Compare(expected, actual);
             }
         }
 
@@ -89,14 +89,14 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         private class ComparerAdapter<T> : ComparisonAdapter
         {
-            private readonly IComparer<T> comparer;
+            private readonly IComparer<T> _comparer;
 
             /// <summary>
             /// Construct a ComparisonAdapter for an <see cref="IComparer{T}"/>
             /// </summary>
             public ComparerAdapter(IComparer<T> comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             /// <summary>
@@ -110,20 +110,20 @@ namespace NUnit.Framework.Constraints
                 if (!TypeHelper.TryCast(actual, out T? actualCast))
                     throw new ArgumentException($"Cannot compare to {actual?.ToString() ?? "null"}");
 
-                return comparer.Compare(expectedCast, actualCast);
+                return _comparer.Compare(expectedCast, actualCast);
             }
         }
 
         private class ComparisonAdapterForComparison<T> : ComparisonAdapter
         {
-            private readonly Comparison<T> comparison;
+            private readonly Comparison<T> _comparison;
 
             /// <summary>
             /// Construct a ComparisonAdapter for a <see cref="Comparison{T}"/>
             /// </summary>
             public ComparisonAdapterForComparison(Comparison<T> comparer)
             {
-                this.comparison = comparer;
+                this._comparison = comparer;
             }
 
             /// <summary>
@@ -137,7 +137,7 @@ namespace NUnit.Framework.Constraints
                 if (!TypeHelper.TryCast(actual, out T? actualCast))
                     throw new ArgumentException($"Cannot compare to {actual?.ToString() ?? "null"}");
 
-                return comparison.Invoke(expectedCast, actualCast);
+                return _comparison.Invoke(expectedCast, actualCast);
             }
         }
     }

--- a/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ComparisonConstraint.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using(IComparer comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using<T>(IComparer<T> comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -115,7 +115,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A constraint modified to use the given comparer</returns>
         public ComparisonConstraint Using<T>(Comparison<T> comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Constraints
 
             _displayName = new Lazy<string>(() =>
             {
-                var type = this.GetType();
+                var type = GetType();
                 var displayName = type.Name;
                 if (type.IsGenericType)
                     displayName = displayName.Substring(0, displayName.Length - 2);
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Constraints
         {
             string rep = GetStringRepresentation();
 
-            return this.Builder is null ? rep : $"<unresolved {rep}>";
+            return Builder is null ? rep : $"<unresolved {rep}>";
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-                ConstraintBuilder? builder = this.Builder;
+                ConstraintBuilder? builder = Builder;
                 if (builder is null)
                 {
                     builder = new ConstraintBuilder();
@@ -236,7 +236,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a ConstraintExpression by appending And
         /// to the current constraint.
         /// </summary>
-        public ConstraintExpression With => this.And;
+        public ConstraintExpression With => And;
 
         /// <summary>
         /// Returns a ConstraintExpression by appending Or
@@ -246,7 +246,7 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-                ConstraintBuilder? builder = this.Builder;
+                ConstraintBuilder? builder = Builder;
                 if (builder is null)
                 {
                     builder = new ConstraintBuilder();

--- a/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         private sealed class OperatorStack
         {
-            private readonly Stack<ConstraintOperator> stack = new Stack<ConstraintOperator>();
+            private readonly Stack<ConstraintOperator> _stack = new Stack<ConstraintOperator>();
 
             /// <summary>
             /// Initializes a new instance of the <see cref="OperatorStack"/> class.
@@ -35,12 +35,12 @@ namespace NUnit.Framework.Constraints
             /// Gets a value indicating whether this <see cref="OperatorStack"/> is empty.
             /// </summary>
             /// <value><see langword="true"/> if empty; otherwise, <see langword="false"/>.</value>
-            public bool Empty => stack.Count == 0;
+            public bool Empty => _stack.Count == 0;
 
             /// <summary>
             /// Gets the topmost operator without modifying the stack.
             /// </summary>
-            public ConstraintOperator Top => stack.Peek();
+            public ConstraintOperator Top => _stack.Peek();
 
             /// <summary>
             /// Pushes the specified operator onto the stack.
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
             /// <param name="op">The operator to put onto the stack.</param>
             public void Push(ConstraintOperator op)
             {
-                stack.Push(op);
+                _stack.Push(op);
             }
 
             /// <summary>
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Constraints
             /// <returns>The topmost operator on the stack</returns>
             public ConstraintOperator Pop()
             {
-                return stack.Pop();
+                return _stack.Pop();
             }
         }
 
@@ -70,8 +70,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public sealed class ConstraintStack
         {
-            private readonly Stack<IConstraint> stack = new Stack<IConstraint>();
-            private readonly ConstraintBuilder builder;
+            private readonly Stack<IConstraint> _stack = new Stack<IConstraint>();
+            private readonly ConstraintBuilder _builder;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ConstraintStack"/> class.
@@ -79,14 +79,14 @@ namespace NUnit.Framework.Constraints
             /// <param name="builder">The ConstraintBuilder using this stack.</param>
             public ConstraintStack(ConstraintBuilder builder)
             {
-                this.builder = builder;
+                this._builder = builder;
             }
 
             /// <summary>
             /// Gets a value indicating whether this <see cref="ConstraintStack"/> is empty.
             /// </summary>
             /// <value><see langword="true"/> if empty; otherwise, <see langword="false"/>.</value>
-            public bool Empty => stack.Count == 0;
+            public bool Empty => _stack.Count == 0;
 
             /// <summary>
             /// Pushes the specified constraint. As a side effect,
@@ -96,8 +96,8 @@ namespace NUnit.Framework.Constraints
             /// <param name="constraint">The constraint to put onto the stack</param>
             public void Push(IConstraint constraint)
             {
-                stack.Push(constraint);
-                constraint.Builder = this.builder;
+                _stack.Push(constraint);
+                constraint.Builder = this._builder;
             }
 
             /// <summary>
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Constraints
             /// <returns>The topmost constraint on the stack</returns>
             public IConstraint Pop()
             {
-                IConstraint constraint = stack.Pop();
+                IConstraint constraint = _stack.Pop();
                 constraint.Builder = null;
                 return constraint;
             }
@@ -118,11 +118,11 @@ namespace NUnit.Framework.Constraints
 
         #region Instance Fields
 
-        private readonly OperatorStack ops;
+        private readonly OperatorStack _ops;
 
-        private readonly ConstraintStack constraints;
+        private readonly ConstraintStack _constraints;
 
-        private object? lastPushed;
+        private object? _lastPushed;
 
         #endregion
 
@@ -133,8 +133,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ConstraintBuilder()
         {
-            this.ops = new OperatorStack();
-            this.constraints = new ConstraintStack(this);
+            this._ops = new OperatorStack();
+            this._constraints = new ConstraintStack(this);
         }
 
         #endregion
@@ -149,15 +149,15 @@ namespace NUnit.Framework.Constraints
         /// <param name="op">The operator to push.</param>
         public void Append(ConstraintOperator op)
         {
-            op.LeftContext = lastPushed;
-            if (lastPushed is ConstraintOperator)
+            op.LeftContext = _lastPushed;
+            if (_lastPushed is ConstraintOperator)
                 SetTopOperatorRightContext(op);
 
             // Reduce any lower precedence operators
             ReduceOperatorStack(op.LeftPrecedence);
 
-            ops.Push(op);
-            lastPushed = op;
+            _ops.Push(op);
+            _lastPushed = op;
         }
 
         /// <summary>
@@ -167,11 +167,11 @@ namespace NUnit.Framework.Constraints
         /// <param name="constraint">The constraint to push.</param>
         public void Append(Constraint constraint)
         {
-            if (lastPushed is ConstraintOperator)
+            if (_lastPushed is ConstraintOperator)
                 SetTopOperatorRightContext(constraint);
 
-            constraints.Push(constraint);
-            lastPushed = constraint;
+            _constraints.Push(constraint);
+            _lastPushed = constraint;
             constraint.Builder = this;
         }
 
@@ -183,17 +183,17 @@ namespace NUnit.Framework.Constraints
         {
             // Some operators change their precedence based on
             // the right context - save current precedence.
-            int oldPrecedence = ops.Top.LeftPrecedence;
+            int oldPrecedence = _ops.Top.LeftPrecedence;
 
-            ops.Top.RightContext = rightContext;
+            _ops.Top.RightContext = rightContext;
 
             // If the precedence increased, we may be able to
             // reduce the region of the stack below the operator
-            if (ops.Top.LeftPrecedence > oldPrecedence)
+            if (_ops.Top.LeftPrecedence > oldPrecedence)
             {
-                ConstraintOperator changedOp = ops.Pop();
+                ConstraintOperator changedOp = _ops.Pop();
                 ReduceOperatorStack(changedOp.LeftPrecedence);
-                ops.Push(changedOp);
+                _ops.Push(changedOp);
             }
         }
 
@@ -204,8 +204,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="targetPrecedence">The target precedence.</param>
         private void ReduceOperatorStack(int targetPrecedence)
         {
-            while (!ops.Empty && ops.Top.RightPrecedence < targetPrecedence)
-                ops.Pop().Reduce(constraints);
+            while (!_ops.Empty && _ops.Top.RightPrecedence < targetPrecedence)
+                _ops.Pop().Reduce(_constraints);
         }
 
         #endregion
@@ -222,13 +222,13 @@ namespace NUnit.Framework.Constraints
             if (!IsResolvable)
                 throw new InvalidOperationException("A partial expression may not be resolved");
 
-            while (!ops.Empty)
+            while (!_ops.Empty)
             {
-                ConstraintOperator op = ops.Pop();
-                op.Reduce(constraints);
+                ConstraintOperator op = _ops.Pop();
+                op.Reduce(_constraints);
             }
 
-            return constraints.Pop();
+            return _constraints.Pop();
         }
 
         #endregion
@@ -241,7 +241,7 @@ namespace NUnit.Framework.Constraints
         /// <value>
         /// 	<see langword="true"/> if this instance is resolvable; otherwise, <see langword="false"/>.
         /// </value>
-        private bool IsResolvable => lastPushed is Constraint || lastPushed is SelfResolvingOperator;
+        private bool IsResolvable => _lastPushed is Constraint || _lastPushed is SelfResolvingOperator;
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Constraints
             /// <param name="builder">The ConstraintBuilder using this stack.</param>
             public ConstraintStack(ConstraintBuilder builder)
             {
-                this._builder = builder;
+                _builder = builder;
             }
 
             /// <summary>
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Constraints
             public void Push(IConstraint constraint)
             {
                 _stack.Push(constraint);
-                constraint.Builder = this._builder;
+                constraint.Builder = _builder;
             }
 
             /// <summary>
@@ -133,8 +133,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ConstraintBuilder()
         {
-            this._ops = new OperatorStack();
-            this._constraints = new ConstraintStack(this);
+            _ops = new OperatorStack();
+            _constraints = new ConstraintStack(this);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -116,13 +116,13 @@ namespace NUnit.Framework.Constraints
         /// Returns a ConstraintExpression that negates any
         /// following constraint.
         /// </summary>
-        public ConstraintExpression Not => this.Append(new NotOperator());
+        public ConstraintExpression Not => Append(new NotOperator());
 
         /// <summary>
         /// Returns a ConstraintExpression that negates any
         /// following constraint.
         /// </summary>
-        public ConstraintExpression No => this.Append(new NotOperator());
+        public ConstraintExpression No => Append(new NotOperator());
 
         #endregion
 
@@ -133,7 +133,7 @@ namespace NUnit.Framework.Constraints
         /// the following constraint to all members of a collection,
         /// succeeding if all of them succeed.
         /// </summary>
-        public ConstraintExpression All => this.Append(new AllOperator());
+        public ConstraintExpression All => Append(new AllOperator());
 
         #endregion
 
@@ -144,7 +144,7 @@ namespace NUnit.Framework.Constraints
         /// the following constraint to all members of a collection,
         /// succeeding if at least one of them succeeds.
         /// </summary>
-        public ConstraintExpression Some => this.Append(new SomeOperator());
+        public ConstraintExpression Some => Append(new SomeOperator());
 
         #endregion
 
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
         /// the following constraint to all members of a collection,
         /// succeeding if all of them fail.
         /// </summary>
-        public ConstraintExpression None => this.Append(new NoneOperator());
+        public ConstraintExpression None => Append(new NoneOperator());
 
         #endregion
 
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ResolvableConstraintExpression Property(string name)
         {
-            return this.Append(new PropOperator(name));
+            return Append(new PropOperator(name));
         }
 
         #endregion
@@ -255,7 +255,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ResolvableConstraintExpression Attribute(Type expectedType)
         {
-            return this.Append(new AttributeOperator(expectedType));
+            return Append(new AttributeOperator(expectedType));
         }
 
         /// <summary>
@@ -274,7 +274,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// With is currently a NOP - reserved for future use.
         /// </summary>
-        public ConstraintExpression With => this.Append(new WithOperator());
+        public ConstraintExpression With => Append(new WithOperator());
 
         #endregion
 
@@ -286,7 +286,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public Constraint Matches(IResolveConstraint constraint)
         {
-            return this.Append((Constraint)constraint.Resolve());
+            return Append((Constraint)constraint.Resolve());
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public Constraint Matches<TActual>(Predicate<TActual> predicate)
         {
-            return this.Append(new PredicateConstraint<TActual>(predicate));
+            return Append(new PredicateConstraint<TActual>(predicate));
         }
 
         #endregion
@@ -305,7 +305,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for null
         /// </summary>
-        public NullConstraint Null => (NullConstraint)this.Append(new NullConstraint());
+        public NullConstraint Null => (NullConstraint)Append(new NullConstraint());
 
         #endregion
 
@@ -314,7 +314,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for default value
         /// </summary>
-        public DefaultConstraint Default => (DefaultConstraint)this.Append(new DefaultConstraint());
+        public DefaultConstraint Default => (DefaultConstraint)Append(new DefaultConstraint());
 
         #endregion
 
@@ -323,7 +323,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for True
         /// </summary>
-        public TrueConstraint True => (TrueConstraint)this.Append(new TrueConstraint());
+        public TrueConstraint True => (TrueConstraint)Append(new TrueConstraint());
 
         #endregion
 
@@ -332,7 +332,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for False
         /// </summary>
-        public FalseConstraint False => (FalseConstraint)this.Append(new FalseConstraint());
+        public FalseConstraint False => (FalseConstraint)Append(new FalseConstraint());
 
         #endregion
 
@@ -341,7 +341,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for a positive value
         /// </summary>
-        public GreaterThanConstraint Positive => (GreaterThanConstraint)this.Append(new GreaterThanConstraint(0));
+        public GreaterThanConstraint Positive => (GreaterThanConstraint)Append(new GreaterThanConstraint(0));
 
         #endregion
 
@@ -350,7 +350,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for a negative value
         /// </summary>
-        public LessThanConstraint Negative => (LessThanConstraint)this.Append(new LessThanConstraint(0));
+        public LessThanConstraint Negative => (LessThanConstraint)Append(new LessThanConstraint(0));
 
         #endregion
 
@@ -359,7 +359,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests if item is equal to zero
         /// </summary>
-        public EqualConstraint Zero => (EqualConstraint)this.Append(new EqualConstraint(0));
+        public EqualConstraint Zero => (EqualConstraint)Append(new EqualConstraint(0));
 
         #endregion
 
@@ -368,7 +368,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for NaN
         /// </summary>
-        public NaNConstraint NaN => (NaNConstraint)this.Append(new NaNConstraint());
+        public NaNConstraint NaN => (NaNConstraint)Append(new NaNConstraint());
 
         #endregion
 
@@ -377,7 +377,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for empty
         /// </summary>
-        public EmptyConstraint Empty => (EmptyConstraint)this.Append(new EmptyConstraint());
+        public EmptyConstraint Empty => (EmptyConstraint)Append(new EmptyConstraint());
 
         #endregion
 
@@ -387,19 +387,19 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether a collection
         /// contains all unique items.
         /// </summary>
-        public UniqueItemsConstraint Unique => (UniqueItemsConstraint)this.Append(new UniqueItemsConstraint());
+        public UniqueItemsConstraint Unique => (UniqueItemsConstraint)Append(new UniqueItemsConstraint());
 
         #endregion
 
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in binary format.
         /// </summary>
-        public BinarySerializableConstraint BinarySerializable => (BinarySerializableConstraint)this.Append(new BinarySerializableConstraint());
+        public BinarySerializableConstraint BinarySerializable => (BinarySerializableConstraint)Append(new BinarySerializableConstraint());
 
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in XML format.
         /// </summary>
-        public XmlSerializableConstraint XmlSerializable => (XmlSerializableConstraint)this.Append(new XmlSerializableConstraint());
+        public XmlSerializableConstraint XmlSerializable => (XmlSerializableConstraint)Append(new XmlSerializableConstraint());
 
         #region EqualTo
 
@@ -408,7 +408,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EqualConstraint EqualTo(object? expected)
         {
-            return (EqualConstraint)this.Append(new EqualConstraint(expected));
+            return (EqualConstraint)Append(new EqualConstraint(expected));
         }
 
         #endregion
@@ -420,7 +420,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SameAsConstraint SameAs(object? expected)
         {
-            return (SameAsConstraint)this.Append(new SameAsConstraint(expected));
+            return (SameAsConstraint)Append(new SameAsConstraint(expected));
         }
 
         #endregion
@@ -433,7 +433,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanConstraint GreaterThan(object expected)
         {
-            return (GreaterThanConstraint)this.Append(new GreaterThanConstraint(expected));
+            return (GreaterThanConstraint)Append(new GreaterThanConstraint(expected));
         }
 
         #endregion
@@ -446,7 +446,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanOrEqualConstraint GreaterThanOrEqualTo(object expected)
         {
-            return (GreaterThanOrEqualConstraint)this.Append(new GreaterThanOrEqualConstraint(expected));
+            return (GreaterThanOrEqualConstraint)Append(new GreaterThanOrEqualConstraint(expected));
         }
 
         /// <summary>
@@ -455,7 +455,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanOrEqualConstraint AtLeast(object expected)
         {
-            return (GreaterThanOrEqualConstraint)this.Append(new GreaterThanOrEqualConstraint(expected));
+            return (GreaterThanOrEqualConstraint)Append(new GreaterThanOrEqualConstraint(expected));
         }
 
         #endregion
@@ -468,7 +468,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanConstraint LessThan(object expected)
         {
-            return (LessThanConstraint)this.Append(new LessThanConstraint(expected));
+            return (LessThanConstraint)Append(new LessThanConstraint(expected));
         }
 
         #endregion
@@ -481,7 +481,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanOrEqualConstraint LessThanOrEqualTo(object expected)
         {
-            return (LessThanOrEqualConstraint)this.Append(new LessThanOrEqualConstraint(expected));
+            return (LessThanOrEqualConstraint)Append(new LessThanOrEqualConstraint(expected));
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanOrEqualConstraint AtMost(object expected)
         {
-            return (LessThanOrEqualConstraint)this.Append(new LessThanOrEqualConstraint(expected));
+            return (LessThanOrEqualConstraint)Append(new LessThanOrEqualConstraint(expected));
         }
 
         #endregion
@@ -503,7 +503,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ExactTypeConstraint TypeOf(Type expectedType)
         {
-            return (ExactTypeConstraint)this.Append(new ExactTypeConstraint(expectedType));
+            return (ExactTypeConstraint)Append(new ExactTypeConstraint(expectedType));
         }
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ExactTypeConstraint TypeOf<TExpected>()
         {
-            return (ExactTypeConstraint)this.Append(new ExactTypeConstraint(typeof(TExpected)));
+            return (ExactTypeConstraint)Append(new ExactTypeConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -525,7 +525,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public InstanceOfTypeConstraint InstanceOf(Type expectedType)
         {
-            return (InstanceOfTypeConstraint)this.Append(new InstanceOfTypeConstraint(expectedType));
+            return (InstanceOfTypeConstraint)Append(new InstanceOfTypeConstraint(expectedType));
         }
 
         /// <summary>
@@ -534,7 +534,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public InstanceOfTypeConstraint InstanceOf<TExpected>()
         {
-            return (InstanceOfTypeConstraint)this.Append(new InstanceOfTypeConstraint(typeof(TExpected)));
+            return (InstanceOfTypeConstraint)Append(new InstanceOfTypeConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -547,7 +547,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableFromConstraint AssignableFrom(Type expectedType)
         {
-            return (AssignableFromConstraint)this.Append(new AssignableFromConstraint(expectedType));
+            return (AssignableFromConstraint)Append(new AssignableFromConstraint(expectedType));
         }
 
         /// <summary>
@@ -556,7 +556,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableFromConstraint AssignableFrom<TExpected>()
         {
-            return (AssignableFromConstraint)this.Append(new AssignableFromConstraint(typeof(TExpected)));
+            return (AssignableFromConstraint)Append(new AssignableFromConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -569,7 +569,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableToConstraint AssignableTo(Type expectedType)
         {
-            return (AssignableToConstraint)this.Append(new AssignableToConstraint(expectedType));
+            return (AssignableToConstraint)Append(new AssignableToConstraint(expectedType));
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableToConstraint AssignableTo<TExpected>()
         {
-            return (AssignableToConstraint)this.Append(new AssignableToConstraint(typeof(TExpected)));
+            return (AssignableToConstraint)Append(new AssignableToConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -592,7 +592,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionEquivalentConstraint EquivalentTo(IEnumerable expected)
         {
-            return (CollectionEquivalentConstraint)this.Append(new CollectionEquivalentConstraint(expected));
+            return (CollectionEquivalentConstraint)Append(new CollectionEquivalentConstraint(expected));
         }
 
         #endregion
@@ -605,7 +605,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionSubsetConstraint SubsetOf(IEnumerable expected)
         {
-            return (CollectionSubsetConstraint)this.Append(new CollectionSubsetConstraint(expected));
+            return (CollectionSubsetConstraint)Append(new CollectionSubsetConstraint(expected));
         }
 
         #endregion
@@ -618,7 +618,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionSupersetConstraint SupersetOf(IEnumerable expected)
         {
-            return (CollectionSupersetConstraint)this.Append(new CollectionSupersetConstraint(expected));
+            return (CollectionSupersetConstraint)Append(new CollectionSupersetConstraint(expected));
         }
 
         #endregion
@@ -628,7 +628,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests whether a collection is ordered
         /// </summary>
-        public CollectionOrderedConstraint Ordered => (CollectionOrderedConstraint)this.Append(new CollectionOrderedConstraint());
+        public CollectionOrderedConstraint Ordered => (CollectionOrderedConstraint)Append(new CollectionOrderedConstraint());
 
         #endregion
 
@@ -640,7 +640,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SomeItemsConstraint Member(object expected)
         {
-            return (SomeItemsConstraint)this.Append(new SomeItemsConstraint(new EqualConstraint(expected)));
+            return (SomeItemsConstraint)Append(new SomeItemsConstraint(new EqualConstraint(expected)));
         }
 
         #endregion
@@ -659,7 +659,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SomeItemsConstraint Contains(object expected)
         {
-            return (SomeItemsConstraint)this.Append(new SomeItemsConstraint(new EqualConstraint(expected)));
+            return (SomeItemsConstraint)Append(new SomeItemsConstraint(new EqualConstraint(expected)));
         }
 
         /// <summary>
@@ -675,7 +675,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ContainsConstraint Contains(string expected)
         {
-            return (ContainsConstraint)this.Append(new ContainsConstraint(expected));
+            return (ContainsConstraint)Append(new ContainsConstraint(expected));
         }
 
         /// <summary>
@@ -710,7 +710,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The key to be matched in the Dictionary key collection</param>
         public DictionaryContainsKeyConstraint ContainKey(object expected)
         {
-            return (DictionaryContainsKeyConstraint)this.Append(new DictionaryContainsKeyConstraint(expected));
+            return (DictionaryContainsKeyConstraint)Append(new DictionaryContainsKeyConstraint(expected));
         }
 
         /// <summary>
@@ -720,7 +720,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The value to be matched in the Dictionary value collection</param>
         public DictionaryContainsValueConstraint ContainValue(object expected)
         {
-            return (DictionaryContainsValueConstraint)this.Append(new DictionaryContainsValueConstraint(expected));
+            return (DictionaryContainsValueConstraint)Append(new DictionaryContainsValueConstraint(expected));
         }
         #endregion
 
@@ -732,7 +732,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public StartsWithConstraint StartWith(string expected)
         {
-            return (StartsWithConstraint)this.Append(new StartsWithConstraint(expected));
+            return (StartsWithConstraint)Append(new StartsWithConstraint(expected));
         }
 
         /// <summary>
@@ -741,7 +741,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public StartsWithConstraint StartsWith(string expected)
         {
-            return (StartsWithConstraint)this.Append(new StartsWithConstraint(expected));
+            return (StartsWithConstraint)Append(new StartsWithConstraint(expected));
         }
 
         #endregion
@@ -754,7 +754,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EndsWithConstraint EndWith(string expected)
         {
-            return (EndsWithConstraint)this.Append(new EndsWithConstraint(expected));
+            return (EndsWithConstraint)Append(new EndsWithConstraint(expected));
         }
 
         /// <summary>
@@ -763,7 +763,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EndsWithConstraint EndsWith(string expected)
         {
-            return (EndsWithConstraint)this.Append(new EndsWithConstraint(expected));
+            return (EndsWithConstraint)Append(new EndsWithConstraint(expected));
         }
 
         #endregion
@@ -776,7 +776,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Match(string pattern)
         {
-            return (RegexConstraint)this.Append(new RegexConstraint(pattern));
+            return (RegexConstraint)Append(new RegexConstraint(pattern));
         }
 
         /// <summary>
@@ -785,7 +785,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Match(Regex regex)
         {
-            return (RegexConstraint)this.Append(new RegexConstraint(regex));
+            return (RegexConstraint)Append(new RegexConstraint(regex));
         }
 
         /// <summary>
@@ -794,7 +794,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Matches(string pattern)
         {
-            return (RegexConstraint)this.Append(new RegexConstraint(pattern));
+            return (RegexConstraint)Append(new RegexConstraint(pattern));
         }
 
         /// <summary>
@@ -803,7 +803,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Matches(Regex regex)
         {
-            return (RegexConstraint)this.Append(new RegexConstraint(regex));
+            return (RegexConstraint)Append(new RegexConstraint(regex));
         }
 
         #endregion
@@ -816,7 +816,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SamePathConstraint SamePath(string expected)
         {
-            return (SamePathConstraint)this.Append(new SamePathConstraint(expected));
+            return (SamePathConstraint)Append(new SamePathConstraint(expected));
         }
 
         #endregion
@@ -829,7 +829,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SubPathConstraint SubPathOf(string expected)
         {
-            return (SubPathConstraint)this.Append(new SubPathConstraint(expected));
+            return (SubPathConstraint)Append(new SubPathConstraint(expected));
         }
 
         #endregion
@@ -842,7 +842,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SamePathOrUnderConstraint SamePathOrUnder(string expected)
         {
-            return (SamePathOrUnderConstraint)this.Append(new SamePathOrUnderConstraint(expected));
+            return (SamePathOrUnderConstraint)Append(new SamePathOrUnderConstraint(expected));
         }
 
         #endregion
@@ -856,7 +856,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="to">Inclusive end of the range.</param>
         public RangeConstraint InRange(object from, object to)
         {
-            return (RangeConstraint)this.Append(new RangeConstraint(from, to));
+            return (RangeConstraint)Append(new RangeConstraint(from, to));
         }
 
         #endregion
@@ -884,7 +884,7 @@ namespace NUnit.Framework.Constraints
                 expected = new object?[] { null };
             }
 
-            return (AnyOfConstraint)this.Append(new AnyOfConstraint(expected));
+            return (AnyOfConstraint)Append(new AnyOfConstraint(expected));
         }
 
         #endregion
@@ -898,7 +898,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="indexArgs">Index accessor values.</param>
         public ConstraintExpression ItemAt(params object[] indexArgs)
         {
-            return this.Append(new IndexerOperator(indexArgs));
+            return Append(new IndexerOperator(indexArgs));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected value contained within the string/collection.</param>
         public ContainsConstraint(object expected)
         {
-            this._expected = expected;
+            _expected = expected;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public DictionaryContainsKeyValuePairConstraint WithValue(object expectedValue)
         {
-            var builder = this.Builder;
+            var builder = Builder;
             if (builder is null)
             {
                 builder = new ConstraintBuilder();

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -74,8 +74,10 @@ namespace NUnit.Framework.Constraints
             {
                 var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
                 foreach (var obj in dictionary.Keys)
+                {
                     if (ItemsEqual(obj, Expected))
                         return true;
+                }
 
                 return false;
             }

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -46,8 +46,11 @@ namespace NUnit.Framework.Constraints
             if (TypeHelper.TryCast<IDictionary>(actual, out var dictionary))
             {
                 foreach (var entry in dictionary)
+                {
                     if (ItemsEqual(entry, _expected))
                         return true;
+                }
+
                 return false;
             }
 
@@ -59,8 +62,11 @@ namespace NUnit.Framework.Constraints
                 var enumerable = (IEnumerable)actual;
 
                 foreach (var item in enumerable)
+                {
                     if (ItemsEqual(item, expected))
                         return true;
+                }
+
                 return false;
             }
 

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -49,8 +49,10 @@ namespace NUnit.Framework.Constraints
             var dictionary = ConstraintUtils.RequireActual<IDictionary>(actual, nameof(actual));
 
             foreach (object? obj in dictionary.Values)
+            {
                 if (ItemsEqual(obj, Expected))
                     return true;
+            }
 
             return false;
         }

--- a/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyConstraint.cs
@@ -11,13 +11,13 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class EmptyConstraint : Constraint
     {
-        private Constraint? realConstraint;
+        private Constraint? _realConstraint;
 
         /// <summary>
         /// The Description of what this constraint tests, for
         /// use in messages and in the ConstraintResult.
         /// </summary>
-        public override string Description => realConstraint is null ? "<empty>" : realConstraint.Description;
+        public override string Description => _realConstraint is null ? "<empty>" : _realConstraint.Description;
 
         /// <summary>
         /// Test whether the constraint is satisfied by a given value
@@ -30,21 +30,21 @@ namespace NUnit.Framework.Constraints
             Type actualType = actual?.GetType() ?? typeof(TActual);
 
             if (actualType == typeof(string))
-                realConstraint = new EmptyStringConstraint();
+                _realConstraint = new EmptyStringConstraint();
             else if (actual is Guid || actualType == typeof(Guid?))
-                realConstraint = new EmptyGuidConstraint();
+                _realConstraint = new EmptyGuidConstraint();
             else if (actual is System.IO.DirectoryInfo)
-                realConstraint = new EmptyDirectoryConstraint();
+                _realConstraint = new EmptyDirectoryConstraint();
             else if (actual is System.Collections.ICollection)
-                realConstraint = new EmptyCollectionConstraint();       // Uses ICollecion.Count
+                _realConstraint = new EmptyCollectionConstraint();       // Uses ICollecion.Count
             else if (actual is System.Collections.IEnumerable)          // Enumerates whole collection
-                realConstraint = new EmptyCollectionConstraint();
+                _realConstraint = new EmptyCollectionConstraint();
             else if (actual is not null && CountZeroConstraint.HasCountProperty(actualType))  // For Collections that have Count but are not ICollection
-                realConstraint = new CountZeroConstraint();
+                _realConstraint = new CountZeroConstraint();
             else
                 throw new ArgumentException($"The actual value must be not-null, a string, Guid, have an int Count property, IEnumerable or DirectoryInfo. The value passed was of type {actualType}.", nameof(actual));
 
-            return realConstraint.ApplyTo(actual);
+            return _realConstraint.ApplyTo(actual);
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected string</param>
         public EndsWithConstraint(string expected) : base(expected)
         {
-            this.descriptionText = "String ending with";
+            descriptionText = "String ending with";
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+            var stringComparison = caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual is not null && actual.EndsWith(expected, stringComparison);
         }
     }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -100,7 +100,9 @@ namespace NUnit.Framework.Constraints
                 writer.WriteMessageLine(StreamsDiffer_1, expected.Length, offset);
             }
             else
+            {
                 writer.WriteMessageLine(StreamsDiffer_2, expected.Length, actual.Length);
+            }
         }
         #endregion
 
@@ -123,11 +125,13 @@ namespace NUnit.Framework.Constraints
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 
                 if (failurePoint.ExpectedHasData && failurePoint.ActualHasData)
+                {
                     DisplayDifferences(
                         writer,
                         failurePoint.ExpectedValue,
                         failurePoint.ActualValue,
                         ++depth);
+                }
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write("  Extra:    ");
@@ -187,9 +191,13 @@ namespace NUnit.Framework.Constraints
             bool useOneIndex = expectedRank == actualRank;
 
             if (expectedArray is not null && actualArray is not null)
+            {
                 for (int r = 1; r < expectedRank && useOneIndex; r++)
+                {
                     if (expectedArray.GetLength(r) != actualArray.GetLength(r))
                         useOneIndex = false;
+                }
+            }
 
             int[] expectedIndices = MsgUtils.GetArrayIndicesFromCollectionIndex(expected, failurePoint.Position);
             if (useOneIndex)
@@ -226,11 +234,13 @@ namespace NUnit.Framework.Constraints
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 
                 if (failurePoint.ExpectedHasData && failurePoint.ActualHasData)
+                {
                     DisplayDifferences(
                         writer,
                         failurePoint.ExpectedValue,
                         failurePoint.ActualValue,
                         ++depth);
+                }
                 else if (failurePoint.ActualHasData)
                 {
                     writer.Write($"  Extra:    < {MsgUtils.FormatValue(failurePoint.ActualValue)}, ... >");

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -13,11 +13,11 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class EqualConstraintResult : ConstraintResult
     {
-        private readonly object? expectedValue;
-        private readonly Tolerance tolerance;
-        private readonly bool caseInsensitive;
-        private readonly bool clipStrings;
-        private readonly IList<NUnitEqualityComparer.FailurePoint> failurePoints;
+        private readonly object? _expectedValue;
+        private readonly Tolerance _tolerance;
+        private readonly bool _caseInsensitive;
+        private readonly bool _clipStrings;
+        private readonly IList<NUnitEqualityComparer.FailurePoint> _failurePoints;
 
         #region Message Strings
         private static readonly string StringsDiffer_1 =
@@ -44,11 +44,11 @@ namespace NUnit.Framework.Constraints
         public EqualConstraintResult(EqualConstraint constraint, object? actual, bool hasSucceeded)
             : base(constraint, actual, hasSucceeded)
         {
-            this.expectedValue = constraint.Arguments[0];
-            this.tolerance = constraint.Tolerance;
-            this.caseInsensitive = constraint.CaseInsensitive;
-            this.clipStrings = constraint.ClipStrings;
-            this.failurePoints = constraint.FailurePoints;
+            this._expectedValue = constraint.Arguments[0];
+            this._tolerance = constraint.Tolerance;
+            this._caseInsensitive = constraint.CaseInsensitive;
+            this._clipStrings = constraint.ClipStrings;
+            this._failurePoints = constraint.FailurePoints;
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="writer">The MessageWriter to write to</param>
         public override void WriteMessageTo(MessageWriter writer)
         {
-            DisplayDifferences(writer, expectedValue, ActualValue, 0);
+            DisplayDifferences(writer, _expectedValue, ActualValue, 0);
         }
 
         private void DisplayDifferences(MessageWriter writer, object? expected, object? actual, int depth)
@@ -71,8 +71,8 @@ namespace NUnit.Framework.Constraints
                 DisplayEnumerableDifferences(writer, expectedEnumerable, actualEnumerable, depth);
             else if (expected is Stream expectedStream && actual is Stream actualStream)
                 DisplayStreamDifferences(writer, expectedStream, actualStream, depth);
-            else if (tolerance is not null)
-                writer.DisplayDifferences(expected, actual, tolerance);
+            else if (_tolerance is not null)
+                writer.DisplayDifferences(expected, actual, _tolerance);
             else
                 writer.DisplayDifferences(expected, actual);
         }
@@ -80,14 +80,14 @@ namespace NUnit.Framework.Constraints
         #region DisplayStringDifferences
         private void DisplayStringDifferences(MessageWriter writer, string expected, string actual)
         {
-            int mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, caseInsensitive);
+            int mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, _caseInsensitive);
 
             if (expected.Length == actual.Length)
                 writer.WriteMessageLine(StringsDiffer_1, expected.Length, mismatch);
             else
                 writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatch);
 
-            writer.DisplayStringDifferences(expected, actual, mismatch, caseInsensitive, clipStrings);
+            writer.DisplayStringDifferences(expected, actual, mismatch, _caseInsensitive, _clipStrings);
         }
         #endregion
 
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Constraints
         {
             if (expected.Length == actual.Length)
             {
-                long offset = failurePoints[depth].Position;
+                long offset = _failurePoints[depth].Position;
                 writer.WriteMessageLine(StreamsDiffer_1, expected.Length, offset);
             }
             else
@@ -116,9 +116,9 @@ namespace NUnit.Framework.Constraints
         {
             DisplayTypesAndSizes(writer, expected, actual, depth);
 
-            if (failurePoints.Count > depth)
+            if (_failurePoints.Count > depth)
             {
-                NUnitEqualityComparer.FailurePoint failurePoint = failurePoints[depth];
+                NUnitEqualityComparer.FailurePoint failurePoint = _failurePoints[depth];
 
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 
@@ -219,9 +219,9 @@ namespace NUnit.Framework.Constraints
         {
             DisplayTypesAndSizes(writer, expected, actual, depth);
 
-            if (failurePoints.Count > depth)
+            if (_failurePoints.Count > depth)
             {
-                NUnitEqualityComparer.FailurePoint failurePoint = failurePoints[depth];
+                NUnitEqualityComparer.FailurePoint failurePoint = _failurePoints[depth];
 
                 DisplayFailurePoint(writer, expected, actual, failurePoint, depth);
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -44,11 +44,11 @@ namespace NUnit.Framework.Constraints
         public EqualConstraintResult(EqualConstraint constraint, object? actual, bool hasSucceeded)
             : base(constraint, actual, hasSucceeded)
         {
-            this._expectedValue = constraint.Arguments[0];
-            this._tolerance = constraint.Tolerance;
-            this._caseInsensitive = constraint.CaseInsensitive;
-            this._clipStrings = constraint.ClipStrings;
-            this._failurePoints = constraint.FailurePoints;
+            _expectedValue = constraint.Arguments[0];
+            _tolerance = constraint.Tolerance;
+            _caseInsensitive = constraint.CaseInsensitive;
+            _clipStrings = constraint.ClipStrings;
+            _failurePoints = constraint.FailurePoints;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -63,16 +63,16 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         private class ComparerAdapter : EqualityAdapter
         {
-            private readonly IComparer comparer;
+            private readonly IComparer _comparer;
 
             public ComparerAdapter(IComparer comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
             {
-                return comparer.Compare(x, y) == 0;
+                return _comparer.Compare(x, y) == 0;
             }
         }
 
@@ -90,16 +90,16 @@ namespace NUnit.Framework.Constraints
 
         private class EqualityComparerAdapter : EqualityAdapter
         {
-            private readonly IEqualityComparer comparer;
+            private readonly IEqualityComparer _comparer;
 
             public EqualityComparerAdapter(IEqualityComparer comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
             {
-                return comparer.Equals(x, y);
+                return _comparer.Equals(x, y);
             }
         }
 
@@ -185,17 +185,17 @@ namespace NUnit.Framework.Constraints
 
         private class EqualityComparerAdapter<T> : GenericEqualityAdapter<T>
         {
-            private readonly IEqualityComparer<T> comparer;
+            private readonly IEqualityComparer<T> _comparer;
 
             public EqualityComparerAdapter(IEqualityComparer<T> comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
             {
                 CastOrThrow(x, y, out var xValue, out var yValue);
-                return comparer.Equals(xValue, yValue);
+                return _comparer.Equals(xValue, yValue);
             }
         }
 
@@ -216,17 +216,17 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         private class ComparerAdapter<T> : GenericEqualityAdapter<T>
         {
-            private readonly IComparer<T> comparer;
+            private readonly IComparer<T> _comparer;
 
             public ComparerAdapter(IComparer<T> comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
             {
                 CastOrThrow(x, y, out var xValue, out var yValue);
-                return comparer.Compare(xValue, yValue) == 0;
+                return _comparer.Compare(xValue, yValue) == 0;
             }
         }
 
@@ -244,17 +244,17 @@ namespace NUnit.Framework.Constraints
 
         private class ComparisonAdapter<T> : GenericEqualityAdapter<T>
         {
-            private readonly Comparison<T> comparer;
+            private readonly Comparison<T> _comparer;
 
             public ComparisonAdapter(Comparison<T> comparer)
             {
-                this.comparer = comparer;
+                this._comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
             {
                 CastOrThrow(x, y, out var xValue, out var yValue);
-                return comparer.Invoke(xValue, yValue) == 0;
+                return _comparer.Invoke(xValue, yValue) == 0;
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualityAdapter.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Constraints
 
             public ComparerAdapter(IComparer comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Constraints
 
             public EqualityComparerAdapter(IEqualityComparer comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
@@ -189,7 +189,7 @@ namespace NUnit.Framework.Constraints
 
             public EqualityComparerAdapter(IEqualityComparer<T> comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
@@ -220,7 +220,7 @@ namespace NUnit.Framework.Constraints
 
             public ComparerAdapter(IComparer<T> comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)
@@ -248,7 +248,7 @@ namespace NUnit.Framework.Constraints
 
             public ComparisonAdapter(Comparison<T> comparer)
             {
-                this._comparer = comparer;
+                _comparer = comparer;
             }
 
             public override bool AreEqual(object x, object y)

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
 
             actualType = actual?.GetType();
 
-            return new ExceptionTypeConstraintResult(this, actual, actualType, this.Matches(actual));
+            return new ExceptionTypeConstraintResult(this, actual, actualType, Matches(actual));
         }
 
         #region Nested Result Class
@@ -39,12 +39,12 @@ namespace NUnit.Framework.Constraints
             public ExceptionTypeConstraintResult(ExceptionTypeConstraint constraint, object? caughtException, Type? type, bool matches)
                 : base(constraint, type, matches)
             {
-                this._caughtException = caughtException;
+                _caughtException = caughtException;
             }
 
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                if (this.Status == ConstraintStatus.Failure)
+                if (Status == ConstraintStatus.Failure)
                 {
                     if (_caughtException is Exception ex)
                     {

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -34,19 +34,19 @@ namespace NUnit.Framework.Constraints
         #region Nested Result Class
         private class ExceptionTypeConstraintResult : ConstraintResult
         {
-            private readonly object? caughtException;
+            private readonly object? _caughtException;
 
             public ExceptionTypeConstraintResult(ExceptionTypeConstraint constraint, object? caughtException, Type? type, bool matches)
                 : base(constraint, type, matches)
             {
-                this.caughtException = caughtException;
+                this._caughtException = caughtException;
             }
 
             public override void WriteActualValueTo(MessageWriter writer)
             {
                 if (this.Status == ConstraintStatus.Failure)
                 {
-                    if (caughtException is Exception ex)
+                    if (_caughtException is Exception ex)
                     {
                         writer.WriteActualValue(ex);
                     }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -299,7 +299,9 @@ namespace NUnit.Framework.Constraints
         private static string FormatDouble(double d)
         {
             if (double.IsNaN(d) || double.IsInfinity(d))
+            {
                 return d.ToString();
+            }
             else
             {
                 string s = d.ToString("G17", CultureInfo.InvariantCulture);
@@ -314,7 +316,9 @@ namespace NUnit.Framework.Constraints
         private static string FormatFloat(float f)
         {
             if (float.IsNaN(f) || float.IsInfinity(f))
+            {
                 return f.ToString();
+            }
             else
             {
                 string s = f.ToString("G9", CultureInfo.InvariantCulture);
@@ -546,9 +550,13 @@ namespace NUnit.Framework.Constraints
                 sb.Append(ELLIPSIS);
             }
             else if (clipStart > 0)
+            {
                 sb.Append(s.Substring(clipStart));
+            }
             else
+            {
                 sb.Append(s);
+            }
 
             return sb.ToString();
         }

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -183,8 +183,10 @@ namespace NUnit.Framework.Constraints
             if (_externalComparers is not null)
             {
                 foreach (EqualityAdapter adapter in _externalComparers)
+                {
                     if (adapter.CanCompare(x, y))
                         return adapter;
+                }
             }
 
             return null;

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Constraints
 
         internal bool AreEqual(object? x, object? y, ref Tolerance tolerance, ComparisonState state)
         {
-            this._failurePoints = new List<FailurePoint>();
+            _failurePoints = new List<FailurePoint>();
 
             if (x is null && y is null)
                 return true;

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// List of comparers used to compare pairs of objects.
         /// </summary>
-        private static readonly EqualMethod[] _comparers =
+        private static readonly EqualMethod[] Comparers =
         {
             ArraysComparer.Equal,
             DictionariesComparer.Equal,
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Constraints
             if (externalComparer is not null)
                 return externalComparer.AreEqual(x, y, ref tolerance);
 
-            foreach (EqualMethod equalMethod in _comparers)
+            foreach (EqualMethod equalMethod in Comparers)
             {
                 bool? result = equalMethod(x, y, ref tolerance, state, this);
                 if (result.HasValue)

--- a/src/NUnitFramework/framework/Constraints/Operators/AndOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/AndOperator.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AndOperator()
         {
-            this.left_precedence = this.right_precedence = 2;
+            left_precedence = right_precedence = 2;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/AttributeOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/AttributeOperator.cs
@@ -17,11 +17,11 @@ namespace NUnit.Framework.Constraints
         /// <param name="type">The Type of attribute tested</param>
         public AttributeOperator(Type type)
         {
-            this._type = type;
+            _type = type;
 
             // Attribute stacks on anything and allows only
             // prefix operators to stack on it.
-            this.left_precedence = this.right_precedence = 1;
+            left_precedence = right_precedence = 1;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/AttributeOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/AttributeOperator.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class AttributeOperator : SelfResolvingOperator
     {
-        private readonly Type type;
+        private readonly Type _type;
 
         /// <summary>
         /// Construct an AttributeOperator for a particular Type
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="type">The Type of attribute tested</param>
         public AttributeOperator(Type type)
         {
-            this.type = type;
+            this._type = type;
 
             // Attribute stacks on anything and allows only
             // prefix operators to stack on it.
@@ -32,9 +32,9 @@ namespace NUnit.Framework.Constraints
         public override void Reduce(ConstraintBuilder.ConstraintStack stack)
         {
             if (RightContext is null || RightContext is BinaryOperator)
-                stack.Push(new AttributeExistsConstraint(type));
+                stack.Push(new AttributeExistsConstraint(_type));
             else
-                stack.Push(new AttributeConstraint(type, stack.Pop()));
+                stack.Push(new AttributeConstraint(_type, stack.Pop()));
         }
     }
  }

--- a/src/NUnitFramework/framework/Constraints/Operators/CollectionOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/CollectionOperator.cs
@@ -15,8 +15,8 @@ namespace NUnit.Framework.Constraints
         {
             // Collection Operators stack on everything
             // and allow all other ops to stack on them
-            this.left_precedence = 1;
-            this.right_precedence = 10;
+            left_precedence = 1;
+            right_precedence = 10;
         }
     }
  }

--- a/src/NUnitFramework/framework/Constraints/Operators/ConstraintOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/ConstraintOperator.cs
@@ -13,8 +13,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public abstract class ConstraintOperator
     {
-        private object? leftContext;
-        private object? rightContext;
+        private object? _leftContext;
+        private object? _rightContext;
 
         /// <summary>
         /// The precedence value used when the operator
@@ -41,8 +41,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public object? LeftContext
         {
-            get => leftContext;
-            set => leftContext = value;
+            get => _leftContext;
+            set => _leftContext = value;
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public object? RightContext
         {
-            get => rightContext;
-            set => rightContext = value;
+            get => _rightContext;
+            set => _rightContext = value;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class ExactCountOperator : SelfResolvingOperator
     {
-        private readonly int expectedCount;
+        private readonly int _expectedCount;
 
         /// <summary>
         /// Construct an ExactCountOperator for a specified count
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Constraints
             this.left_precedence = 1;
             this.right_precedence = 10;
 
-            this.expectedCount = expectedCount;
+            this._expectedCount = expectedCount;
         }
 
         /// <summary>
@@ -33,9 +33,9 @@ namespace NUnit.Framework.Constraints
         public override void Reduce(ConstraintBuilder.ConstraintStack stack)
         {
             if (RightContext is null || RightContext is BinaryOperator)
-                stack.Push(new ExactCountConstraint(expectedCount));
+                stack.Push(new ExactCountConstraint(_expectedCount));
             else
-                stack.Push(new ExactCountConstraint(expectedCount, stack.Pop()));
+                stack.Push(new ExactCountConstraint(_expectedCount, stack.Pop()));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/ExactCountOperator.cs
@@ -18,10 +18,10 @@ namespace NUnit.Framework.Constraints
         {
             // Collection Operators stack on everything
             // and allow all other ops to stack on them
-            this.left_precedence = 1;
-            this.right_precedence = 10;
+            left_precedence = 1;
+            right_precedence = 10;
 
-            this._expectedCount = expectedCount;
+            _expectedCount = expectedCount;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/IndexerOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/IndexerOperator.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Constraints
             
             // Indexer stacks on anything and allows only
             // prefix operators to stack on it.
-            this.left_precedence = this.right_precedence = 1;
+            left_precedence = right_precedence = 1;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/NotOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/NotOperator.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework.Constraints
         {
             // Not stacks on anything and only allows other
             // prefix ops to stack on top of it.
-            this.left_precedence = this.right_precedence = 1;
+            left_precedence = right_precedence = 1;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/OrOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/OrOperator.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public OrOperator()
         {
-            this.left_precedence = this.right_precedence = 3;
+            left_precedence = right_precedence = 3;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/PropOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/PropOperator.cs
@@ -9,19 +9,19 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class PropOperator : SelfResolvingOperator
     {
-        private readonly string name;
+        private readonly string _name;
 
         /// <summary>
         /// Gets the name of the property to which the operator applies
         /// </summary>
-        public string Name => name;
+        public string Name => _name;
 
         /// <summary>
         /// Constructs a PropOperator for a particular named property
         /// </summary>
         public PropOperator(string name)
         {
-            this.name = name;
+            this._name = name;
 
             // Prop stacks on anything and allows only
             // prefix operators to stack on it.
@@ -37,9 +37,9 @@ namespace NUnit.Framework.Constraints
         public override void Reduce(ConstraintBuilder.ConstraintStack stack)
         {
             if (RightContext is null || RightContext is BinaryOperator)
-                stack.Push(new PropertyExistsConstraint(name));
+                stack.Push(new PropertyExistsConstraint(_name));
             else
-                stack.Push(new PropertyConstraint(name, stack.Pop()));
+                stack.Push(new PropertyConstraint(_name, stack.Pop()));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Operators/PropOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/PropOperator.cs
@@ -21,11 +21,11 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public PropOperator(string name)
         {
-            this._name = name;
+            _name = name;
 
             // Prop stacks on anything and allows only
             // prefix operators to stack on it.
-            this.left_precedence = this.right_precedence = 1;
+            left_precedence = right_precedence = 1;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/ThrowsOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/ThrowsOperator.cs
@@ -16,8 +16,8 @@ namespace NUnit.Framework.Constraints
             // ThrowsOperator stacks on everything but
             // it's always the first item on the stack
             // anyway. It is evaluated last of all ops.
-            this.left_precedence = 1;
-            this.right_precedence = 100;
+            left_precedence = 1;
+            right_precedence = 100;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Operators/WithOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/WithOperator.cs
@@ -15,8 +15,8 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public WithOperator()
         {
-            this.left_precedence = 1;
-            this.right_precedence = 4;
+            left_precedence = 1;
+            right_precedence = 4;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/PathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PathConstraint.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Constraints
         protected PathConstraint(string expected)
             : base(expected)
         {
-            this.caseInsensitive = Path.DirectorySeparatorChar == WindowsDirectorySeparatorChar;
+            caseInsensitive = Path.DirectorySeparatorChar == WindowsDirectorySeparatorChar;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/PathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PathConstraint.cs
@@ -62,7 +62,10 @@ namespace NUnit.Framework.Constraints
                 {
                     leadingSeparators += Path.DirectorySeparatorChar;
                 }
-                else break;
+                else
+                {
+                    break;
+                }
             }
 
             string[] parts = path.Split(DirectorySeparatorChars, StringSplitOptions.RemoveEmptyEntries);

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -12,14 +12,14 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class PredicateConstraint<T> : Constraint
     {
-        private readonly Predicate<T> predicate;
+        private readonly Predicate<T> _predicate;
 
         /// <summary>
         /// Construct a PredicateConstraint from a predicate
         /// </summary>
         public PredicateConstraint(Predicate<T> predicate)
         {
-            this.predicate = predicate;
+            this._predicate = predicate;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
         {
             get
             {
-                var name = predicate.GetMethodInfo().Name;
+                var name = _predicate.GetMethodInfo().Name;
                 return name.StartsWith("<", StringComparison.Ordinal)
                     ? "value matching lambda expression"
                     : "value matching " + name;
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Constraints
         {
             var argument = ConstraintUtils.RequireActual<T>(actual, nameof(actual), allowNull: true);
 
-            return new ConstraintResult(this, actual, predicate(argument));
+            return new ConstraintResult(this, actual, _predicate(argument));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PredicateConstraint.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public PredicateConstraint(Predicate<T> predicate)
         {
-            this._predicate = predicate;
+            _predicate = predicate;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -12,8 +12,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class PropertyConstraint : PrefixConstraint
     {
-        private readonly string name;
-        private object? propValue;
+        private readonly string _name;
+        private object? _propValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyConstraint"/> class.
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Constraints
         public PropertyConstraint(string name, IConstraint baseConstraint)
             : base(baseConstraint, "property " + name)
         {
-            this.name = name;
+            this._name = name;
         }
 
         /// <summary>
@@ -36,13 +36,13 @@ namespace NUnit.Framework.Constraints
             Guard.ArgumentNotNull(actual, nameof(actual));
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-            PropertyInfo? property = Reflect.GetUltimateShadowingProperty(typeof(TActual), name, bindingFlags);
+            PropertyInfo? property = Reflect.GetUltimateShadowingProperty(typeof(TActual), _name, bindingFlags);
 
             if (property is null && typeof(TActual).IsInterface)
             {
                 foreach (var @interface in typeof(TActual).GetInterfaces())
                 {
-                    property = Reflect.GetUltimateShadowingProperty(@interface, name, bindingFlags);
+                    property = Reflect.GetUltimateShadowingProperty(@interface, _name, bindingFlags);
                     if (property is not null) break;
                 }
             }
@@ -51,23 +51,23 @@ namespace NUnit.Framework.Constraints
             {
                 if (actual is Type actualType)
                 {
-                    property = Reflect.GetUltimateShadowingProperty(actualType, name, bindingFlags);
+                    property = Reflect.GetUltimateShadowingProperty(actualType, _name, bindingFlags);
                 }
 
                 if (property is null)
                 {
                     actualType = actual.GetType();
 
-                    property = Reflect.GetUltimateShadowingProperty(actualType, name, bindingFlags);
+                    property = Reflect.GetUltimateShadowingProperty(actualType, _name, bindingFlags);
 
                     // TODO: Use an error result here
                     if (property is null)
-                        throw new ArgumentException($"Property {name} was not found on {actualType}.", nameof(name));
+                        throw new ArgumentException($"Property {_name} was not found on {actualType}.", nameof(_name));
                 }
             }
 
-            propValue = property.GetValue(actual, null);
-            var baseResult = BaseConstraint.ApplyTo(propValue);
+            _propValue = property.GetValue(actual, null);
+            var baseResult = BaseConstraint.ApplyTo(_propValue);
             return new PropertyConstraintResult(this, baseResult);
         }
 
@@ -76,7 +76,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected override string GetStringRepresentation()
         {
-            return $"<property {name} {BaseConstraint}>";
+            return $"<property {_name} {BaseConstraint}>";
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Constraints
         public PropertyConstraint(string name, IConstraint baseConstraint)
             : base(baseConstraint, "property " + name)
         {
-            this._name = name;
+            _name = name;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
@@ -16,8 +16,8 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class PropertyExistsConstraint : Constraint
     {
-        private readonly string name;
-        private Type? actualType;
+        private readonly string _name;
+        private Type? _actualType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyExistsConstraint"/> class.
@@ -26,14 +26,14 @@ namespace NUnit.Framework.Constraints
         public PropertyExistsConstraint(string name)
             : base(name)
         {
-            this.name = name;
+            this._name = name;
         }
 
         /// <summary>
         /// The Description of what this constraint tests, for
         /// use in messages and in the ConstraintResult.
         /// </summary>
-        public override string Description => "property " + name;
+        public override string Description => "property " + _name;
 
         /// <summary>
         /// Test whether the property exists for a given object
@@ -45,14 +45,14 @@ namespace NUnit.Framework.Constraints
             Guard.ArgumentNotNull(actual, nameof(actual));
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-            actualType = typeof(TActual);
-            PropertyInfo? property = Reflect.GetUltimateShadowingProperty(actualType, name, bindingFlags);
+            _actualType = typeof(TActual);
+            PropertyInfo? property = Reflect.GetUltimateShadowingProperty(_actualType, _name, bindingFlags);
 
             if (property is null && typeof(TActual).IsInterface)
             {
                 foreach (var @interface in typeof(TActual).GetInterfaces())
                 {
-                    property = Reflect.GetUltimateShadowingProperty(@interface, name, bindingFlags);
+                    property = Reflect.GetUltimateShadowingProperty(@interface, _name, bindingFlags);
                     if (property is not null) break;
                 }
             }
@@ -61,23 +61,23 @@ namespace NUnit.Framework.Constraints
             {
                 if (actual is Type actualIsType)
                 {
-                    actualType = actualIsType;
-                    property = Reflect.GetUltimateShadowingProperty(actualType, name, bindingFlags);
+                    _actualType = actualIsType;
+                    property = Reflect.GetUltimateShadowingProperty(_actualType, _name, bindingFlags);
 
                     if (property is null)
                     {
                         // Do not set actualType to System.RuntimeType as that is no expected
-                        property = Reflect.GetUltimateShadowingProperty(actual.GetType(), name, bindingFlags);
+                        property = Reflect.GetUltimateShadowingProperty(actual.GetType(), _name, bindingFlags);
                     }
                 }
                 else
                 {
-                    actualType = actual.GetType();
-                    property = Reflect.GetUltimateShadowingProperty(actualType, name, bindingFlags);
+                    _actualType = actual.GetType();
+                    property = Reflect.GetUltimateShadowingProperty(_actualType, _name, bindingFlags);
                 }
             }
 
-            return new ConstraintResult(this, actualType, property is not null);
+            return new ConstraintResult(this, _actualType, property is not null);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override string GetStringRepresentation()
         {
-            return $"<propertyexists {name}>";
+            return $"<propertyexists {_name}>";
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyExistsConstraint.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints
         public PropertyExistsConstraint(string name)
             : base(name)
         {
-            this._name = name;
+            _name = name;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
@@ -24,8 +24,8 @@ namespace NUnit.Framework.Constraints
         /// <param name="to">Inclusive end of the range.</param>
         public RangeConstraint(object from, object to) : base(from, to)
         {
-            this._from = from;
-            this._to = to;
+            _from = from;
+            _to = to;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using(IComparer comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using<T>(IComparer<T> comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using<T>(Comparison<T> comparer)
         {
-            this._comparer = ComparisonAdapter.For(comparer);
+            _comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RangeConstraint.cs
@@ -12,10 +12,10 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class RangeConstraint : Constraint
     {
-        private readonly object from;
-        private readonly object to;
+        private readonly object _from;
+        private readonly object _to;
 
-        private ComparisonAdapter comparer = ComparisonAdapter.Default;
+        private ComparisonAdapter _comparer = ComparisonAdapter.Default;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RangeConstraint"/> class.
@@ -24,14 +24,14 @@ namespace NUnit.Framework.Constraints
         /// <param name="to">Inclusive end of the range.</param>
         public RangeConstraint(object from, object to) : base(from, to)
         {
-            this.from = from;
-            this.to = to;
+            this._from = from;
+            this._to = to;
         }
 
         /// <summary>
         /// Gets text describing a constraint
         /// </summary>
-        public override string Description => $"in range ({from},{to})";
+        public override string Description => $"in range ({_from},{_to})";
 
         /// <summary>
         /// Test whether the constraint is satisfied by a given value
@@ -40,10 +40,10 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            if ( from is null || to is null || actual is null)
+            if ( _from is null || _to is null || actual is null)
                 throw new ArgumentException( "Cannot compare using a null reference", nameof(actual) );
             CompareFromAndTo();
-            bool isInsideRange = comparer.Compare(from, actual) <= 0 && comparer.Compare(to, actual) >= 0;
+            bool isInsideRange = _comparer.Compare(_from, actual) <= 0 && _comparer.Compare(_to, actual) >= 0;
             return new ConstraintResult(this, actual, isInsideRange);
         }
 
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using(IComparer comparer)
         {
-            this.comparer = ComparisonAdapter.For(comparer);
+            this._comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using<T>(IComparer<T> comparer)
         {
-            this.comparer = ComparisonAdapter.For(comparer);
+            this._comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
@@ -70,13 +70,13 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RangeConstraint Using<T>(Comparison<T> comparer)
         {
-            this.comparer = ComparisonAdapter.For(comparer);
+            this._comparer = ComparisonAdapter.For(comparer);
             return this;
         }
 
         private void CompareFromAndTo()
         {
-            if (comparer.Compare(from, to) > 0)
+            if (_comparer.Compare(_from, _to) > 0)
                 throw new ArgumentException("The from value must be less than or equal to the to value.");
         }
     }

--- a/src/NUnitFramework/framework/Constraints/ResolvableConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ResolvableConstraintExpression.cs
@@ -30,12 +30,12 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Appends an And Operator to the expression
         /// </summary>
-        public ConstraintExpression And => this.Append(new AndOperator());
+        public ConstraintExpression And => Append(new AndOperator());
 
         /// <summary>
         /// Appends an Or operator to the expression.
         /// </summary>
-        public ConstraintExpression Or => this.Append(new OrOperator());
+        public ConstraintExpression Or => Append(new OrOperator());
 
         #region IResolveConstraint Members
 

--- a/src/NUnitFramework/framework/Constraints/ReusableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ReusableConstraint.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The expression to be resolved and reused</param>
         public ReusableConstraint(IResolveConstraint c)
         {
-            this._constraint = c.Resolve();
+            _constraint = c.Resolve();
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ReusableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ReusableConstraint.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class ReusableConstraint : IResolveConstraint
     {
-        private readonly IConstraint constraint;
+        private readonly IConstraint _constraint;
 
         /// <summary>
         /// Construct a ReusableConstraint from a constraint expression
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="c">The expression to be resolved and reused</param>
         public ReusableConstraint(IResolveConstraint c)
         {
-            this.constraint = c.Resolve();
+            this._constraint = c.Resolve();
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Constraints
         /// </returns>
         public override string ToString()
         {
-            return constraint.ToString()!;
+            return _constraint.ToString()!;
         }
 
         #region IResolveConstraint Members
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         public IConstraint Resolve()
         {
-            return constraint;
+            return _constraint;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class SameAsConstraint : Constraint
     {
-        private readonly object? expected;
+        private readonly object? _expected;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SameAsConstraint"/> class.
@@ -16,14 +16,14 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected object.</param>
         public SameAsConstraint(object? expected) : base(expected)
         {
-            this.expected = expected;
+            this._expected = expected;
         }
 
         /// <summary>
         /// The Description of what this constraint tests, for
         /// use in messages and in the ConstraintResult.
         /// </summary>
-        public override string Description => "same as " + MsgUtils.FormatValue(expected);
+        public override string Description => "same as " + MsgUtils.FormatValue(_expected);
 
         /// <summary>
         /// Test whether the constraint is satisfied by a given value
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            bool hasSucceeded = ReferenceEquals(expected, actual);
+            bool hasSucceeded = ReferenceEquals(_expected, actual);
 
             return new ConstraintResult(this, actual, hasSucceeded);
         }

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The expected object.</param>
         public SameAsConstraint(object? expected) : base(expected)
         {
-            this._expected = expected;
+            _expected = expected;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -45,8 +45,10 @@ namespace NUnit.Framework.Constraints
             var enumerable = ConstraintUtils.RequireActual<IEnumerable>(actual, nameof(actual));
 
             foreach (object item in enumerable)
+            {
                 if (BaseConstraint.ApplyTo(item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Success);
+            }
 
             return new ConstraintResult(this, actual, ConstraintStatus.Failure);
         }

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
         /// <returns></returns>
         protected override bool Matches(string actual)
         {
-            var stringComparison = this.caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+            var stringComparison = caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual is not null && actual.StartsWith(expected, stringComparison);
         }
     }

--- a/src/NUnitFramework/framework/Constraints/StringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StringConstraint.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         protected StringConstraint()
         {
-            this.expected = string.Empty;
+            expected = string.Empty;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
@@ -52,9 +52,9 @@ namespace NUnit.Framework.Constraints
         /// than <paramref name="comparisonType"/> was already set.</exception>
         public SubstringConstraint Using(StringComparison comparisonType)
         {
-            if (this._comparisonType == null)
-                this._comparisonType = comparisonType;
-            else if (this._comparisonType != comparisonType)
+            if (_comparisonType == null)
+                _comparisonType = comparisonType;
+            else if (_comparisonType != comparisonType)
                 throw new InvalidOperationException("A different comparison type was already set.");
 
             return this;

--- a/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class SubstringConstraint : StringConstraint
     {
-        private StringComparison? comparisonType;
+        private StringComparison? _comparisonType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SubstringConstraint"/> class.
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
         {
             if (actual is null) return false;
 
-            var actualComparison = comparisonType ?? StringComparison.CurrentCulture;
+            var actualComparison = _comparisonType ?? StringComparison.CurrentCulture;
             return actual.IndexOf(expected, actualComparison) >= 0;
         }
 
@@ -52,9 +52,9 @@ namespace NUnit.Framework.Constraints
         /// than <paramref name="comparisonType"/> was already set.</exception>
         public SubstringConstraint Using(StringComparison comparisonType)
         {
-            if (this.comparisonType == null)
-                this.comparisonType = comparisonType;
-            else if (this.comparisonType != comparisonType)
+            if (this._comparisonType == null)
+                this._comparisonType = comparisonType;
+            else if (this._comparisonType != comparisonType)
                 throw new InvalidOperationException("A different comparison type was already set.");
 
             return this;

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -11,7 +11,7 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class ThrowsConstraint : PrefixConstraint
     {
-        private Exception? caughtException;
+        private Exception? _caughtException;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ThrowsConstraint"/> class,
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Get the actual exception thrown - used by Assert.Throws.
         /// </summary>
-        public Exception? ActualException => caughtException;
+        public Exception? ActualException => _caughtException;
 
         #region Constraint Overrides
 
@@ -44,14 +44,14 @@ namespace NUnit.Framework.Constraints
         {
             var @delegate = ConstraintUtils.RequireActual<Delegate>(actual, nameof(actual));
 
-            caughtException = ExceptionHelper.RecordException(@delegate, nameof(actual));
+            _caughtException = ExceptionHelper.RecordException(@delegate, nameof(actual));
 
-            if (caughtException is not null)
+            if (_caughtException is not null)
             {
                 return new ThrowsConstraintResult(
                     this,
-                    caughtException,
-                    BaseConstraint.ApplyTo(caughtException));
+                    _caughtException,
+                    BaseConstraint.ApplyTo(_caughtException));
 
             }
             return new ThrowsConstraintResult(this);
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Constraints
 
         private sealed class ThrowsConstraintResult : ConstraintResult
         {
-            private readonly ConstraintResult? baseResult;
+            private readonly ConstraintResult? _baseResult;
 
             public ThrowsConstraintResult(ThrowsConstraint constraint)
                 : base(constraint, null)
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Constraints
                 else
                     Status = ConstraintStatus.Failure;
 
-                this.baseResult = baseResult;
+                this._baseResult = baseResult;
             }
 
             /// <summary>
@@ -103,10 +103,10 @@ namespace NUnit.Framework.Constraints
             /// <param name="writer">The writer on which the actual value is displayed</param>
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                if (baseResult is null)
+                if (_baseResult is null)
                     writer.Write("no exception thrown");
                 else
-                    baseResult.WriteActualValueTo(writer);
+                    _baseResult.WriteActualValueTo(writer);
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsConstraint.cs
@@ -92,7 +92,7 @@ namespace NUnit.Framework.Constraints
                 else
                     Status = ConstraintStatus.Failure;
 
-                this._baseResult = baseResult;
+                _baseResult = baseResult;
             }
 
             /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ThrowsExceptionConstraint.cs
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Constraints
 
             public override void WriteActualValueTo(MessageWriter writer)
             {
-                if (this.Status == ConstraintStatus.Failure)
+                if (Status == ConstraintStatus.Failure)
                     writer.Write("no exception thrown");
                 else
                     base.WriteActualValueTo(writer);

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -215,9 +215,11 @@ namespace NUnit.Framework.Constraints
         private void CheckLinearAndNumeric()
         {
             if (Mode != ToleranceMode.Linear)
+            {
                 throw new InvalidOperationException(Mode == ToleranceMode.Unset
                     ? ModeMustFollowTolerance
                     : MultipleToleranceModes);
+            }
 
             if (!Numerics.IsNumericType(Amount))
                 throw new InvalidOperationException(NumericToleranceRequired);

--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -36,8 +36,8 @@ namespace NUnit.Framework.Constraints
         protected TypeConstraint(Type type, string descriptionPrefix)
             : base(type)
         {
-            this.expectedType = type;
-            this.Description = descriptionPrefix + MsgUtils.FormatValue(expectedType);
+            expectedType = type;
+            Description = descriptionPrefix + MsgUtils.FormatValue(expectedType);
         }
 
         /// <inheritdoc/>
@@ -53,9 +53,9 @@ namespace NUnit.Framework.Constraints
             actualType = actual?.GetType();
 
             if (actual is Exception)
-                return new ConstraintResult(this, actual, this.Matches(actual));
+                return new ConstraintResult(this, actual, Matches(actual));
 
-            return new ConstraintResult(this, actualType, this.Matches(actual));
+            return new ConstraintResult(this, actualType, Matches(actual));
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -63,7 +63,9 @@ namespace NUnit.Framework.Constraints
                 }
 
                 if (isUnique)
+                {
                     processedItems.Add(o1);
+                }
                 else if (unknownNonUnique)
                 {
                     nonUniques.Add(o1);
@@ -123,15 +125,21 @@ namespace NUnit.Framework.Constraints
         private static bool IsSpecialComparisonType(Type type)
         {
             if (type.IsGenericType)
+            {
                 return type.FullName().StartsWith("System.Collections.Generic.KeyValuePair`2", StringComparison.Ordinal);
+            }
             else if (Numerics.IsNumericType(type))
+            {
                 return true;
+            }
             else
+            {
                 return
                     type == typeof(string)
                     || type == typeof(char)
                     || type == typeof(DateTimeOffset)
                     || type == typeof(DictionaryEntry);
+            }
         }
 
         private ICollection GetNonUniqueItems(IEnumerable actual)

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -276,7 +276,7 @@ namespace NUnit.Framework.Constraints
 
             public override void WriteAdditionalLinesTo(MessageWriter writer)
             {
-                if (this.Status == ConstraintStatus.Failure)
+                if (Status == ConstraintStatus.Failure)
                 {
                     writer.Write("  Not unique items: ");
                     var output = MsgUtils.FormatCollection(NonUniqueItems, 0, MsgUtils.DefaultMaxItems);

--- a/src/NUnitFramework/framework/Interfaces/ResultState.cs
+++ b/src/NUnitFramework/framework/Interfaces/ResultState.cs
@@ -170,7 +170,7 @@ namespace NUnit.Framework.Interfaces
         /// <returns>A new ResultState</returns>
         public ResultState WithSite(FailureSite site)
         {
-            return new ResultState(this.Status, this.Label, site);
+            return new ResultState(Status, Label, site);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -304,10 +304,12 @@ namespace NUnit.Framework.Interfaces
                 writer.WriteAttributeString(pair.Key, pair.Value);
 
             if (Value is not null)
+            {
                 if (ValueIsCDATA)
                     writer.WriteCDataSafe(Value);
                 else
                     writer.WriteString(Value);
+            }
 
             var count = ChildNodes.Count;
             for (var i = 0; i < count; i++)
@@ -333,8 +335,10 @@ namespace NUnit.Framework.Interfaces
             }
 
             foreach (XmlNode child in xmlNode.ChildNodes)
+            {
                 if (child.NodeType == XmlNodeType.Element)
                     tNode.AddChildNode(FromXml(child));
+            }
 
             return tNode;
         }

--- a/src/NUnitFramework/framework/Interfaces/TNode.cs
+++ b/src/NUnitFramework/framework/Interfaces/TNode.cs
@@ -21,8 +21,8 @@ namespace NUnit.Framework.Interfaces
     [DebuggerDisplay("{OuterXml}")]
     public sealed class TNode
     {
-        internal List<TNode>? _childNodes;
-        internal Dictionary<string, string>? _attributes;
+        private List<TNode>? _childNodes;
+        private Dictionary<string, string>? _attributes;
 
         #region Constructors
 
@@ -425,107 +425,108 @@ namespace NUnit.Framework.Interfaces
         }
 
         #endregion
-    }
 
-    /// <summary>
-    /// Class used to represent a list of XmlResults
-    /// </summary>
-    public readonly struct NodeList : IEnumerable<TNode>
-    {
-        private static readonly List<TNode> _emptyList = new();
-
-        private readonly TNode _parent;
-
-        internal NodeList(TNode parent)
-        {
-            _parent = parent;
-        }
 
         /// <summary>
-        /// Gets or sets the element at the specified index.
+        /// Class used to represent a list of XmlResults
         /// </summary>
-        public TNode this[int index]
+        public readonly struct NodeList : IEnumerable<TNode>
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
+            private static readonly List<TNode> EmptyList = new();
+
+            private readonly TNode _parent;
+
+            internal NodeList(TNode parent)
             {
-                if (_parent._childNodes is null || (uint) index >= (uint) _parent._childNodes.Count)
-                    ThrowArgumentOutOfRangeException(index);
-
-                return _parent._childNodes![index];
+                _parent = parent;
             }
-        }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowArgumentOutOfRangeException(int index)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, "Index was out or range of valida values");
-        }
-
-        /// <summary>
-        /// Gets the number of elements contained in the collection.
-        /// </summary>
-        public int Count
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _parent._childNodes?.Count ?? 0;
-        }
-
-        /// <summary>
-        /// Returns an enumerator that iterates through the collection.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public List<TNode>.Enumerator GetEnumerator() => _parent._childNodes?.GetEnumerator() ?? _emptyList.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        IEnumerator<TNode> IEnumerable<TNode>.GetEnumerator() => GetEnumerator();
-    }
-
-    /// <summary>
-    /// Class used to represent the attributes of a node
-    /// </summary>
-    public readonly struct AttributeDictionary
-    {
-        private static readonly Dictionary<string, string> _emptyDictionary = new();
-
-        private readonly TNode _parent;
-
-        internal AttributeDictionary(TNode parent)
-        {
-            _parent = parent;
-        }
-
-        /// <summary>
-        /// Gets or sets the value associated with the specified key.
-        /// Overridden to return null if attribute is not found.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <returns>Value of the attribute or null</returns>
-        public string? this[string key]
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
+            /// <summary>
+            /// Gets or sets the element at the specified index.
+            /// </summary>
+            public TNode this[int index]
             {
-                string? value = null;
-                _parent._attributes?.TryGetValue(key, out value);
-                return value;
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get
+                {
+                    if (_parent._childNodes is null || (uint)index >= (uint)_parent._childNodes.Count)
+                        ThrowArgumentOutOfRangeException(index);
+
+                    return _parent._childNodes![index];
+                }
             }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static void ThrowArgumentOutOfRangeException(int index)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Index was out or range of valida values");
+            }
+
+            /// <summary>
+            /// Gets the number of elements contained in the collection.
+            /// </summary>
+            public int Count
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => _parent._childNodes?.Count ?? 0;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public List<TNode>.Enumerator GetEnumerator() => _parent._childNodes?.GetEnumerator() ?? EmptyList.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            IEnumerator<TNode> IEnumerable<TNode>.GetEnumerator() => GetEnumerator();
         }
 
         /// <summary>
-        /// Returns an enumerator that iterates through the collection.
+        /// Class used to represent the attributes of a node
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Dictionary<string,string>.Enumerator GetEnumerator() => _parent._attributes?.GetEnumerator() ?? _emptyDictionary.GetEnumerator();
-
-        /// <summary>
-        /// Gets the number of key/value pairs contained in the <see cref="T:System.Collections.Generic.Dictionary`2" />.
-        /// </summary>
-        public int Count
+        public readonly struct AttributeDictionary
         {
+            private static readonly Dictionary<string, string> EmptyDictionary = new();
+
+            private readonly TNode _parent;
+
+            internal AttributeDictionary(TNode parent)
+            {
+                _parent = parent;
+            }
+
+            /// <summary>
+            /// Gets or sets the value associated with the specified key.
+            /// Overridden to return null if attribute is not found.
+            /// </summary>
+            /// <param name="key">The key.</param>
+            /// <returns>Value of the attribute or null</returns>
+            public string? this[string key]
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get
+                {
+                    string? value = null;
+                    _parent._attributes?.TryGetValue(key, out value);
+                    return value;
+                }
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _parent._attributes?.Count ?? 0;
+            public Dictionary<string, string>.Enumerator GetEnumerator() => _parent._attributes?.GetEnumerator() ?? EmptyDictionary.GetEnumerator();
+
+            /// <summary>
+            /// Gets the number of key/value pairs contained in the <see cref="T:System.Collections.Generic.Dictionary`2" />.
+            /// </summary>
+            public int Count
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => _parent._attributes?.Count ?? 0;
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -72,24 +72,24 @@ namespace NUnit.Framework.Internal
 #if NETSTANDARD2_0
         private sealed class ReflectionAssemblyLoader
         {
-            private static ReflectionAssemblyLoader? instance;
-            private static bool isInitialized;
+            private static ReflectionAssemblyLoader? _instance;
+            private static bool _isInitialized;
 
-            private readonly Func<string, Assembly> loadFromAssemblyPath;
+            private readonly Func<string, Assembly> _loadFromAssemblyPath;
 
-            public Assembly LoadFromAssemblyPath(string assemblyPath) => loadFromAssemblyPath.Invoke(assemblyPath);
+            public Assembly LoadFromAssemblyPath(string assemblyPath) => _loadFromAssemblyPath.Invoke(assemblyPath);
 
             private ReflectionAssemblyLoader(Func<string, Assembly> loadFromAssemblyPath)
             {
-                this.loadFromAssemblyPath = loadFromAssemblyPath;
+                this._loadFromAssemblyPath = loadFromAssemblyPath;
             }
 
             public static ReflectionAssemblyLoader? TryGet()
             {
-                if (isInitialized) return instance;
-                instance = TryInitialize();
-                isInitialized = true;
-                return instance;
+                if (_isInitialized) return _instance;
+                _instance = TryInitialize();
+                _isInitialized = true;
+                return _instance;
             }
 
             private static ReflectionAssemblyLoader? TryInitialize()

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
 
             private ReflectionAssemblyLoader(Func<string, Assembly> loadFromAssemblyPath)
             {
-                this._loadFromAssemblyPath = loadFromAssemblyPath;
+                _loadFromAssemblyPath = loadFromAssemblyPath;
             }
 
             public static ReflectionAssemblyLoader? TryGet()

--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -9,12 +9,12 @@ namespace NUnit.Framework.Internal
 {
     internal static class AsyncToSyncAdapter
     {
-        private static readonly Type? _asyncStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncStateMachineAttribute, System.Runtime", false);
+        private static readonly Type? AsyncStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncStateMachineAttribute, System.Runtime", false);
 
         public static bool IsAsyncOperation(MethodInfo method)
         {
             return AwaitAdapter.IsAwaitable(method.ReturnType)
-                || (_asyncStateMachineAttributeType is not null && method.IsDefined(_asyncStateMachineAttributeType, false));
+                || (AsyncStateMachineAttributeType is not null && method.IsDefined(AsyncStateMachineAttributeType, false));
         }
 
         public static bool IsAsyncOperation(Delegate @delegate)

--- a/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DatapointProvider.cs
@@ -50,10 +50,14 @@ namespace NUnit.Framework.Internal.Builders
 
                 if (member.IsDefined(typeof(DatapointAttribute), true) &&
                     GetTypeFromMemberInfo(member) == parameterType)
+                {
                     return true;
+                }
                 else if (member.IsDefined(typeof(DatapointSourceAttribute), true) &&
                     GetElementTypeFromMemberInfo(member) == parameterType)
+                {
                     return true;
+                }
             }
 
             return false;

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -140,8 +140,10 @@ namespace NUnit.Framework.Internal.Builders
                     // Count how many have arguments
                     int withArgs = 0;
                     foreach (var attr in attrs)
+                    {
                         if (HasArguments(attr))
                             withArgs++;
+                    }
 
                     // If all have args, just return them
                     if (withArgs == attrs.Length)
@@ -155,8 +157,10 @@ namespace NUnit.Framework.Internal.Builders
                     var result = new IFixtureBuilder[withArgs];
                     int count = 0;
                     foreach (var attr in attrs)
+                    {
                         if (HasArguments(attr))
                             result[count++] = attr;
+                    }
 
                     return result;
                 }

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -92,7 +92,9 @@ namespace NUnit.Framework.Internal.Builders
                 // See if we need to add a CombinatorialAttribute for parameterized data
                 if (method.MethodInfo.GetParameters().Any(param => param.HasAttribute<IParameterDataSource>(false))
                     && !builders.Any(builder => builder is CombiningStrategyAttribute))
+                {
                     builders.Add(new CombinatorialAttribute());
+                }
 
                 foreach (var attr in builders)
                 {

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Internal.Builders
 
             if (parms is not null)
             {
-                testMethod.parms = parms;
+                testMethod.Parms = parms;
                 testMethod.RunState = parms.RunState;
 
                 arglist = parms.Arguments;

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -176,12 +176,16 @@ namespace NUnit.Framework.Internal.Builders
                 var voidResult = Reflect.IsVoidOrUnit(AwaitAdapter.GetResultType(returnType));
 
                 if (!voidResult && (parms is null || !parms.HasExpectedResult))
+                {
                     return MarkAsNotRunnable(testMethod,
                         "Async test method must return an awaitable with a void result when no result is expected");
+                }
 
                 if (voidResult && parms is not null && parms.HasExpectedResult)
+                {
                     return MarkAsNotRunnable(testMethod,
                         "Async test method must return an awaitable with a non-void result when a result is expected");
+                }
             }
             else if (metadata.IsVoidOrUnit)
             {
@@ -189,7 +193,9 @@ namespace NUnit.Framework.Internal.Builders
                     return MarkAsNotRunnable(testMethod, "Method returning void cannot have an expected result");
             }
             else if (parms is null || !parms.HasExpectedResult)
+            {
                 return MarkAsNotRunnable(testMethod, "Method has non-void return value, but no result is expected");
+            }
 
             if (argsProvided > 0 && maxArgsNeeded == 0)
                 return MarkAsNotRunnable(testMethod, "Arguments provided for method with no parameters");

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestFixtureBuilder.cs
@@ -81,8 +81,10 @@ namespace NUnit.Framework.Internal.Builders
                 {
                     int cnt = 0;
                     foreach (object? o in arguments)
+                    {
                         if (o is Type) cnt++;
                         else break;
+                    }
 
                     typeArgs = new Type[cnt];
                     for (int i = 0; i < cnt; i++)
@@ -140,8 +142,10 @@ namespace NUnit.Framework.Internal.Builders
                 fixture.RunState = testFixtureData.RunState;
 
             foreach (string key in testFixtureData.Properties.Keys)
+            {
                 foreach (object val in testFixtureData.Properties[key])
                     fixture.Properties.Add(key, val);
+            }
 
             if (fixture.RunState != RunState.NotRunnable)
                 CheckTestFixtureIsValid(fixture);

--- a/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/ParameterDataProvider.cs
@@ -29,8 +29,10 @@ namespace NUnit.Framework.Internal.Builders
         public bool HasDataFor(IParameterInfo parameter)
         {
             foreach (var provider in _providers)
+            {
                 if (provider.HasDataFor(parameter))
                     return true;
+            }
 
             return false;
         }
@@ -42,8 +44,10 @@ namespace NUnit.Framework.Internal.Builders
         public IEnumerable GetDataFor(IParameterInfo parameter)
         {
             foreach (var provider in _providers)
+            {
                 foreach (object? data in provider.GetDataFor(parameter))
                     yield return data;
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Builders/SequentialStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/SequentialStrategy.cs
@@ -31,13 +31,17 @@ namespace NUnit.Framework.Internal.Builders
                 object?[] testdata = new object?[sources.Length];
 
                 for (int i = 0; i < sources.Length; i++)
+                {
                     if (enumerators[i].MoveNext())
                     {
                         testdata[i] = enumerators[i].Current;
                         gotData = true;
                     }
                     else
+                    {
                         testdata[i] = null;
+                    }
+                }
 
                 if (!gotData)
                     break;

--- a/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
@@ -39,8 +39,10 @@ namespace NUnit.Framework.Internal.Commands
                     double elapsedTime = result.Duration * 1000d;
 
                     if (elapsedTime > maxTime)
+                    {
                         result.SetResult(ResultState.Failure,
                             $"Elapsed time of {elapsedTime}ms exceeds maximum of {maxTime}ms");
+                    }
                 }
             };
         }

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -62,6 +62,7 @@ namespace NUnit.Framework.Internal.Commands
             // As of NUnit 3.0, we will only run teardown at a given
             // inheritance level if we actually ran setup at that level.
             if (_setUpWasRun)
+            {
                 try
                 {
                     // Count of assertion results so far
@@ -82,6 +83,7 @@ namespace NUnit.Framework.Internal.Commands
                 {
                     context.CurrentResult.RecordTearDownException(ex);
                 }
+            }
         }
 
         private void RunSetUpOrTearDownMethod(TestExecutionContext context, IMethodInfo method)

--- a/src/NUnitFramework/framework/Internal/CultureDetector.cs
+++ b/src/NUnitFramework/framework/Internal/CultureDetector.cs
@@ -41,8 +41,10 @@ namespace NUnit.Framework.Internal
         public bool IsCultureSupported( string[] cultures )
         {
             foreach( string culture in cultures )
+            {
                 if ( IsCultureSupported( culture ) )
                     return true;
+            }
 
             return false;
         }

--- a/src/NUnitFramework/framework/Internal/CultureDetector.cs
+++ b/src/NUnitFramework/framework/Internal/CultureDetector.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public CultureDetector()
         {
-            this._currentCulture = CultureInfo.CurrentCulture;
+            _currentCulture = CultureInfo.CurrentCulture;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal
         /// <param name="culture">The culture to be used</param>
         public CultureDetector( string culture )
         {
-            this._currentCulture = new CultureInfo( culture );
+            _currentCulture = new CultureInfo( culture );
         }
 
         /// <summary>
@@ -90,11 +90,11 @@ namespace NUnit.Framework.Internal
             }
             else
             {
-                if( this._currentCulture.Name == culture || this._currentCulture.TwoLetterISOLanguageName == culture)
+                if( _currentCulture.Name == culture || _currentCulture.TwoLetterISOLanguageName == culture)
                     return true;
             }
 
-            this._reason = "Only supported under culture " + culture;
+            _reason = "Only supported under culture " + culture;
             return false;
         }
 

--- a/src/NUnitFramework/framework/Internal/CultureDetector.cs
+++ b/src/NUnitFramework/framework/Internal/CultureDetector.cs
@@ -10,17 +10,17 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class CultureDetector
     {
-        private readonly CultureInfo currentCulture;
+        private readonly CultureInfo _currentCulture;
 
         // Set whenever we fail to support a list of platforms
-        private string reason = string.Empty;
+        private string _reason = string.Empty;
 
         /// <summary>
         /// Default constructor uses the current culture.
         /// </summary>
         public CultureDetector()
         {
-            this.currentCulture = CultureInfo.CurrentCulture;
+            this._currentCulture = CultureInfo.CurrentCulture;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Internal
         /// <param name="culture">The culture to be used</param>
         public CultureDetector( string culture )
         {
-            this.currentCulture = new CultureInfo( culture );
+            this._currentCulture = new CultureInfo( culture );
         }
 
         /// <summary>
@@ -60,13 +60,13 @@ namespace NUnit.Framework.Internal
 
             if (include is not null && !IsCultureSupported(include))
             {
-                reason = $"Only supported under culture {include}";
+                _reason = $"Only supported under culture {include}";
                 return false;
             }
 
             if (exclude is not null && IsCultureSupported(exclude))
             {
-                reason = $"Not supported under culture {exclude}";
+                _reason = $"Not supported under culture {exclude}";
                 return false;
             }
 
@@ -90,11 +90,11 @@ namespace NUnit.Framework.Internal
             }
             else
             {
-                if( this.currentCulture.Name == culture || this.currentCulture.TwoLetterISOLanguageName == culture)
+                if( this._currentCulture.Name == culture || this._currentCulture.TwoLetterISOLanguageName == culture)
                     return true;
             }
 
-            this.reason = "Only supported under culture " + culture;
+            this._reason = "Only supported under culture " + culture;
             return false;
         }
 
@@ -103,6 +103,6 @@ namespace NUnit.Framework.Internal
         /// defined if called before IsSupported( Attribute )
         /// is called.
         /// </summary>
-        public string Reason => reason;
+        public string Reason => _reason;
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -320,9 +320,9 @@ namespace NUnit.Framework.Internal.Execution
             // executed on the same thread since the time that
             // this test started, so we have to re-establish
             // the proper execution environment
-            this.Context.EstablishExecutionEnvironment();
+            Context.EstablishExecutionEnvironment();
 
-            _teardownCommand?.Execute(this.Context);
+            _teardownCommand?.Execute(Context);
         }
 
         private string? GetSkipReason()
@@ -445,7 +445,7 @@ namespace NUnit.Framework.Internal.Execution
                     foreach (var childResult in Result.Children)
                         if (childResult.ResultState == ResultState.Cancelled)
                         {
-                            this.Result.SetResult(ResultState.Cancelled, "Cancelled by user");
+                            Result.SetResult(ResultState.Cancelled, "Cancelled by user");
                             break;
                         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -373,7 +373,7 @@ namespace NUnit.Framework.Internal.Execution
                 Context.Dispatcher.Dispatch(new OneTimeTearDownWorkItem(this));
         }
 
-        private readonly object cancelLock = new object();
+        private readonly object _cancelLock = new object();
 
         /// <summary>
         /// Cancel (abort or stop) a CompositeWorkItem and all of its children
@@ -381,7 +381,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="force">true if the CompositeWorkItem and all of its children should be aborted, false if it should allow all currently running tests to complete</param>
         public override void Cancel(bool force)
         {
-            lock (cancelLock)
+            lock (_cancelLock)
             {
                 foreach (var child in Children)
                 {

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -57,9 +57,13 @@ namespace NUnit.Framework.Internal.Execution
         protected override void PerformWork()
         {
             if (!CheckForCancellation())
+            {
                 if (Test.RunState == RunState.Explicit && !Filter.IsExplicitMatch(Test))
+                {
                     SkipFixture(ResultState.Explicit, GetSkipReason(), null);
+                }
                 else
+                {
                     switch (Test.RunState)
                     {
                         default:
@@ -101,7 +105,10 @@ namespace NUnit.Framework.Internal.Execution
                                     PerformOneTimeTearDown();
                             }
                             else if (Test.TestType == "Theory")
+                            {
                                 Result.SetResult(ResultState.Failure, "No test cases were provided");
+                            }
+
                             break;
 
                         case RunState.Skipped:
@@ -116,6 +123,8 @@ namespace NUnit.Framework.Internal.Execution
                             SkipFixture(ResultState.NotRunnable, GetSkipReason(), GetProviderStackTrace());
                             break;
                     }
+                }
+            }
 
             // Fall through in case nothing was run.
             // Otherwise, this is done in the completion event.
@@ -276,12 +285,14 @@ namespace NUnit.Framework.Internal.Execution
             // If run was cancelled, reduce countdown by number of
             // child items not yet staged and check if we are done.
             if (childCount > 0)
-                lock(_childCompletionLock)
+            {
+                lock (_childCompletionLock)
                 {
                     _childTestCountdown.Signal(childCount);
                     if (_childTestCountdown.CurrentCount == 0)
                         OnAllChildItemsCompleted();
                 }
+            }
         }
 
         private void SkipFixture(ResultState resultState, string? message, string? stackTrace)
@@ -443,11 +454,13 @@ namespace NUnit.Framework.Internal.Execution
                         _originalWorkItem.PerformOneTimeTearDown();
 
                     foreach (var childResult in Result.Children)
+                    {
                         if (childResult.ResultState == ResultState.Cancelled)
                         {
                             Result.SetResult(ResultState.Cancelled, "Cancelled by user");
                             break;
                         }
+                    }
 
                     _originalWorkItem.WorkItemComplete();
                 }

--- a/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventPump.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class EventPump : IDisposable
     {
-        private static readonly Logger log = InternalTrace.GetLogger("EventPump");
+        private static readonly Logger Log = InternalTrace.GetLogger("EventPump");
 
         #region Instance Variables
 
@@ -142,7 +142,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         private void PumpThreadProc()
         {
-            log.Debug("Starting EventPump");
+            Log.Debug("Starting EventPump");
 
             //ITestListener hostListeners = CoreExtensions.Host.Listeners;
             try
@@ -159,22 +159,22 @@ namespace NUnit.Framework.Internal.Execution
                     }
                     catch (Exception ex)
                     {
-                        log.Error("Exception in event handler {0}", ExceptionHelper.BuildStackTrace(ex));
+                        Log.Error("Exception in event handler {0}", ExceptionHelper.BuildStackTrace(ex));
                     }
                 }
 
-                log.Debug("EventPump Terminating");
+                Log.Debug("EventPump Terminating");
             }
             catch (Exception ex)
             {
-                log.Error("Exception in pump thread {0}", ExceptionHelper.BuildStackTrace(ex));
+                Log.Error("Exception in pump thread {0}", ExceptionHelper.BuildStackTrace(ex));
             }
             finally
             {
                 _pumpState = (int)EventPumpState.Stopped;
                 //pumpThread = null;
                 if (_events.Count > 0)
-                    log.Error("Event pump thread exiting with {0} events remaining");
+                    Log.Error("Event pump thread exiting with {0} events remaining");
             }
         }
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/EventQueue.cs
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class EventQueue
     {
-        private const int spinCount = 5;
+        private const int SpinCount = 5;
 
 //        static readonly Logger log = InternalTrace.GetLogger("EventQueue");
 
@@ -232,7 +232,7 @@ namespace NUnit.Framework.Internal.Execution
                         return null;
 
                     // Spin a few times to see if something changes
-                    if (sw.Count <= spinCount)
+                    if (sw.Count <= SpinCount)
                     {
                         sw.SpinOnce();
                     }

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class ParallelWorkItemDispatcher : IWorkItemDispatcher
     {
-        private static readonly Logger log = InternalTrace.GetLogger("Dispatcher");
+        private static readonly Logger Log = InternalTrace.GetLogger("Dispatcher");
 
         private const int WAIT_FOR_FORCED_TERMINATION = 5000;
 
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="levelOfParallelism">Number of workers to use</param>
         public ParallelWorkItemDispatcher(int levelOfParallelism)
         {
-            log.Info("Initializing with {0} workers", levelOfParallelism);
+            Log.Info("Initializing with {0} workers", levelOfParallelism);
 
             LevelOfParallelism = levelOfParallelism;
 
@@ -183,7 +183,7 @@ namespace NUnit.Framework.Internal.Execution
         // Separate method so it can be used by Start
         private void Dispatch(WorkItem work, ParallelExecutionStrategy strategy)
         {
-            log.Debug("Using {0} strategy for {1}", strategy, work.Name);
+            Log.Debug("Using {0} strategy for {1}", strategy, work.Name);
 
             // Currently, we only track CompositeWorkItems - this could be expanded
             if (work is CompositeWorkItem composite)
@@ -271,7 +271,7 @@ namespace NUnit.Framework.Internal.Execution
                 throw new InvalidOperationException("Called IsolateQueues without Start");
             }
 
-            log.Info("Saving Queue State for {0}", work.Name);
+            Log.Info("Saving Queue State for {0}", work.Name);
             lock (_queueLock)
             {
                 foreach (WorkItemQueue queue in Queues)
@@ -294,11 +294,11 @@ namespace NUnit.Framework.Internal.Execution
             {
                 if (_isolationLevel <= 0)
                 {
-                    log.Debug("Ignoring call to restore Queue State");
+                    Log.Debug("Ignoring call to restore Queue State");
                     return;
                 }
 
-                log.Info("Restoring Queue State");
+                Log.Info("Restoring Queue State");
 
                 foreach (WorkItemQueue queue in Queues)
                     queue.Restore();

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -359,8 +359,10 @@ namespace NUnit.Framework.Internal.Execution
         private WorkShift? SelectNextShift()
         {
             foreach (var shift in Shifts)
+            {
                 if (shift.HasWork)
                     return shift;
+            }
 
             return null;
         }

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -90,8 +90,10 @@ namespace NUnit.Framework.Internal.Execution
 
                 // Create TestActionCommands using attributes of the method
                 foreach (ITestAction action in Test.Actions)
+                {
                     if (action.Targets == ActionTargets.Default || action.Targets.HasFlag(ActionTargets.Test))
-                        command = new TestActionCommand(command, action); ;
+                        command = new TestActionCommand(command, action);
+                }
 
                 // Try to locate the parent fixture. In current implementations, the test method
                 // is either one or two levels below the TestFixture - if this changes,

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Internal.Execution
             _topLevelWorkItem.Execute();
         }
 
-        private readonly object cancelLock = new object();
+        private readonly object _cancelLock = new object();
 
         /// <summary>
         /// Cancel (abort or stop) the ongoing run.
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="force">true if the run should be aborted, false if it should allow its currently running test to complete</param>
         public void CancelRun(bool force)
         {
-            lock (cancelLock)
+            lock (_cancelLock)
             {
                 if (_topLevelWorkItem is not null)
                 {

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -11,7 +11,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class TestWorker
     {
-        private static readonly Logger log = InternalTrace.GetLogger("TestWorker");
+        private static readonly Logger Log = InternalTrace.GetLogger("TestWorker");
 
         private Thread? _workerThread;
 
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal.Execution
                     if (_currentWorkItem is null)
                         break;
 
-                    log.Info("{0} executing {1}", Thread.CurrentThread.Name!, _currentWorkItem.Name);
+                    Log.Info("{0} executing {1}", Thread.CurrentThread.Name!, _currentWorkItem.Name);
 
                     _currentWorkItem.TestWorker = this;
 
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal.Execution
             }
             finally
             {
-                log.Info("{0} stopping - {1} WorkItems processed.", Name, _workItemCount);
+                Log.Info("{0} stopping - {1} WorkItems processed.", Name, _workItemCount);
             }
         }
 
@@ -142,11 +142,11 @@ namespace NUnit.Framework.Internal.Execution
             {
             }
 
-            log.Info("{0} starting on thread [{1}]", Name, _workerThread.ManagedThreadId);
+            Log.Info("{0} starting on thread [{1}]", Name, _workerThread.ManagedThreadId);
             _workerThread.Start();
         }
 
-        private readonly object cancelLock = new object();
+        private readonly object _cancelLock = new object();
 
         /// <summary>
         /// Stop the thread, either immediately or after finishing the current WorkItem
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Internal.Execution
             if (force)
                 _running = false;
 
-            lock (cancelLock)
+            lock (_cancelLock)
                 if (_workerThread is not null && _currentWorkItem is not null)
                 {
                     _currentWorkItem.Cancel(force);

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -158,12 +158,14 @@ namespace NUnit.Framework.Internal.Execution
                 _running = false;
 
             lock (_cancelLock)
+            {
                 if (_workerThread is not null && _currentWorkItem is not null)
                 {
                     _currentWorkItem.Cancel(force);
                     if (force)
                         _currentWorkItem = null;
                 }
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal
         public TextMessageWriter(string? userMessage, params object?[]? args)
         {
             if (userMessage is not null && userMessage != string.Empty)
-                this.WriteMessageLine(userMessage, args);
+                WriteMessageLine(userMessage, args);
         }
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Internal
         #endregion
 
         #region Instance Fields
-        private int maxLineLength = DEFAULT_LINE_LENGTH;
+        private int _maxLineLength = DEFAULT_LINE_LENGTH;
         private bool _sameValDiffTypes = false;
         private string? _expectedType, _actualType;
         #endregion
@@ -70,8 +70,8 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override int MaxLineLength
         {
-            get => maxLineLength;
-            set => maxLineLength = value;
+            get => _maxLineLength;
+            set => _maxLineLength = value;
         }
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -218,7 +218,9 @@ namespace NUnit.Framework.Internal.Execution
                 RunOnSeparateThread(targetApartment);
             }
             else
+            {
                 RunOnCurrentThread();
+            }
         }
 
         private readonly ManualResetEventSlim _completionEvent = new ManualResetEventSlim();
@@ -405,8 +407,10 @@ namespace NUnit.Framework.Internal.Execution
             var list = new List<IMethodInfo>();
 
             foreach (var method in methods)
+            {
                 if (method.TypeInfo.Type == type)
                     list.Add(method);
+            }
 
             return list;
         }
@@ -500,7 +504,9 @@ namespace NUnit.Framework.Internal.Execution
             // Item is not explicitly marked, so check the inherited context
             if (Context.ParallelScope.HasFlag(ParallelScope.Children) ||
                 Test is TestFixture && Context.ParallelScope.HasFlag(ParallelScope.Fixtures))
+            {
                 return ParallelExecutionStrategy.Parallel;
+            }
 
             // There is no scope specified either on the item itself or in the context.
             // In that case, simple work items are test cases and just run on the same

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -462,12 +462,12 @@ namespace NUnit.Framework.Internal.Execution
         [SecuritySafeCritical]
         private void RunOnCurrentThread()
         {
-            Context.CurrentTest = this.Test;
-            Context.CurrentResult = this.Result;
-            Context.Listener.TestStarted(this.Test);
+            Context.CurrentTest = Test;
+            Context.CurrentResult = Result;
+            Context.Listener.TestStarted(Test);
             Context.StartTime = DateTime.UtcNow;
             Context.StartTicks = Stopwatch.GetTimestamp();
-            Context.TestWorker = this.TestWorker;
+            Context.TestWorker = TestWorker;
 
             Context.EstablishExecutionEnvironment();
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -72,7 +72,9 @@ namespace NUnit.Framework.Internal.Execution
                         countOrderedItems++;
                     }
                     else
+                    {
                         work.Children.Add(childItem);
+                    }
                 }
 
                 if (countOrderedItems > 0)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -154,8 +154,10 @@ namespace NUnit.Framework.Internal.Execution
             get
             {
                 foreach (var q in _innerQueues)
+                {
                     if (!q.IsEmpty)
                         return false;
+                }
 
                 return true;
             }
@@ -256,9 +258,13 @@ namespace NUnit.Framework.Internal.Execution
                 // Dequeue our work item
                 WorkItem? work = null;
                 while (work is null)
+                {
                     foreach (var q in _innerQueues)
+                    {
                         if (q.TryDequeue(out work))
                             break;
+                    }
+                }
 
                 // Add to items processed using CAS
                 Interlocked.Increment(ref _itemsProcessed);
@@ -353,13 +359,17 @@ namespace NUnit.Framework.Internal.Execution
             sb.AppendLine($"Contents of {Name} at isolation level {_savedState.Count}");
 
             if (IsEmpty)
+            {
                 sb.AppendLine("  <empty>");
+            }
             else
+            {
                 for (int priority = 0; priority < PRIORITY_LEVELS; priority++)
                 {
                     foreach (WorkItem work in _innerQueues[priority])
                         sb.AppendLine($"pri-{priority}: {work.Name}");
                 }
+            }
 
             int level = 0;
             foreach (var state in _savedState)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -45,7 +45,7 @@ namespace NUnit.Framework.Internal.Execution
         private const int NORMAL_PRIORITY = 1;
         private const int PRIORITY_LEVELS = 2;
 
-        private readonly Logger log = InternalTrace.GetLogger("WorkItemQueue");
+        private readonly Logger _log = InternalTrace.GetLogger("WorkItemQueue");
 
         private ConcurrentQueue<WorkItem>[] _innerQueues;
 
@@ -272,7 +272,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Start()
         {
-            log.Info("{0}.{1} starting", Name, _savedState.Count);
+            _log.Info("{0}.{1} starting", Name, _savedState.Count);
 
             if (Interlocked.CompareExchange(ref _state, (int)WorkItemQueueState.Running, (int)WorkItemQueueState.Paused) == (int)WorkItemQueueState.Paused)
                 _mreAdd.Set();
@@ -283,7 +283,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Stop()
         {
-            log.Info("{0}.{1} stopping - {2} WorkItems processed", Name, _savedState.Count, ItemsProcessed);
+            _log.Info("{0}.{1} stopping - {2} WorkItems processed", Name, _savedState.Count, ItemsProcessed);
 
             if (Interlocked.Exchange(ref _state, (int)WorkItemQueueState.Stopped) != (int)WorkItemQueueState.Stopped)
                 _mreAdd.Set();
@@ -294,7 +294,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Pause()
         {
-            log.Debug("{0}.{1} pausing", Name, _savedState.Count);
+            _log.Debug("{0}.{1} pausing", Name, _savedState.Count);
 
             Interlocked.CompareExchange(ref _state, (int)WorkItemQueueState.Paused, (int)WorkItemQueueState.Running);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal.Execution
     /// </summary>
     public class WorkShift
     {
-        private static readonly Logger log = InternalTrace.GetLogger("WorkShift");
+        private static readonly Logger Log = InternalTrace.GetLogger("WorkShift");
 
         private readonly object _syncRoot = new object();
         private int _busyCount = 0;
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void AddQueue(WorkItemQueue queue)
         {
-            log.Debug("{0} shift adding queue {1}", Name, queue.Name);
+            Log.Debug("{0} shift adding queue {1}", Name, queue.Name);
 
             Queues.Add(queue);
 
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="worker"></param>
         public void Assign(TestWorker worker)
         {
-            log.Debug("{0} shift assigned worker {1}", Name, worker.Name);
+            Log.Debug("{0} shift assigned worker {1}", Name, worker.Name);
 
             Workers.Add(worker);
         }
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void Start()
         {
-            log.Info("{0} shift starting", Name);
+            Log.Info("{0} shift starting", Name);
 
             IsActive = true;
 
@@ -172,7 +172,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         public void EndShift()
         {
-            log.Info("{0} shift ending", Name);
+            Log.Info("{0} shift ending", Name);
 
             IsActive = false;
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -67,8 +67,10 @@ namespace NUnit.Framework.Internal.Execution
             get
             {
                 foreach (var q in Queues)
+                {
                     if (!q.IsEmpty)
                         return true;
+                }
 
                 return false;
             }

--- a/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/CompositeFilter.cs
@@ -62,8 +62,10 @@ namespace NUnit.Framework.Internal.Filters
             TNode result = parentNode.AddElement(ElementName);
 
             if (recursive)
+            {
                 foreach (ITestFilter filter in Filters)
                     filter.AddToXml(result, true);
+            }
 
             return result;
         }

--- a/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
@@ -101,8 +101,10 @@ namespace NUnit.Framework.Internal
                     Type[] argTypes = argType.GetGenericArguments();
 
                     if (argTypes.Length == genericArgTypes.Length)
+                    {
                         for (int i = 0; i < genericArgTypes.Length; i++)
                             TryApplyArgType(genericArgTypes[i], argTypes[i]);
+                    }
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/IgnoredTestCaseData.cs
+++ b/src/NUnitFramework/framework/Internal/IgnoredTestCaseData.cs
@@ -28,15 +28,15 @@ namespace NUnit.Framework
 
         internal IgnoredTestCaseData(TestCaseData data, RunState prevRunState)
         {
-            this.Arguments = data.Arguments;
-            this.ArgDisplayNames = data.ArgDisplayNames;
-            this.ExpectedResult = data.ExpectedResult;
-            this.HasExpectedResult = data.HasExpectedResult;
-            this.OriginalArguments = data.OriginalArguments;
-            this.Properties = data.Properties;
-            this.RunState = data.RunState;
-            this.TestName = data.TestName;
-            this._prevRunState = prevRunState;
+            Arguments = data.Arguments;
+            ArgDisplayNames = data.ArgDisplayNames;
+            ExpectedResult = data.ExpectedResult;
+            HasExpectedResult = data.HasExpectedResult;
+            OriginalArguments = data.OriginalArguments;
+            Properties = data.Properties;
+            RunState = data.RunState;
+            TestName = data.TestName;
+            _prevRunState = prevRunState;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Logging/InternalTrace.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/InternalTrace.cs
@@ -50,7 +50,9 @@ namespace NUnit.Framework.Internal
 
             }
             else
+            {
                 _traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {_traceLevel} to level {level}");
+            }
         }
 
         /// <summary>
@@ -72,7 +74,9 @@ namespace NUnit.Framework.Internal
 
             }
             else
+            {
                 _traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {_traceLevel} to level {level}");
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Logging/InternalTrace.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/InternalTrace.cs
@@ -22,13 +22,13 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public static class InternalTrace
     {
-        private static InternalTraceLevel traceLevel;
-        private static InternalTraceWriter? traceWriter;
+        private static InternalTraceLevel _traceLevel;
+        private static InternalTraceWriter? _traceWriter;
 
         /// <summary>
         /// Gets a flag indicating whether the InternalTrace is initialized
         /// </summary>
-        public static bool Initialized => traceWriter is not null;
+        public static bool Initialized => _traceWriter is not null;
 
         /// <summary>
         /// Initialize the internal trace facility using the name of the log
@@ -38,19 +38,19 @@ namespace NUnit.Framework.Internal
         /// <param name="level">The trace level</param>
         public static void Initialize(string logName, InternalTraceLevel level)
         {
-            if (traceWriter is null)
+            if (_traceWriter is null)
             {
-                traceLevel = level;
+                _traceLevel = level;
 
-                if (traceLevel > InternalTraceLevel.Off)
+                if (_traceLevel > InternalTraceLevel.Off)
                 {
-                    traceWriter = new InternalTraceWriter(logName);
-                    traceWriter.WriteLine("InternalTrace: Initializing to level {0}", traceLevel);
+                    _traceWriter = new InternalTraceWriter(logName);
+                    _traceWriter.WriteLine("InternalTrace: Initializing to level {0}", _traceLevel);
                 }
 
             }
             else
-                traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {traceLevel} to level {level}");
+                _traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {_traceLevel} to level {level}");
         }
 
         /// <summary>
@@ -60,19 +60,19 @@ namespace NUnit.Framework.Internal
         /// <param name="level">The InternalTraceLevel</param>
         public static void Initialize(TextWriter writer, InternalTraceLevel level)
         {
-            if (traceWriter is null)
+            if (_traceWriter is null)
             {
-                traceLevel = level;
+                _traceLevel = level;
 
-                if (traceLevel > InternalTraceLevel.Off)
+                if (_traceLevel > InternalTraceLevel.Off)
                 {
-                    traceWriter = new InternalTraceWriter(writer);
-                    traceWriter.WriteLine($"InternalTrace: Initializing to level {traceLevel}");
+                    _traceWriter = new InternalTraceWriter(writer);
+                    _traceWriter.WriteLine($"InternalTrace: Initializing to level {_traceLevel}");
                 }
 
             }
             else
-                traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {traceLevel} to level {level}");
+                _traceWriter.WriteLine($"InternalTrace: Ignoring attempted re-initialization from level {_traceLevel} to level {level}");
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal
         /// <returns></returns>
         public static Logger GetLogger(string name)
         {
-            return new Logger(name, traceLevel, traceWriter);
+            return new Logger(name, _traceLevel, _traceWriter);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Logging/InternalTraceWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/InternalTraceWriter.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Internal
         {
             var streamWriter = new StreamWriter(new FileStream(logPath, FileMode.Append, FileAccess.Write, FileShare.Write));
             streamWriter.AutoFlush = true;
-            this._writer = streamWriter;
+            _writer = streamWriter;
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
         /// <param name="writer"></param>
         public InternalTraceWriter(TextWriter writer)
         {
-            this._writer = writer;
+            _writer = writer;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Logging/InternalTraceWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/InternalTraceWriter.cs
@@ -9,8 +9,8 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class InternalTraceWriter : TextWriter
     {
-        private TextWriter writer;
-        private readonly object myLock = new object();
+        private readonly TextWriter _writer;
+        private readonly object _myLock = new object();
 
         /// <summary>
         /// Construct an InternalTraceWriter that writes to a file.
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Internal
         {
             var streamWriter = new StreamWriter(new FileStream(logPath, FileMode.Append, FileAccess.Write, FileShare.Write));
             streamWriter.AutoFlush = true;
-            this.writer = streamWriter;
+            this._writer = streamWriter;
         }
 
         /// <summary>
@@ -30,14 +30,14 @@ namespace NUnit.Framework.Internal
         /// <param name="writer"></param>
         public InternalTraceWriter(TextWriter writer)
         {
-            this.writer = writer;
+            this._writer = writer;
         }
 
         /// <summary>
         /// Returns the character encoding in which the output is written.
         /// </summary>
         /// <returns>The character encoding in which the output is written.</returns>
-        public override System.Text.Encoding Encoding => writer.Encoding;
+        public override System.Text.Encoding Encoding => _writer.Encoding;
 
         /// <summary>
         /// Writes a character to the text string or stream.
@@ -45,9 +45,9 @@ namespace NUnit.Framework.Internal
         /// <param name="value">The character to write to the text stream.</param>
         public override void Write(char value)
         {
-            lock (myLock)
+            lock (_myLock)
             {
-                writer.Write(value);
+                _writer.Write(value);
             }
         }
 
@@ -57,9 +57,9 @@ namespace NUnit.Framework.Internal
         /// <param name="value">The string to write.</param>
         public override void Write(string? value)
         {
-            lock (myLock)
+            lock (_myLock)
             {
-                writer.Write(value);
+                _writer.Write(value);
             }
         }
 
@@ -69,9 +69,9 @@ namespace NUnit.Framework.Internal
         /// <param name="value">The string to write. If <paramref name="value" /> is null, only the line terminator is written.</param>
         public override void WriteLine(string? value)
         {
-            lock (myLock)
+            lock (_myLock)
             {
-                writer.WriteLine(value);
+                _writer.WriteLine(value);
             }
         }
 
@@ -81,10 +81,10 @@ namespace NUnit.Framework.Internal
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && writer is not null)
+            if (disposing && _writer is not null)
             {
-                writer.Flush();
-                writer.Dispose();
+                _writer.Flush();
+                _writer.Dispose();
             }
 
             base.Dispose(disposing);
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public override void Flush()
         {
-            writer.Flush();
+            _writer.Flush();
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Logging/Logger.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/Logger.cs
@@ -26,12 +26,12 @@ namespace NUnit.Framework.Internal
         /// <param name="writer">The writer where logs are sent.</param>
         public Logger(string name, InternalTraceLevel level, TextWriter? writer)
         {
-            this._maxLevel = level;
-            this._writer = writer;
-            this._fullname = this._name = name;
+            _maxLevel = level;
+            _writer = writer;
+            _fullname = _name = name;
             int index = _fullname.LastIndexOf('.');
             if (index >= 0)
-                this._name = _fullname.Substring(index + 1);
+                _name = _fullname.Substring(index + 1);
         }
 
         #region Error
@@ -129,13 +129,13 @@ namespace NUnit.Framework.Internal
         #region Helper Methods
         private void Log(InternalTraceLevel level, string message)
         {
-            if (this._maxLevel >= level)
+            if (_maxLevel >= level)
                 WriteLog(level, message);
         }
 
         private void Log(InternalTraceLevel level, string format, params object[] args)
         {
-            if (this._maxLevel >= level)
+            if (_maxLevel >= level)
                 WriteLog(level, string.Format( format, args ) );
         }
 

--- a/src/NUnitFramework/framework/Internal/Logging/Logger.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/Logger.cs
@@ -13,10 +13,10 @@ namespace NUnit.Framework.Internal
         private readonly static string TIME_FMT = "HH:mm:ss.fff";
         private readonly static string TRACE_FMT = "{0} {1,-5} [{2,2}] {3}: {4}";
 
-        private readonly string name;
-        private readonly string fullname;
-        private readonly InternalTraceLevel maxLevel;
-        private readonly TextWriter? writer;
+        private readonly string _name;
+        private readonly string _fullname;
+        private readonly InternalTraceLevel _maxLevel;
+        private readonly TextWriter? _writer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Logger"/> class.
@@ -26,12 +26,12 @@ namespace NUnit.Framework.Internal
         /// <param name="writer">The writer where logs are sent.</param>
         public Logger(string name, InternalTraceLevel level, TextWriter? writer)
         {
-            this.maxLevel = level;
-            this.writer = writer;
-            this.fullname = this.name = name;
-            int index = fullname.LastIndexOf('.');
+            this._maxLevel = level;
+            this._writer = writer;
+            this._fullname = this._name = name;
+            int index = _fullname.LastIndexOf('.');
             if (index >= 0)
-                this.name = fullname.Substring(index + 1);
+                this._name = _fullname.Substring(index + 1);
         }
 
         #region Error
@@ -129,23 +129,23 @@ namespace NUnit.Framework.Internal
         #region Helper Methods
         private void Log(InternalTraceLevel level, string message)
         {
-            if (this.maxLevel >= level)
+            if (this._maxLevel >= level)
                 WriteLog(level, message);
         }
 
         private void Log(InternalTraceLevel level, string format, params object[] args)
         {
-            if (this.maxLevel >= level)
+            if (this._maxLevel >= level)
                 WriteLog(level, string.Format( format, args ) );
         }
 
         private void WriteLog(InternalTraceLevel level, string message)
         {
-            writer?.WriteLine(TRACE_FMT,
+            _writer?.WriteLine(TRACE_FMT,
                 DateTime.Now.ToString(TIME_FMT),
                 level == InternalTraceLevel.Verbose ? "Debug" : level.ToString(),
                 System.Threading.Thread.CurrentThread.ManagedThreadId,
-                name,
+                _name,
                 message);
         }
 

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework.Internal
     public class OSPlatform
     {
         #region Static Members
-        private static readonly Lazy<OSPlatform> currentPlatform = new Lazy<OSPlatform> (() =>
+        private static readonly Lazy<OSPlatform> LazyCurrentPlatform = new Lazy<OSPlatform> (() =>
         {
             OSPlatform currentPlatform;
 
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Get the OSPlatform under which we are currently running
         /// </summary>
-        public static OSPlatform CurrentPlatform => currentPlatform.Value;
+        public static OSPlatform CurrentPlatform => LazyCurrentPlatform.Value;
 
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -45,7 +45,9 @@ namespace NUnit.Framework.Internal
                 currentPlatform = new OSPlatform(PlatformID.MacOSX, os.Version);
             }
             else
+            {
                 currentPlatform = new OSPlatform(os.Platform, os.Version);
+            }
 
             return currentPlatform;
         });

--- a/src/NUnitFramework/framework/Internal/On.cs
+++ b/src/NUnitFramework/framework/Internal/On.cs
@@ -22,16 +22,16 @@ namespace NUnit.Framework.Internal
 
         private sealed class DisposableAction : IDisposable
         {
-            private Action? action;
+            private Action? _action;
 
             public DisposableAction(Action action)
             {
-                this.action = action;
+                this._action = action;
             }
 
             public void Dispose()
             {
-                Interlocked.Exchange(ref action, null)?.Invoke();
+                Interlocked.Exchange(ref _action, null)?.Invoke();
             }
         }
     }

--- a/src/NUnitFramework/framework/Internal/On.cs
+++ b/src/NUnitFramework/framework/Internal/On.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Internal
 
             public DisposableAction(Action action)
             {
-                this._action = action;
+                _action = action;
             }
 
             public void Dispose()

--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -115,7 +115,7 @@ namespace NUnit.Framework.Internal
 
         private class FilterElement
         {
-            private FilterElementType ElementType = FilterElementType.Unknown;
+            private FilterElementType _elementType = FilterElementType.Unknown;
             public string Text;
             public string? ClassName;
             public string? MethodName;
@@ -144,7 +144,7 @@ namespace NUnit.Framework.Internal
 
             private bool MatchElementType(Type type)
             {
-                switch(ElementType)
+                switch(_elementType)
                 {
                     default:
                     case FilterElementType.Unknown:
@@ -162,19 +162,19 @@ namespace NUnit.Framework.Internal
             {
                 if (MatchFixtureElement(type))
                 {
-                    ElementType = FilterElementType.Fixture;
+                    _elementType = FilterElementType.Fixture;
                     return true;
                 }
 
                 if (MatchNamespaceElement(type))
                 {
-                    ElementType = FilterElementType.Namespace;
+                    _elementType = FilterElementType.Namespace;
                     return true;
                 }
 
                 if (MatchMethodElement(type))
                 {
-                    ElementType = FilterElementType.Method;
+                    _elementType = FilterElementType.Method;
                     return true;
                 }
 

--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -51,8 +51,10 @@ namespace NUnit.Framework.Internal
             // Check to see if it makes any of the existing
             // filter elements redundant.
             for (int index = _filters.Count - 1; index >= 0; index--)
+            {
                 if (_filters[index].Text.StartsWith(filterText + "."))
                     _filters.RemoveAt(index);
+            }
 
             _filters.Add(new FilterElement(filterText));
         }

--- a/src/NUnitFramework/framework/Internal/PropertyBag.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyBag.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class PropertyBag : IPropertyBag
     {
-        private readonly Dictionary<string, IList> inner = new Dictionary<string, IList>();
+        private readonly Dictionary<string, IList> _inner = new Dictionary<string, IList>();
 
         #region IPropertyBagMembers
 
@@ -30,10 +30,10 @@ namespace NUnit.Framework.Internal
         {
             Guard.ArgumentNotNull(value, "value");
 
-            if (!inner.TryGetValue(key, out var list))
+            if (!_inner.TryGetValue(key, out var list))
             {
                 list = new List<object>();
-                inner.Add(key, list);
+                _inner.Add(key, list);
             }
             list.Add(value);
         }
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Internal
 
             IList list = new List<object>();
             list.Add(value);
-            inner[key] = list;
+            _inner[key] = list;
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Internal
         /// <returns></returns>
         public object? Get(string key)
         {
-            return inner.TryGetValue(key, out var list) && list.Count > 0
+            return _inner.TryGetValue(key, out var list) && list.Count > 0
                 ? list[0]
                 : null;
         }
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Internal
         /// </returns>
         public bool ContainsKey(string key)
         {
-            return inner.ContainsKey(key);
+            return _inner.ContainsKey(key);
         }
 
         /// <summary>
@@ -90,14 +90,14 @@ namespace NUnit.Framework.Internal
         /// <returns>true if found</returns>
         public bool TryGet(string key, [NotNullWhen(true)] out IList? values)
         {
-            return inner.TryGetValue(key, out values);
+            return _inner.TryGetValue(key, out values);
         }
 
         /// <summary>
         /// Gets a collection containing all the keys in the property set
         /// </summary>
         /// <value></value>
-        public ICollection<string> Keys => inner.Keys;
+        public ICollection<string> Keys => _inner.Keys;
 
         /// <summary>
         /// Gets or sets the list of values for a particular key
@@ -106,14 +106,14 @@ namespace NUnit.Framework.Internal
         {
             get
             {
-                if (!inner.TryGetValue(key, out var list))
+                if (!_inner.TryGetValue(key, out var list))
                 {
                     list = new List<object>();
-                    inner.Add(key, list);
+                    _inner.Add(key, list);
                 }
                 return list;
             }
-            set => inner[key] = value;
+            set => _inner[key] = value;
         }
 
         #endregion
@@ -142,7 +142,7 @@ namespace NUnit.Framework.Internal
             TNode properties = parentNode.AddElement("properties");
 
             // enumerating dictionary directly with struct enumerator which is fastest
-            foreach (var pair in inner)
+            foreach (var pair in _inner)
             {
                 // Use for-loop to avoid allocating the enumerator
                 var list = pair.Value;

--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -67,7 +67,9 @@ namespace NUnit.Framework.Internal
         public static Randomizer GetRandomizer(MemberInfo member)
         {
             if (Randomizers.TryGetValue(member, out var randomizer))
+            {
                 return randomizer;
+            }
             else
             {
                 var r = CreateRandomizer();

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -306,8 +306,10 @@ namespace NUnit.Framework.Internal
                        if (parameters.Length != parameterTypes.Length) return false;
 
                        for (var i = 0; i < parameterTypes.Length; i++)
+                       {
                            if (parameters[i].ParameterType != parameterTypes[i])
                                return false;
+                       }
 
                        return true;
                    });
@@ -326,7 +328,8 @@ namespace NUnit.Framework.Internal
                      .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                      .SingleOrDefault(candidate =>
                      {
-                         if (candidate.Name != name) return false;
+                         if (candidate.Name != name)
+                             return false;
 
                          var indexParameters = candidate.GetIndexParameters();
                          if (indexParameters.Length != indexParameterTypes.Length) return false;

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -126,7 +126,7 @@ namespace NUnit.Framework.Internal
         }
 
         // §6.1.2 (Implicit numeric conversions) of the specification
-        private static readonly Dictionary<Type, List<Type>> convertibleValueTypes = new Dictionary<Type, List<Type>>() {
+        private static readonly Dictionary<Type, List<Type>> ConvertibleValueTypes = new Dictionary<Type, List<Type>>() {
             { typeof(decimal), new List<Type> { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char) } },
             { typeof(double), new List<Type> { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char), typeof(float) } },
             { typeof(float), new List<Type> { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char), typeof(float) } },
@@ -153,7 +153,7 @@ namespace NUnit.Framework.Internal
                 return to.IsClass || to.FullName().StartsWith("System.Nullable", StringComparison.Ordinal);
             }
 
-            if (convertibleValueTypes.TryGetValue(to, out var types) && types.Contains(from))
+            if (ConvertibleValueTypes.TryGetValue(to, out var types) && types.Contains(from))
                 return true;
 
             return from

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -368,8 +368,10 @@ namespace NUnit.Framework.Internal
                 AddAttachmentsElement(thisNode);
 
             if (recursive && HasChildren)
+            {
                 foreach (var child in Children)
                     child.AddToXml(thisNode, recursive);
+            }
 
             return thisNode;
         }

--- a/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestSuiteResult.cs
@@ -222,8 +222,11 @@ namespace NUnit.Framework.Internal
 
                 case TestStatus.Skipped:
                     if (childResultState.Label == "Ignored")
+                    {
                         if (ResultState.Status == TestStatus.Inconclusive || ResultState.Status == TestStatus.Passed)
                             SetResult(ResultState.ChildIgnored, CHILD_IGNORE_MESSAGE);
+                    }
+
                     break;
             }
         }

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -142,6 +142,7 @@ namespace NUnit.Framework.Internal
             FrameworkVersion = ClrVersion = version;
 
             if (version.Major > 0) // 0 means any version
+            {
                 switch (Runtime)
                 {
                     case RuntimeType.NetCore:
@@ -184,6 +185,7 @@ namespace NUnit.Framework.Internal
                         }
                         break;
                 }
+            }
         }
 
         private static void ThrowInvalidFrameworkVersion(Version version)
@@ -321,7 +323,9 @@ namespace NUnit.Framework.Internal
             if (Runtime != RuntimeType.Any
                 && target.Runtime != RuntimeType.Any
                 && Runtime != target.Runtime)
+            {
                 return false;
+            }
 
             if (AllowAnyVersion || target.AllowAnyVersion)
                 return true;

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static readonly Version DefaultVersion = new Version(0,0);
 
-        private static readonly Lazy<RuntimeFramework> currentFramework = new Lazy<RuntimeFramework>(() =>
+        private static readonly Lazy<RuntimeFramework> LazyCurrentFramework = new Lazy<RuntimeFramework>(() =>
         {
             Type? monoRuntimeType = null;
             Type? monoTouchType = null;
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Internal
         /// Static method to return a RuntimeFramework object
         /// for the framework that is currently in use.
         /// </summary>
-        public static RuntimeFramework CurrentFramework => currentFramework.Value;
+        public static RuntimeFramework CurrentFramework => LazyCurrentFramework.Value;
 
         /// <summary>
         /// The type of this runtime framework

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -67,9 +67,11 @@ namespace NUnit.Framework.Internal
                 var line = sr.ReadLine();
 
                 if (_topOfStackRegex is not null)
+                {
                     // First, skip past any Assert, Assume or MultipleAssertBlock lines
                     while (line is not null && _topOfStackRegex.IsMatch(line))
                         line = sr.ReadLine();
+                }
 
                 // Copy lines down to the line that invoked the failing method.
                 // This is actually only needed for the compact framework, but

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -128,17 +128,16 @@ namespace NUnit.Framework.Internal
         // NOTE: We use different implementations for various platforms.
 
 #if !NETFRAMEWORK
-        private static readonly AsyncLocal<TestExecutionContext?> _currentContext = new();
+        private static readonly AsyncLocal<TestExecutionContext?> AsyncLocalCurrentContext = new();
         /// <summary>
         /// Gets and sets the current context.
         /// </summary>
         [AllowNull]
         public static TestExecutionContext CurrentContext
         {
-            get => _currentContext.Value ?? (_currentContext.Value = new AdhocContext());
+            get => AsyncLocalCurrentContext.Value ??= new AdhocContext();
             internal set // internal so that AdhocTestExecutionTests can get at it
-                =>
-                    _currentContext.Value = value;
+                => AsyncLocalCurrentContext.Value = value;
         }
 #else
         // In all other builds, we use the CallContext

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -206,7 +206,9 @@ namespace NUnit.Framework.Internal
                 if (arg is Array {Rank: 1} argArray)
                 {
                     if (argArray.Length == 0)
+                    {
                         display = "[]";
+                    }
                     else
                     {
                         var builder = new StringBuilder();
@@ -244,15 +246,25 @@ namespace NUnit.Framework.Internal
                 else if (arg is double dbl)
                 {
                     if (double.IsNaN(dbl))
+                    {
                         display = "double.NaN";
+                    }
                     else if (double.IsPositiveInfinity(dbl))
+                    {
                         display = "double.PositiveInfinity";
+                    }
                     else if (double.IsNegativeInfinity(dbl))
+                    {
                         display = "double.NegativeInfinity";
+                    }
                     else if (dbl == double.MaxValue)
+                    {
                         display = "double.MaxValue";
+                    }
                     else if (dbl == double.MinValue)
+                    {
                         display = "double.MinValue";
+                    }
                     else
                     {
                         if (display.IndexOf('.') == -1)
@@ -263,15 +275,25 @@ namespace NUnit.Framework.Internal
                 else if (arg is float f)
                 {
                     if (float.IsNaN(f))
+                    {
                         display = "float.NaN";
+                    }
                     else if (float.IsPositiveInfinity(f))
+                    {
                         display = "float.PositiveInfinity";
+                    }
                     else if (float.IsNegativeInfinity(f))
+                    {
                         display = "float.NegativeInfinity";
+                    }
                     else if (f == float.MaxValue)
+                    {
                         display = "float.MaxValue";
+                    }
                     else if (f == float.MinValue)
+                    {
                         display = "float.MinValue";
+                    }
                     else
                     {
                         if (display.IndexOf('.') == -1)

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Internal
             TestName = data.TestName;
 
             foreach (string key in data.Properties.Keys)
-                this.Properties[key] = data.Properties[key];
+                Properties[key] = data.Properties[key];
         }
 
         private TestParameters(RunState runState, object?[] args)
@@ -110,8 +110,8 @@ namespace NUnit.Framework.Internal
         /// <param name="test">A test.</param>
         public void ApplyToTest(Test test)
         {
-            if (this.RunState != RunState.Runnable)
-                test.RunState = this.RunState;
+            if (RunState != RunState.Runnable)
+                test.RunState = RunState;
 
             foreach (string key in Properties.Keys)
                 foreach (object value in Properties[key])

--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -114,8 +114,10 @@ namespace NUnit.Framework.Internal
                 test.RunState = RunState;
 
             foreach (string key in Properties.Keys)
+            {
                 foreach (object value in Properties[key])
                     test.Properties.Add(key, value);
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
+++ b/src/NUnitFramework/framework/Internal/TestProgressReporter.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public sealed class TestProgressReporter : ITestListener
     {
-        private static readonly Logger log = InternalTrace.GetLogger("TestProgressReporter");
+        private static readonly Logger Log = InternalTrace.GetLogger("TestProgressReporter");
 
         private readonly ICallbackEventHandler _handler;
 
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
             }
             catch (Exception ex)
             {
-                log.Error($"Exception processing {test.FullName}{Environment.NewLine}{ex}");
+                Log.Error($"Exception processing {test.FullName}{Environment.NewLine}{ex}");
             }
         }
 
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Internal
             }
             catch (Exception ex)
             {
-                log.Error($"Exception processing {result.FullName}{Environment.NewLine}{ex}");
+                Log.Error($"Exception processing {result.FullName}{Environment.NewLine}{ex}");
             }
         }
 
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Internal
             }
             catch (Exception ex)
             {
-                log.Error($"Exception processing TestOutput event{Environment.NewLine}{ex}");
+                Log.Error($"Exception processing TestOutput event{Environment.NewLine}{ex}");
             }
         }
 
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Internal
             }
             catch (Exception ex)
             {
-                log.Error($"Exception processing SendMessage event{Environment.NewLine}{ex}");
+                Log.Error($"Exception processing SendMessage event{Environment.NewLine}{ex}");
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/ParameterizedMethodSuite.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Internal
         {
             base.Method = method;
             _isTheory = method.IsDefined<TheoryAttribute>(true);
-            this.MaintainTestOrder = true;
+            MaintainTestOrder = true;
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
                 if (_isTheory)
                     return "Theory";
 
-                if (this.Method.ContainsGenericParameters)
+                if (Method.ContainsGenericParameters)
                     return "GenericMethod";
 
                 return "ParameterizedMethod";

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -195,7 +195,7 @@ namespace NUnit.Framework.Internal
         /// value in the XML representation of a test and has no other
         /// function in the framework.
         /// </summary>
-        public virtual string TestType => this.GetType().Name;
+        public virtual string TestType => GetType().Name;
 
         /// <summary>
         /// Gets a count of test cases represented by
@@ -386,14 +386,14 @@ namespace NUnit.Framework.Internal
         /// <param name="recursive"></param>
         protected void PopulateTestNode(TNode thisNode, bool recursive)
         {
-            thisNode.AddAttribute("id", this.Id);
-            thisNode.AddAttribute("name", this.Name);
-            thisNode.AddAttribute("fullname", this.FullName);
-            if (this.MethodName is not null)
-                thisNode.AddAttribute("methodname", this.MethodName);
-            if (this.ClassName is not null)
-                thisNode.AddAttribute("classname", this.ClassName);
-            thisNode.AddAttribute("runstate", this.RunState.ToString());
+            thisNode.AddAttribute("id", Id);
+            thisNode.AddAttribute("name", Name);
+            thisNode.AddAttribute("fullname", FullName);
+            if (MethodName is not null)
+                thisNode.AddAttribute("methodname", MethodName);
+            if (ClassName is not null)
+                thisNode.AddAttribute("classname", ClassName);
+            thisNode.AddAttribute("runstate", RunState.ToString());
 
             if (Properties.Keys.Count > 0)
                 Properties.AddToXml(thisNode, recursive);
@@ -450,7 +450,7 @@ namespace NUnit.Framework.Internal
         /// <param name="other">An object to compare with this instance.</param>
         public int CompareTo(Test? other)
         {
-            return other is null ? -1 : this.FullName.CompareTo(other.FullName);
+            return other is null ? -1 : FullName.CompareTo(other.FullName);
         }
 
 #endregion

--- a/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestAssembly.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Internal
         public TestAssembly(Assembly assembly, string assemblyNameOrPath)
             : this(assemblyNameOrPath)
         {
-            this.Assembly = assembly;
+            Assembly = assembly;
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Internal
         /// </param>
         public TestAssembly(string assemblyNameOrPath) : base(assemblyNameOrPath)
         {
-            this.Name = Path.GetFileName(assemblyNameOrPath);
+            Name = Path.GetFileName(assemblyNameOrPath);
         }
 
         /// <summary>
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal
         public TestAssembly(TestAssembly assembly, ITestFilter filter)
             : base(assembly, filter)
         {
-            this.Name     = assembly.Name;
-            this.Assembly = assembly.Assembly;
+            Name     = assembly.Name;
+            Assembly = assembly.Assembly;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The ParameterSet used to create this test method
         /// </summary>
-        internal TestCaseParameters? parms;
+        internal TestCaseParameters? Parms;
 
 #endregion
 
@@ -45,9 +45,9 @@ namespace NUnit.Framework.Internal
 
 #region Properties
 
-        internal bool HasExpectedResult => parms is {HasExpectedResult: true};
+        internal bool HasExpectedResult => Parms is {HasExpectedResult: true};
 
-        internal object? ExpectedResult => parms?.ExpectedResult;
+        internal object? ExpectedResult => Parms?.ExpectedResult;
 
         #endregion
 
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The arguments to use in executing the test method, or empty array if none are provided.
         /// </summary>
-        public override object?[] Arguments => parms is null ? TestParameters.NoArguments : parms.Arguments;
+        public override object?[] Arguments => Parms is null ? TestParameters.NoArguments : Parms.Arguments;
 
         /// <summary>
         /// Overridden to return a TestCaseResult.

--- a/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestMethod.cs
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Internal
 
             PopulateTestNode(thisNode, recursive);
 
-            thisNode.AddAttribute("seed", this.Seed.ToString());
+            thisNode.AddAttribute("seed", Seed.ToString());
 
             return thisNode;
         }

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -82,14 +82,14 @@ namespace NUnit.Framework.Internal
         public TestSuite(TestSuite suite, ITestFilter filter)
             : this(suite.Name)
         {
-            this.FullName = suite.FullName;
-            this.Method   = suite.Method;
-            this.RunState = suite.RunState;
-            this.Fixture  = suite.Fixture;
+            FullName = suite.FullName;
+            Method   = suite.Method;
+            RunState = suite.RunState;
+            Fixture  = suite.Fixture;
 
             foreach (string key in suite.Properties.Keys)
             foreach (object val in suite.Properties[key])
-                this.Properties.Add(key, val);
+                Properties.Add(key, val);
 
             foreach (var child in suite._tests)
             {
@@ -99,11 +99,11 @@ namespace NUnit.Framework.Internal
                     {
                         TestSuite childSuite = ((TestSuite)child).Copy(filter);
                         childSuite.Parent    = this;
-                        this._tests.Add(childSuite);
+                        _tests.Add(childSuite);
                     }
                     else
                     {
-                        this._tests.Add(child);
+                        _tests.Add(child);
                     }
                 }
             }
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         {
             if (!MaintainTestOrder)
             {
-                this._tests.Sort();
+                _tests.Sort();
 
                 foreach (Test test in Tests)
                 {
@@ -286,10 +286,10 @@ namespace NUnit.Framework.Internal
         public override TNode AddToXml(TNode parentNode, bool recursive)
         {
             TNode thisNode = parentNode.AddElement("test-suite");
-            thisNode.AddAttribute("type", this.TestType);
+            thisNode.AddAttribute("type", TestType);
 
             PopulateTestNode(thisNode, recursive);
-            thisNode.AddAttribute("testcasecount", this.TestCaseCount.ToString());
+            thisNode.AddAttribute("testcasecount", TestCaseCount.ToString());
 
 
             if (recursive)

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -88,8 +88,10 @@ namespace NUnit.Framework.Internal
             Fixture  = suite.Fixture;
 
             foreach (string key in suite.Properties.Keys)
-            foreach (object val in suite.Properties[key])
+            {
+                foreach (object val in suite.Properties[key])
                 Properties.Add(key, val);
+            }
 
             foreach (var child in suite._tests)
             {

--- a/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/TestSuite.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Our collection of child tests
         /// </summary>
-        private readonly List<ITest> tests = new List<ITest>();
+        private readonly List<ITest> _tests = new List<ITest>();
 
         #endregion
 
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Internal
             foreach (object val in suite.Properties[key])
                 this.Properties.Add(key, val);
 
-            foreach (var child in suite.tests)
+            foreach (var child in suite._tests)
             {
                 if(filter.Pass(child))
                 {
@@ -99,11 +99,11 @@ namespace NUnit.Framework.Internal
                     {
                         TestSuite childSuite = ((TestSuite)child).Copy(filter);
                         childSuite.Parent    = this;
-                        this.tests.Add(childSuite);
+                        this._tests.Add(childSuite);
                     }
                     else
                     {
-                        this.tests.Add(child);
+                        this._tests.Add(child);
                     }
                 }
             }
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
         {
             if (!MaintainTestOrder)
             {
-                this.tests.Sort();
+                this._tests.Sort();
 
                 foreach (Test test in Tests)
                 {
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Internal
         public void Add(Test test)
         {
             test.Parent = this;
-            tests.Add(test);
+            _tests.Add(test);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Internal
         /// Gets this test's child tests
         /// </summary>
         /// <value>The list of child tests</value>
-        public override IList<ITest> Tests => tests;
+        public override IList<ITest> Tests => _tests;
 
         /// <summary>
         /// Gets a count of test cases represented by
@@ -268,7 +268,7 @@ namespace NUnit.Framework.Internal
         /// Gets a bool indicating whether the current test
         /// has any descendant tests.
         /// </summary>
-        public override bool HasChildren => tests.Count > 0;
+        public override bool HasChildren => _tests.Count > 0;
 
         /// <summary>
         /// Gets the name used for the top-level element in the

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        private static bool isNotOnWindows;
+        private static bool _isNotOnWindows;
 
         /// <summary>
         /// Captures the current thread's native id. If provided to <see cref="Kill(Thread,int)"/> later, allows the thread to be killed if it's in a message pump native blocking wait.
@@ -162,17 +162,19 @@ namespace NUnit.Framework.Internal
         [SecuritySafeCritical]
         public static int GetCurrentThreadNativeId()
         {
-            if (isNotOnWindows) return 0;
+            if (_isNotOnWindows) return 0;
             try
             {
                 return GetCurrentThreadId();
             }
             catch (EntryPointNotFoundException)
             {
-                isNotOnWindows = true;
+                _isNotOnWindows = true;
                 return 0;
             }
         }
+
+        private const int ERROR_INVALID_THREAD_ID = 0x5A4;
 
         /// <summary>
         /// Sends a message to the thread to dislodge it from native code and allow a return to managed code, where a ThreadAbortException can be generated.
@@ -185,7 +187,6 @@ namespace NUnit.Framework.Internal
             {
                 // ReSharper disable once InconsistentNaming
                 // P/invoke doesn’t need to follow naming convention
-                const int ERROR_INVALID_THREAD_ID = 0x5A4;
                 var errorCode = Marshal.GetLastWin32Error();
                 if (errorCode != ERROR_INVALID_THREAD_ID)
                     throw new Win32Exception(errorCode);

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -68,7 +68,9 @@ namespace NUnit.Framework.Internal
                         sb.Append(">");
                     }
                     else
+                    {
                         sb.Append(nestedClass);
+                    }
                 }
 
                 return sb.ToString();
@@ -109,9 +111,18 @@ namespace NUnit.Framework.Internal
                         display += ".0";
                     display += arg is double ? "d" : "f";
                 }
-                else if (arg is decimal) display += "m";
-                else if (arg is long) display += "L";
-                else if (arg is ulong) display += "UL";
+                else if (arg is decimal)
+                {
+                    display += "m";
+                }
+                else if (arg is long)
+                {
+                    display += "L";
+                }
+                else if (arg is ulong)
+                {
+                    display += "UL";
+                }
                 else if (arg is string)
                 {
                     if (display.Length > STRING_MAX)
@@ -234,8 +245,10 @@ namespace NUnit.Framework.Internal
                     }
 
                     if (convert)
+                    {
                         arglist[i] = Convert.ChangeType(arg, targetType,
                             System.Globalization.CultureInfo.InvariantCulture);
+                    }
                 }
             }
         }

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework
         /// <returns>A modified TestCaseData</returns>
         public TestCaseData Returns(object? result)
         {
-            this.ExpectedResult = result;
+            ExpectedResult = result;
             return this;
         }
 
@@ -76,7 +76,7 @@ namespace NUnit.Framework
         /// <returns>The modified TestCaseData instance</returns>
         public TestCaseData SetName(string? name)
         {
-            this.TestName = name;
+            TestName = name;
             return this;
         }
 
@@ -97,7 +97,7 @@ namespace NUnit.Framework
         /// <returns>The modified TestCaseData instance.</returns>
         public TestCaseData SetDescription(string description)
         {
-            this.Properties.Set(PropertyNames.Description, description);
+            Properties.Set(PropertyNames.Description, description);
             return this;
         }
 
@@ -108,7 +108,7 @@ namespace NUnit.Framework
         /// <returns></returns>
         public TestCaseData SetCategory(string category)
         {
-            this.Properties.Add(PropertyNames.Category, category);
+            Properties.Add(PropertyNames.Category, category);
             return this;
         }
 
@@ -120,7 +120,7 @@ namespace NUnit.Framework
         /// <returns></returns>
         public TestCaseData SetProperty(string propName, string propValue)
         {
-            this.Properties.Add(propName, propValue);
+            Properties.Add(propName, propValue);
             return this;
         }
 
@@ -132,7 +132,7 @@ namespace NUnit.Framework
         /// <returns></returns>
         public TestCaseData SetProperty(string propName, int propValue)
         {
-            this.Properties.Add(propName, propValue);
+            Properties.Add(propName, propValue);
             return this;
         }
 
@@ -144,7 +144,7 @@ namespace NUnit.Framework
         /// <returns></returns>
         public TestCaseData SetProperty(string propName, double propValue)
         {
-            this.Properties.Add(propName, propValue);
+            Properties.Add(propName, propValue);
             return this;
         }
 
@@ -152,7 +152,7 @@ namespace NUnit.Framework
         /// Marks the test case as explicit.
         /// </summary>
         public TestCaseData Explicit()	{
-            this.RunState = RunState.Explicit;
+            RunState = RunState.Explicit;
             return this;
         }
 
@@ -161,8 +161,8 @@ namespace NUnit.Framework
         /// </summary>
         public TestCaseData Explicit(string reason)
         {
-            this.RunState = RunState.Explicit;
-            this.Properties.Set(PropertyNames.SkipReason, reason);
+            RunState = RunState.Explicit;
+            Properties.Set(PropertyNames.SkipReason, reason);
             return this;
         }
 
@@ -173,9 +173,9 @@ namespace NUnit.Framework
         /// <returns></returns>
         public IgnoredTestCaseData Ignore(string reason)
         {
-            RunState prevRunState = this.RunState;
-            this.RunState = RunState.Ignored;
-            this.Properties.Set(PropertyNames.SkipReason, reason);
+            RunState prevRunState = RunState;
+            RunState = RunState.Ignored;
+            Properties.Set(PropertyNames.SkipReason, reason);
             var ignoredData = new IgnoredTestCaseData(this, prevRunState);
             return ignoredData;
         }

--- a/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/ExtendedTextWrapperTests.cs
@@ -9,8 +9,8 @@ namespace NUnit.Common.Tests
 {
     public class ExtendedTextWrapperTests
     {
-        private StringBuilder sb;
-        private ExtendedTextWrapper writer;
+        private StringBuilder _sb;
+        private ExtendedTextWrapper _writer;
 
         private const string LABEL = "My Label: ";
         private const string OPTION = "option value";
@@ -20,64 +20,64 @@ namespace NUnit.Common.Tests
         [SetUp]
         public void SetUp()
         {
-            sb = new StringBuilder();
-            writer = new ExtendedTextWrapper(new StringWriter(sb));
+            _sb = new StringBuilder();
+            _writer = new ExtendedTextWrapper(new StringWriter(_sb));
         }
 
         [Test]
         public void Write()
         {
-            writer.Write(TESTING);
-            Assert.That(sb.ToString(), Is.EqualTo(TESTING));
+            _writer.Write(TESTING);
+            Assert.That(_sb.ToString(), Is.EqualTo(TESTING));
         }
 
         [Test]
         public void Write_ColorStyle()
         {
-            writer.Write(ColorStyle.Error, TESTING);
-            Assert.That(sb.ToString(), Is.EqualTo(TESTING));
+            _writer.Write(ColorStyle.Error, TESTING);
+            Assert.That(_sb.ToString(), Is.EqualTo(TESTING));
         }
 
         [Test]
         public void WriteLine()
         {
-            writer.WriteLine(TESTING);
-            Assert.That(sb.ToString(), Is.EqualTo(TESTING + NL));
+            _writer.WriteLine(TESTING);
+            Assert.That(_sb.ToString(), Is.EqualTo(TESTING + NL));
         }
 
         [Test]
         public void WriteLine_ColorStyle()
         {
-            writer.WriteLine(ColorStyle.SectionHeader, TESTING);
-            Assert.That(sb.ToString(), Is.EqualTo(TESTING + NL));
+            _writer.WriteLine(ColorStyle.SectionHeader, TESTING);
+            Assert.That(_sb.ToString(), Is.EqualTo(TESTING + NL));
         }
 
         [Test]
         public void WriteLabel()
         {
-            writer.WriteLabel(LABEL, OPTION);
-            Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION));
+            _writer.WriteLabel(LABEL, OPTION);
+            Assert.That(_sb.ToString(), Is.EqualTo(LABEL + OPTION));
         }
 
         [Test]
         public void WriteLabel_ColorStyle()
         {
-            writer.WriteLabel(LABEL, OPTION, ColorStyle.Pass);
-            Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION));
+            _writer.WriteLabel(LABEL, OPTION, ColorStyle.Pass);
+            Assert.That(_sb.ToString(), Is.EqualTo(LABEL + OPTION));
         }
 
         [Test]
         public void WriteLabelLine()
         {
-            writer.WriteLabelLine(LABEL, OPTION);
-            Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
+            _writer.WriteLabelLine(LABEL, OPTION);
+            Assert.That(_sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
         }
 
         [Test]
         public void WriteLabelLine_ColorStyle()
         {
-            writer.WriteLabelLine(LABEL, OPTION, ColorStyle.Pass);
-            Assert.That(sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
+            _writer.WriteLabelLine(LABEL, OPTION, ColorStyle.Pass);
+            Assert.That(_sb.ToString(), Is.EqualTo(LABEL + OPTION + NL));
         }
 
         [Test]

--- a/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
@@ -7,7 +7,7 @@ namespace NUnitLite.Tests
 {
     public class MakeRunSettingsTests
     {
-        private static TestCaseData[] SettingsData =
+        private static readonly TestCaseData[] SettingsData =
         {
             new TestCaseData("--timeout=50", "DefaultTimeout", 50),
             new TestCaseData("--work=results", "WorkDirectory", Path.GetFullPath("results")),

--- a/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit2XmlOutputWriterTests.cs
@@ -12,11 +12,11 @@ namespace NUnitLite.Tests
 {
     public class NUnit2XmlOutputWriterTests
     {
-        private XmlDocument doc;
-        private XmlNode topNode;
-        private XmlNode envNode;
-        private XmlNode cultureNode;
-        private XmlNode suiteNode;
+        private XmlDocument _doc;
+        private XmlNode _topNode;
+        private XmlNode _envNode;
+        private XmlNode _cultureNode;
+        private XmlNode _suiteNode;
 
         [OneTimeSetUp]
         public void RunMockAssemblyTests()
@@ -35,57 +35,57 @@ namespace NUnitLite.Tests
             sw.Close();
 #endif
 
-            doc = new XmlDocument();
-            doc.LoadXml(sb.ToString());
+            _doc = new XmlDocument();
+            _doc.LoadXml(sb.ToString());
 
-            topNode = doc.SelectSingleNode("/test-results");
-            if (topNode is not null)
+            _topNode = _doc.SelectSingleNode("/test-results");
+            if (_topNode is not null)
             {
-                envNode = topNode.SelectSingleNode("environment");
-                cultureNode = topNode.SelectSingleNode("culture-info");
-                suiteNode = topNode.SelectSingleNode("test-suite");
+                _envNode = _topNode.SelectSingleNode("environment");
+                _cultureNode = _topNode.SelectSingleNode("culture-info");
+                _suiteNode = _topNode.SelectSingleNode("test-suite");
             }
         }
 
         [Test]
         public void Document_HasThreeChildren()
         {
-            Assert.That(doc.ChildNodes.Count, Is.EqualTo(3));
+            Assert.That(_doc.ChildNodes.Count, Is.EqualTo(3));
         }
 
         [Test]
         public void Document_FirstChildIsXmlDeclaration()
         {
-            Assume.That(doc.FirstChild is not null);
-            Assert.That(doc.FirstChild.NodeType, Is.EqualTo(XmlNodeType.XmlDeclaration));
-            Assert.That(doc.FirstChild.Name, Is.EqualTo("xml"));
+            Assume.That(_doc.FirstChild is not null);
+            Assert.That(_doc.FirstChild.NodeType, Is.EqualTo(XmlNodeType.XmlDeclaration));
+            Assert.That(_doc.FirstChild.Name, Is.EqualTo("xml"));
         }
 
         [Test]
         public void Document_SecondChildIsComment()
         {
-            Assume.That(doc.ChildNodes.Count >= 2);
-            Assert.That(doc.ChildNodes[1].Name, Is.EqualTo("#comment"));
+            Assume.That(_doc.ChildNodes.Count >= 2);
+            Assert.That(_doc.ChildNodes[1].Name, Is.EqualTo("#comment"));
         }
 
         [Test]
         public void Document_ThirdChildIsTestResults()
         {
-            Assume.That(doc.ChildNodes.Count >= 3);
-            Assert.That(doc.ChildNodes[2].Name, Is.EqualTo("test-results"));
+            Assume.That(_doc.ChildNodes.Count >= 3);
+            Assert.That(_doc.ChildNodes[2].Name, Is.EqualTo("test-results"));
         }
 
         [Test]
         public void Document_HasTestResults()
         {
-            Assert.That(topNode, Is.Not.Null);
-            Assert.That(topNode.Name, Is.EqualTo("test-results"));
+            Assert.That(_topNode, Is.Not.Null);
+            Assert.That(_topNode.Name, Is.EqualTo("test-results"));
         }
 
         [Test]
         public void TestResults_AssemblyPathIsCorrect()
         {
-            Assert.That(RequiredAttribute(topNode, "name"), Is.EqualTo("NUnit.Tests.Assemblies.MockTestFixture"));
+            Assert.That(RequiredAttribute(_topNode, "name"), Is.EqualTo("NUnit.Tests.Assemblies.MockTestFixture"));
         }
 
         [TestCase("total", MockTestFixture.Tests)]
@@ -98,27 +98,27 @@ namespace NUnitLite.Tests
         [TestCase("invalid", MockTestFixture.Failed_NotRunnable)]
         public void TestResults_CounterIsCorrect(string name, int count)
         {
-            Assert.That(RequiredAttribute(topNode, name), Is.EqualTo(count.ToString()));
+            Assert.That(RequiredAttribute(_topNode, name), Is.EqualTo(count.ToString()));
         }
 
         [Test]
         public void TestResults_HasValidDateAttribute()
         {
-            string dateString = RequiredAttribute(topNode, "date");
+            string dateString = RequiredAttribute(_topNode, "date");
             Assert.That(DateTime.TryParse(dateString, out _), "Invalid date attribute: {0}", dateString);
         }
 
         [Test]
         public void TestResults_HasValidTimeAttribute()
         {
-            string timeString = RequiredAttribute(topNode, "time");
+            string timeString = RequiredAttribute(_topNode, "time");
             Assert.That(DateTime.TryParse(timeString, out _), "Invalid time attribute: {0}", timeString);
         }
 
         [Test]
         public void Environment_HasEnvironmentElement()
         {
-            Assert.That(envNode, Is.Not.Null, "Missing environment element");
+            Assert.That(_envNode, Is.Not.Null, "Missing environment element");
         }
 
         [TestCase("nunit-version")]
@@ -131,20 +131,20 @@ namespace NUnitLite.Tests
         [TestCase("user-domain")]
         public void Environment_HasRequiredAttribute(string name)
         {
-            RequiredAttribute(envNode, name);
+            RequiredAttribute(_envNode, name);
         }
 
         [Test]
         public void CultureInfo_HasCultureInfoElement()
         {
-            Assert.That(cultureNode, Is.Not.Null, "Missing culture-info element");
+            Assert.That(_cultureNode, Is.Not.Null, "Missing culture-info element");
         }
 
         [TestCase("current-culture")]
         [TestCase("current-uiculture")]
         public void CultureInfo_HasRequiredAttribute(string name)
         {
-            string cultureName = RequiredAttribute(cultureNode, name);
+            string cultureName = RequiredAttribute(_cultureNode, name);
             System.Globalization.CultureInfo culture = null;
 
             try
@@ -162,7 +162,7 @@ namespace NUnitLite.Tests
         [Test]
         public void TestSuite_HasTestSuiteElement()
         {
-            Assert.That(suiteNode, Is.Not.Null, "Missing test-suite element");
+            Assert.That(_suiteNode, Is.Not.Null, "Missing test-suite element");
         }
 
         [TestCase("type", "TestFixture")]
@@ -174,13 +174,13 @@ namespace NUnitLite.Tests
         [TestCase("asserts", "0")]
         public void TestSuite_ExpectedAttribute(string name, string value)
         {
-            Assert.That(RequiredAttribute(suiteNode, name), Is.EqualTo(value));
+            Assert.That(RequiredAttribute(_suiteNode, name), Is.EqualTo(value));
         }
 
         [Test]
         public void TestSuite_HasValidTimeAttribute()
         {
-            var timeString = RequiredAttribute(suiteNode, "time");
+            var timeString = RequiredAttribute(_suiteNode, "time");
             // NOTE: We use the TryParse overload with 4 args because it's supported in .NET 1.1
             var success = double.TryParse(timeString, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out _);
             Assert.That(success, "{0} is an invalid value for time", timeString);

--- a/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/NUnit3XmlOutputWriterTests.cs
@@ -14,10 +14,10 @@ namespace NUnitLite.Tests
 {
     public class NUnit3XmlOutputWriterTests
     {
-        private XmlDocument doc;
-        private XmlNode topNode;
-        private XmlNode envNode;
-        private XmlNode suiteNode;
+        private XmlDocument _doc;
+        private XmlNode _topNode;
+        private XmlNode _envNode;
+        private XmlNode _suiteNode;
 
         [OneTimeSetUp]
         public void RunMockAssemblyTests()
@@ -36,50 +36,50 @@ namespace NUnitLite.Tests
             sw.Close();
 #endif
 
-            doc = new XmlDocument();
-            doc.LoadXml(sb.ToString());
+            _doc = new XmlDocument();
+            _doc.LoadXml(sb.ToString());
 
-            topNode = doc.SelectSingleNode("/test-run");
-            if (topNode is not null)
+            _topNode = _doc.SelectSingleNode("/test-run");
+            if (_topNode is not null)
             {
-                suiteNode = topNode.SelectSingleNode("test-suite");
-                envNode = suiteNode.SelectSingleNode("environment");
+                _suiteNode = _topNode.SelectSingleNode("test-suite");
+                _envNode = _suiteNode.SelectSingleNode("environment");
             }
         }
 
         [Test]
         public void Document_HasTwoChildren()
         {
-            Assert.That(doc.ChildNodes.Count, Is.EqualTo(2));
+            Assert.That(_doc.ChildNodes.Count, Is.EqualTo(2));
         }
 
         [Test]
         public void Document_FirstChildIsXmlDeclaration()
         {
-            Assume.That(doc.FirstChild is not null);
-            Assert.That(doc.FirstChild.NodeType, Is.EqualTo(XmlNodeType.XmlDeclaration));
-            Assert.That(doc.FirstChild.Name, Is.EqualTo("xml"));
+            Assume.That(_doc.FirstChild is not null);
+            Assert.That(_doc.FirstChild.NodeType, Is.EqualTo(XmlNodeType.XmlDeclaration));
+            Assert.That(_doc.FirstChild.Name, Is.EqualTo("xml"));
         }
 
         [Test]
         public void Document_SecondChildIsComment()
         {
-            Assume.That(doc.ChildNodes.Count >= 2);
-            Assert.That(doc.ChildNodes[1].Name, Is.EqualTo("test-run"));
+            Assume.That(_doc.ChildNodes.Count >= 2);
+            Assert.That(_doc.ChildNodes[1].Name, Is.EqualTo("test-run"));
         }
 
         [Test]
         public void Document_HasTestResults()
         {
-            Assert.That(topNode, Is.Not.Null);
-            Assert.That(topNode.Name, Is.EqualTo("test-run"));
+            Assert.That(_topNode, Is.Not.Null);
+            Assert.That(_topNode.Name, Is.EqualTo("test-run"));
         }
 
         [Test]
         public void TestResults_AssemblyPathIsCorrect()
         {
-            Assert.That(RequiredAttribute(topNode, "fullname"), Is.EqualTo("NUnit.Tests.Assemblies.MockTestFixture"));
-            Assert.That(RequiredAttribute(topNode, "name"), Is.EqualTo("MockTestFixture"));
+            Assert.That(RequiredAttribute(_topNode, "fullname"), Is.EqualTo("NUnit.Tests.Assemblies.MockTestFixture"));
+            Assert.That(RequiredAttribute(_topNode, "name"), Is.EqualTo("MockTestFixture"));
         }
 
         [TestCase("testcasecount", MockTestFixture.Tests)]
@@ -89,27 +89,27 @@ namespace NUnitLite.Tests
         [TestCase("skipped", MockTestFixture.Skipped)]
         public void TestResults_CounterIsCorrect(string name, int count)
         {
-            Assert.That(RequiredAttribute(topNode, name), Is.EqualTo(count.ToString()));
+            Assert.That(RequiredAttribute(_topNode, name), Is.EqualTo(count.ToString()));
         }
 
         [Test]
         public void TestResults_HasValidStartTimeAttribute()
         {
-            string startTimeString = RequiredAttribute(topNode, "start-time");
+            string startTimeString = RequiredAttribute(_topNode, "start-time");
             Assert.That(DateTime.TryParseExact(startTimeString, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out _), "Invalid start time attribute: {0}. Expecting DateTime in 'o' format.", startTimeString);
         }
 
         [Test]
         public void TestResults_HasValidEndTimeAttribute()
         {
-            string endTimeString = RequiredAttribute(topNode, "end-time");
+            string endTimeString = RequiredAttribute(_topNode, "end-time");
             Assert.That(DateTime.TryParseExact(endTimeString, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out _), "Invalid end time attribute: {0}. Expecting DateTime in 'o' format.", endTimeString);
         }
 
         [Test]
         public void Environment_HasEnvironmentElement()
         {
-            Assert.That(envNode, Is.Not.Null, "Missing environment element");
+            Assert.That(_envNode, Is.Not.Null, "Missing environment element");
         }
 
         [TestCase("framework-version")]
@@ -123,20 +123,20 @@ namespace NUnitLite.Tests
         [TestCase("os-architecture")]
         public void Environment_HasRequiredAttribute(string name)
         {
-            RequiredAttribute(envNode, name);
+            RequiredAttribute(_envNode, name);
         }
 
         [Test]
         public void CultureInfo_HasCultureInfoElement()
         {
-            Assert.That(envNode.Attributes["culture"], Is.Not.Null, "Missing culture-info attribute");
+            Assert.That(_envNode.Attributes["culture"], Is.Not.Null, "Missing culture-info attribute");
         }
 
         [TestCase("culture")]
         [TestCase("uiculture")]
         public void CultureInfo_HasRequiredAttribute(string name)
         {
-            string cultureName = RequiredAttribute(envNode, name);
+            string cultureName = RequiredAttribute(_envNode, name);
             System.Globalization.CultureInfo culture = null;
 
             try
@@ -154,7 +154,7 @@ namespace NUnitLite.Tests
         [Test]
         public void TestSuite_HasTestSuiteElement()
         {
-            Assert.That(suiteNode, Is.Not.Null, "Missing test-suite element");
+            Assert.That(_suiteNode, Is.Not.Null, "Missing test-suite element");
         }
 
         [TestCase("type", "TestFixture")]
@@ -166,13 +166,13 @@ namespace NUnitLite.Tests
         [TestCase("asserts", "0")]
         public void TestSuite_ExpectedAttribute(string name, string value)
         {
-            Assert.That(RequiredAttribute(suiteNode, name), Is.EqualTo(value));
+            Assert.That(RequiredAttribute(_suiteNode, name), Is.EqualTo(value));
         }
 
         [Test]
         public void TestSuite_HasValidStartTimeAttribute()
         {
-            var startTimeString = RequiredAttribute(suiteNode, "start-time");
+            var startTimeString = RequiredAttribute(_suiteNode, "start-time");
 
             var success = DateTime.TryParse(startTimeString, out _);
             Assert.That(success, "{0} is an invalid value for start time", startTimeString);
@@ -181,7 +181,7 @@ namespace NUnitLite.Tests
         [Test]
         public void TestSuite_HasValidEndTimeAttribute()
         {
-            var endTimeString = RequiredAttribute(suiteNode, "end-time");
+            var endTimeString = RequiredAttribute(_suiteNode, "end-time");
 
             var success = DateTime.TryParse(endTimeString, out _);
             Assert.That(success, "{0} is an invalid value for end time", endTimeString);
@@ -190,10 +190,10 @@ namespace NUnitLite.Tests
         [Test]
         public void IgnoredTestCases_HaveValidStartAndEndTimeAttributes()
         {
-            DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
-            DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
+            DateTime.TryParse(RequiredAttribute(_topNode, "start-time"), out var testRunStartTime);
+            DateTime.TryParse(RequiredAttribute(_topNode, "end-time"), out var testRunEndTime);
 
-            var testCaseNodes = suiteNode.SelectNodes("test-suite[@name='SkippedTest']/test-case");
+            var testCaseNodes = _suiteNode.SelectNodes("test-suite[@name='SkippedTest']/test-case");
             Assert.That(testCaseNodes, Is.Not.Null.And.Count.EqualTo(3));
 
             foreach (XmlNode testCase in testCaseNodes)
@@ -215,10 +215,10 @@ namespace NUnitLite.Tests
         [Test]
         public void ExplicitTest_HasValidStartAndEndTimeAttributes()
         {
-            DateTime.TryParse(RequiredAttribute(topNode, "start-time"), out var testRunStartTime);
-            DateTime.TryParse(RequiredAttribute(topNode, "end-time"), out var testRunEndTime);
+            DateTime.TryParse(RequiredAttribute(_topNode, "start-time"), out var testRunStartTime);
+            DateTime.TryParse(RequiredAttribute(_topNode, "end-time"), out var testRunEndTime);
 
-            var testCaseNodes = suiteNode.SelectNodes("test-case[@name='ExplicitTest']");
+            var testCaseNodes = _suiteNode.SelectNodes("test-case[@name='ExplicitTest']");
             Assert.That(testCaseNodes, Is.Not.Null.And.Count.EqualTo(1));
 
             XmlNode testCase = testCaseNodes[0];

--- a/src/NUnitFramework/nunitlite.tests/TextUITests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUITests.cs
@@ -227,7 +227,6 @@ namespace NUnitLite.Tests
             Assert.That(Report, Is.EqualTo(expected));
         }
 
-#pragma warning disable 414
         private static readonly TestCaseData[] ImmediateOutputData = new[] {
             new TestCaseData("Off",
                 new [] { new TestOutput("OUTPUT\n", "", null, "SomeMethod") },
@@ -272,7 +271,6 @@ namespace NUnitLite.Tests
                 new [] { new TestOutput("Hello", "", null, "EN"), new TestOutput("Ciao!", "", null, "IT"), new TestOutput("World!", "", null, "EN") },
                 "=> EN\nHello\n=> IT\nCiao!\n=> EN\nWorld!"),
         };
-#pragma warning restore 414
 
         [TestCaseSource(nameof(ImmediateOutputData))]
         public void ImmediateOutput(string labels, TestOutput[] outputs, string expected)

--- a/src/NUnitFramework/nunitlite/ColorConsole.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsole.cs
@@ -32,9 +32,11 @@ namespace NUnit.Common
             ConsoleColor bg = Console.BackgroundColor;
 
             if (color == bg || color == ConsoleColor.Red && bg == ConsoleColor.Magenta)
+            {
                 return bg == ConsoleColor.Black
                     ? ConsoleColor.White
                     : ConsoleColor.Black;
+            }
 
             return color;
         }

--- a/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
@@ -34,12 +34,16 @@ namespace NUnit.Common
         public override void Write(ColorStyle style, string value)
         {
             if (ColorEnabled)
+            {
                 using (new ColorConsole(style))
                 {
                     Write(value);
                 }
+            }
             else
+            {
                 Write(value);
+            }
         }
 
         /// <summary>
@@ -50,12 +54,16 @@ namespace NUnit.Common
         public override void WriteLine(ColorStyle style, string value)
         {
             if (ColorEnabled)
+            {
                 using (new ColorConsole(style))
                 {
                     WriteLine(value);
                 }
+            }
             else
+            {
                 WriteLine(value);
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
+++ b/src/NUnitFramework/nunitlite/ColorConsoleWriter.cs
@@ -8,7 +8,7 @@ namespace NUnit.Common
     {
         // ReSharper disable once InconsistentNaming
         // Disregarding naming convention for back-compat
-        public bool _colorEnabled;
+        public bool ColorEnabled;
 
         /// <summary>
         /// Construct a ColorConsoleWriter.
@@ -22,7 +22,7 @@ namespace NUnit.Common
         public ColorConsoleWriter(bool colorEnabled)
             : base(Console.Out, shouldDisposeWriter:false)
         {
-            _colorEnabled = colorEnabled;
+            ColorEnabled = colorEnabled;
         }
 
         #region Extended Methods
@@ -33,7 +33,7 @@ namespace NUnit.Common
         /// <param name="value">The value.</param>
         public override void Write(ColorStyle style, string value)
         {
-            if (_colorEnabled)
+            if (ColorEnabled)
                 using (new ColorConsole(style))
                 {
                     Write(value);
@@ -49,7 +49,7 @@ namespace NUnit.Common
         /// <param name="value">The value.</param>
         public override void WriteLine(ColorStyle style, string value)
         {
-            if (_colorEnabled)
+            if (ColorEnabled)
                 using (new ColorConsole(style))
                 {
                     WriteLine(value);

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -253,9 +253,10 @@ namespace NUnit.Common
                 isValid = false;
 
                 foreach (string valid in validValues)
+                {
                     if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
                         return valid;
-
+                }
             }
 
             if (!isValid)
@@ -304,7 +305,9 @@ namespace NUnit.Common
                     var fullTestListPath = ExpandToFullPath(testListFile);
 
                     if (!File.Exists(fullTestListPath))
+                    {
                         ErrorMessages.Add("Unable to locate file: " + testListFile);
+                    }
                     else
                     {
                         try
@@ -421,14 +424,20 @@ namespace NUnit.Common
             Add("<>", v =>
             {
                 if (LooksLikeAnOption(v))
+                {
                     ErrorMessages.Add("Invalid argument: " + v);
+                }
                 else if (InputFileRequired)
+                {
                     if (InputFile is null)
                         InputFile = v;
                     else
                         ErrorMessages.Add("Multiple file names are not allowed on the command-line.\n    Invalid entry: " + v);
+                }
                 else
+                {
                     ErrorMessages.Add("Do not provide a file name when running a self-executing test.\n    Invalid entry: " + v);
+                }
             });
         }
 

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -23,8 +23,8 @@ namespace NUnit.Common
         private static readonly string DEFAULT_WORK_DIRECTORY =
             Directory.GetCurrentDirectory();
 
-        private bool validated;
-        private bool noresult;
+        private bool _validated;
+        private bool _noresult;
 
         #region Constructors
 
@@ -184,25 +184,25 @@ namespace NUnit.Common
 
         public string DisplayTestLabels { get; private set; }
 
-        private string workDirectory = null;
-        public string WorkDirectory => workDirectory ?? DEFAULT_WORK_DIRECTORY;
-        public bool WorkDirectorySpecified => workDirectory is not null;
+        private string _workDirectory = null;
+        public string WorkDirectory => _workDirectory ?? DEFAULT_WORK_DIRECTORY;
+        public bool WorkDirectorySpecified => _workDirectory is not null;
 
         public string InternalTraceLevel { get; private set; }
         public bool InternalTraceLevelSpecified => InternalTraceLevel is not null;
 
-        private readonly List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
+        private readonly List<OutputSpecification> _resultOutputSpecifications = new List<OutputSpecification>();
         public IList<OutputSpecification> ResultOutputSpecifications
         {
             get
             {
-                if (noresult)
+                if (_noresult)
                     return Array.Empty<OutputSpecification>();
 
-                if (resultOutputSpecifications.Count == 0)
-                    resultOutputSpecifications.Add(new OutputSpecification("TestResult.xml"));
+                if (_resultOutputSpecifications.Count == 0)
+                    _resultOutputSpecifications.Add(new OutputSpecification("TestResult.xml"));
 
-                return resultOutputSpecifications;
+                return _resultOutputSpecifications;
             }
         }
 
@@ -218,11 +218,11 @@ namespace NUnit.Common
 
         public bool Validate()
         {
-            if (!validated)
+            if (!_validated)
             {
                 CheckOptionCombinations();
 
-                validated = true;
+                _validated = true;
             }
 
             return ErrorMessages.Count == 0;
@@ -373,7 +373,7 @@ namespace NUnit.Common
 
             // Output Control
             this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
-                v => workDirectory = RequiredValue(v, "--work"));
+                v => _workDirectory = RequiredValue(v, "--work"));
 
             this.Add("output|out=", "File {PATH} to contain text output from the tests.",
                 v => OutFile = RequiredValue(v, "--output"));
@@ -382,7 +382,7 @@ namespace NUnit.Common
                 v => ErrFile = RequiredValue(v, "--err"));
 
             this.Add("result=", "An output {SPEC} for saving the test results. This option may be repeated.",
-                v => ResolveOutputSpecification(RequiredValue(v, "--resultxml"), resultOutputSpecifications));
+                v => ResolveOutputSpecification(RequiredValue(v, "--resultxml"), _resultOutputSpecifications));
 
             this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
             {
@@ -391,7 +391,7 @@ namespace NUnit.Common
             });
 
             this.Add("noresult", "Don't save any test results.",
-                v => noresult = v is not null);
+                v => _noresult = v is not null);
 
             this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
                 v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "Before", "After", "All"));

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -293,10 +293,10 @@ namespace NUnit.Common
             // determines the display order for the help.
 
             // Select Tests
-            this.Add("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
+            Add("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
                 v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));
 
-            this.Add("testlist=", "File {PATH} containing a list of tests to run, one per line. This option may be repeated.",
+            Add("testlist=", "File {PATH} containing a list of tests to run, one per line. This option may be repeated.",
                 v =>
                 {
                     string testListFile = RequiredValue(v, "--testlist");
@@ -328,13 +328,13 @@ namespace NUnit.Common
                     }
                 });
 
-            this.Add("prefilter=", "Comma-separated list of {NAMES} of test classes or namespaces to be loaded. This option may be repeated.",
+            Add("prefilter=", "Comma-separated list of {NAMES} of test classes or namespaces to be loaded. This option may be repeated.",
                 v => ((List<string>)PreFilters).AddRange(TestNameParser.Parse(RequiredValue(v, "--prefilter"))));
 
-            this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
+            Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
 
-            this.Add("params|p=", "Define a test parameter.",
+            Add("params|p=", "Define a test parameter.",
                 v =>
                 {
                     string parameters = RequiredValue(v, "--params");
@@ -356,69 +356,69 @@ namespace NUnit.Common
                         }
                     }
                 });
-            this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
+            Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
                 v => DefaultTimeout = RequiredInt(v, "--timeout"));
 
-            this.Add("seed=", "Set the random {SEED} used to generate test cases.",
+            Add("seed=", "Set the random {SEED} used to generate test cases.",
                 v => RandomSeed = RequiredInt(v, "--seed"));
 
-            this.Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
+            Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
                 v => NumberOfTestWorkers = RequiredInt(v, "--workers"));
 
-            this.Add("stoponerror", "Stop run immediately upon any test failure or error.",
+            Add("stoponerror", "Stop run immediately upon any test failure or error.",
                 v => StopOnError = v is not null);
 
-            this.Add("wait", "Wait for input before closing console window.",
+            Add("wait", "Wait for input before closing console window.",
                 v => WaitBeforeExit = v is not null);
 
             // Output Control
-            this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
+            Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
                 v => _workDirectory = RequiredValue(v, "--work"));
 
-            this.Add("output|out=", "File {PATH} to contain text output from the tests.",
+            Add("output|out=", "File {PATH} to contain text output from the tests.",
                 v => OutFile = RequiredValue(v, "--output"));
 
-            this.Add("err=", "File {PATH} to contain error output from the tests.",
+            Add("err=", "File {PATH} to contain error output from the tests.",
                 v => ErrFile = RequiredValue(v, "--err"));
 
-            this.Add("result=", "An output {SPEC} for saving the test results. This option may be repeated.",
+            Add("result=", "An output {SPEC} for saving the test results. This option may be repeated.",
                 v => ResolveOutputSpecification(RequiredValue(v, "--resultxml"), _resultOutputSpecifications));
 
-            this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
+            Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
             {
                 Explore = true;
                 ResolveOutputSpecification(v, ExploreOutputSpecifications);
             });
 
-            this.Add("noresult", "Don't save any test results.",
+            Add("noresult", "Don't save any test results.",
                 v => _noresult = v is not null);
 
-            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
+            Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
                 v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "Before", "After", "All"));
 
-            this.Add("test-name-format=", "Non-standard naming pattern to use in generating test names.",
+            Add("test-name-format=", "Non-standard naming pattern to use in generating test names.",
                 v => DefaultTestNamePattern = RequiredValue(v, "--test-name-format"));
 
-            this.Add("teamcity", "Turns on use of TeamCity service messages.",
+            Add("teamcity", "Turns on use of TeamCity service messages.",
                 v => TeamCity = v is not null);
 
-            this.Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
+            Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
                 v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
 
-            this.Add("noheader|noh", "Suppress display of program information at start of run.",
+            Add("noheader|noh", "Suppress display of program information at start of run.",
                 v => NoHeader = v is not null);
 
-            this.Add("nocolor|noc", "Displays console output without color.",
+            Add("nocolor|noc", "Displays console output without color.",
                 v => NoColor = v is not null);
 
-            this.Add("help|h", "Display this message and exit.",
+            Add("help|h", "Display this message and exit.",
                 v => ShowHelp = v is not null);
 
-            this.Add("version|V", "Display the header and exit.",
+            Add("version|V", "Display the header and exit.",
                 v => ShowVersion = v is not null);
 
             // Default
-            this.Add("<>", v =>
+            Add("<>", v =>
             {
                 if (LooksLikeAnOption(v))
                     ErrorMessages.Add("Invalid argument: " + v);

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -206,9 +206,11 @@ namespace NUnit.Options
                 throw new ArgumentOutOfRangeException (nameof(index));
             if (_c.Option.OptionValueType == OptionValueType.Required &&
                     index >= _values.Count)
+            {
                 throw new OptionException (string.Format (
                             _c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), _c.OptionName),
                         _c.OptionName);
+            }
         }
 
         public string this [int index] {
@@ -304,20 +306,28 @@ namespace NUnit.Options
             _type        = ParsePrototype ();
 
             if (_count == 0 && _type != OptionValueType.None)
+            {
                 throw new ArgumentException (
                         "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
                             "OptionValueType.Optional.",
                         nameof(maxValueCount));
+            }
+
             if (_type == OptionValueType.None && maxValueCount > 1)
+            {
                 throw new ArgumentException (
                     $"Cannot provide maxValueCount of {maxValueCount} for OptionValueType.None.",
                     nameof(maxValueCount));
+            }
+
             if (Array.IndexOf (_names, "<>") >= 0 &&
                     ((_names.Length == 1 && _type != OptionValueType.None) ||
                      (_names.Length > 1 && MaxValueCount > 1)))
+            {
                 throw new ArgumentException (
                         "The default option handler '<>' cannot require values.",
                         nameof(prototype));
+            }
         }
 
         public string           Prototype => _prototype;
@@ -380,11 +390,16 @@ namespace NUnit.Options
                     continue;
                 _names [i] = name.Substring (0, end);
                 if (type == '\0' || type == name [end])
+                {
                     type = name [end];
+                }
                 else
+                {
                     throw new ArgumentException (
                         $"Conflicting option types: '{type}' vs. '{name[end]}'.",
                         "prototype");
+                }
+
                 AddSeparators (name, end, seps);
             }
 
@@ -392,9 +407,12 @@ namespace NUnit.Options
                 return OptionValueType.None;
 
             if (_count <= 1 && seps.Count != 0)
+            {
                 throw new ArgumentException (
                     $"Cannot provide key/value separators for Options taking {_count} value(s).",
                     "prototype");
+            }
+
             if (_count > 1) {
                 if (seps.Count == 0)
                     _separators = new[]{":", "="};
@@ -414,16 +432,22 @@ namespace NUnit.Options
                 switch (name [i]) {
                     case '{':
                         if (start != -1)
+                        {
                             throw new ArgumentException (
                                 $"Ill-formed name/value separator found in \"{name}\".",
                                 "prototype");
+                        }
+
                         start = i+1;
                         break;
                     case '}':
                         if (start == -1)
+                        {
                             throw new ArgumentException (
                                 $"Ill-formed name/value separator found in \"{name}\".",
                                 "prototype");
+                        }
+
                         seps.Add (name.Substring (start, i-start));
                         start = -1;
                         break;
@@ -434,9 +458,11 @@ namespace NUnit.Options
                 }
             }
             if (start != -1)
+            {
                 throw new ArgumentException (
                     $"Ill-formed name/value separator found in \"{name}\".",
                     "prototype");
+            }
         }
 
         public void Invoke (OptionContext c)
@@ -773,14 +799,19 @@ namespace NUnit.Options
         private void ParseValue (string option, OptionContext c)
         {
             if (option is not null)
+            {
                 foreach (string o in c.Option.ValueSeparators is not null
                         ? option.Split (c.Option.ValueSeparators, StringSplitOptions.None)
                         : new[]{option}) {
                     c.OptionValues.Add (o);
                 }
+            }
+
             if (c.OptionValues.Count == c.Option.MaxValueCount ||
                     c.Option.OptionValueType == OptionValueType.Optional)
+            {
                 c.Option.Invoke (c);
+            }
             else if (c.OptionValues.Count > c.Option.MaxValueCount) {
                 throw new OptionException (Localizer ($"Error: Found {c.OptionValues.Count} option values when expecting {c.Option.MaxValueCount}."),
                         c.OptionName);
@@ -856,7 +887,9 @@ namespace NUnit.Options
                     continue;
 
                 if (written < OptionWidth)
+                {
                     o.Write (new string (' ', OptionWidth - written));
+                }
                 else {
                     o.WriteLine ();
                     o.Write (new string (' ', OptionWidth));
@@ -968,7 +1001,10 @@ namespace NUnit.Options
                             start = -1;
                         }
                         else if (start < 0)
+                        {
                             start = i + 1;
+                        }
+
                         break;
                     case '}':
                         if (start < 0) {

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -146,127 +146,127 @@ using System.Text.RegularExpressions;
 namespace NUnit.Options
 {
     public class OptionValueCollection : IList, IList<string> {
-        private readonly List<string> values = new List<string>();
-        private readonly OptionContext c;
+        private readonly List<string> _values = new List<string>();
+        private readonly OptionContext _c;
 
         internal OptionValueCollection (OptionContext c)
         {
-            this.c = c;
+            this._c = c;
         }
 
         #region ICollection
-        void ICollection.CopyTo (Array array, int index)  {(values as ICollection).CopyTo (array, index);}
-        bool ICollection.IsSynchronized => (values as ICollection).IsSynchronized;
-        object ICollection.SyncRoot => (values as ICollection).SyncRoot;
+        void ICollection.CopyTo (Array array, int index)  {(_values as ICollection).CopyTo (array, index);}
+        bool ICollection.IsSynchronized => (_values as ICollection).IsSynchronized;
+        object ICollection.SyncRoot => (_values as ICollection).SyncRoot;
 
         #endregion
 
         #region ICollection<T>
-        public void Add (string item)                       {values.Add (item);}
-        public void Clear ()                                {values.Clear ();}
-        public bool Contains (string item)                  {return values.Contains (item);}
-        public void CopyTo (string[] array, int arrayIndex) {values.CopyTo (array, arrayIndex);}
-        public bool Remove (string item)                    {return values.Remove (item);}
-        public int Count => values.Count;
+        public void Add (string item)                       {_values.Add (item);}
+        public void Clear ()                                {_values.Clear ();}
+        public bool Contains (string item)                  {return _values.Contains (item);}
+        public void CopyTo (string[] array, int arrayIndex) {_values.CopyTo (array, arrayIndex);}
+        public bool Remove (string item)                    {return _values.Remove (item);}
+        public int Count => _values.Count;
         public bool IsReadOnly => false;
 
         #endregion
 
         #region IEnumerable
-        IEnumerator IEnumerable.GetEnumerator () {return values.GetEnumerator ();}
+        IEnumerator IEnumerable.GetEnumerator () {return _values.GetEnumerator ();}
         #endregion
 
         #region IEnumerable<T>
-        public IEnumerator<string> GetEnumerator () {return values.GetEnumerator ();}
+        public IEnumerator<string> GetEnumerator () {return _values.GetEnumerator ();}
         #endregion
 
         #region IList
-        int IList.Add (object value)                {return (values as IList).Add (value);}
-        bool IList.Contains (object value)          {return (values as IList).Contains (value);}
-        int IList.IndexOf (object value)            {return (values as IList).IndexOf (value);}
-        void IList.Insert (int index, object value) {(values as IList).Insert (index, value);}
-        void IList.Remove (object value)            {(values as IList).Remove (value);}
-        void IList.RemoveAt (int index)             {(values as IList).RemoveAt (index);}
+        int IList.Add (object value)                {return (_values as IList).Add (value);}
+        bool IList.Contains (object value)          {return (_values as IList).Contains (value);}
+        int IList.IndexOf (object value)            {return (_values as IList).IndexOf (value);}
+        void IList.Insert (int index, object value) {(_values as IList).Insert (index, value);}
+        void IList.Remove (object value)            {(_values as IList).Remove (value);}
+        void IList.RemoveAt (int index)             {(_values as IList).RemoveAt (index);}
         bool IList.IsFixedSize => false;
         object IList.this [int index]               {get => this [index];
-            set => (values as IList)[index] = value;
+            set => (_values as IList)[index] = value;
         }
         #endregion
 
         #region IList<T>
-        public int IndexOf (string item)            {return values.IndexOf (item);}
-        public void Insert (int index, string item) {values.Insert (index, item);}
-        public void RemoveAt (int index)            {values.RemoveAt (index);}
+        public int IndexOf (string item)            {return _values.IndexOf (item);}
+        public void Insert (int index, string item) {_values.Insert (index, item);}
+        public void RemoveAt (int index)            {_values.RemoveAt (index);}
 
         private void AssertValid (int index)
         {
-            if (c.Option is null)
+            if (_c.Option is null)
                 throw new InvalidOperationException ("OptionContext.Option is null.");
-            if (index >= c.Option.MaxValueCount)
+            if (index >= _c.Option.MaxValueCount)
                 throw new ArgumentOutOfRangeException (nameof(index));
-            if (c.Option.OptionValueType == OptionValueType.Required &&
-                    index >= values.Count)
+            if (_c.Option.OptionValueType == OptionValueType.Required &&
+                    index >= _values.Count)
                 throw new OptionException (string.Format (
-                            c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName),
-                        c.OptionName);
+                            _c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), _c.OptionName),
+                        _c.OptionName);
         }
 
         public string this [int index] {
             get {
                 AssertValid (index);
-                return index >= values.Count ? null : values [index];
+                return index >= _values.Count ? null : _values [index];
             }
-            set => values [index] = value;
+            set => _values [index] = value;
         }
         #endregion
 
         public List<string> ToList ()
         {
-            return new List<string> (values);
+            return new List<string> (_values);
         }
 
         public string[] ToArray ()
         {
-            return values.ToArray ();
+            return _values.ToArray ();
         }
 
         public override string ToString ()
         {
-            return string.Join (", ", values.ToArray ());
+            return string.Join (", ", _values.ToArray ());
         }
     }
 
     public class OptionContext {
-        private Option                option;
-        private string                name;
-        private int                   index;
-        private readonly OptionSet             set;
-        private readonly OptionValueCollection c;
+        private Option                _option;
+        private string                _name;
+        private int                   _index;
+        private readonly OptionSet             _set;
+        private readonly OptionValueCollection _c;
 
         public OptionContext (OptionSet set)
         {
-            this.set = set;
-            this.c   = new OptionValueCollection (this);
+            this._set = set;
+            this._c   = new OptionValueCollection (this);
         }
 
         public Option Option {
-            get => option;
-            set => option = value;
+            get => _option;
+            set => _option = value;
         }
 
         public string OptionName {
-            get => name;
-            set => name = value;
+            get => _name;
+            set => _name = value;
         }
 
         public int OptionIndex {
-            get => index;
-            set => index = value;
+            get => _index;
+            set => _index = value;
         }
 
-        public OptionSet OptionSet => set;
+        public OptionSet OptionSet => _set;
 
-        public OptionValueCollection OptionValues => c;
+        public OptionValueCollection OptionValues => _c;
     }
 
     public enum OptionValueType {
@@ -276,12 +276,12 @@ namespace NUnit.Options
     }
 
     public abstract class Option {
-        private readonly string prototype;
-        private readonly string description;
-        private readonly string[] names;
-        private readonly OptionValueType type;
-        private readonly int count;
-        private string[] separators;
+        private readonly string _prototype;
+        private readonly string _description;
+        private readonly string[] _names;
+        private readonly OptionValueType _type;
+        private readonly int _count;
+        private string[] _separators;
 
         protected Option (string prototype, string description)
             : this (prototype, description, 1)
@@ -297,44 +297,44 @@ namespace NUnit.Options
             if (maxValueCount < 0)
                 throw new ArgumentOutOfRangeException (nameof(maxValueCount));
 
-            this.prototype   = prototype;
-            this.names       = prototype.Split ('|');
-            this.description = description;
-            this.count       = maxValueCount;
-            this.type        = ParsePrototype ();
+            this._prototype   = prototype;
+            this._names       = prototype.Split ('|');
+            this._description = description;
+            this._count       = maxValueCount;
+            this._type        = ParsePrototype ();
 
-            if (this.count == 0 && type != OptionValueType.None)
+            if (this._count == 0 && _type != OptionValueType.None)
                 throw new ArgumentException (
                         "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
                             "OptionValueType.Optional.",
                         nameof(maxValueCount));
-            if (this.type == OptionValueType.None && maxValueCount > 1)
+            if (this._type == OptionValueType.None && maxValueCount > 1)
                 throw new ArgumentException (
                     $"Cannot provide maxValueCount of {maxValueCount} for OptionValueType.None.",
                     nameof(maxValueCount));
-            if (Array.IndexOf (names, "<>") >= 0 &&
-                    ((names.Length == 1 && this.type != OptionValueType.None) ||
-                     (names.Length > 1 && this.MaxValueCount > 1)))
+            if (Array.IndexOf (_names, "<>") >= 0 &&
+                    ((_names.Length == 1 && this._type != OptionValueType.None) ||
+                     (_names.Length > 1 && this.MaxValueCount > 1)))
                 throw new ArgumentException (
                         "The default option handler '<>' cannot require values.",
                         nameof(prototype));
         }
 
-        public string           Prototype => prototype;
-        public string           Description => description;
-        public OptionValueType  OptionValueType => type;
-        public int              MaxValueCount => count;
+        public string           Prototype => _prototype;
+        public string           Description => _description;
+        public OptionValueType  OptionValueType => _type;
+        public int              MaxValueCount => _count;
 
         public string[] GetNames ()
         {
-            return (string[]) names.Clone ();
+            return (string[]) _names.Clone ();
         }
 
         public string[] GetValueSeparators ()
         {
-            if (separators is null)
+            if (_separators is null)
                 return new string [0];
-            return (string[]) separators.Clone ();
+            return (string[]) _separators.Clone ();
         }
 
         protected static T Parse<T> (string value, OptionContext c)
@@ -361,8 +361,8 @@ namespace NUnit.Options
             return t;
         }
 
-        internal string[] Names => names;
-        internal string[] ValueSeparators => separators;
+        internal string[] Names => _names;
+        internal string[] ValueSeparators => _separators;
 
         private static readonly char[] NameTerminator = new[]{'=', ':'};
 
@@ -370,15 +370,15 @@ namespace NUnit.Options
         {
             char type = '\0';
             List<string> seps = new List<string> ();
-            for (int i = 0; i < names.Length; ++i) {
-                string name = names [i];
+            for (int i = 0; i < _names.Length; ++i) {
+                string name = _names [i];
                 if (name.Length == 0)
                     throw new ArgumentException ("Empty option names are not supported.", "prototype");
 
                 int end = name.IndexOfAny (NameTerminator);
                 if (end == -1)
                     continue;
-                names [i] = name.Substring (0, end);
+                _names [i] = name.Substring (0, end);
                 if (type == '\0' || type == name [end])
                     type = name [end];
                 else
@@ -391,17 +391,17 @@ namespace NUnit.Options
             if (type == '\0')
                 return OptionValueType.None;
 
-            if (count <= 1 && seps.Count != 0)
+            if (_count <= 1 && seps.Count != 0)
                 throw new ArgumentException (
-                    $"Cannot provide key/value separators for Options taking {count} value(s).",
+                    $"Cannot provide key/value separators for Options taking {_count} value(s).",
                     "prototype");
-            if (count > 1) {
+            if (_count > 1) {
                 if (seps.Count == 0)
-                    this.separators = new[]{":", "="};
+                    this._separators = new[]{":", "="};
                 else if (seps.Count == 1 && seps [0].Length == 0)
-                    this.separators = null;
+                    this._separators = null;
                 else
-                    this.separators = seps.ToArray ();
+                    this._separators = seps.ToArray ();
             }
 
             return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
@@ -458,7 +458,7 @@ namespace NUnit.Options
     [Serializable]
     public class OptionException : Exception
     {
-        private readonly string option;
+        private readonly string _option;
 
         public OptionException ()
         {
@@ -467,28 +467,28 @@ namespace NUnit.Options
         public OptionException (string message, string optionName)
             : base (message)
         {
-            this.option = optionName;
+            this._option = optionName;
         }
 
         public OptionException (string message, string optionName, Exception innerException)
             : base (message, innerException)
         {
-            this.option = optionName;
+            this._option = optionName;
         }
 
         protected OptionException (SerializationInfo info, StreamingContext context)
             : base (info, context)
         {
-            this.option = info.GetString ("OptionName");
+            this._option = info.GetString ("OptionName");
         }
 
-        public string OptionName => this.option;
+        public string OptionName => this._option;
 
         [SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
         public override void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData (info, context);
-            info.AddValue ("OptionName", option);
+            info.AddValue ("OptionName", _option);
         }
     }
 
@@ -566,19 +566,19 @@ namespace NUnit.Options
         }
 
         private sealed class ActionOption : Option {
-            private readonly Action<OptionValueCollection> action;
+            private readonly Action<OptionValueCollection> _action;
 
             public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action)
                 : base (prototype, description, count)
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this.action = action;
+                this._action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)
             {
-                action (c.OptionValues);
+                _action (c.OptionValues);
             }
         }
 
@@ -613,36 +613,36 @@ namespace NUnit.Options
         }
 
         private sealed class ActionOption<T> : Option {
-            private readonly Action<T> action;
+            private readonly Action<T> _action;
 
             public ActionOption (string prototype, string description, Action<T> action)
                 : base (prototype, description, 1)
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this.action = action;
+                this._action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)
             {
-                action (Parse<T> (c.OptionValues [0], c));
+                _action (Parse<T> (c.OptionValues [0], c));
             }
         }
 
         private sealed class ActionOption<TKey, TValue> : Option {
-            private readonly OptionAction<TKey, TValue> action;
+            private readonly OptionAction<TKey, TValue> _action;
 
             public ActionOption (string prototype, string description, OptionAction<TKey, TValue> action)
                 : base (prototype, description, 2)
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this.action = action;
+                this._action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)
             {
-                action (
+                _action (
                         Parse<TKey> (c.OptionValues [0], c),
                         Parse<TValue> (c.OptionValues [1], c));
             }

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -151,7 +151,7 @@ namespace NUnit.Options
 
         internal OptionValueCollection (OptionContext c)
         {
-            this._c = c;
+            _c = c;
         }
 
         #region ICollection
@@ -245,8 +245,8 @@ namespace NUnit.Options
 
         public OptionContext (OptionSet set)
         {
-            this._set = set;
-            this._c   = new OptionValueCollection (this);
+            _set = set;
+            _c   = new OptionValueCollection (this);
         }
 
         public Option Option {
@@ -297,24 +297,24 @@ namespace NUnit.Options
             if (maxValueCount < 0)
                 throw new ArgumentOutOfRangeException (nameof(maxValueCount));
 
-            this._prototype   = prototype;
-            this._names       = prototype.Split ('|');
-            this._description = description;
-            this._count       = maxValueCount;
-            this._type        = ParsePrototype ();
+            _prototype   = prototype;
+            _names       = prototype.Split ('|');
+            _description = description;
+            _count       = maxValueCount;
+            _type        = ParsePrototype ();
 
-            if (this._count == 0 && _type != OptionValueType.None)
+            if (_count == 0 && _type != OptionValueType.None)
                 throw new ArgumentException (
                         "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
                             "OptionValueType.Optional.",
                         nameof(maxValueCount));
-            if (this._type == OptionValueType.None && maxValueCount > 1)
+            if (_type == OptionValueType.None && maxValueCount > 1)
                 throw new ArgumentException (
                     $"Cannot provide maxValueCount of {maxValueCount} for OptionValueType.None.",
                     nameof(maxValueCount));
             if (Array.IndexOf (_names, "<>") >= 0 &&
-                    ((_names.Length == 1 && this._type != OptionValueType.None) ||
-                     (_names.Length > 1 && this.MaxValueCount > 1)))
+                    ((_names.Length == 1 && _type != OptionValueType.None) ||
+                     (_names.Length > 1 && MaxValueCount > 1)))
                 throw new ArgumentException (
                         "The default option handler '<>' cannot require values.",
                         nameof(prototype));
@@ -397,11 +397,11 @@ namespace NUnit.Options
                     "prototype");
             if (_count > 1) {
                 if (seps.Count == 0)
-                    this._separators = new[]{":", "="};
+                    _separators = new[]{":", "="};
                 else if (seps.Count == 1 && seps [0].Length == 0)
-                    this._separators = null;
+                    _separators = null;
                 else
-                    this._separators = seps.ToArray ();
+                    _separators = seps.ToArray ();
             }
 
             return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
@@ -467,22 +467,22 @@ namespace NUnit.Options
         public OptionException (string message, string optionName)
             : base (message)
         {
-            this._option = optionName;
+            _option = optionName;
         }
 
         public OptionException (string message, string optionName, Exception innerException)
             : base (message, innerException)
         {
-            this._option = optionName;
+            _option = optionName;
         }
 
         protected OptionException (SerializationInfo info, StreamingContext context)
             : base (info, context)
         {
-            this._option = info.GetString ("OptionName");
+            _option = info.GetString ("OptionName");
         }
 
-        public string OptionName => this._option;
+        public string OptionName => _option;
 
         [SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
         public override void GetObjectData (SerializationInfo info, StreamingContext context)
@@ -573,7 +573,7 @@ namespace NUnit.Options
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this._action = action;
+                _action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)
@@ -620,7 +620,7 @@ namespace NUnit.Options
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this._action = action;
+                _action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)
@@ -637,7 +637,7 @@ namespace NUnit.Options
             {
                 if (action is null)
                     throw new ArgumentNullException (nameof(action));
-                this._action = action;
+                _action = action;
             }
 
             protected override void OnParseComplete (OptionContext c)

--- a/src/NUnitFramework/nunitlite/OutputSpecification.cs
+++ b/src/NUnitFramework/nunitlite/OutputSpecification.cs
@@ -26,7 +26,7 @@ namespace NUnit.Common
             if (parts.Length > 2)
                 throw new ArgumentException($"Invalid output spec: {spec}.");
 
-            this.OutputPath = parts[0];
+            OutputPath = parts[0];
 
             if (parts.Length == 1)
                 return;
@@ -36,7 +36,7 @@ namespace NUnit.Common
             if (opt.Length != 2 || opt[0].Trim() != "format")
                 throw new ArgumentException($"Invalid output spec: {spec}.");
 
-            this.Format = opt[1].Trim();
+            Format = opt[1].Trim();
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -16,7 +16,7 @@ namespace NUnitLite
     /// </summary>
     public class NUnit2XmlOutputWriter : OutputWriter
     {
-        private XmlWriter xmlWriter;
+        private XmlWriter _xmlWriter;
 
         /// <summary>
         /// Write info about a test
@@ -46,7 +46,7 @@ namespace NUnitLite
 
         private void WriteXmlOutput(ITestResult result, XmlWriter xmlWriter)
         {
-            this.xmlWriter = xmlWriter;
+            this._xmlWriter = xmlWriter;
 
             InitializeXmlFile(result);
             WriteResultElement(result);
@@ -57,63 +57,63 @@ namespace NUnitLite
         {
             ResultSummary summary = new ResultSummary(result);
 
-            xmlWriter.WriteStartDocument(false);
-            xmlWriter.WriteComment("This file represents the results of running a test suite");
+            _xmlWriter.WriteStartDocument(false);
+            _xmlWriter.WriteComment("This file represents the results of running a test suite");
 
-            xmlWriter.WriteStartElement("test-results");
+            _xmlWriter.WriteStartElement("test-results");
 
-            xmlWriter.WriteAttributeString("name", result.FullName);
-            xmlWriter.WriteAttributeString("total", summary.TestCount.ToString());
-            xmlWriter.WriteAttributeString("errors", summary.ErrorCount.ToString());
-            xmlWriter.WriteAttributeString("failures", summary.FailureCount.ToString());
-            xmlWriter.WriteAttributeString("not-run", summary.NotRunCount.ToString());
-            xmlWriter.WriteAttributeString("inconclusive", summary.InconclusiveCount.ToString());
-            xmlWriter.WriteAttributeString("ignored", summary.IgnoreCount.ToString());
-            xmlWriter.WriteAttributeString("skipped", summary.SkipCount.ToString());
-            xmlWriter.WriteAttributeString("invalid", summary.InvalidCount.ToString());
+            _xmlWriter.WriteAttributeString("name", result.FullName);
+            _xmlWriter.WriteAttributeString("total", summary.TestCount.ToString());
+            _xmlWriter.WriteAttributeString("errors", summary.ErrorCount.ToString());
+            _xmlWriter.WriteAttributeString("failures", summary.FailureCount.ToString());
+            _xmlWriter.WriteAttributeString("not-run", summary.NotRunCount.ToString());
+            _xmlWriter.WriteAttributeString("inconclusive", summary.InconclusiveCount.ToString());
+            _xmlWriter.WriteAttributeString("ignored", summary.IgnoreCount.ToString());
+            _xmlWriter.WriteAttributeString("skipped", summary.SkipCount.ToString());
+            _xmlWriter.WriteAttributeString("invalid", summary.InvalidCount.ToString());
 
-            xmlWriter.WriteAttributeString("date", result.StartTime.ToString("yyyy-MM-dd"));
-            xmlWriter.WriteAttributeString("time", result.StartTime.ToString("HH:mm:ss"));
+            _xmlWriter.WriteAttributeString("date", result.StartTime.ToString("yyyy-MM-dd"));
+            _xmlWriter.WriteAttributeString("time", result.StartTime.ToString("HH:mm:ss"));
             WriteEnvironment();
             WriteCultureInfo();
         }
 
         private void WriteCultureInfo()
         {
-            xmlWriter.WriteStartElement("culture-info");
-            xmlWriter.WriteAttributeString("current-culture",
+            _xmlWriter.WriteStartElement("culture-info");
+            _xmlWriter.WriteAttributeString("current-culture",
                                            CultureInfo.CurrentCulture.ToString());
-            xmlWriter.WriteAttributeString("current-uiculture",
+            _xmlWriter.WriteAttributeString("current-uiculture",
                                            CultureInfo.CurrentUICulture.ToString());
-            xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
         }
 
         private void WriteEnvironment()
         {
-            xmlWriter.WriteStartElement("environment");
+            _xmlWriter.WriteStartElement("environment");
             var assemblyName = AssemblyHelper.GetAssemblyName(typeof(NUnit2XmlOutputWriter).Assembly);
-            xmlWriter.WriteAttributeString("nunit-version",
+            _xmlWriter.WriteAttributeString("nunit-version",
                                            assemblyName.Version.ToString());
-            xmlWriter.WriteAttributeString("clr-version",
+            _xmlWriter.WriteAttributeString("clr-version",
                 Environment.Version.ToString());
 #if NETSTANDARD2_0
-            xmlWriter.WriteAttributeString("os-version",
+            _xmlWriter.WriteAttributeString("os-version",
                                            System.Runtime.InteropServices.RuntimeInformation.OSDescription);
 #else
-            xmlWriter.WriteAttributeString("os-version",
+            _xmlWriter.WriteAttributeString("os-version",
                                            OSPlatform.CurrentPlatform.ToString());
 #endif
-            xmlWriter.WriteAttributeString("platform",
+            _xmlWriter.WriteAttributeString("platform",
                 Environment.OSVersion.Platform.ToString());
-            xmlWriter.WriteAttributeString("cwd",
+            _xmlWriter.WriteAttributeString("cwd",
                                            Directory.GetCurrentDirectory());
-            xmlWriter.WriteAttributeString("machine-name",
+            _xmlWriter.WriteAttributeString("machine-name",
                                            Environment.MachineName);
-            xmlWriter.WriteAttributeString("user",
+            _xmlWriter.WriteAttributeString("user",
                                            Environment.UserName);
-            xmlWriter.WriteAttributeString("user-domain",
+            _xmlWriter.WriteAttributeString("user-domain",
                                            Environment.UserDomainName);
-            xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
         }
 
         private void WriteResultElement(ITestResult result)
@@ -137,15 +137,15 @@ namespace NUnitLite
             if (result.Test is TestSuite)
                 WriteChildResults(result);
 
-            xmlWriter.WriteEndElement(); // test element
+            _xmlWriter.WriteEndElement(); // test element
         }
 
         private void TerminateXmlFile()
         {
-            xmlWriter.WriteEndElement(); // test-results
-            xmlWriter.WriteEndDocument();
-            xmlWriter.Flush();
-            ((IDisposable)xmlWriter).Dispose();
+            _xmlWriter.WriteEndElement(); // test-results
+            _xmlWriter.WriteEndDocument();
+            _xmlWriter.Flush();
+            ((IDisposable)_xmlWriter).Dispose();
         }
 
 
@@ -157,22 +157,22 @@ namespace NUnitLite
 
             if (test is TestSuite suite)
             {
-                xmlWriter.WriteStartElement("test-suite");
-                xmlWriter.WriteAttributeString("type", suite.TestType == "ParameterizedMethod" ? "ParameterizedTest" : suite.TestType);
-                xmlWriter.WriteAttributeString("name", suite.TestType == "Assembly" || suite.TestType == "Project"
+                _xmlWriter.WriteStartElement("test-suite");
+                _xmlWriter.WriteAttributeString("type", suite.TestType == "ParameterizedMethod" ? "ParameterizedTest" : suite.TestType);
+                _xmlWriter.WriteAttributeString("name", suite.TestType == "Assembly" || suite.TestType == "Project"
                     ? result.Test.FullName
                     : result.Test.Name);
             }
             else
             {
-                xmlWriter.WriteStartElement("test-case");
-                xmlWriter.WriteAttributeString("name", result.Name);
+                _xmlWriter.WriteStartElement("test-case");
+                _xmlWriter.WriteAttributeString("name", result.Name);
             }
 
             if (test.Properties.ContainsKey(PropertyNames.Description))
             {
                 string description = (string)test.Properties.Get(PropertyNames.Description);
-                xmlWriter.WriteAttributeString("description", description);
+                _xmlWriter.WriteAttributeString("description", description);
             }
 
             TestStatus status = result.ResultState.Status;
@@ -180,16 +180,16 @@ namespace NUnitLite
 
             if (status != TestStatus.Skipped)
             {
-                xmlWriter.WriteAttributeString("executed", "True");
-                xmlWriter.WriteAttributeString("result", translatedResult);
-                xmlWriter.WriteAttributeString("success", status == TestStatus.Passed ? "True" : "False");
-                xmlWriter.WriteAttributeString("time", result.Duration.ToString("0.000", NumberFormatInfo.InvariantInfo));
-                xmlWriter.WriteAttributeString("asserts", result.AssertCount.ToString());
+                _xmlWriter.WriteAttributeString("executed", "True");
+                _xmlWriter.WriteAttributeString("result", translatedResult);
+                _xmlWriter.WriteAttributeString("success", status == TestStatus.Passed ? "True" : "False");
+                _xmlWriter.WriteAttributeString("time", result.Duration.ToString("0.000", NumberFormatInfo.InvariantInfo));
+                _xmlWriter.WriteAttributeString("asserts", result.AssertCount.ToString());
             }
             else
             {
-                xmlWriter.WriteAttributeString("executed", "False");
-                xmlWriter.WriteAttributeString("result", translatedResult);
+                _xmlWriter.WriteAttributeString("executed", "False");
+                _xmlWriter.WriteAttributeString("result", translatedResult);
             }
         }
 
@@ -230,16 +230,16 @@ namespace NUnitLite
 
             if (properties.ContainsKey(PropertyNames.Category))
             {
-                xmlWriter.WriteStartElement("categories");
+                _xmlWriter.WriteStartElement("categories");
 
                 foreach (string category in properties[PropertyNames.Category])
                 {
-                    xmlWriter.WriteStartElement("category");
-                    xmlWriter.WriteAttributeString("name", category);
-                    xmlWriter.WriteEndElement();
+                    _xmlWriter.WriteStartElement("category");
+                    _xmlWriter.WriteAttributeString("name", category);
+                    _xmlWriter.WriteEndElement();
                 }
 
-                xmlWriter.WriteEndElement();
+                _xmlWriter.WriteEndElement();
             }
         }
 
@@ -253,52 +253,52 @@ namespace NUnitLite
                 if (key != PropertyNames.Category)
                 {
                     if (nprops++ == 0)
-                        xmlWriter.WriteStartElement("properties");
+                        _xmlWriter.WriteStartElement("properties");
 
                     foreach (object prop in properties[key])
                     {
-                        xmlWriter.WriteStartElement("property");
-                        xmlWriter.WriteAttributeString("name", key);
-                        xmlWriter.WriteAttributeString("value", prop.ToString());
-                        xmlWriter.WriteEndElement();
+                        _xmlWriter.WriteStartElement("property");
+                        _xmlWriter.WriteAttributeString("name", key);
+                        _xmlWriter.WriteAttributeString("value", prop.ToString());
+                        _xmlWriter.WriteEndElement();
                     }
                 }
             }
 
             if (nprops > 0)
-                xmlWriter.WriteEndElement();
+                _xmlWriter.WriteEndElement();
         }
 
         private void WriteReasonElement(string message)
         {
-            xmlWriter.WriteStartElement("reason");
-            xmlWriter.WriteStartElement("message");
+            _xmlWriter.WriteStartElement("reason");
+            _xmlWriter.WriteStartElement("message");
             WriteCData(message);
-            xmlWriter.WriteEndElement();
-            xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
         }
 
         private void WriteFailureElement(string message, string stackTrace)
         {
-            xmlWriter.WriteStartElement("failure");
-            xmlWriter.WriteStartElement("message");
+            _xmlWriter.WriteStartElement("failure");
+            _xmlWriter.WriteStartElement("message");
             WriteCData(message);
-            xmlWriter.WriteEndElement();
-            xmlWriter.WriteStartElement("stack-trace");
+            _xmlWriter.WriteEndElement();
+            _xmlWriter.WriteStartElement("stack-trace");
             if (stackTrace is not null)
                 WriteCData(stackTrace);
-            xmlWriter.WriteEndElement();
-            xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
         }
 
         private void WriteChildResults(ITestResult result)
         {
-            xmlWriter.WriteStartElement("results");
+            _xmlWriter.WriteStartElement("results");
 
             foreach (ITestResult childResult in result.Children)
                 WriteResultElement(childResult);
 
-            xmlWriter.WriteEndElement();
+            _xmlWriter.WriteEndElement();
         }
 
 #endregion
@@ -345,16 +345,16 @@ namespace NUnitLite
                 int illegal = text.IndexOf("]]>", start, StringComparison.Ordinal);
                 if (illegal < 0)
                     break;
-                xmlWriter.WriteCData(text.Substring(start, illegal - start + 2));
+                _xmlWriter.WriteCData(text.Substring(start, illegal - start + 2));
                 start = illegal + 2;
                 if (start >= text.Length)
                     return;
             }
 
             if (start > 0)
-                xmlWriter.WriteCData(text.Substring(start));
+                _xmlWriter.WriteCData(text.Substring(start));
             else
-                xmlWriter.WriteCData(text);
+                _xmlWriter.WriteCData(text);
         }
 
 #endregion

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -46,7 +46,7 @@ namespace NUnitLite
 
         private void WriteXmlOutput(ITestResult result, XmlWriter xmlWriter)
         {
-            this._xmlWriter = xmlWriter;
+            _xmlWriter = xmlWriter;
 
             InitializeXmlFile(result);
             WriteResultElement(result);

--- a/src/NUnitFramework/nunitlite/OutputWriters/TestCaseOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/TestCaseOutputWriter.cs
@@ -20,10 +20,14 @@ namespace NUnitLite
         public override void WriteTestFile(ITest test, TextWriter writer)
         {
             if (test.IsSuite)
+            {
                 foreach (var child in test.Tests)
                     WriteTestFile(child, writer);
+            }
             else
+            {
                 writer.WriteLine(test.FullName);
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
+++ b/src/NUnitFramework/nunitlite/TeamCityEventListener.cs
@@ -54,8 +54,11 @@ namespace NUnitLite
             string testName = result.Test.Name;
 
             if (result.Test.IsSuite)
+            {
                 TC_TestSuiteFinished(testName);
+            }
             else
+            {
                 switch (result.ResultState.Status)
                 {
                     case TestStatus.Passed:
@@ -75,6 +78,7 @@ namespace NUnitLite
                         TC_TestFinished(testName, result.Duration);
                         break;
                 }
+            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunitlite/TestSelectionParser.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParser.cs
@@ -204,8 +204,10 @@ namespace NUnit.Common
             Token token = NextToken();
 
             foreach (TokenKind kind in kinds)
+            {
                 if (token.Kind == kind)
                     return token;
+            }
 
             throw InvalidTokenError(token);
         }
@@ -216,8 +218,10 @@ namespace NUnit.Common
             Token token = NextToken();
 
             foreach (Token item in valid)
+            {
                 if (token == item)
                     return token;
+            }
 
             throw InvalidTokenError(token);
         }
@@ -232,8 +236,10 @@ namespace NUnit.Common
         private bool LookingAt(params Token[] tokens)
         {
             foreach (Token token in tokens)
+            {
                 if (LookAhead == token)
                     return true;
+            }
 
             return false;
         }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -303,7 +303,9 @@ namespace NUnitLite
             var specs = _options.ExploreOutputSpecifications;
 
             if (specs.Count == 0)
+            {
                 new TestCaseOutputWriter().WriteTestFile(testNode, Console.Out);
+            }
             else
             {
                 var outputManager = new OutputManager(_options.WorkDirectory);
@@ -324,7 +326,9 @@ namespace NUnitLite
             var runSettings = new Dictionary<string, object>();
 
             if (options.PreFilters.Count > 0)
+            {
                 runSettings[FrameworkPackageSettings.LOAD] = options.PreFilters;
+            }
             else if (options.TestList.Count > 0)
             {
                 var prefilters = new List<string>();

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -462,16 +462,22 @@ namespace NUnitLite
                     DisplayErrorsFailuresAndWarnings(childResult);
             }
             else if (display)
+            {
                 DisplayTestResult(result);
+            }
         }
 
         private void DisplayNotRunResults(ITestResult result)
         {
             if (result.HasChildren)
+            {
                 foreach (ITestResult childResult in result.Children)
                     DisplayNotRunResults(childResult);
+            }
             else if (result.ResultState.Status == TestStatus.Skipped)
+            {
                 DisplayTestResult(result);
+            }
         }
 
         private static readonly char[] TRIM_CHARS = new char[] { '\r', '\n' };

--- a/src/NUnitFramework/nunitlite/Tokenizer.cs
+++ b/src/NUnitFramework/nunitlite/Tokenizer.cs
@@ -144,11 +144,13 @@ namespace NUnit.Common
                 case '!':
                     GetChar();
                     foreach(string dbl in DOUBLE_CHAR_SYMBOLS)
+                    {
                         if (ch == dbl[0] && NextChar == dbl[1])
                         {
                             GetChar();
                             return new Token(TokenKind.Symbol, dbl) { Pos = pos };
                         }
+                    }
 
                     return new Token(TokenKind.Symbol, ch);
 

--- a/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
@@ -189,7 +189,7 @@ namespace NUnit.TestData.LifeCycleTests
 
             [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 
-            [TestFixtureSource(nameof(FixtureArgs))]
+            [TestFixtureSource(""FixtureUnderTest"")]
             public class FixtureUnderTest
             {
                 private readonly int _initialValue;

--- a/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
@@ -189,7 +189,7 @@ namespace NUnit.TestData.LifeCycleTests
 
             [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 
-            [TestFixtureSource(""FixtureArgs"")]
+            [TestFixtureSource(nameof(FixtureArgs))]
             public class FixtureUnderTest
             {
                 private readonly int _initialValue;

--- a/src/NUnitFramework/testdata/AssertMultipleData.cs
+++ b/src/NUnitFramework/testdata/AssertMultipleData.cs
@@ -12,7 +12,7 @@ namespace NUnit.TestData.AssertMultipleData
 
     public class AssertMultipleFixture
     {
-        private static readonly ComplexNumber complex = new ComplexNumber(5.2, 3.9);
+        private static readonly ComplexNumber Complex = new ComplexNumber(5.2, 3.9);
 
         [Test]
         public void EmptyBlock()
@@ -34,8 +34,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
             });
         }
 
@@ -45,8 +45,8 @@ namespace NUnit.TestData.AssertMultipleData
             Assert.Multiple(() =>
             {
                 Assert.That(2 + 2, Is.EqualTo(4));
-                Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
             });
         }
 
@@ -59,8 +59,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
                 });
             });
         }
@@ -77,8 +77,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
                 });
             });
         }
@@ -159,8 +159,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 Assert.Fail("Message from Assert.Fail");
             });
         }
@@ -170,8 +170,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 Assert.Warn("WARNING");
             });
         }
@@ -182,8 +182,8 @@ namespace NUnit.TestData.AssertMultipleData
             Assert.Multiple(() =>
             {
                 Assert.Warn("WARNING");
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
             });
         }
 
@@ -192,8 +192,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
             });
         }
 
@@ -202,8 +202,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
             });
         }
 
@@ -212,8 +212,8 @@ namespace NUnit.TestData.AssertMultipleData
         {
             Assert.Multiple(() =>
             {
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
             });
         }
 
@@ -226,8 +226,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
                 });
             });
         }
@@ -241,8 +241,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 });
             });
         }
@@ -259,8 +259,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9), "ImaginaryPart");
                 });
             });
         }
@@ -277,8 +277,8 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 });
             });
         }
@@ -356,8 +356,8 @@ namespace NUnit.TestData.AssertMultipleData
             {
                 await Task.Delay(100);
                 Assert.That(2 + 2, Is.EqualTo(4));
-                Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
             });
         }
 
@@ -372,8 +372,8 @@ namespace NUnit.TestData.AssertMultipleData
                 Assert.Multiple(async () =>
                 {
                     await Task.Delay(100);
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
                 });
             });
         }
@@ -391,9 +391,9 @@ namespace NUnit.TestData.AssertMultipleData
 
                 Assert.Multiple(async () =>
                 {
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2));
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2));
                     await Task.Delay(100);
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(3.9));
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(3.9));
                 });
             });
         }
@@ -404,8 +404,8 @@ namespace NUnit.TestData.AssertMultipleData
             Assert.Multiple(async () =>
             {
                 await Task.Delay(100);
-                Assert.That(complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
             });
         }
 
@@ -423,8 +423,8 @@ namespace NUnit.TestData.AssertMultipleData
                 Assert.Multiple(async () =>
                 {
                     await Task.Delay(100);
-                    Assert.That(complex.RealPart, Is.EqualTo(5.2), "RealPart");
-                    Assert.That(complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                    Assert.That(Complex.RealPart, Is.EqualTo(5.2), "RealPart");
+                    Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 });
             });
         }

--- a/src/NUnitFramework/testdata/AttributeInheritanceData.cs
+++ b/src/NUnitFramework/testdata/AttributeInheritanceData.cs
@@ -10,13 +10,13 @@ namespace NUnit.TestData.AttributeInheritanceData
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=false)]
     internal class ConcernAttribute : TestFixtureAttribute
     {
-#pragma warning disable 414
-        private Type typeOfConcern;
-#pragma warning restore 414
+#pragma warning disable IDE0052 // Remove unread private members
+        private Type _typeOfConcern;
+#pragma warning restore IDE0052 // Remove unread private members
 
         public ConcernAttribute( Type typeOfConcern )
         {
-            this.typeOfConcern = typeOfConcern;
+            this._typeOfConcern = typeOfConcern;
         }
     }
 

--- a/src/NUnitFramework/testdata/AttributeInheritanceData.cs
+++ b/src/NUnitFramework/testdata/AttributeInheritanceData.cs
@@ -11,7 +11,7 @@ namespace NUnit.TestData.AttributeInheritanceData
     internal class ConcernAttribute : TestFixtureAttribute
     {
 #pragma warning disable IDE0052 // Remove unread private members
-        private Type _typeOfConcern;
+        private readonly Type _typeOfConcern;
 #pragma warning restore IDE0052 // Remove unread private members
 
         public ConcernAttribute( Type typeOfConcern )

--- a/src/NUnitFramework/testdata/AttributeInheritanceData.cs
+++ b/src/NUnitFramework/testdata/AttributeInheritanceData.cs
@@ -16,7 +16,7 @@ namespace NUnit.TestData.AttributeInheritanceData
 
         public ConcernAttribute( Type typeOfConcern )
         {
-            this._typeOfConcern = typeOfConcern;
+            _typeOfConcern = typeOfConcern;
         }
     }
 

--- a/src/NUnitFramework/testdata/CategoryAttributeData.cs
+++ b/src/NUnitFramework/testdata/CategoryAttributeData.cs
@@ -24,11 +24,9 @@ namespace NUnit.TestData.CategoryAttributeData
         [Test, Category("A-B"), Category("A,B"), Category("A!B"), Category("A+B")]
         public void TestValidSpecialChars() { }
 
-#pragma warning disable 414
-        private static TestCaseData[] Test3Data = new TestCaseData[] {
+        private static readonly TestCaseData[] Test3Data = new TestCaseData[] {
             new TestCaseData(5).SetCategory("Bottom")
         };
-#pragma warning restore 414
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=false)]

--- a/src/NUnitFramework/testdata/DatapointFixture.cs
+++ b/src/NUnitFramework/testdata/DatapointFixture.cs
@@ -23,31 +23,31 @@ namespace NUnit.TestData.DatapointFixture
     public class SquareRootTest_Field_Double : SquareRootTest
     {
         [Datapoint]
-        public double zero = 0;
+        public double Zero = 0;
 
         [Datapoint]
-        public double positive = 1;
+        public double Positive = 1;
 
         [Datapoint]
-        public double negative = -1;
+        public double Negative = -1;
 
         [Datapoint]
-        public double max = double.MaxValue;
+        public double Max = double.MaxValue;
 
         [Datapoint]
-        public double infinity = double.PositiveInfinity;
+        public double Infinity = double.PositiveInfinity;
     }
 
     public class SquareRootTest_Field_ArrayOfDouble : SquareRootTest
     {
         [Datapoints]
-        public double[] values = new[] { 0.0, 1.0, -1.0, double.MaxValue, double.PositiveInfinity };
+        public double[] Values = new[] { 0.0, 1.0, -1.0, double.MaxValue, double.PositiveInfinity };
     }
 
     public class SquareRootTest_Field_IEnumerableOfDouble : SquareRootTest
     {
         [Datapoints]
-        public IEnumerable<double> values = new List<double> { 0.0, 1.0, -1.0, double.MaxValue, double.PositiveInfinity };
+        public IEnumerable<double> Values = new List<double> { 0.0, 1.0, -1.0, double.MaxValue, double.PositiveInfinity };
     }
 
     public class SquareRootTest_Property_IEnumerableOfDouble : SquareRootTest
@@ -123,22 +123,22 @@ namespace NUnit.TestData.DatapointFixture
     public class InheritedDatapointSquareRoot : SquareRootTest
     {
         [Datapoint]
-        public double zero = 0;
+        public double Zero = 0;
 
         [Datapoint]
-        public double positive = 1;
+        public double Positive = 1;
 
         [Datapoint]
-        public double negative = -1;
+        public double Negative = -1;
     }
 
     public class DatapointCanBeInherited : InheritedDatapointSquareRoot
     {
         [Datapoint]
-        public double max = double.MaxValue;
+        public double Max = double.MaxValue;
 
         [Datapoint]
-        public double infinity = double.PositiveInfinity;
+        public double Infinity = double.PositiveInfinity;
     }
 
     public class InheritedDatapointsSquareRoot : SquareRootTest

--- a/src/NUnitFramework/testdata/GenericTestMethodData.cs
+++ b/src/NUnitFramework/testdata/GenericTestMethodData.cs
@@ -22,14 +22,12 @@ namespace NUnit.TestData
         {
         }
 
-#pragma warning disable 414
         private static readonly object[] Source = new object[] {
             new object[] { 5, 2, "ABC" },
             new object[] { 5, "Y", "ABC" },
             new object[] { "X", 2, "ABC" },
             new object[] { "X", "Y", "ABC" }
         };
-#pragma warning restore 414
     }
 
     public class IncompatibleGenericCombinatorialData

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -19,10 +19,10 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
     [Order(1)]
     public class MultipleTestFixtureAttributesOrder1
     {
-        private string s;
+        private string _s;
         public MultipleTestFixtureAttributesOrder1(string s)
         {
-            this.s = s;
+            this._s = s;
         }
 
         [Test]

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -19,7 +19,7 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
     [Order(1)]
     public class MultipleTestFixtureAttributesOrder1
     {
-        private string _s;
+        private readonly string _s;
         public MultipleTestFixtureAttributesOrder1(string s)
         {
             _s = s;

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -22,7 +22,7 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
         private string _s;
         public MultipleTestFixtureAttributesOrder1(string s)
         {
-            this._s = s;
+            _s = s;
         }
 
         [Test]

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -174,14 +174,14 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         public void Init2()
         {
             DerivedSetUpCount++;
-            BaseSetUpCalledFirst = this.SetUpCount > 0;
+            BaseSetUpCalledFirst = SetUpCount > 0;
         }
 
         [OneTimeTearDown]
         public void Destroy2()
         {
             DerivedTearDownCount++;
-            BaseTearDownCalledLast = this.TearDownCount == 0;
+            BaseTearDownCalledLast = TearDownCount == 0;
         }
 
         [Test]

--- a/src/NUnitFramework/testdata/RandomAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/RandomAttributeFixture.cs
@@ -12,7 +12,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Int
 
-        private readonly List<int> previousIntValues = new List<int>();
+        private readonly List<int> _previousIntValues = new List<int>();
 
         [Test]
         public void RandomInt([Random(COUNT)] int x)
@@ -29,8 +29,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomInt_IntRange_Distinct([Random(1, 4, COUNT, Distinct = true)] int x)
         {
-            Assert.That(previousIntValues, Does.Not.Contain(x));
-            previousIntValues.Add(x);
+            Assert.That(_previousIntValues, Does.Not.Contain(x));
+            _previousIntValues.Add(x);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Unsigned Int
 
-        private readonly List<uint> previousUIntValues = new List<uint>();
+        private readonly List<uint> _previousUIntValues = new List<uint>();
 
         [Test]
         public void RandomUInt([Random(COUNT)] uint x)
@@ -59,8 +59,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomUInt_UIntRange_Distinct([Random(1u, 4u, COUNT, Distinct = true)] uint x)
         {
-            Assert.That(previousUIntValues, Does.Not.Contain(x));
-            previousUIntValues.Add(x);
+            Assert.That(_previousUIntValues, Does.Not.Contain(x));
+            _previousUIntValues.Add(x);
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Short
 
-        private readonly List<short> previousShortValues = new List<short>();
+        private readonly List<short> _previousShortValues = new List<short>();
 
         [Test]
         public void RandomShort([Random(COUNT)] short x)
@@ -96,8 +96,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomShort_ShortRange_Distinct([Random((short)1, (short)4, COUNT, Distinct = true)] short x)
         {
-            Assert.That(previousShortValues, Does.Not.Contain(x));
-            previousShortValues.Add(x);
+            Assert.That(_previousShortValues, Does.Not.Contain(x));
+            _previousShortValues.Add(x);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Unsigned Short
 
-        private readonly List<ushort> previousUShortValues = new List<ushort>();
+        private readonly List<ushort> _previousUShortValues = new List<ushort>();
 
         [Test]
         public void RandomUShort([Random(COUNT)] ushort x)
@@ -133,8 +133,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomShort_UShortRange_Distinct([Random((ushort)1, (ushort)4, COUNT, Distinct = true)] ushort x)
         {
-            Assert.That(previousUShortValues, Does.Not.Contain(x));
-            previousUShortValues.Add(x);
+            Assert.That(_previousUShortValues, Does.Not.Contain(x));
+            _previousUShortValues.Add(x);
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Long
 
-        private readonly List<long> previousLongValues = new List<long>();
+        private readonly List<long> _previousLongValues = new List<long>();
 
         [Test]
         public void RandomLong([Random(COUNT)] long x)
@@ -163,8 +163,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomLong_LongRange_Distinct([Random(1L, 4L, COUNT, Distinct = true)] long x)
         {
-            Assert.That(previousLongValues, Does.Not.Contain(x));
-            previousLongValues.Add(x);
+            Assert.That(_previousLongValues, Does.Not.Contain(x));
+            _previousLongValues.Add(x);
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Unsigned Long
 
-        private readonly List<ulong> previousULongValues = new List<ulong>();
+        private readonly List<ulong> _previousULongValues = new List<ulong>();
 
         [Test]
         public void RandomULong([Random(COUNT)] ulong x)
@@ -194,8 +194,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomULong_ULongRange_Distinct([Random(1uL, 4uL, COUNT, Distinct = true)] ulong x)
         {
-            Assert.That(previousULongValues, Does.Not.Contain(x));
-            previousULongValues.Add(x);
+            Assert.That(_previousULongValues, Does.Not.Contain(x));
+            _previousULongValues.Add(x);
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Double
 
-        private readonly List<double> previousDoubleValues = new List<double>();
+        private readonly List<double> _previousDoubleValues = new List<double>();
 
         [Test]
         public void RandomDouble([Random(COUNT)] double x)
@@ -225,15 +225,15 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomDouble_DoubleRange_Distinct([Random(1.0d, 4.0d, COUNT, Distinct = true)] double x)
         {
-            Assert.That(previousDoubleValues, Does.Not.Contain(x));
-            previousDoubleValues.Add(x);
+            Assert.That(_previousDoubleValues, Does.Not.Contain(x));
+            _previousDoubleValues.Add(x);
         }
 
         #endregion
 
         #region Float
 
-        private readonly List<float> previousFloatValues = new List<float>();
+        private readonly List<float> _previousFloatValues = new List<float>();
 
         [Test]
         public void RandomFloat([Random(COUNT)] float x)
@@ -250,15 +250,15 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomFloat_FloatRange_Distinct([Random(1.0f, 4.0f, COUNT, Distinct = true)] float x)
         {
-            Assert.That(previousFloatValues, Does.Not.Contain(x));
-            previousFloatValues.Add(x);
+            Assert.That(_previousFloatValues, Does.Not.Contain(x));
+            _previousFloatValues.Add(x);
         }
 
         #endregion
 
         #region Enum
 
-        private readonly List<TestEnum> previousEnumValues = new List<TestEnum>();
+        private readonly List<TestEnum> _previousEnumValues = new List<TestEnum>();
 
         [Test]
         public void RandomEnum([Random(COUNT)] TestEnum x)
@@ -269,8 +269,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomEnum_EnumRange_Distinct([Random(COUNT, Distinct = true)] TestEnum x)
         {
-            Assert.That(previousEnumValues, Does.Not.Contain(x));
-            previousEnumValues.Add(x);
+            Assert.That(_previousEnumValues, Does.Not.Contain(x));
+            _previousEnumValues.Add(x);
         }
 
         public enum TestEnum
@@ -282,7 +282,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Decimal
 
-        private readonly List<decimal> previousDecimalValues = new List<decimal>();
+        private readonly List<decimal> _previousDecimalValues = new List<decimal>();
 
         [Test]
         public void RandomDecimal([Random(COUNT)] decimal x)
@@ -305,15 +305,15 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomDecimal_IntRange_Distinct([Random(1, 4, COUNT, Distinct = true)] decimal x)
         {
-            Assert.That(previousDecimalValues, Does.Not.Contain(x));
-            previousDecimalValues.Add(x);
+            Assert.That(_previousDecimalValues, Does.Not.Contain(x));
+            _previousDecimalValues.Add(x);
         }
 
         #endregion
 
         #region Byte
 
-        private readonly List<decimal> previousByteValues = new List<decimal>();
+        private readonly List<decimal> _previousByteValues = new List<decimal>();
 
         [Test]
         public void RandomByte([Random(COUNT)] byte x)
@@ -342,8 +342,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomByte_IntRange_Distinct([Random(1, 4, COUNT, Distinct = true)] byte x)
         {
-            Assert.That(previousByteValues, Does.Not.Contain(x));
-            previousByteValues.Add(x);
+            Assert.That(_previousByteValues, Does.Not.Contain(x));
+            _previousByteValues.Add(x);
         }
 
         [Test]
@@ -356,7 +356,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region SByte
 
-        private readonly List<decimal> previousSByteValues = new List<decimal>();
+        private readonly List<decimal> _previousSByteValues = new List<decimal>();
 
         [Test]
         public void RandomSByte([Random(COUNT)] sbyte x)
@@ -385,8 +385,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomSByte_IntRange_Distinct([Random(1, 4, COUNT, Distinct = true)] sbyte x)
         {
-            Assert.That(previousSByteValues, Does.Not.Contain(x));
-            previousSByteValues.Add(x);
+            Assert.That(_previousSByteValues, Does.Not.Contain(x));
+            _previousSByteValues.Add(x);
         }
 
         [Test]
@@ -399,7 +399,7 @@ namespace NUnit.TestData.RandomAttributeTests
 
         #region Guid
 
-        private readonly List<Guid> previousGuidValues = new List<Guid>();
+        private readonly List<Guid> _previousGuidValues = new List<Guid>();
 
         [Test]
         public void RandomGuid([Random(COUNT)] Guid x)
@@ -410,8 +410,8 @@ namespace NUnit.TestData.RandomAttributeTests
         [Test]
         public void RandomGuid_Distinct([Random(COUNT, Distinct = true)] Guid x)
         {
-            Assert.That(previousGuidValues, Does.Not.Contain(x));
-            previousGuidValues.Add(x);
+            Assert.That(_previousGuidValues, Does.Not.Contain(x));
+            _previousGuidValues.Add(x);
         }
 
         #endregion

--- a/src/NUnitFramework/testdata/RepeatingTestsFixtureBase.cs
+++ b/src/NUnitFramework/testdata/RepeatingTestsFixtureBase.cs
@@ -8,46 +8,46 @@ namespace NUnit.TestData.RepeatingTests
     [TestFixture]
     public class RepeatingTestsFixtureBase
     {
-        private int fixtureSetupCount;
-        private int fixtureTeardownCount;
-        private int setupCount;
-        private int teardownCount;
-        private readonly List<string> tearDownResults = new List<string>();
+        private int _fixtureSetupCount;
+        private int _fixtureTeardownCount;
+        private int _setupCount;
+        private int _teardownCount;
+        private readonly List<string> _tearDownResults = new List<string>();
 
         [OneTimeSetUp]
         public void FixtureSetUp()
         {
-            fixtureSetupCount++;
+            _fixtureSetupCount++;
         }
 
         [OneTimeTearDown]
         public void FixtureTearDown()
         {
-            fixtureTeardownCount++;
+            _fixtureTeardownCount++;
         }
 
         [SetUp]
         public void SetUp()
         {
-            setupCount++;
+            _setupCount++;
         }
 
         [TearDown]
         public void TearDown()
         {
-            tearDownResults.Add(TestContext.CurrentContext.Result.Outcome.ToString());
-            teardownCount++;
+            _tearDownResults.Add(TestContext.CurrentContext.Result.Outcome.ToString());
+            _teardownCount++;
         }
 
-        public int FixtureSetupCount => fixtureSetupCount;
+        public int FixtureSetupCount => _fixtureSetupCount;
 
-        public int FixtureTeardownCount => fixtureTeardownCount;
+        public int FixtureTeardownCount => _fixtureTeardownCount;
 
-        public int SetupCount => setupCount;
+        public int SetupCount => _setupCount;
 
-        public int TeardownCount => teardownCount;
+        public int TeardownCount => _teardownCount;
 
-        public List<string> TearDownResults => tearDownResults;
+        public List<string> TearDownResults => _tearDownResults;
         public int Count { get; protected set; }
     }
 }

--- a/src/NUnitFramework/testdata/SetUpFixtureData.cs
+++ b/src/NUnitFramework/testdata/SetUpFixtureData.cs
@@ -95,7 +95,7 @@ namespace NUnit.TestUtilities
         // Currently, only one fixture uses it, if more use it, they should not be run in parallel.
         // TODO: Create a utility that can be used by multiple fixtures
 
-        private static readonly Queue<string> _events = new Queue<string>();
+        private static readonly Queue<string> Events = new Queue<string>();
 
         /// <summary>
         /// Registers an event.
@@ -103,7 +103,7 @@ namespace NUnit.TestUtilities
         /// <param name="evnt">The event to register.</param>
         public static void RegisterEvent(string evnt)
         {
-            _events.Enqueue(evnt);
+            Events.Enqueue(evnt);
         }
 
 
@@ -116,7 +116,7 @@ namespace NUnit.TestUtilities
             foreach (string expected in expectedEvents)
             {
                 int item = 0;
-                string actual = _events.Count > 0 ? _events.Dequeue() : null;
+                string actual = Events.Count > 0 ? Events.Dequeue() : null;
                 Assert.AreEqual( expected, actual, "Item {0}", item++ );
             }
         }
@@ -128,7 +128,7 @@ namespace NUnit.TestUtilities
         /// <returns>An ExpectedEventsRecorder so that further expected events can be recorded and verified</returns>
         public static ExpectedEventsRecorder ExpectEvents(params string[] expectedEvents)
         {
-            return new ExpectedEventsRecorder(_events, expectedEvents);
+            return new ExpectedEventsRecorder(Events, expectedEvents);
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace NUnit.TestUtilities
         /// </summary>
         public static void Clear()
         {
-            _events.Clear();
+            Events.Clear();
         }
     }
 }

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -150,12 +150,9 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
 
         private class DivideDataProvider
         {
-#pragma warning disable 0169, 0649    // x is never assigned
-#pragma warning disable IDE0051 // Remove unused private members
-            private static object[] _myObject;
-#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
             public static string MyField;
-#pragma warning restore 0169, 0649
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
             public static int MyProperty { get; set; }
             public static IEnumerable HereIsTheDataWithParameters(int inject1, int inject2, int inject3)
             {

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -13,16 +13,14 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
     {
         #region Test Calling Assert.Ignore
 
-        [TestCaseSource(nameof(source))]
+        [TestCaseSource(nameof(Source))]
         public void MethodCallsIgnore(int x, int y, int z)
         {
             Assert.Ignore("Ignore this");
         }
 
-#pragma warning disable 414
-        private static object[] source = new object[] {
+        private static readonly object[] Source = new object[] {
             new TestCaseData( 2, 3, 4 ) };
-#pragma warning restore 414
 
         #endregion
 
@@ -77,35 +75,35 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         [Test, TestCaseSource(nameof(InstanceProperty))]
         public void MethodWithInstancePropertyAsSource(string source)
         {
-            Assert.AreEqual("InstanceProperty", source);
+            Assert.AreEqual(nameof(InstanceProperty), source);
         }
 
         private IEnumerable InstanceProperty =>
             new object[]
             {
-                new object[] { "InstanceProperty" }
+                new object[] { nameof(InstanceProperty) }
             };
 
         [Test, TestCaseSource(nameof(InstanceMethod))]
         public void MethodWithInstanceMethodAsSource(string source)
         {
-            Assert.AreEqual("InstanceMethod", source);
+            Assert.AreEqual(nameof(InstanceMethod), source);
         }
 
         private IEnumerable InstanceMethod()
         {
-            return new object[] { new object[] { "InstanceMethod" } };
+            return new object[] { new object[] { nameof(InstanceMethod) } };
         }
 
         [Test, TestCaseSource(nameof(InstanceField))]
         public void MethodWithInstanceFieldAsSource(string source)
         {
-            Assert.AreEqual("InstanceField", source);
+            Assert.AreEqual(nameof(InstanceField), source);
         }
 
-#pragma warning disable 414
-        private object[] InstanceField = { new object[] { "InstanceField" } };
-#pragma warning restore 414
+#pragma warning disable IDE1006 // Naming Styles
+        private readonly object[] InstanceField = { new object[] { nameof(InstanceField) } };
+#pragma warning restore IDE1006 // Naming Styles
 
         #endregion
 
@@ -153,7 +151,9 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         private class DivideDataProvider
         {
 #pragma warning disable 0169, 0649    // x is never assigned
-            private static object[] myObject;
+#pragma warning disable IDE0051 // Remove unused private members
+            private static object[] _myObject;
+#pragma warning restore IDE0051 // Remove unused private members
             public static string MyField;
 #pragma warning restore 0169, 0649
             public static int MyProperty { get; set; }
@@ -171,7 +171,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             }
         }
 
-        private static object[] ComplexArrayBasedTestInput = new[]
+        private static readonly object[] ComplexArrayBasedTestInput = new[]
         {
             new[] { 1, "text", new object() },
             Array.Empty<object>(),

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -14,53 +14,51 @@ namespace NUnit.TestData.TestFixtureSourceData
 {
     public abstract class TestFixtureSourceTest
     {
-        private readonly string Arg;
-        private readonly string Expected;
+        private readonly string _arg;
+        private readonly string _expected;
 
         public TestFixtureSourceTest(string arg, string expected)
         {
-            Arg = arg;
-            Expected = expected;
+            _arg = arg;
+            _expected = expected;
         }
 
         [Test]
         public void CheckSource()
         {
-            Assert.That(Arg, Is.EqualTo(Expected));
+            Assert.That(_arg, Is.EqualTo(_expected));
         }
     }
 
     public abstract class TestFixtureSourceDivideTest
     {
-        private readonly int X;
-        private readonly int Y;
-        private readonly int Z;
+        private readonly int _x;
+        private readonly int _y;
+        private readonly int _z;
 
         public TestFixtureSourceDivideTest(int x, int y, int z)
         {
-            X = x;
-            Y = y;
-            Z = z;
+            _x = x;
+            _y = y;
+            _z = z;
         }
 
         [Test]
         public void CheckSource()
         {
-            Assert.That(X / Y, Is.EqualTo(Z));
+            Assert.That(_x / _y, Is.EqualTo(_z));
         }
     }
 
-    [TestFixtureSource("StaticField")]
+    [TestFixtureSource(nameof(StaticField))]
     public class StaticField_SameClass : TestFixtureSourceTest
     {
         public StaticField_SameClass(string arg) : base(arg, "StaticFieldInClass") { }
 
-#pragma warning disable 414
-        private static object[] StaticField = new object[] { "StaticFieldInClass" };
-#pragma warning restore 414
+        private static readonly object[] StaticField = new object[] { "StaticFieldInClass" };
     }
 
-    [TestFixtureSource("StaticProperty")]
+    [TestFixtureSource(nameof(StaticProperty))]
     public class StaticProperty_SameClass : TestFixtureSourceTest
     {
         public StaticProperty_SameClass(string arg) : base(arg, "StaticPropertyInClass") { }
@@ -73,13 +71,13 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource("StaticProperty")]
+    [TestFixtureSource(nameof(StaticProperty))]
     public class StaticProperty_InheritedClass : StaticProperty_SameClass
     {
         public StaticProperty_InheritedClass(string arg) : base(arg, "StaticPropertyInClass") { }
     }
 
-    [TestFixtureSource("StaticMethod")]
+    [TestFixtureSource(nameof(StaticMethod))]
     public class StaticMethod_SameClass : TestFixtureSourceTest
     {
         public StaticMethod_SameClass(string arg) : base(arg, "StaticMethodInClass") { }
@@ -101,17 +99,17 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource("InstanceField")]
+    [TestFixtureSource(nameof(InstanceField))]
     public class InstanceField_SameClass : TestFixtureSourceTest
     {
         public InstanceField_SameClass(string arg) : base(arg, "InstanceFieldInClass") { }
 
-#pragma warning disable 414
-        private object[] InstanceField = new object[] { "InstanceFieldInClass" };
-#pragma warning restore 414
+#pragma warning disable IDE1006 // Naming Styles
+        private readonly object[] InstanceField = new object[] { "InstanceFieldInClass" };
+#pragma warning restore IDE1006 // Naming Styles
     }
 
-    [TestFixtureSource("InstanceProperty")]
+    [TestFixtureSource(nameof(InstanceProperty))]
     public class InstanceProperty_SameClass : TestFixtureSourceTest
     {
         public InstanceProperty_SameClass(string arg) : base(arg, "InstancePropertyInClass") { }
@@ -123,7 +121,7 @@ namespace NUnit.TestData.TestFixtureSourceData
             };
     }
 
-    [TestFixtureSource("InstanceMethod")]
+    [TestFixtureSource(nameof(InstanceMethod))]
     public class InstanceMethod_SameClass : TestFixtureSourceTest
     {
         public InstanceMethod_SameClass(string arg) : base(arg, "InstanceMethodInClass") { }
@@ -155,10 +153,10 @@ namespace NUnit.TestData.TestFixtureSourceData
     [TestFixtureSource(typeof(SourceData_IEnumerable))]
     public class IEnumerableSource : TestFixtureSourceTest
     {
-        public IEnumerableSource(string arg) : base(arg, "SourceData_IEnumerable") { }
+        public IEnumerableSource(string arg) : base(arg, nameof(SourceData_IEnumerable)) { }
     }
 
-    [TestFixtureSource("MyData")]
+    [TestFixtureSource(nameof(MyData))]
     public class SourceReturnsObjectArray : TestFixtureSourceDivideTest
     {
         public SourceReturnsObjectArray(int x, int y, int z) : base(x, y, z) { }
@@ -171,7 +169,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource("MyData")]
+    [TestFixtureSource(nameof(MyData))]
     public class SourceReturnsFixtureParameters : TestFixtureSourceDivideTest
     {
         public SourceReturnsFixtureParameters(int x, int y, int z) : base(x, y, z) { }
@@ -185,7 +183,7 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 
     [TestFixture]
-    [TestFixtureSource("MyData")]
+    [TestFixtureSource(nameof(MyData))]
     public class ExtraTestFixtureAttributeIsIgnored : TestFixtureSourceDivideTest
     {
         public ExtraTestFixtureAttributeIsIgnored(int x, int y, int z) : base(x, y, z) { }
@@ -199,8 +197,8 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 
     [TestFixture]
-    [TestFixtureSource("MyData")]
-    [TestFixtureSource("MoreData", Category = "Extra")]
+    [TestFixtureSource(nameof(MyData))]
+    [TestFixtureSource(nameof(MoreData), Category = "Extra")]
     [TestFixture(12, 12, 1)]
     public class TestFixtureMayUseMultipleSourceAttributes : TestFixtureSourceDivideTest
     {
@@ -213,14 +211,12 @@ namespace NUnit.TestData.TestFixtureSourceData
             yield return new object[] { 12, 6, 2 };
         }
 
-#pragma warning disable 414
-        private static object[] MoreData = new object[] {
+        private static readonly object[] MoreData = new object[] {
             new object[] { 12, 1, 12 },
             new object[] { 12, 2, 6 } };
-#pragma warning restore 414
     }
 
-    [TestFixtureSource("IgnoredData")]
+    [TestFixtureSource(nameof(IgnoredData))]
     public class IndividualInstancesMayBeIgnored : TestFixtureSourceTest
     {
         public IndividualInstancesMayBeIgnored(string arg) : base(arg, "IgnoredData") { }
@@ -233,7 +229,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource("ExplicitData")]
+    [TestFixtureSource(nameof(ExplicitData))]
     public class IndividualInstancesMayBeExplicit : TestFixtureSourceTest
     {
         public IndividualInstancesMayBeExplicit(string arg) : base(arg, "ExplicitData") { }
@@ -338,7 +334,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         };
     }
 
-    [TestFixtureSource(typeof(GenericFixtureSource), "Source")]
+    [TestFixtureSource(typeof(GenericFixtureSource), nameof(GenericFixtureSource.Source))]
     public class GenericFixtureSourceWithProperArgsProvided<T>
     {
         [Test]
@@ -367,7 +363,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         }
     }
 
-    [TestFixtureSource(typeof(GenericFixtureWithTypeAndConstructorArgsSource), "Source")]
+    [TestFixtureSource(typeof(GenericFixtureWithTypeAndConstructorArgsSource), nameof(GenericFixtureWithTypeAndConstructorArgsSource.Source))]
     public class GenericFixtureSourceWithTypeAndConstructorArgs<T>
     {
         private readonly T _arg;
@@ -393,7 +389,7 @@ namespace NUnit.TestData.TestFixtureSourceData
         };
     }
 
-    [TestFixtureSource(typeof(GenericFixtureWithConstructorArgsSource), "Source")]
+    [TestFixtureSource(typeof(GenericFixtureWithConstructorArgsSource), nameof(GenericFixtureWithConstructorArgsSource.Source))]
     public class GenericFixtureSourceWithConstructorArgs<T>
     {
         private readonly T _arg;
@@ -421,31 +417,23 @@ namespace NUnit.TestData.TestFixtureSourceData
 
         public IEnumerator GetEnumerator()
         {
-            yield return "SourceData_IEnumerable";
+            yield return nameof(SourceData_IEnumerable);
         }
     }
 
     internal class SourceData
     {
-        public static object[] InheritedStaticProperty =>
-            new object[]
-            {
-                new object[] { "StaticProperty" }
-            };
-
-#pragma warning disable 414
-        private static object[] StaticField = new object[] { "StaticField" };
-#pragma warning restore 414
+        private static readonly object[] StaticField = new object[] { nameof(StaticField) };
 
         private static object[] StaticProperty =>
             new object[]
             {
-                new object[] { "StaticProperty" }
+                new object[] { nameof(StaticProperty) }
             };
 
         private static object[] StaticMethod()
         {
-            return new object[] { new object[] { "StaticMethod" } };
+            return new object[] { new object[] { nameof(StaticMethod) } };
         }
     }
 
@@ -493,7 +481,7 @@ namespace NUnit.TestData.TestFixtureSourceData
     }
 }
 
-[TestFixtureSource("MyData")]
+[TestFixtureSource(nameof(MyData))]
 public class NoNamespaceTestFixtureSourceWithTwoValues
 {
     public NoNamespaceTestFixtureSourceWithTwoValues(int i) { }
@@ -503,12 +491,10 @@ public class NoNamespaceTestFixtureSourceWithTwoValues
     {
     }
 
-#pragma warning disable 414
-    private static object[] MyData = { 1, 2 };
-#pragma warning restore 414
+    private static readonly object[] MyData = { 1, 2 };
 }
 
-[TestFixtureSource("MyData")]
+[TestFixtureSource(nameof(MyData))]
 public class NoNamespaceTestFixtureSourceWithSingleValue
 {
     public NoNamespaceTestFixtureSourceWithSingleValue(int i) { }
@@ -518,12 +504,10 @@ public class NoNamespaceTestFixtureSourceWithSingleValue
     {
     }
 
-#pragma warning disable 414
-    private static object[] MyData = { 1 };
-#pragma warning restore 414
+    private static readonly object[] MyData = { 1 };
 }
 
-[TestFixtureSource("Data")]
+[TestFixtureSource(nameof(Data))]
 [Parallelizable(ParallelScope.All)]
 public class TextFixtureSourceWithParallelizableAttribute
 {

--- a/src/NUnitFramework/testdata/TheoryFixture.cs
+++ b/src/NUnitFramework/testdata/TheoryFixture.cs
@@ -10,9 +10,9 @@ namespace NUnit.TestData.TheoryFixture
 #pragma warning disable IDE0051 // Remove unused private members
 #pragma warning disable CS0414 // The field is assigned but its value is never used
         [Datapoint]
-        private int _i0 = 0;
+        private readonly int _i0 = 0;
         [Datapoint]
-        private static int _i1 = 1;
+        private static readonly int I1 = 1;
 #pragma warning restore CS0414 // The field is assigned but its value is never used
 #pragma warning restore IDE0051 // Remove unused private members
         [Datapoint]

--- a/src/NUnitFramework/testdata/TheoryFixture.cs
+++ b/src/NUnitFramework/testdata/TheoryFixture.cs
@@ -7,12 +7,14 @@ namespace NUnit.TestData.TheoryFixture
     [TestFixture]
     public class TheoryFixture
     {
-#pragma warning disable 414
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0414 // The field is assigned but its value is never used
         [Datapoint]
-        private int i0 = 0;
+        private int _i0 = 0;
         [Datapoint]
-        private static int i1 = 1;
-#pragma warning restore 414
+        private static int _i1 = 1;
+#pragma warning restore CS0414 // The field is assigned but its value is never used
+#pragma warning restore IDE0051 // Remove unused private members
         [Datapoint]
         public int I100 = 100;
 

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -66,7 +66,7 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
     internal class CustomException : Exception
     {
 #pragma warning disable IDE0052 // Remove unread private members
-        private CustomType _custom;
+        private readonly CustomType _custom;
 #pragma warning restore IDE0052 // Remove unread private members
 
         public CustomException(string msg, CustomType custom)

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -72,7 +72,7 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
         public CustomException(string msg, CustomType custom)
             : base(msg)
         {
-            this._custom = custom;
+            _custom = custom;
         }
     }
 

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -65,14 +65,14 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
 
     internal class CustomException : Exception
     {
-        #pragma warning disable 414
-        private CustomType custom;
-        #pragma warning restore 414
+#pragma warning disable IDE0052 // Remove unread private members
+        private CustomType _custom;
+#pragma warning restore IDE0052 // Remove unread private members
 
         public CustomException(string msg, CustomType custom)
             : base(msg)
         {
-            this.custom = custom;
+            this._custom = custom;
         }
     }
 

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -77,14 +77,14 @@ namespace NUnit.Framework.Assertions
 
         private static class AdhocTests
         {
-            private static readonly MethodInfo[] _methods =
+            private static readonly MethodInfo[] Methods =
                 typeof(AdhocTests).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 
             public static IEnumerable<MethodInfo> TestMethods
             {
                 get
                 {
-                    foreach (var method in _methods)
+                    foreach (var method in Methods)
                         if (method.Name.StartsWith("Test"))
                             yield return method;
                 }

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -85,8 +85,10 @@ namespace NUnit.Framework.Assertions
                 get
                 {
                     foreach (var method in Methods)
+                    {
                         if (method.Name.StartsWith("Test"))
                             yield return method;
+                    }
                 }
             }
 

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class ArrayEqualsFailureMessageFixture
     {
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         [Test]
         public void ArraysHaveDifferentRanks()

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
@@ -173,13 +173,13 @@ namespace NUnit.Framework.Assertions
             Assert.That(actual, Is.EqualTo(expected).AsCollection);
         }
 
-        private static readonly int[] underlyingArray = { 1, 2, 3, 4, 5 };
+        private static readonly int[] UnderlyingArray = { 1, 2, 3, 4, 5 };
 
         [Test]
         public void ArraySegmentAndArray()
         {
             Assume.That(ArraySegmentImplementsIEnumerable);
-            Assert.That(new ArraySegment<int>(underlyingArray, 1, 3), Is.EqualTo(new[] { 2, 3, 4 }));
+            Assert.That(new ArraySegment<int>(UnderlyingArray, 1, 3), Is.EqualTo(new[] { 2, 3, 4 }));
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace NUnit.Framework.Assertions
         public void ArrayAndArraySegment()
         {
             Assume.That(ArraySegmentImplementsIEnumerable);
-            Assert.That(new[] { 2, 3, 4 }, Is.EqualTo(new ArraySegment<int>(underlyingArray, 1, 3)));
+            Assert.That(new[] { 2, 3, 4 }, Is.EqualTo(new ArraySegment<int>(UnderlyingArray, 1, 3)));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Assertions
         public void TwoArraySegments()
         {
             Assume.That(ArraySegmentImplementsIEnumerable);
-            Assert.That(new ArraySegment<int>(underlyingArray, 1, 3), Is.EqualTo(new ArraySegment<int>(underlyingArray, 1, 3)));
+            Assert.That(new ArraySegment<int>(UnderlyingArray, 1, 3), Is.EqualTo(new ArraySegment<int>(UnderlyingArray, 1, 3)));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Assertions
 {
     public class AssertMultipleTests
     {
-        private static readonly ComplexNumber _complex = new ComplexNumber(5.2, 3.9);
+        private static readonly ComplexNumber Complex = new ComplexNumber(5.2, 3.9);
 
         [TestCase(nameof(AM.EmptyBlock), 0)]
         [TestCase(nameof(AM.SingleAssertSucceeds), 1)]
@@ -161,7 +161,7 @@ namespace NUnit.Framework.Assertions
     [Explicit("Used to display error messages for visual confirmation")]
     public class MultipleAssertDemo
     {
-        private static readonly ComplexNumber _complex = new ComplexNumber(5.2, 3.9);
+        private static readonly ComplexNumber Complex = new ComplexNumber(5.2, 3.9);
 
         [Test]
         // Shows multiple failures including one from Assert.Fail
@@ -169,8 +169,8 @@ namespace NUnit.Framework.Assertions
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(_complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 Assert.Fail("Assert.Fail Called");
             });
         }
@@ -181,8 +181,8 @@ namespace NUnit.Framework.Assertions
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_complex.RealPart, Is.EqualTo(5.0), "RealPart");
-                Assert.That(_complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
+                Assert.That(Complex.RealPart, Is.EqualTo(5.0), "RealPart");
+                Assert.That(Complex.ImaginaryPart, Is.EqualTo(4.2), "ImaginaryPart");
                 throw new Exception("Simulated Error");
             });
         }

--- a/src/NUnitFramework/tests/Assertions/AssertPolarityTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertPolarityTests.cs
@@ -7,59 +7,59 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class AssertPolarityTests
     {
-        private readonly int i1 = 1;
-        private readonly int i2 = -1;
-        private readonly uint u1 = 123456789;
-        private readonly long l1 = 123456789;
-        private readonly long l2 = -12345879;
-        private readonly ulong ul1 = 123456890;
-        private readonly float f1 = 8.543F;
-        private readonly float f2 = -8.543F;
-        private readonly decimal de1 = 83.4M;
-        private readonly decimal de2 = -83.4M;
-        private readonly double d1 = 8.0;
-        private readonly double d2 = -8.0;
+        private readonly int _i1 = 1;
+        private readonly int _i2 = -1;
+        private readonly uint _u1 = 123456789;
+        private readonly long _l1 = 123456789;
+        private readonly long _l2 = -12345879;
+        private readonly ulong _ul1 = 123456890;
+        private readonly float _f1 = 8.543F;
+        private readonly float _f2 = -8.543F;
+        private readonly decimal _de1 = 83.4M;
+        private readonly decimal _de2 = -83.4M;
+        private readonly double _d1 = 8.0;
+        private readonly double _d2 = -8.0;
 
         [Test]
         public void PositiveNumbersPassPositiveAssertion()
         {
-            Assert.Positive(i1);
-            Assert.Positive(l1);
-            Assert.Positive(f1);
-            Assert.Positive(de1);
-            Assert.Positive(d1);
+            Assert.Positive(_i1);
+            Assert.Positive(_l1);
+            Assert.Positive(_f1);
+            Assert.Positive(_de1);
+            Assert.Positive(_d1);
         }
 
         [Test]
         public void AssertNegativeNumbersFailPositiveAssertion()
         {
-            Assert.Throws<AssertionException>(() => Assert.Positive(i2));
-            Assert.Throws<AssertionException>(() => Assert.Positive(l2));
-            Assert.Throws<AssertionException>(() => Assert.Positive(f2));
-            Assert.Throws<AssertionException>(() => Assert.Positive(de2));
-            Assert.Throws<AssertionException>(() => Assert.Positive(d2));
+            Assert.Throws<AssertionException>(() => Assert.Positive(_i2));
+            Assert.Throws<AssertionException>(() => Assert.Positive(_l2));
+            Assert.Throws<AssertionException>(() => Assert.Positive(_f2));
+            Assert.Throws<AssertionException>(() => Assert.Positive(_de2));
+            Assert.Throws<AssertionException>(() => Assert.Positive(_d2));
         }
 
         [Test]
         public void NegativeNumbersPassNegativeAssertion()
         {
-            Assert.Negative(i2);
-            Assert.Negative(l2);
-            Assert.Negative(f2);
-            Assert.Negative(de2);
-            Assert.Negative(d2);
+            Assert.Negative(_i2);
+            Assert.Negative(_l2);
+            Assert.Negative(_f2);
+            Assert.Negative(_de2);
+            Assert.Negative(_d2);
         }
 
         [Test]
         public void AssertPositiveNumbersFailNegativeAssertion()
         {
-            Assert.Throws<AssertionException>(() => Assert.Negative(i1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(u1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(l1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(ul1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(f1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(de1));
-            Assert.Throws<AssertionException>(() => Assert.Negative(d1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_i1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_u1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_l1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_ul1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_f1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_de1));
+            Assert.Throws<AssertionException>(() => Assert.Negative(_d1));
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than 0" + Environment.NewLine +
                 "  But was:  -1" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Positive(i2));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Positive(_i2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -106,7 +106,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than 0" + Environment.NewLine +
                 "  But was:  1" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Negative(i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Negative(_i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
     }

--- a/src/NUnitFramework/tests/Assertions/AssertZeroTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertZeroTests.cs
@@ -7,67 +7,67 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class AssertZeroTests
     {
-        private readonly int i1 = 0;
-        private readonly int i2 = 1234;
-        private readonly uint u1 = 0;
-        private readonly uint u2 = 12345879;
-        private readonly long l1 = 0;
-        private readonly long l2 = 12345879;
-        private readonly ulong ul1 = 0;
-        private readonly ulong ul2 = 12345879;
-        private readonly float f1 = 0F;
-        private readonly float f2 = 8.543F;
-        private readonly decimal de1 = 0M;
-        private readonly decimal de2 = 83.4M;
-        private readonly double d1 = 0.0;
-        private readonly double d2 = 8.0;
+        private readonly int _i1 = 0;
+        private readonly int _i2 = 1234;
+        private readonly uint _u1 = 0;
+        private readonly uint _u2 = 12345879;
+        private readonly long _l1 = 0;
+        private readonly long _l2 = 12345879;
+        private readonly ulong _ul1 = 0;
+        private readonly ulong _ul2 = 12345879;
+        private readonly float _f1 = 0F;
+        private readonly float _f2 = 8.543F;
+        private readonly decimal _de1 = 0M;
+        private readonly decimal _de2 = 83.4M;
+        private readonly double _d1 = 0.0;
+        private readonly double _d2 = 8.0;
 
         [Test]
         public void ZeroIsZero()
         {
-            Assert.Zero(i1);
-            Assert.Zero(u1);
-            Assert.Zero(l1);
-            Assert.Zero(ul1);
-            Assert.Zero(f1);
-            Assert.Zero(de1);
-            Assert.Zero(d1);
+            Assert.Zero(_i1);
+            Assert.Zero(_u1);
+            Assert.Zero(_l1);
+            Assert.Zero(_ul1);
+            Assert.Zero(_f1);
+            Assert.Zero(_de1);
+            Assert.Zero(_d1);
         }
 
         [Test]
         public void AssertZeroFailsWhenNumberIsNotAZero()
         {
-            Assert.Throws<AssertionException>(() => Assert.Zero(i2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(u2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(l2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(ul2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(f2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(de2));
-            Assert.Throws<AssertionException>(() => Assert.Zero(d2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_i2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_u2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_l2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_ul2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_f2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_de2));
+            Assert.Throws<AssertionException>(() => Assert.Zero(_d2));
         }
 
         [Test]
         public void NotZeroIsNotZero()
         {
-            Assert.NotZero(i2);
-            Assert.NotZero(u2);
-            Assert.NotZero(l2);
-            Assert.NotZero(ul2);
-            Assert.NotZero(f2);
-            Assert.NotZero(de2);
-            Assert.NotZero(d2);
+            Assert.NotZero(_i2);
+            Assert.NotZero(_u2);
+            Assert.NotZero(_l2);
+            Assert.NotZero(_ul2);
+            Assert.NotZero(_f2);
+            Assert.NotZero(_de2);
+            Assert.NotZero(_d2);
         }
 
         [Test]
         public void AssertNotZeroFailsWhenNumberIsZero()
         {
-            Assert.Throws<AssertionException>(() => Assert.NotZero(i1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(u1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(l1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(ul1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(f1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(de1));
-            Assert.Throws<AssertionException>(() => Assert.NotZero(d1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_i1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_u1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_l1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_ul1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_f1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_de1));
+            Assert.Throws<AssertionException>(() => Assert.NotZero(_d1));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: 0" + Environment.NewLine +
                 "  But was:  1234" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Zero(i2));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Zero(_i2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
     }

--- a/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/GreaterEqualFixture.cs
@@ -9,70 +9,70 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class GreaterEqualFixture
     {
-        private readonly int i1 = 5;
-        private readonly int i2 = 4;
-        private readonly uint u1 = 12345879;
-        private readonly uint u2 = 12345678;
-        private readonly long l1 = 12345879;
-        private readonly long l2 = 12345678;
-        private readonly ulong ul1 = 12345879;
-        private readonly ulong ul2 = 12345678;
-        private readonly float f1 = 3.543F;
-        private readonly float f2 = 2.543F;
-        private readonly decimal de1 = 53.4M;
-        private readonly decimal de2 = 33.4M;
-        private readonly double d1 = 4.85948654;
-        private readonly double d2 = 1.0;
-        private readonly System.Enum e1 = RunState.Explicit;
-        private readonly System.Enum e2 = RunState.Ignored;
+        private readonly int _i1 = 5;
+        private readonly int _i2 = 4;
+        private readonly uint _u1 = 12345879;
+        private readonly uint _u2 = 12345678;
+        private readonly long _l1 = 12345879;
+        private readonly long _l2 = 12345678;
+        private readonly ulong _ul1 = 12345879;
+        private readonly ulong _ul2 = 12345678;
+        private readonly float _f1 = 3.543F;
+        private readonly float _f2 = 2.543F;
+        private readonly decimal _de1 = 53.4M;
+        private readonly decimal _de2 = 33.4M;
+        private readonly double _d1 = 4.85948654;
+        private readonly double _d2 = 1.0;
+        private readonly Enum _e1 = RunState.Explicit;
+        private readonly Enum _e2 = RunState.Ignored;
 
         [Test]
         public void GreaterOrEqual_Int32()
         {
-            Assert.GreaterOrEqual(i1, i1);           
-            Assert.GreaterOrEqual(i1, i2);
+            Assert.GreaterOrEqual(_i1, _i1);           
+            Assert.GreaterOrEqual(_i1, _i2);
         }
 
         [Test]
         public void GreaterOrEqual_UInt32()
         {
-            Assert.GreaterOrEqual(u1, u1);
-            Assert.GreaterOrEqual(u1, u2);
+            Assert.GreaterOrEqual(_u1, _u1);
+            Assert.GreaterOrEqual(_u1, _u2);
         }
 
         [Test]
         public void GreaterOrEqual_Long()
         {
-            Assert.GreaterOrEqual(l1, l1);
-            Assert.GreaterOrEqual(l1, l2);
+            Assert.GreaterOrEqual(_l1, _l1);
+            Assert.GreaterOrEqual(_l1, _l2);
         }
 
         [Test]
         public void GreaterOrEqual_ULong()
         {
-            Assert.GreaterOrEqual(ul1, ul1);
-            Assert.GreaterOrEqual(ul1, ul2);
+            Assert.GreaterOrEqual(_ul1, _ul1);
+            Assert.GreaterOrEqual(_ul1, _ul2);
         }
 
         [Test]
         public void GreaterOrEqual_Double()
         {
-            Assert.GreaterOrEqual(d1, d1, "double");
-            Assert.GreaterOrEqual(d1, d2, "double");
+            Assert.GreaterOrEqual(_d1, _d1, "double");
+            Assert.GreaterOrEqual(_d1, _d2, "double");
         }
 
         [Test]
         public void GreaterOrEqual_Decimal()
         {
-            Assert.GreaterOrEqual(de1, de1, "{0}", "decimal");
-            Assert.GreaterOrEqual(de1, de2, "{0}", "decimal");
+            Assert.GreaterOrEqual(_de1, _de1, "{0}", "decimal");
+            Assert.GreaterOrEqual(_de1, _de2, "{0}", "decimal");
         }
 
         [Test]
         public void GreaterOrEqual_Float()
         {
-            Assert.GreaterOrEqual(f1, f1, "float");
-            Assert.GreaterOrEqual(f1, f2, "float");
+            Assert.GreaterOrEqual(_f1, _f1, "float");
+            Assert.GreaterOrEqual(_f1, _f2, "float");
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than or equal to 5" + Environment.NewLine +
                 "  But was:  4" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(i2, i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(_i2, _i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than or equal to Ignored" + Environment.NewLine +
                 "  But was:  Explicit" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(e1, e2));
+            var ex = Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(_e1, _e2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/GreaterFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/GreaterFixture.cs
@@ -8,33 +8,33 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class GreaterFixture
     {
-        private readonly int i1 = 5;
-        private readonly int i2 = 4;
-        private readonly uint u1 = 12345879;
-        private readonly uint u2 = 12345678;
-        private readonly long l1 = 12345879;
-        private readonly long l2 = 12345678;
-        private readonly ulong ul1 = 12345879;
-        private readonly ulong ul2 = 12345678;
-        private readonly float f1 = 3.543F;
-        private readonly float f2 = 2.543F;
-        private readonly decimal de1 = 53.4M;
-        private readonly decimal de2 = 33.4M;
-        private readonly double d1 = 4.85948654;
-        private readonly double d2 = 1.0;
-        private readonly System.Enum e1 = RunState.Explicit;
-        private readonly System.Enum e2 = RunState.Ignored;
+        private readonly int _i1 = 5;
+        private readonly int _i2 = 4;
+        private readonly uint _u1 = 12345879;
+        private readonly uint _u2 = 12345678;
+        private readonly long _l1 = 12345879;
+        private readonly long _l2 = 12345678;
+        private readonly ulong _ul1 = 12345879;
+        private readonly ulong _ul2 = 12345678;
+        private readonly float _f1 = 3.543F;
+        private readonly float _f2 = 2.543F;
+        private readonly decimal _de1 = 53.4M;
+        private readonly decimal _de2 = 33.4M;
+        private readonly double _d1 = 4.85948654;
+        private readonly double _d2 = 1.0;
+        private readonly Enum _e1 = RunState.Explicit;
+        private readonly Enum _e2 = RunState.Ignored;
 
         [Test]
         public void Greater()
         {
-            Assert.Greater(i1,i2);
-            Assert.Greater(u1,u2);
-            Assert.Greater(l1,l2);
-            Assert.Greater(ul1,ul2);
-            Assert.Greater(d1,d2, "double");
-            Assert.Greater(de1,de2, "{0}", "decimal");
-            Assert.Greater(f1,f2, "float");
+            Assert.Greater(_i1,_i2);
+            Assert.Greater(_u1,_u2);
+            Assert.Greater(_l1,_l2);
+            Assert.Greater(_ul1,_ul2);
+            Assert.Greater(_d1,_d2, "double");
+            Assert.Greater(_de1,_de2, "{0}", "decimal");
+            Assert.Greater(_f1,_f2, "float");
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than 5" + Environment.NewLine +
                 "  But was:  5" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(i1,i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(_i1,_i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than 5" + Environment.NewLine +
                 "  But was:  4" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(i2,i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(_i2,_i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: greater than Ignored" + Environment.NewLine +
                 "  But was:  Explicit" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(e1,e2));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Greater(_e1,_e2));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/LessEqualFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LessEqualFixture.cs
@@ -8,71 +8,71 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class LessEqualFixture
     {
-        private readonly int i1 = 5;
-        private readonly int i2 = 8;
-        private readonly uint u1 = 12345678;
-        private readonly uint u2 = 12345879;
-        private readonly long l1 = 12345678;
-        private readonly long l2 = 12345879;
-        private readonly ulong ul1 = 12345678;
-        private readonly ulong ul2 = 12345879;
-        private readonly float f1 = 3.543F;
-        private readonly float f2 = 8.543F;
-        private readonly decimal de1 = 53.4M;
-        private readonly decimal de2 = 83.4M;
-        private readonly double d1 = 4.85948654;
-        private readonly double d2 = 8.0;
-        private readonly System.Enum e1 = RunState.Explicit;
-        private readonly System.Enum e2 = RunState.Ignored;
+        private readonly int _i1 = 5;
+        private readonly int _i2 = 8;
+        private readonly uint _u1 = 12345678;
+        private readonly uint _u2 = 12345879;
+        private readonly long _l1 = 12345678;
+        private readonly long _l2 = 12345879;
+        private readonly ulong _ul1 = 12345678;
+        private readonly ulong _ul2 = 12345879;
+        private readonly float _f1 = 3.543F;
+        private readonly float _f2 = 8.543F;
+        private readonly decimal _de1 = 53.4M;
+        private readonly decimal _de2 = 83.4M;
+        private readonly double _d1 = 4.85948654;
+        private readonly double _d2 = 8.0;
+        private readonly Enum _e1 = RunState.Explicit;
+        private readonly Enum _e2 = RunState.Ignored;
 
         [Test]
         public void LessOrEqual()
         {
             // Test equality check for all forms
-            Assert.LessOrEqual(i1, i1);
-            Assert.LessOrEqual(i1, i1, "int");
-            Assert.LessOrEqual(i1, i1, "{0}", "int");
-            Assert.LessOrEqual(u1, u1);
-            Assert.LessOrEqual(u1, u1, "uint");
-            Assert.LessOrEqual(u1, u1, "{0}", "uint");
-            Assert.LessOrEqual(l1, l1);
-            Assert.LessOrEqual(l1, l1, "long");
-            Assert.LessOrEqual(l1, l1, "{0}", "long");
-            Assert.LessOrEqual(ul1, ul1);
-            Assert.LessOrEqual(ul1, ul1, "ulong");
-            Assert.LessOrEqual(ul1, ul1, "{0}", "ulong");
-            Assert.LessOrEqual(d1, d1);
-            Assert.LessOrEqual(d1, d1, "double");
-            Assert.LessOrEqual(d1, d1, "{0}", "double");
-            Assert.LessOrEqual(de1, de1);
-            Assert.LessOrEqual(de1, de1, "decimal");
-            Assert.LessOrEqual(de1, de1, "{0}", "decimal");
-            Assert.LessOrEqual(f1, f1);
-            Assert.LessOrEqual(f1, f1, "float");
-            Assert.LessOrEqual(f1, f1, "{0}", "float");
+            Assert.LessOrEqual(_i1, _i1);
+            Assert.LessOrEqual(_i1, _i1, "int");
+            Assert.LessOrEqual(_i1, _i1, "{0}", "int");
+            Assert.LessOrEqual(_u1, _u1);
+            Assert.LessOrEqual(_u1, _u1, "uint");
+            Assert.LessOrEqual(_u1, _u1, "{0}", "uint");
+            Assert.LessOrEqual(_l1, _l1);
+            Assert.LessOrEqual(_l1, _l1, "long");
+            Assert.LessOrEqual(_l1, _l1, "{0}", "long");
+            Assert.LessOrEqual(_ul1, _ul1);
+            Assert.LessOrEqual(_ul1, _ul1, "ulong");
+            Assert.LessOrEqual(_ul1, _ul1, "{0}", "ulong");
+            Assert.LessOrEqual(_d1, _d1);
+            Assert.LessOrEqual(_d1, _d1, "double");
+            Assert.LessOrEqual(_d1, _d1, "{0}", "double");
+            Assert.LessOrEqual(_de1, _de1);
+            Assert.LessOrEqual(_de1, _de1, "decimal");
+            Assert.LessOrEqual(_de1, _de1, "{0}", "decimal");
+            Assert.LessOrEqual(_f1, _f1);
+            Assert.LessOrEqual(_f1, _f1, "float");
+            Assert.LessOrEqual(_f1, _f1, "{0}", "float");
 
             // Testing all forms after seeing some bugs. CFP
-            Assert.LessOrEqual(i1, i2);
-            Assert.LessOrEqual(i1, i2, "int");
-            Assert.LessOrEqual(i1, i2, "{0}", "int");
-            Assert.LessOrEqual(u1, u2);
-            Assert.LessOrEqual(u1, u2, "uint");
-            Assert.LessOrEqual(u1, u2, "{0}", "uint");
-            Assert.LessOrEqual(l1, l2);
-            Assert.LessOrEqual(l1, l2, "long");
-            Assert.LessOrEqual(l1, l2, "{0}", "long");
-            Assert.LessOrEqual(ul1, ul2);
-            Assert.LessOrEqual(ul1, ul2, "ulong");
-            Assert.LessOrEqual(ul1, ul2, "{0}", "ulong");
-            Assert.LessOrEqual(d1, d2);
-            Assert.LessOrEqual(d1, d2, "double");
-            Assert.LessOrEqual(d1, d2, "{0}", "double");
-            Assert.LessOrEqual(de1, de2);
-            Assert.LessOrEqual(de1, de2, "decimal");
-            Assert.LessOrEqual(de1, de2, "{0}", "decimal");
-            Assert.LessOrEqual(f1, f2);
-            Assert.LessOrEqual(f1, f2, "float");
-            Assert.LessOrEqual(f1, f2, "{0}", "float");
+            Assert.LessOrEqual(_i1, _i2);
+            Assert.LessOrEqual(_i1, _i2, "int");
+            Assert.LessOrEqual(_i1, _i2, "{0}", "int");
+            Assert.LessOrEqual(_u1, _u2);
+            Assert.LessOrEqual(_u1, _u2, "uint");
+            Assert.LessOrEqual(_u1, _u2, "{0}", "uint");
+            Assert.LessOrEqual(_l1, _l2);
+            Assert.LessOrEqual(_l1, _l2, "long");
+            Assert.LessOrEqual(_l1, _l2, "{0}", "long");
+            Assert.LessOrEqual(_ul1, _ul2);
+            Assert.LessOrEqual(_ul1, _ul2, "ulong");
+            Assert.LessOrEqual(_ul1, _ul2, "{0}", "ulong");
+            Assert.LessOrEqual(_d1, _d2);
+            Assert.LessOrEqual(_d1, _d2, "double");
+            Assert.LessOrEqual(_d1, _d2, "{0}", "double");
+            Assert.LessOrEqual(_de1, _de2);
+            Assert.LessOrEqual(_de1, _de2, "decimal");
+            Assert.LessOrEqual(_de1, _de2, "{0}", "decimal");
+            Assert.LessOrEqual(_f1, _f2);
+            Assert.LessOrEqual(_f1, _f2, "float");
+            Assert.LessOrEqual(_f1, _f2, "{0}", "float");
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than or equal to 5" + Environment.NewLine +
                 "  But was:  8" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.LessOrEqual(i2, i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.LessOrEqual(_i2, _i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than or equal to Explicit" + Environment.NewLine +
                 "  But was:  Ignored" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.LessOrEqual(e2, e1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.LessOrEqual(_e2, _e1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/LessFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LessFixture.cs
@@ -9,45 +9,45 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class LessFixture
     {
-        private readonly int i1 = 5;
-        private readonly int i2 = 8;
-        private readonly uint u1 = 12345678;
-        private readonly uint u2 = 12345879;
-        private readonly long l1 = 12345678;
-        private readonly long l2 = 12345879;
-        private readonly ulong ul1 = 12345678;
-        private readonly ulong ul2 = 12345879;
-        private readonly float f1 = 3.543F;
-        private readonly float f2 = 8.543F;
-        private readonly decimal de1 = 53.4M;
-        private readonly decimal de2 = 83.4M;
-        private readonly double d1 = 4.85948654;
-        private readonly double d2 = 8.0;
-        private readonly System.Enum e1 = RunState.Explicit;
-        private readonly System.Enum e2 = RunState.Ignored;
+        private readonly int _i1 = 5;
+        private readonly int _i2 = 8;
+        private readonly uint _u1 = 12345678;
+        private readonly uint _u2 = 12345879;
+        private readonly long _l1 = 12345678;
+        private readonly long _l2 = 12345879;
+        private readonly ulong _ul1 = 12345678;
+        private readonly ulong _ul2 = 12345879;
+        private readonly float _f1 = 3.543F;
+        private readonly float _f2 = 8.543F;
+        private readonly decimal _de1 = 53.4M;
+        private readonly decimal _de2 = 83.4M;
+        private readonly double _d1 = 4.85948654;
+        private readonly double _d2 = 8.0;
+        private readonly Enum _e1 = RunState.Explicit;
+        private readonly Enum _e2 = RunState.Ignored;
 
         [Test]
         public void Less()
         {
             // Testing all forms after seeing some bugs. CFP
-            Assert.Less(i1,i2);
-            Assert.Less(i1,i2,"int");
-            Assert.Less(i1,i2,"{0}","int");
-            Assert.Less(u1,u2,"uint");
-            Assert.Less(u1,u2,"{0}","uint");
-            Assert.Less(l1,l2,"long");
-            Assert.Less(l1,l2,"{0}","long");
-            Assert.Less(ul1,ul2,"ulong");
-            Assert.Less(ul1,ul2,"{0}","ulong");
-            Assert.Less(d1,d2);
-            Assert.Less(d1,d2, "double");
-            Assert.Less(d1,d2, "{0}", "double");
-            Assert.Less(de1,de2);
-            Assert.Less(de1,de2, "decimal");
-            Assert.Less(de1,de2, "{0}", "decimal");
-            Assert.Less(f1,f2);
-            Assert.Less(f1,f2, "float");
-            Assert.Less(f1,f2, "{0}", "float");
+            Assert.Less(_i1,_i2);
+            Assert.Less(_i1,_i2,"int");
+            Assert.Less(_i1,_i2,"{0}","int");
+            Assert.Less(_u1,_u2,"uint");
+            Assert.Less(_u1,_u2,"{0}","uint");
+            Assert.Less(_l1,_l2,"long");
+            Assert.Less(_l1,_l2,"{0}","long");
+            Assert.Less(_ul1,_ul2,"ulong");
+            Assert.Less(_ul1,_ul2,"{0}","ulong");
+            Assert.Less(_d1,_d2);
+            Assert.Less(_d1,_d2, "double");
+            Assert.Less(_d1,_d2, "{0}", "double");
+            Assert.Less(_de1,_de2);
+            Assert.Less(_de1,_de2, "decimal");
+            Assert.Less(_de1,_de2, "{0}", "decimal");
+            Assert.Less(_f1,_f2);
+            Assert.Less(_f1,_f2, "float");
+            Assert.Less(_f1,_f2, "{0}", "float");
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than 5" + Environment.NewLine +
                 "  But was:  5" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Less(i1,i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Less(_i1,_i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than 5" + Environment.NewLine +
                 "  But was:  8" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Less(i2,i1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Less(_i2,_i1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: less than Explicit" + Environment.NewLine +
                 "  But was:  Ignored" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Less(e2,e1));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Less(_e2,_e1));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
@@ -11,14 +11,14 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class ListContentsTests
     {
-        private static readonly object[] testArray = { "abc", 123, "xyz" };
+        private static readonly object[] TestArray = { "abc", 123, "xyz" };
 
         [Test]
         public void ArraySucceeds()
         {
-            Assert.Contains("abc", testArray);
-            Assert.Contains(123, testArray);
-            Assert.Contains("xyz", testArray, "expected array containing '{0}'", "xyz");
+            Assert.Contains("abc", TestArray);
+            Assert.Contains(123, TestArray);
+            Assert.Contains("xyz", TestArray, "expected array containing '{0}'", "xyz");
         }
 
         [Test]
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
                 "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Contains("def", testArray));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Contains("def", TestArray));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void ArrayListSucceeds()
         {
-            var list = new SimpleObjectList( testArray );
+            var list = new SimpleObjectList( TestArray );
 
             Assert.Contains( "abc", list );
             Assert.Contains( 123, list );
@@ -63,14 +63,14 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
                 "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.Contains( "def", new SimpleObjectList( testArray ) ));
+            var ex = Assert.Throws<AssertionException>(() => Assert.Contains( "def", new SimpleObjectList( TestArray ) ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void DifferentTypesMayBeEqual()
         {
-            Assert.Contains( 123.0, new SimpleObjectList( testArray ) );
+            Assert.Contains( 123.0, new SimpleObjectList( TestArray ) );
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/NotSameFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/NotSameFixture.cs
@@ -7,13 +7,13 @@ namespace NUnit.Framework.Assertions
     [TestFixture]
     public class NotSameFixture
     {
-        private readonly string s1 = "S1";
-        private readonly string s2 = "S2";
+        private readonly string _s1 = "S1";
+        private readonly string _s2 = "S2";
 
         [Test]
         public void NotSame()
         {
-            Assert.AreNotSame(s1, s2);
+            Assert.AreNotSame(_s1, _s2);
         }
 
         [Test]
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Assertions
             var expectedMessage =
                 "  Expected: not same as \"S1\"" + Environment.NewLine +
                 "  But was:  \"S1\"" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.AreNotSame( s1, s1 ));
+            var ex = Assert.Throws<AssertionException>(() => Assert.AreNotSame( _s1, _s1 ));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 

--- a/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
+++ b/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
@@ -205,8 +205,8 @@ namespace NUnit.Framework.Assertions
 
             public MyStruct(int i, string s)
             {
-                this._i = i;
-                this._s = s;
+                _i = i;
+                _s = s;
             }
         }
 

--- a/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
+++ b/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
@@ -199,14 +199,14 @@ namespace NUnit.Framework.Assertions
         private readonly struct MyStruct
         {
 #pragma warning disable IDE0052 // Remove unread private members
-            private readonly int i;
-            private readonly string s;
+            private readonly int _i;
+            private readonly string _s;
 #pragma warning restore IDE0052 // Remove unread private members
 
             public MyStruct(int i, string s)
             {
-                this.i = i;
-                this.s = s;
+                this._i = i;
+                this._s = s;
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ActionAttributeTests.cs
@@ -63,12 +63,16 @@ namespace NUnit.Framework
             var notExpected = new List<string>();
 
             foreach (var item in ExpectedEvents)
+            {
                 if (!ActionAttributeFixture.Events.Contains(item))
                     notFound.Add(item);
+            }
 
             foreach (var item in ActionAttributeFixture.Events)
+            {
                 if (!ExpectedEvents.Contains(item))
                     notExpected.Add(item);
+            }
 
             if (notFound.Count > 0 || notExpected.Count > 0)
             {

--- a/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ApplyToTestTests.cs
@@ -10,13 +10,13 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class ApplyToTestTests
     {
-        private Test test;
+        private Test _test;
 
         [SetUp]
         public void SetUp()
         {
-            test = new TestDummy();
-            test.RunState = RunState.Runnable;
+            _test = new TestDummy();
+            _test.RunState = RunState.Runnable;
         }
 
         #region CategoryAttribute
@@ -28,31 +28,31 @@ namespace NUnit.Framework.Attributes
         public void CategoryAttributePassesOnSpecialCharacters(char specialCharacter)
         {
             var categoryName = new string(specialCharacter, 5);
-            new CategoryAttribute(categoryName).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.Category), Is.EqualTo(categoryName));
+            new CategoryAttribute(categoryName).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.Category), Is.EqualTo(categoryName));
         }
 
         [Test]
         public void CategoryAttributeSetsCategory()
         {
-            new CategoryAttribute("database").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.Category), Is.EqualTo("database"));
+            new CategoryAttribute("database").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.Category), Is.EqualTo("database"));
         }
 
         [Test]
         public void CategoryAttributeSetsCategoryOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new CategoryAttribute("database").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.Category), Is.EqualTo("database"));
+            _test.RunState = RunState.NotRunnable;
+            new CategoryAttribute("database").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.Category), Is.EqualTo("database"));
         }
 
         [Test]
         public void CategoryAttributeSetsMultipleCategories()
         {
-            new CategoryAttribute("group1").ApplyToTest(test);
-            new CategoryAttribute("group2").ApplyToTest(test);
-            Assert.That(test.Properties[PropertyNames.Category],
+            new CategoryAttribute("group1").ApplyToTest(_test);
+            new CategoryAttribute("group2").ApplyToTest(_test);
+            Assert.That(_test.Properties[PropertyNames.Category],
                 Is.EquivalentTo( new[] { "group1", "group2" } ));
         }
 
@@ -63,16 +63,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DescriptionAttributeSetsDescription()
         {
-            new DescriptionAttribute("Cool test!").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.Description), Is.EqualTo("Cool test!"));
+            new DescriptionAttribute("Cool test!").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.Description), Is.EqualTo("Cool test!"));
         }
 
         [Test]
         public void DescriptionAttributeSetsDescriptionOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new DescriptionAttribute("Cool test!").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.Description), Is.EqualTo("Cool test!"));
+            _test.RunState = RunState.NotRunnable;
+            new DescriptionAttribute("Cool test!").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.Description), Is.EqualTo("Cool test!"));
         }
 
         #endregion
@@ -82,27 +82,27 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void IgnoreAttributeIgnoresTest()
         {
-            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+            new IgnoreAttribute("BECAUSE").ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
         [Test]
         public void IgnoreAttributeSetsIgnoreReason()
         {
-            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
+            new IgnoreAttribute("BECAUSE").ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
         }
 
         [Test]
         public void IgnoreAttributeDoesNotAffectNonRunnableTest()
         {
-            test.MakeInvalid("UNCHANGED");
-            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
+            _test.MakeInvalid("UNCHANGED");
+            new IgnoreAttribute("BECAUSE").ApplyToTest(_test);
             Assert.Multiple(() =>
             {
-                Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-                Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
+                Assert.That(_test.RunState, Is.EqualTo(RunState.NotRunnable));
+                Assert.That(_test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
             });
         }
 
@@ -111,8 +111,8 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "4242-01-01";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
         [Test]
@@ -120,8 +120,8 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "4242-01-01 12:00:00Z";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
         [Test]
@@ -129,8 +129,8 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "1492-01-01";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [TestCase("4242-01-01")]
@@ -140,8 +140,8 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = date;
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Ignoring until 4242-01-01 00:00:00Z. BECAUSE"));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("Ignoring until 4242-01-01 00:00:00Z. BECAUSE"));
         }
 
         [Test]
@@ -156,8 +156,8 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "4242-01-01";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("4242-01-01 00:00:00Z"));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("4242-01-01 00:00:00Z"));
         }
 
         [Test]
@@ -165,16 +165,16 @@ namespace NUnit.Framework.Attributes
         {
             var ignoreAttribute = new IgnoreAttribute("BECAUSE");
             ignoreAttribute.Until = "1242-01-01";
-            ignoreAttribute.ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("1242-01-01 00:00:00Z"));
+            ignoreAttribute.ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.IgnoreUntilDate), Is.EqualTo("1242-01-01 00:00:00Z"));
         }
 
         [Test]
         public void IgnoreAttributeWithExplicitIgnoresTest()
         {
-            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
-            new ExplicitAttribute().ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+            new IgnoreAttribute("BECAUSE").ApplyToTest(_test);
+            new ExplicitAttribute().ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
         #endregion
@@ -184,33 +184,33 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ExplicitAttributeMakesTestExplicit()
         {
-            new ExplicitAttribute().ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Explicit));
+            new ExplicitAttribute().ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Explicit));
         }
 
         [Test]
         public void ExplicitAttributeSetsIgnoreReason()
         {
-            new ExplicitAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Explicit));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
+            new ExplicitAttribute("BECAUSE").ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Explicit));
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("BECAUSE"));
         }
 
         [Test]
         public void ExplicitAttributeDoesNotAffectNonRunnableTest()
         {
-            test.MakeInvalid("UNCHANGED");
-            new ExplicitAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
+            _test.MakeInvalid("UNCHANGED");
+            new ExplicitAttribute("BECAUSE").ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.NotRunnable));
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason), Is.EqualTo("UNCHANGED"));
         }
 
         [Test]
         public void ExplicitAttributeWithIgnoreIgnoresTest()
         {
-            new ExplicitAttribute().ApplyToTest(test);
-            new IgnoreAttribute("BECAUSE").ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Ignored));
+            new ExplicitAttribute().ApplyToTest(_test);
+            new IgnoreAttribute("BECAUSE").ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Ignored));
         }
 
         #endregion
@@ -220,16 +220,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CombinatorialAttributeSetsJoinType()
         {
-            new CombinatorialAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Combinatorial"));
+            new CombinatorialAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Combinatorial"));
         }
 
         [Test]
         public void CombinatorialAttributeSetsJoinTypeOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new CombinatorialAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Combinatorial"));
+            _test.RunState = RunState.NotRunnable;
+            new CombinatorialAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Combinatorial"));
         }
 
         #endregion
@@ -240,17 +240,17 @@ namespace NUnit.Framework.Attributes
         public void CultureAttributeIncludingCurrentCultureRunsTest()
         {
             string name = System.Globalization.CultureInfo.CurrentCulture.Name;
-            new CultureAttribute(name).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+            new CultureAttribute(name).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
         public void CultureAttributeDoesNotAffectNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
+            _test.RunState = RunState.NotRunnable;
             string name = System.Globalization.CultureInfo.CurrentCulture.Name;
-            new CultureAttribute(name).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+            new CultureAttribute(name).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
         [Test]
@@ -259,9 +259,9 @@ namespace NUnit.Framework.Attributes
             string name = System.Globalization.CultureInfo.CurrentCulture.Name;
             CultureAttribute attr = new CultureAttribute(name);
             attr.Exclude = name;
-            attr.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Skipped));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
+            attr.ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Skipped));
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason),
                 Is.EqualTo("Not supported under culture " + name));
         }
 
@@ -272,9 +272,9 @@ namespace NUnit.Framework.Attributes
             if (System.Globalization.CultureInfo.CurrentCulture.Name == name)
                 name = "en-US";
 
-            new CultureAttribute(name).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Skipped));
-            Assert.That(test.Properties.Get(PropertyNames.SkipReason),
+            new CultureAttribute(name).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Skipped));
+            Assert.That(_test.Properties.Get(PropertyNames.SkipReason),
                 Is.EqualTo("Only supported under culture " + name));
         }
 
@@ -287,8 +287,8 @@ namespace NUnit.Framework.Attributes
 
             CultureAttribute attr = new CultureAttribute();
             attr.Exclude = other;
-            attr.ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+            attr.ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
@@ -298,8 +298,8 @@ namespace NUnit.Framework.Attributes
             string other = current == "fr-FR" ? "en-US" : "fr-FR";
             string cultures = current + "," + other;
 
-            new CultureAttribute(cultures).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+            new CultureAttribute(cultures).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         #endregion
@@ -309,16 +309,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MaxTimeAttributeSetsMaxTime()
         {
-            new MaxTimeAttribute(2000).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(2000));
+            new MaxTimeAttribute(2000).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(2000));
         }
 
         [Test]
         public void MaxTimeAttributeSetsMaxTimeOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new MaxTimeAttribute(2000).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(2000));
+            _test.RunState = RunState.NotRunnable;
+            new MaxTimeAttribute(2000).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.MaxTime), Is.EqualTo(2000));
         }
 
         #endregion
@@ -328,16 +328,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void PairwiseAttributeSetsJoinType()
         {
-            new PairwiseAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Pairwise"));
+            new PairwiseAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Pairwise"));
         }
 
         [Test]
         public void PairwiseAttributeSetsJoinTypeOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new PairwiseAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Pairwise"));
+            _test.RunState = RunState.NotRunnable;
+            new PairwiseAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Pairwise"));
         }
 
         #endregion
@@ -348,8 +348,8 @@ namespace NUnit.Framework.Attributes
         public void PlatformAttributeRunsTest()
         {
             string myPlatform = GetMyPlatform();
-            new PlatformAttribute(myPlatform).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+            new PlatformAttribute(myPlatform).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Runnable));
         }
 
         [Test]
@@ -357,26 +357,26 @@ namespace NUnit.Framework.Attributes
         {
             string notMyPlatform = System.IO.Path.DirectorySeparatorChar == '/'
                 ? "Win" : "Linux";
-            new PlatformAttribute(notMyPlatform).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.Skipped));
+            new PlatformAttribute(notMyPlatform).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.Skipped));
         }
 
         [Test]
         public void PlatformAttributeDoesNotAffectNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
+            _test.RunState = RunState.NotRunnable;
             string myPlatform = GetMyPlatform();
-            new PlatformAttribute(myPlatform).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
+            new PlatformAttribute(myPlatform).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
         [Test]
         public void InvalidPlatformAttributeIsNotRunnable()
         {
             var invalidPlatform = "FakePlatform";
-            new PlatformAttribute(invalidPlatform).ApplyToTest(test);
-            Assert.That(test.RunState, Is.EqualTo(RunState.NotRunnable));
-            string? skipReason = (string?)test.Properties.Get(PropertyNames.SkipReason);
+            new PlatformAttribute(invalidPlatform).ApplyToTest(_test);
+            Assert.That(_test.RunState, Is.EqualTo(RunState.NotRunnable));
+            string? skipReason = (string?)_test.Properties.Get(PropertyNames.SkipReason);
             Assert.That(skipReason, Is.Not.Null);
             Assert.Multiple(() =>
             {
@@ -401,16 +401,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void RepeatAttributeSetsRepeatCount()
         {
-            new RepeatAttribute(5).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
+            new RepeatAttribute(5).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
         }
 
         [Test]
         public void RepeatAttributeSetsRepeatCountOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new RepeatAttribute(5).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
+            _test.RunState = RunState.NotRunnable;
+            new RepeatAttribute(5).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.RepeatCount), Is.EqualTo(5));
         }
 
         #endregion
@@ -420,17 +420,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void RequiresMTAAttributeSetsApartmentState()
         {
-            new ApartmentAttribute(ApartmentState.MTA).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+            new ApartmentAttribute(ApartmentState.MTA).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.ApartmentState),
                 Is.EqualTo(ApartmentState.MTA));
         }
 
         [Test]
         public void RequiresMTAAttributeSetsApartmentStateOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new ApartmentAttribute(ApartmentState.MTA).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+            _test.RunState = RunState.NotRunnable;
+            new ApartmentAttribute(ApartmentState.MTA).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.ApartmentState),
                 Is.EqualTo(ApartmentState.MTA));
         }
 
@@ -441,17 +441,17 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void RequiresSTAAttributeSetsApartmentState()
         {
-            new ApartmentAttribute(ApartmentState.STA).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+            new ApartmentAttribute(ApartmentState.STA).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.ApartmentState),
                 Is.EqualTo(ApartmentState.STA));
         }
 
         [Test]
         public void RequiresSTAAttributeSetsApartmentStateOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new ApartmentAttribute(ApartmentState.STA).ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+            _test.RunState = RunState.NotRunnable;
+            new ApartmentAttribute(ApartmentState.STA).ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.ApartmentState),
                 Is.EqualTo(ApartmentState.STA));
         }
 
@@ -462,26 +462,26 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void RequiresThreadAttributeSetsRequiresThread()
         {
-            new RequiresThreadAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
+            new RequiresThreadAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
         }
 
         [Test]
         public void RequiresThreadAttributeSetsRequiresThreadOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new RequiresThreadAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
+            _test.RunState = RunState.NotRunnable;
+            new RequiresThreadAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
         }
 
         [Test]
         public void RequiresThreadAttributeMaySetApartmentState()
         {
-            new RequiresThreadAttribute(ApartmentState.STA).ApplyToTest(test);
+            new RequiresThreadAttribute(ApartmentState.STA).ApplyToTest(_test);
             Assert.Multiple(() =>
             {
-                Assert.That(test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
-                Assert.That(test.Properties.Get(PropertyNames.ApartmentState),
+                Assert.That(_test.Properties.Get(PropertyNames.RequiresThread), Is.EqualTo(true));
+                Assert.That(_test.Properties.Get(PropertyNames.ApartmentState),
                     Is.EqualTo(ApartmentState.STA));
             });
         }
@@ -493,16 +493,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SequentialAttributeSetsJoinType()
         {
-            new SequentialAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Sequential"));
+            new SequentialAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Sequential"));
         }
 
         [Test]
         public void SequentialAttributeSetsJoinTypeOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new SequentialAttribute().ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Sequential"));
+            _test.RunState = RunState.NotRunnable;
+            new SequentialAttribute().ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.JoinType), Is.EqualTo("Sequential"));
         }
 
         #endregion
@@ -512,16 +512,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SetCultureAttributeSetsSetCultureProperty()
         {
-            new SetCultureAttribute("fr-FR").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SetCulture), Is.EqualTo("fr-FR"));
+            new SetCultureAttribute("fr-FR").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.SetCulture), Is.EqualTo("fr-FR"));
         }
 
         [Test]
         public void SetCultureAttributeSetsSetCulturePropertyOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new SetCultureAttribute("fr-FR").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SetCulture), Is.EqualTo("fr-FR"));
+            _test.RunState = RunState.NotRunnable;
+            new SetCultureAttribute("fr-FR").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.SetCulture), Is.EqualTo("fr-FR"));
         }
 
         #endregion
@@ -531,16 +531,16 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SetUICultureAttributeSetsSetUICultureProperty()
         {
-            new SetUICultureAttribute("fr-FR").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SetUICulture), Is.EqualTo("fr-FR"));
+            new SetUICultureAttribute("fr-FR").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.SetUICulture), Is.EqualTo("fr-FR"));
         }
 
         [Test]
         public void SetUICultureAttributeSetsSetUICulturePropertyOnNonRunnableTest()
         {
-            test.RunState = RunState.NotRunnable;
-            new SetUICultureAttribute("fr-FR").ApplyToTest(test);
-            Assert.That(test.Properties.Get(PropertyNames.SetUICulture), Is.EqualTo("fr-FR"));
+            _test.RunState = RunState.NotRunnable;
+            new SetUICultureAttribute("fr-FR").ApplyToTest(_test);
+            Assert.That(_test.Properties.Get(PropertyNames.SetUICulture), Is.EqualTo("fr-FR"));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CategoryAttributeTests.cs
@@ -13,25 +13,25 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class CategoryAttributeTests
     {
-        private TestSuite fixture;
+        private TestSuite _fixture;
 
         [SetUp]
         public void CreateFixture()
         {
-            fixture = TestBuilder.MakeFixture( typeof( FixtureWithCategories ) );
+            _fixture = TestBuilder.MakeFixture( typeof( FixtureWithCategories ) );
         }
 
         [Test]
         public void CategoryOnFixture()
         {
-            Assert.That(fixture.Properties["Category"], Contains.Item("DataBase"));
+            Assert.That(_fixture.Properties["Category"], Contains.Item("DataBase"));
             //Assert.That( fixture.Properties.Contains("Category", "DataBase"));
         }
 
         [Test]
         public void CategoryOnTestMethod()
         {
-            Test test1 = (Test)fixture.Tests[0];
+            Test test1 = (Test)_fixture.Tests[0];
             Assert.That(test1.Properties["Category"], Contains.Item("Long"));
             //Assert.That( test1.Properties.Contains("Category", "Long") );
         }
@@ -39,21 +39,21 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void CanDeriveFromCategoryAttribute()
         {
-            Test test2 = (Test)fixture.Tests[1];
+            Test test2 = (Test)_fixture.Tests[1];
             Assert.That(test2.Properties["Category"], Contains.Item("Critical") );
         }
 
         [Test]
         public void DerivedCategoryMayBeInherited()
         {
-            Assert.That(fixture.Properties["Category"], Contains.Item("MyCategory"));
+            Assert.That(_fixture.Properties["Category"], Contains.Item("MyCategory"));
             //Assert.That(fixture.Properties.Contains("Category", "MyCategory"));
         }
 
         [Test]
         public void CanSpecifyOnMethodAndTestCase()
         {
-            TestSuite test3 = (TestSuite)fixture.Tests[2];
+            TestSuite test3 = (TestSuite)_fixture.Tests[2];
             Assert.That(test3.Name, Is.EqualTo("Test3"));
             Assert.That(test3.Properties["Category"], Contains.Item("Top"));
             Test testCase = (Test)test3.Tests[0];
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void TestWithValidCategoryNameIsNotRunnable()
         {
-            Test testValidSpecialChars = (Test)fixture.Tests[3];
+            Test testValidSpecialChars = (Test)_fixture.Tests[3];
             Assert.That(testValidSpecialChars.RunState, Is.EqualTo(RunState.Runnable));
         }
     }

--- a/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CommandWrapperTests.cs
@@ -106,14 +106,20 @@ namespace NUnit.Framework.Attributes
                     }
 
                     if (caughtType == _expectedType)
+                    {
                         context.CurrentResult.SetResult(ResultState.Success);
+                    }
                     else if (caughtType is not null)
+                    {
                         context.CurrentResult.SetResult(ResultState.Failure,
                             $"Expected {_expectedType.Name} but got {caughtType.Name}");
+                    }
                     else
+                    {
                         context.CurrentResult.SetResult(ResultState.Failure,
                             $"Expected {_expectedType.Name} but no exception was thrown");
-                    
+                    }
+
                     return context.CurrentResult;
 }
             }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
@@ -8,50 +8,50 @@ namespace NUnit.Framework.Attributes
     [Parallelizable(ParallelScope.All)]
     public class LifeCycleAttributeParallelTests
     {
-        private static readonly ObjectIDGenerator generator = new ObjectIDGenerator();
-        private readonly int constructorCount = 0;
-        private int setupCount = 0;
+        private static readonly ObjectIDGenerator Generator = new ObjectIDGenerator();
+        private readonly int _constructorCount = 0;
+        private int _setupCount = 0;
 
         public LifeCycleAttributeParallelTests()
         {
             OutputReferenceId("Ctor");
-            constructorCount++;
+            _constructorCount++;
         }
 
         [SetUp]
         public void SetUp()
         {
             OutputReferenceId("SetUp");
-            setupCount++;
+            _setupCount++;
         }
 
         [Test]
         public void EnsureParallelTestsRunInNewInstance1()
         {
             OutputReferenceId("EnsureParallelTestsRunInNewInstance1");
-            Assert.That(constructorCount, Is.EqualTo(1)); 
-            Assert.That(setupCount, Is.EqualTo(1));
+            Assert.That(_constructorCount, Is.EqualTo(1)); 
+            Assert.That(_setupCount, Is.EqualTo(1));
         }
 
         [Test]
         public void EnsureParallelTestsRunInNewInstance2()
         {
             OutputReferenceId("EnsureParallelTestsRunInNewInstance2");
-            Assert.That(constructorCount, Is.EqualTo(1));
-            Assert.That(setupCount, Is.EqualTo(1));
+            Assert.That(_constructorCount, Is.EqualTo(1));
+            Assert.That(_setupCount, Is.EqualTo(1));
         }
 
         [Test]
         public void EnsureParallelTestsRunInNewInstance3()
         {
             OutputReferenceId("EnsureParallelTestsRunInNewInstance3");
-            Assert.That(constructorCount, Is.EqualTo(1));
-            Assert.That(setupCount, Is.EqualTo(1));
+            Assert.That(_constructorCount, Is.EqualTo(1));
+            Assert.That(_setupCount, Is.EqualTo(1));
         }
 
         private void OutputReferenceId(string location)
         {
-            long id = generator.GetId(this, out bool _);
+            long id = Generator.GetId(this, out bool _);
             TestContext.WriteLine($"{location}: {id}>");
         }
     }

--- a/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
@@ -79,20 +79,24 @@ namespace NUnit.Framework.Attributes
             foreach (NUnit.Framework.Internal.TestCaseParameters parms in strategy.GetTestCases(sources))
             {
                 for (int i = 1; i < features; i++)
+                {
                     for (int j = 0; j < i; j++)
                     {
                         string? a = parms.Arguments[i] as string;
                         string? b = parms.Arguments[j] as string;
                         pairs[a + b] = null;
                     }
+                }
 
                 ++cases;
             }
 
             int expectedPairs = 0;
             for (int i = 1; i < features; i++)
+            {
                 for (int j = 0; j < i; j++)
                     expectedPairs += dimensions[i] * dimensions[j];
+            }
 
             Assert.That(pairs, Has.Count.EqualTo(expectedPairs), "Number of pairs is incorrect");
             Assert.That(cases, Is.AtMost(bestSoFar), "Regression: Number of test cases exceeded target previously reached");

--- a/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PairwiseTests.cs
@@ -11,18 +11,18 @@ namespace NUnit.Framework.Attributes
         [TestFixture]
         public class LiveTest
         {
-            private PairCounter pairsTested = new PairCounter();
+            private PairCounter _pairsTested = new PairCounter();
 
             [OneTimeSetUp]
             public void OneTimeSetUp()
             {
-                pairsTested = new PairCounter();
+                _pairsTested = new PairCounter();
             }
 
             [OneTimeTearDown]
             public void OneTimeTearDown()
             {
-                Assert.That(pairsTested, Has.Count.EqualTo(16));
+                Assert.That(_pairsTested, Has.Count.EqualTo(16));
             }
 
             [Test, Pairwise]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Attributes
             {
                 //Console.WriteLine("Pairwise: {0} {1} {2}", a, b, c);
 
-                pairsTested[a + b] = null;
-                pairsTested[a + c] = null;
-                pairsTested[b + c] = null;
+                _pairsTested[a + b] = null;
+                _pairsTested[a + c] = null;
+                _pairsTested[b + c] = null;
             }
         }
 
         // Test data is taken from various sources. See "Lessons Learned
         // in Software Testing" pp 53-59, for example. For orthogonal cases, see
         // https://web.archive.org/web/20100305233703/www.freequality.org/sites/www_freequality_org/documents/tools/Tagarray_files/tamatrix.htm
-        static internal object[] cases = new object[]
+        static internal object[] Cases = new object[]
         {
             new TestCaseData( new[] { 2, 4 }, 8, 8 ).SetName("Test 2x4"),
             new TestCaseData( new[] { 2, 2, 2 }, 4, 4 ).SetName("Test 2x2x2"),
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Attributes
             new TestCaseData( new[] { 5, 5, 5 }, 25, 25 ).SetName("Test 5x5x5")
         };
 
-        [Test, TestCaseSource(nameof(cases))]
+        [Test, TestCaseSource(nameof(Cases))]
         public void Test(int[] dimensions, int bestSoFar, int targetCases)
         {
             int features = dimensions.Length;

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -46,15 +46,15 @@ namespace NUnit.Framework.Attributes
     [TestFixture(default(string), default(string), "typed null test")]
     public class ParameterizedTestFixture
     {
-        private readonly string? eq1;
-        private readonly string? eq2;
-        private readonly string? neq;
+        private readonly string? _eq1;
+        private readonly string? _eq2;
+        private readonly string? _neq;
 
         public ParameterizedTestFixture(string? eq1, string? eq2, string? neq)
         {
-            this.eq1 = eq1;
-            this.eq2 = eq2;
-            this.neq = neq;
+            this._eq1 = eq1;
+            this._eq2 = eq2;
+            this._neq = neq;
         }
 
         public ParameterizedTestFixture(string? eq1, string? eq2)
@@ -62,49 +62,49 @@ namespace NUnit.Framework.Attributes
 
         public ParameterizedTestFixture(int eq1, int eq2, int neq)
         {
-            this.eq1 = eq1.ToString();
-            this.eq2 = eq2.ToString();
-            this.neq = neq.ToString();
+            this._eq1 = eq1.ToString();
+            this._eq2 = eq2.ToString();
+            this._neq = neq.ToString();
         }
 
         [Test]
         public void TestEquality()
         {
-            Assert.That(eq2, Is.EqualTo(eq1));
-            if (eq1 is not null && eq2 is not null)
-                Assert.That(eq2.GetHashCode(), Is.EqualTo(eq1.GetHashCode()));
+            Assert.That(_eq2, Is.EqualTo(_eq1));
+            if (_eq1 is not null && _eq2 is not null)
+                Assert.That(_eq2.GetHashCode(), Is.EqualTo(_eq1.GetHashCode()));
         }
 
         [Test]
         public void TestInequality()
         {
-            Assert.That(neq, Is.Not.EqualTo(eq1));
-            if (eq1 is not null && neq is not null)
-                Assert.That(neq.GetHashCode(), Is.Not.EqualTo(eq1.GetHashCode()));
+            Assert.That(_neq, Is.Not.EqualTo(_eq1));
+            if (_eq1 is not null && _neq is not null)
+                Assert.That(_neq.GetHashCode(), Is.Not.EqualTo(_eq1.GetHashCode()));
         }
     }
 
     public class ParameterizedTestFixtureNamingTests
     {
-        private TestSuite fixture;
+        private TestSuite _fixture;
 
         [SetUp]
         public void MakeFixture()
         {
-            fixture = TestBuilder.MakeFixture(typeof(NUnit.TestData.ParameterizedTestFixture));
+            _fixture = TestBuilder.MakeFixture(typeof(NUnit.TestData.ParameterizedTestFixture));
         }
 
         [Test]
         public void TopLevelSuiteIsNamedCorrectly()
         {
-            Assert.That(fixture.Name, Is.EqualTo("ParameterizedTestFixture"));
-            Assert.That(fixture.FullName, Is.EqualTo("NUnit.TestData.ParameterizedTestFixture"));
+            Assert.That(_fixture.Name, Is.EqualTo("ParameterizedTestFixture"));
+            Assert.That(_fixture.FullName, Is.EqualTo("NUnit.TestData.ParameterizedTestFixture"));
         }
 
         [Test]
         public void SuiteHasCorrectNumberOfInstances()
         {
-            Assert.That(fixture.Tests, Has.Count.EqualTo(2));
+            Assert.That(_fixture.Tests, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Attributes
         {
             var names = new List<string>();
             var fullnames = new List<string>();
-            foreach (Test test in fixture.Tests)
+            foreach (Test test in _fixture.Tests)
             {
                 names.Add(test.Name);
                 fullnames.Add(test.FullName);
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MethodWithoutParamsIsNamedCorrectly()
         {
-            TestSuite instance = (TestSuite)fixture.Tests[0];
+            TestSuite instance = (TestSuite)_fixture.Tests[0];
             Test? method = TestFinder.Find("MethodWithoutParams", instance, false);
             Assert.That(method, Is.Not.Null );
             Assert.That(method.FullName, Is.EqualTo(instance.FullName + ".MethodWithoutParams"));
@@ -136,7 +136,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void MethodWithParamsIsNamedCorrectly()
         {
-            TestSuite instance = (TestSuite)fixture.Tests[0];
+            TestSuite instance = (TestSuite)_fixture.Tests[0];
             TestSuite? method = (TestSuite?)TestFinder.Find("MethodWithParams", instance, false);
             Assert.That(method, Is.Not.Null);
             

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -52,9 +52,9 @@ namespace NUnit.Framework.Attributes
 
         public ParameterizedTestFixture(string? eq1, string? eq2, string? neq)
         {
-            this._eq1 = eq1;
-            this._eq2 = eq2;
-            this._neq = neq;
+            _eq1 = eq1;
+            _eq2 = eq2;
+            _neq = neq;
         }
 
         public ParameterizedTestFixture(string? eq1, string? eq2)
@@ -62,9 +62,9 @@ namespace NUnit.Framework.Attributes
 
         public ParameterizedTestFixture(int eq1, int eq2, int neq)
         {
-            this._eq1 = eq1.ToString();
-            this._eq2 = eq2.ToString();
-            this._neq = neq.ToString();
+            _eq1 = eq1.ToString();
+            _eq2 = eq2.ToString();
+            _neq = neq.ToString();
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/PropertyAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/PropertyAttributeTests.cs
@@ -9,25 +9,25 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class PropertyAttributeTests
     {
-        private TestSuite fixture;
+        private TestSuite _fixture;
 
         [SetUp]
         public void CreateFixture()
         {
-            fixture = TestBuilder.MakeFixture(typeof(FixtureWithProperties));
+            _fixture = TestBuilder.MakeFixture(typeof(FixtureWithProperties));
         }
 
         [Test]
         public void PropertyWithStringValue()
         {
-            Test test1 = (Test)fixture.Tests[0];
+            Test test1 = (Test)_fixture.Tests[0];
             Assert.That(test1.Properties["user"].Contains("Charlie"));
         }
 
         [Test]
         public void PropertiesWithNumericValues()
         {
-            Test test2 = (Test)fixture.Tests[1];
+            Test test2 = (Test)_fixture.Tests[1];
             Assert.That(test2.Properties.Get("X"), Is.EqualTo(10.0));
             Assert.That(test2.Properties.Get("Y"), Is.EqualTo(17.0));
         }
@@ -35,27 +35,27 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void PropertyWorksOnFixtures()
         {
-            Assert.That(fixture.Properties.Get("ClassUnderTest"), Is.EqualTo("SomeClass"));
+            Assert.That(_fixture.Properties.Get("ClassUnderTest"), Is.EqualTo("SomeClass"));
         }
 
         [Test]
         public void CanDeriveFromPropertyAttribute()
         {
-            Test test3 = (Test)fixture.Tests[2];
+            Test test3 = (Test)_fixture.Tests[2];
             Assert.That(test3.Properties.Get("Priority"), Is.EqualTo(5));
         }
 
         [Test]
         public void CustomPropertyAttribute()
         {
-            Test test4 = (Test)fixture.Tests[3];
+            Test test4 = (Test)_fixture.Tests[3];
             Assert.That(test4.Properties.Get("CustomProperty"), Is.Not.Null);
         }
 
         [Test]
         public void ManyProperties()
         {
-            Test test5 = (Test)fixture.Tests[4];
+            Test test5 = (Test)_fixture.Tests[4];
             Assert.That(test5.Properties.Keys, Has.Count.EqualTo(6));
             Assert.That(test5.Properties.Get("A"), Is.EqualTo("A"));
             Assert.That(test5.Properties.Get("B"), Is.EqualTo("B"));

--- a/src/NUnitFramework/tests/Attributes/RandomAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RandomAttributeTests.cs
@@ -24,11 +24,13 @@ namespace NUnit.Framework.Attributes
                 msg.AppendFormat("Unexpected Result: {0}\n", result.ResultState);
 
                 if (result.ResultState.Site == FailureSite.Child)
+                {
                     foreach (var child in result.Children)
                     {
                         msg.AppendFormat(" {0}: {1}\n", child.Name, child.ResultState);
                         msg.AppendFormat("{0}\n", child.Message);
                     }
+                }
 
                 Assert.Fail(msg.ToString());
             }
@@ -39,8 +41,10 @@ namespace NUnit.Framework.Attributes
             public IEnumerator GetEnumerator()
             {
                 foreach (var method in typeof(RandomAttributeFixture).GetMethods())
+                {
                     if (method.HasAttribute<TestAttribute>(inherit: false))
                         yield return new TestCaseData(method.Name).SetName(method.Name);
+                }
             }
         }
     }

--- a/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
@@ -14,14 +14,14 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class RepeatableTestsWithTimeoutAttributesTests
     {
-        private int retryOnlyCount;
+        private int _retryOnlyCount;
 
         [Test]
         [Retry(3)]
         public void ShouldPassAfter3Retries()
         {
-            retryOnlyCount++;
-            Assert.That(retryOnlyCount, Is.GreaterThanOrEqualTo(2));
+            _retryOnlyCount++;
+            Assert.That(_retryOnlyCount, Is.GreaterThanOrEqualTo(2));
         }
 
         public class HelperMethodForTimeoutsClass

--- a/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetCultureAttributeTests.cs
@@ -8,41 +8,41 @@ namespace NUnit.Framework.Attributes
     [TestFixture]
     public class SetCultureAttributeTests
     {
-        private CultureInfo originalCulture;
-        private CultureInfo originalUICulture;
+        private CultureInfo _originalCulture;
+        private CultureInfo _originalUICulture;
 
         [SetUp]
         public void Setup()
         {
-            originalCulture = CultureInfo.CurrentCulture;
-            originalUICulture = CultureInfo.CurrentUICulture;
+            _originalCulture = CultureInfo.CurrentCulture;
+            _originalUICulture = CultureInfo.CurrentUICulture;
         }
 
         [Test, SetUICulture("fr-FR")]
         public void SetUICultureOnlyToFrench()
         {
-            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(_originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
             Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-FR"), "UICulture not set correctly");
         }
 
         [Test, SetUICulture("fr-CA")]
         public void SetUICultureOnlyToFrenchCanadian()
         {
-            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(_originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
             Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("fr-CA"), "UICulture not set correctly");
         }
 
         [Test, SetUICulture("ru-RU")]
         public void SetUICultureOnlyToRussian()
         {
-            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
+            Assert.That(_originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture should not change");
             Assert.That(CultureInfo.CurrentUICulture.Name, Is.EqualTo("ru-RU"), "UICulture not set correctly");
         }
 
         [Test, SetCulture("fr-FR")]
         public void SetCultureOnlyToFrench()
         {
-            Assert.That(originalUICulture, Is.EqualTo(CultureInfo.CurrentUICulture), "UICulture should not change");
+            Assert.That(_originalUICulture, Is.EqualTo(CultureInfo.CurrentUICulture), "UICulture should not change");
             Assert.That(CultureInfo.CurrentCulture.Name, Is.EqualTo("fr-FR"), "Culture not set correctly");
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -378,14 +378,14 @@ namespace NUnit.Framework.Attributes
             Assert.That(suiteToTest.Tests[0].RunState, Is.EqualTo(RunState.NotRunnable));
         }
 
-        private static readonly object[] testCases =
+        private static readonly object[] TestCases =
         {
             new TestCaseData(
                 new[] { "A" },
                 new[] { "B" })
         };
 
-        [Test, TestCaseSource(nameof(testCases))]
+        [Test, TestCaseSource(nameof(TestCases))]
         public void MethodTakingTwoStringArrays(string[] a, string[] b)
         {
             Assert.Multiple(() =>

--- a/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
@@ -6,9 +6,9 @@ namespace NUnit.Framework.Attributes
 {
     public class TestFixtureAttributeTests
     {
-        private static readonly object[] fixtureArgs = { 10, 20, "Charlie" };
-        private static readonly Type[] typeArgs = { typeof(int), typeof(string) };
-        private static readonly object[] combinedArgs = { typeof(int), typeof(string), 10, 20, "Charlie" };
+        private static readonly object[] FixtureArgs = { 10, 20, "Charlie" };
+        private static readonly Type[] TypeArgs = { typeof(int), typeof(string) };
+        private static readonly object[] CombinedArgs = { typeof(int), typeof(string), 10, 20, "Charlie" };
 
         [Test]
         public void ConstructWithoutArguments()
@@ -24,10 +24,10 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ConstructWithFixtureArgs()
         {
-            TestFixtureAttribute attr = new TestFixtureAttribute(fixtureArgs);
+            TestFixtureAttribute attr = new TestFixtureAttribute(FixtureArgs);
             Assert.Multiple(() =>
             {
-                Assert.That(attr.Arguments, Is.EqualTo(fixtureArgs));
+                Assert.That(attr.Arguments, Is.EqualTo(FixtureArgs));
                 Assert.That(attr.TypeArgs, Is.Empty);
             });
         }
@@ -35,7 +35,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ConstructWithJustTypeArgs()
         {
-            TestFixtureAttribute attr = new TestFixtureAttribute(typeArgs);
+            TestFixtureAttribute attr = new TestFixtureAttribute(TypeArgs);
             Assert.Multiple(() =>
             {
                 Assert.That(attr.Arguments, Has.Length.EqualTo(2));
@@ -47,33 +47,33 @@ namespace NUnit.Framework.Attributes
         public void ConstructWithNoArgumentsAndSetTypeArgs()
         {
             TestFixtureAttribute attr = new TestFixtureAttribute();
-            attr.TypeArgs = typeArgs;
+            attr.TypeArgs = TypeArgs;
             Assert.Multiple(() =>
             {
                 Assert.That(attr.Arguments, Is.Empty);
-                Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+                Assert.That(attr.TypeArgs, Is.EqualTo(TypeArgs));
             });
         }
 
         [Test]
         public void ConstructWithFixtureArgsAndSetTypeArgs()
         {
-            TestFixtureAttribute attr = new TestFixtureAttribute(fixtureArgs);
-            attr.TypeArgs = typeArgs;
+            TestFixtureAttribute attr = new TestFixtureAttribute(FixtureArgs);
+            attr.TypeArgs = TypeArgs;
             Assert.Multiple(() =>
             {
-                Assert.That(attr.Arguments, Is.EqualTo(fixtureArgs));
-                Assert.That(attr.TypeArgs, Is.EqualTo(typeArgs));
+                Assert.That(attr.Arguments, Is.EqualTo(FixtureArgs));
+                Assert.That(attr.TypeArgs, Is.EqualTo(TypeArgs));
             });
         }
 
         [Test]
         public void ConstructWithCombinedArgs()
         {
-            TestFixtureAttribute attr = new TestFixtureAttribute(combinedArgs);
+            TestFixtureAttribute attr = new TestFixtureAttribute(CombinedArgs);
             Assert.Multiple(() =>
             {
-                Assert.That(attr.Arguments, Is.EqualTo(combinedArgs));
+                Assert.That(attr.Arguments, Is.EqualTo(CombinedArgs));
                 Assert.That(attr.TypeArgs, Is.Empty);
             });
         }

--- a/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestMethodBuilderTests.cs
@@ -220,7 +220,7 @@ namespace NUnit.Framework.Attributes
             new object[] { 12, 6, 2 } };
 
         [DatapointSource]
-        private readonly int[] ints = new int[] { 1, 2, 3 };
+        private readonly int[] _ints = new int[] { 1, 2, 3 };
 
         #endregion
     }

--- a/src/NUnitFramework/tests/Attributes/TheoryTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TheoryTests.cs
@@ -9,30 +9,30 @@ namespace NUnit.Framework.Attributes
 {
     public class TheoryTests
     {
-        private static readonly Type fixtureType = typeof(TheoryFixture);
+        private static readonly Type FixtureType = typeof(TheoryFixture);
 
         [Test]
         public void TheoryWithNoArgumentsIsTreatedAsTest()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TheoryWithNoArguments));
+            TestAssert.IsRunnable(FixtureType, nameof(TheoryFixture.TheoryWithNoArguments));
         }
 
         [Test]
         public void TheoryWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TheoryWithArgumentsButNoDatapoints), ResultState.Failure);
+            TestAssert.IsRunnable(FixtureType, nameof(TheoryFixture.TheoryWithArgumentsButNoDatapoints), ResultState.Failure);
         }
 
         [Test]
         public void UnsupportedNullableTypeArgumentWithNoDatapointsIsRunnableButFails()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TheoryFixture.TestWithUnsupportedNullableTypeArgumentWithNoDataPoints), ResultState.Failure);
+            TestAssert.IsRunnable(FixtureType, nameof(TheoryFixture.TestWithUnsupportedNullableTypeArgumentWithNoDataPoints), ResultState.Failure);
         }
 
         [Test]
         public void TheoryWithDatapointsIsRunnable()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TheoryWithArgumentsAndDatapoints));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TheoryWithArgumentsAndDatapoints));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(9));
         }
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void BooleanArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithBooleanArguments));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithBooleanArguments));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NullableBooleanArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithNullableBooleanArguments));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithNullableBooleanArguments));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(9));
         }
@@ -56,24 +56,24 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void DatapointAndAttributeDataMayBeCombined()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithBothDatapointAndAttributeData));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithBothDatapointAndAttributeData));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(6));
         }
 
-        [Datapoint] private readonly object? nullObj = null;
+        [Datapoint] private readonly object? _nullObj = null;
 
         [Theory]
         public void NullDatapointIsOK(object o)
         {
             Assert.That(o, Is.Null);
-            Assert.That(nullObj, Is.Null); // to avoid a warning
+            Assert.That(_nullObj, Is.Null); // to avoid a warning
         }
 
         [Test]
         public void EnumArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithEnumAsArgument));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithEnumAsArgument));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(16));
         }
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void NullableEnumArgumentsAreSuppliedAutomatically()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithNullableEnumAsArgument));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithNullableEnumAsArgument));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(17));
         }
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Attributes
             // TheoryAttribute and CombinatorialAttribute were adding cases.
             // Solution is to make TheoryAttribute a CombiningAttribute so
             // that no extra attribute is added to the method.
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithAllDataSuppliedByAttributes));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithAllDataSuppliedByAttributes));
             TestAssert.IsRunnable(test);
             Assert.That(test.TestCaseCount, Is.EqualTo(4));
         }
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Attributes
         }
 
         [Datapoints]
-        private readonly string[] vals = new string[] { "xyz1", "xyz2", "xyz3" };
+        private readonly string[] _vals = new string[] { "xyz1", "xyz2", "xyz3" };
 
         [Theory]
         public void ArrayWithDatapointsAttributeIsUsed(string s)
@@ -132,14 +132,14 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SimpleTestIgnoresDataPoints()
         {
-            Test test = TestBuilder.MakeParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithArguments));
+            Test test = TestBuilder.MakeParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithArguments));
             Assert.That(test.TestCaseCount, Is.EqualTo(2));
         }
 
         [Test]
         public void TheoryFailsIfAllTestsAreInconclusive()
         {
-            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, nameof(TheoryFixture.TestWithAllBadValues));
+            ITestResult result = TestBuilder.RunParameterizedMethodSuite(FixtureType, nameof(TheoryFixture.TestWithAllBadValues));
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
             Assert.That(result.Message, Is.EqualTo("All test cases were inconclusive"));
         }
@@ -176,30 +176,30 @@ namespace NUnit.Framework.Attributes
 
         public class NestedTheoryThatSearchesInDeclaringTypes
         {
-            private static readonly Type nestedType = typeof(TheoryFixture.NestedWhileSearchingInDeclaringType);
+            private static readonly Type NestedType = typeof(TheoryFixture.NestedWhileSearchingInDeclaringType);
 
             [Test]
             public void WithNoArgumentsIsTreatedAsTest()
             {
-                TestAssert.IsRunnable(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNoArguments));
+                TestAssert.IsRunnable(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNoArguments));
             }
 
             [Test]
             public void WithNoDatapointsIsRunnableButFails()
             {
-                TestAssert.IsRunnable(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithArgumentsButNoDatapoints), ResultState.Failure);
+                TestAssert.IsRunnable(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithArgumentsButNoDatapoints), ResultState.Failure);
             }
 
             [Test]
             public void WithUnsupportedNullableTypeArgumentWithNoDatapointsIsRunnableButFails()
             {
-                TestAssert.IsRunnable(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithUnsupportedNullableTypeArgumentWithNoDataPoints), ResultState.Failure);
+                TestAssert.IsRunnable(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithUnsupportedNullableTypeArgumentWithNoDataPoints), ResultState.Failure);
             }
 
             [Test]
             public void WithDatapointsIsRunnable()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithArgumentsAndDatapoints));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithArgumentsAndDatapoints));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(9));
             }
@@ -207,7 +207,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void WithBooleanArgumentsHasValuesSuppliedAutomatically()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithBooleanArguments));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithBooleanArguments));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(4));
             }
@@ -215,7 +215,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void WithNullableBooleanArgumentsHasValuesSuppliedAutomatically()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNullableBooleanArguments));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNullableBooleanArguments));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(9));
             }
@@ -223,7 +223,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void WithDatapointAndAttributeDataIsRunnable()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithBothDatapointAndAttributeData));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithBothDatapointAndAttributeData));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(6));
             }
@@ -231,7 +231,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void WithEnumArgumentsHasValuesSuppliedAutomatically()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithEnumAsArgument));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithEnumAsArgument));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(16));
             }
@@ -239,7 +239,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void WithNullableEnumArgumentsHasValuesSuppliedAutomatically()
             {
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNullableEnumAsArgument));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithNullableEnumAsArgument));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(17));
             }
@@ -251,7 +251,7 @@ namespace NUnit.Framework.Attributes
                 // TheoryAttribute and CombinatorialAttribute were adding cases.
                 // Solution is to make TheoryAttribute a CombiningAttribute so
                 // that no extra attribute is added to the method.
-                Test test = TestBuilder.MakeParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithAllDataSuppliedByAttributes));
+                Test test = TestBuilder.MakeParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithAllDataSuppliedByAttributes));
                 TestAssert.IsRunnable(test);
                 Assert.That(test.TestCaseCount, Is.EqualTo(4));
             }
@@ -259,7 +259,7 @@ namespace NUnit.Framework.Attributes
             [Test]
             public void FailsIfAllTestsAreInconclusive()
             {
-                ITestResult result = TestBuilder.RunParameterizedMethodSuite(nestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithAllBadValues));
+                ITestResult result = TestBuilder.RunParameterizedMethodSuite(NestedType, nameof(TheoryFixture.NestedWhileSearchingInDeclaringType.WithAllBadValues));
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Failure));
                 Assert.That(result.Message, Is.EqualTo("All test cases were inconclusive"));
             }

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class AllItemsConstraintTests
     {
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         [Test]
         public void AllItemsAreNotNull()

--- a/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class AndConstraintTests : ConstraintTestBase
     {
-        private TextMessageWriter messageWriter;
+        private TextMessageWriter _messageWriter;
 
         protected override Constraint TheConstraint { get; } = new AndConstraint(new GreaterThanConstraint(40), new LessThanConstraint(50));
 
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Constraints
         {
             ExpectedDescription = "greater than 40 and less than 50";
             StringRepresentation = "<and <greaterthan 40> <lessthan 50>>";
-            messageWriter = new TextMessageWriter();
+            _messageWriter = new TextMessageWriter();
         }
 
 #pragma warning disable IDE0052 // Remove unread private members
@@ -58,8 +58,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(constraintResult.IsSuccess, Is.False);
 
-            constraintResult.WriteMessageTo(messageWriter);
-            Assert.That(messageWriter.ToString(), Is.EqualTo(expectedMsg));
+            constraintResult.WriteMessageTo(_messageWriter);
+            Assert.That(_messageWriter.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -76,8 +76,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(constraintResult.IsSuccess, Is.False);
 
-            constraintResult.WriteMessageTo(messageWriter);
-            Assert.That(messageWriter.ToString(), Is.EqualTo(expectedMsg));
+            constraintResult.WriteMessageTo(_messageWriter);
+            Assert.That(_messageWriter.ToString(), Is.EqualTo(expectedMsg));
         }
 
         [Test]
@@ -94,8 +94,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.That(constraintResult.IsSuccess, Is.False);
 
-            constraintResult.WriteMessageTo(messageWriter);
-            Assert.That(messageWriter.ToString(), Is.EqualTo(expectedMsg));
+            constraintResult.WriteMessageTo(_messageWriter);
+            Assert.That(_messageWriter.ToString(), Is.EqualTo(expectedMsg));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class CollectionOrderedConstraintTests
     {
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         #region Ordering Tests
 

--- a/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
+++ b/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
@@ -56,17 +56,17 @@ namespace NUnit.Framework.Constraints
 
     internal class ClassWithIComparable : IComparable
     {
-        private readonly int val;
+        private readonly int _val;
 
         public ClassWithIComparable(int val)
         {
-            this.val = val;
+            this._val = val;
         }
 
         public int CompareTo(object? x)
         {
             if (x is ClassWithIComparable other)
-                return val.CompareTo(other.val);
+                return _val.CompareTo(other._val);
 
             throw new ArgumentException();
         }
@@ -74,23 +74,23 @@ namespace NUnit.Framework.Constraints
 
     internal class ClassWithIComparableOfT : IComparable<ClassWithIComparableOfT>, IComparable<int>
     {
-        private readonly int val;
+        private readonly int _val;
 
         public ClassWithIComparableOfT(int val)
         {
-            this.val = val;
+            this._val = val;
         }
 
         public int CompareTo(ClassWithIComparableOfT? other)
         {
             if (other is null)
                 return 1;
-            return val.CompareTo(other.val);
+            return _val.CompareTo(other._val);
         }
 
         public int CompareTo(int other)
         {
-            return val.CompareTo(other);
+            return _val.CompareTo(other);
         }
     }
 

--- a/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
+++ b/src/NUnitFramework/tests/Constraints/ComparisonConstraintTestBase.cs
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Constraints
 
         public ClassWithIComparable(int val)
         {
-            this._val = val;
+            _val = val;
         }
 
         public int CompareTo(object? x)
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Constraints
 
         public ClassWithIComparableOfT(int val)
         {
-            this._val = val;
+            _val = val;
         }
 
         public int CompareTo(ClassWithIComparableOfT? other)

--- a/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
@@ -11,7 +11,7 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class ConstraintExpressionTests
     {
-        private static readonly Func<int, int, bool> myIntComparer = (x, y) => x == y;
+        private static readonly Func<int, int, bool> MyIntComparer = (x, y) => x == y;
 
         [Test]
         public void ConstraintExpressionMemberAnd()
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Constraints
         public void ConstraintExpressionContainsUsing()
         {
             var constraintExpression = new ConstraintExpression();
-            var constraint = constraintExpression.Contains(4).Using(myIntComparer);
+            var constraint = constraintExpression.Contains(4).Using(MyIntComparer);
             var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
             Assert.That(collection1, constraint);
         }
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Constraints
         public void ConstraintExpressionContainUsing()
         {
             var constraintExpression = new ConstraintExpression();
-            var constraint = constraintExpression.Contain(8).Using(myIntComparer);
+            var constraint = constraintExpression.Contain(8).Using(MyIntComparer);
             var collection1 = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
             Assert.That(collection1, constraint);
         }

--- a/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
@@ -7,7 +7,7 @@ namespace NUnit.Framework.Constraints
 {
     public class ContainsConstraintTests
     {
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         [Test]
         public void HonorsIgnoreCaseForStringCollection()

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -22,9 +22,9 @@ namespace NUnit.Framework.Constraints
         private const int POLLING = 50;
         private const int MIN = AFTER - 10;
 
-        private static bool boolValue;
-        private static List<int> list;
-        private static string? statusString;
+        private static bool _boolValue;
+        private static List<int> _list;
+        private static string? _statusString;
 
         protected override Constraint TheConstraint { get; } = new DelayedConstraint(new EqualConstraint(true), 500);
 
@@ -34,9 +34,9 @@ namespace NUnit.Framework.Constraints
             ExpectedDescription = "True after 500 milliseconds delay";
             StringRepresentation = "<after 500 <equal True>>";
 
-            boolValue = false;
-            list = new List<int>();
-            statusString = null;
+            _boolValue = false;
+            _list = new List<int>();
+            _statusString = null;
             //SetValueTrueAfterDelay(300);
         }
 
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
         public void SimpleTestUsingBoolean()
         {
             SetValuesAfterDelay(DELAY);
-            Assert.That(() => boolValue, new DelayedConstraint(new EqualConstraint(true), AFTER, POLLING));
+            Assert.That(() => _boolValue, new DelayedConstraint(new EqualConstraint(true), AFTER, POLLING));
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Constraints
             // https://github.com/nunit/nunit.analyzers/issues/431
             // It was decided to keep to analyzer warning
 #pragma warning disable NUnit2044 // Non-delegate actual parameter
-            Assert.That(list, Has.Count.EqualTo(1).After(AFTER, POLLING));
+            Assert.That(_list, Has.Count.EqualTo(1).After(AFTER, POLLING));
 #pragma warning restore NUnit2044 // Non-delegate actual parameter
         }
 
@@ -125,14 +125,14 @@ namespace NUnit.Framework.Constraints
         public void CanTestContentsOfDelegateReturningList()
         {
             SetValuesAfterDelay(1);
-            Assert.That(() => list, Has.Count.EqualTo(1).After(AFTER, POLLING));
+            Assert.That(() => _list, Has.Count.EqualTo(1).After(AFTER, POLLING));
         }
 
         [Test]
         public void CanTestInitiallyNullDelegate()
         {
             SetValuesAfterDelay(DELAY);
-            Assert.That(() => statusString, Is.Not.Null.And.Length.GreaterThan(0).After(AFTER, POLLING));
+            Assert.That(() => _statusString, Is.Not.Null.And.Length.GreaterThan(0).After(AFTER, POLLING));
         }
 
         [Test]
@@ -246,32 +246,32 @@ namespace NUnit.Framework.Constraints
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
 
-        private static int setValuesDelay;
+        private static int _setValuesDelay;
 
-        private static object MethodReturningValue() { return boolValue; }
+        private static object MethodReturningValue() { return _boolValue; }
 
         private static object MethodReturningFalse() { return false; }
 
         private static object MethodReturningZero() { return 0; }
 
-        private static readonly AutoResetEvent waitEvent = new AutoResetEvent(false);
+        private static readonly AutoResetEvent WaitEvent = new AutoResetEvent(false);
 
         private static void Delay(int delay)
         {
-            waitEvent.WaitOne(delay);
+            WaitEvent.WaitOne(delay);
         }
 
         private static void MethodSetsValues()
         {
-            Delay(setValuesDelay);
-            boolValue = true;
-            list.Add(1);
-            statusString = "Finished";
+            Delay(_setValuesDelay);
+            _boolValue = true;
+            _list.Add(1);
+            _statusString = "Finished";
         }
 
         private static void SetValuesAfterDelay(int delayInMilliSeconds)
         {
-            setValuesDelay = delayInMilliSeconds;
+            _setValuesDelay = delayInMilliSeconds;
             Thread thread = new Thread(MethodSetsValues);
             thread.Start();
         }

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -810,7 +810,7 @@ namespace NUnit.Framework.Constraints
 
             public Dummy(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()
@@ -825,7 +825,7 @@ namespace NUnit.Framework.Constraints
 
             public Dummy1(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()
@@ -889,7 +889,7 @@ namespace NUnit.Framework.Constraints
                 {
                     return false;
                 }
-                return obj.ToString() == this.ToString();
+                return obj.ToString() == ToString();
             }
             public override int GetHashCode()
             {
@@ -912,7 +912,7 @@ namespace NUnit.Framework.Constraints
                 {
                     return false;
                 }
-                return obj.ToString()==this.ToString();
+                return obj.ToString()==ToString();
             }
             public override int GetHashCode()
             {

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -780,7 +780,7 @@ namespace NUnit.Framework.Constraints
         #endregion
 
         #region TypeEqualityMessages
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
         private static IEnumerable DifferentTypeSameValueTestData
         {
             get
@@ -806,31 +806,31 @@ namespace NUnit.Framework.Constraints
 
         private class Dummy
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
 
         private class Dummy1
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy1(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/EqualTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualTest.cs
@@ -19,13 +19,13 @@ namespace NUnit.Framework.Constraints
                 }));
         }
 
-        private static readonly string testString = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private static readonly string TestString = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
         [Test]
         public void LongStringsAreTruncated()
         {
-            string expected = testString;
-            string actual = testString.Replace('k', 'X');
+            string expected = TestString;
+            string actual = TestString.Replace('k', 'X');
 
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
@@ -37,8 +37,8 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void LongStringsAreTruncatedAtBothEndsIfNecessary()
         {
-            string expected = testString;
-            string actual = testString.Replace('Z', '?');
+            string expected = TestString;
+            string actual = TestString.Replace('Z', '?');
 
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
@@ -50,8 +50,8 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void LongStringsAreTruncatedAtFrontEndIfNecessary()
         {
-            string expected = testString;
-            string actual = testString  + "+++++";
+            string expected = TestString;
+            string actual = TestString  + "+++++";
 
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>

--- a/src/NUnitFramework/tests/Constraints/EqualTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualTest.cs
@@ -94,7 +94,9 @@ namespace NUnit.Framework.Constraints
                 if (caret > minLength ||
                     expected.Substring(0, minMatch) != actual.Substring(0, minMatch) ||
                     expected[caret] == actual[caret])
+                {
                     Assert.Fail("Message Error: Caret does not point at first mismatch..." + nl + ex.Message);
+                }
             }
 
             if (expected.Length > 68 || actual.Length > 68 || caret > 68)

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -7,13 +7,13 @@ namespace NUnit.Framework.Constraints
 {
     public class ExactCountConstraintTests
     {
-        private static readonly string[] names = new[] { "Charlie", "Fred", "Joe", "Charlie" };
+        private static readonly string[] Names = new[] { "Charlie", "Fred", "Joe", "Charlie" };
 
         [Test]
         public void ZeroItemsMatch()
         {
-            Assert.That(names, new ExactCountConstraint(0, Is.EqualTo("Sam")));
-            Assert.That(names, Has.Exactly(0).EqualTo("Sam"));
+            Assert.That(Names, new ExactCountConstraint(0, Is.EqualTo("Sam")));
+            Assert.That(Names, Has.Exactly(0).EqualTo("Sam"));
         }
 
         [Test]
@@ -22,15 +22,15 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "no item equal to \"Charlie\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(0, Is.EqualTo("Charlie"))));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(0, Is.EqualTo("Charlie"))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ExactlyOneItemMatches()
         {
-            Assert.That(names, new ExactCountConstraint(1, Is.EqualTo("Fred")));
-            Assert.That(names, Has.Exactly(1).EqualTo("Fred"));
+            Assert.That(Names, new ExactCountConstraint(1, Is.EqualTo("Fred")));
+            Assert.That(Names, Has.Exactly(1).EqualTo("Fred"));
         }
 
         [Test]
@@ -39,35 +39,35 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly one item equal to \"Charlie\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(1, Is.EqualTo("Charlie"))));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1, Is.EqualTo("Charlie"))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ExactlyTwoItemsMatch()
         {
-            Assert.That(names, new ExactCountConstraint(2, Is.EqualTo("Charlie")));
-            Assert.That(names, Has.Exactly(2).EqualTo("Charlie"));
+            Assert.That(Names, new ExactCountConstraint(2, Is.EqualTo("Charlie")));
+            Assert.That(Names, Has.Exactly(2).EqualTo("Charlie"));
         }
 
         [Test]
         public void ExactlyAndExactly()
         {
-            Assert.That(names, Has.Exactly(2).EqualTo("Charlie").And.Exactly(1).EqualTo("Fred"));
-            Assert.That(names, Has.Exactly(4).Items.And.Exactly(2).EqualTo("Charlie"));
-            Assert.That(names, Has.Exactly(2).EqualTo("Charlie").And.Exactly(4).Items);
+            Assert.That(Names, Has.Exactly(2).EqualTo("Charlie").And.Exactly(1).EqualTo("Fred"));
+            Assert.That(Names, Has.Exactly(4).Items.And.Exactly(2).EqualTo("Charlie"));
+            Assert.That(Names, Has.Exactly(2).EqualTo("Charlie").And.Exactly(4).Items);
         }
 
         [Test]
         public void ExactlyOrExactly()
         {
-            Assert.That(names, Has.Exactly(3).EqualTo("Fred").Or.Exactly(2).EqualTo("Charlie"));
+            Assert.That(Names, Has.Exactly(3).EqualTo("Fred").Or.Exactly(2).EqualTo("Charlie"));
         }
 
         [Test]
         public void ExactlyFollowedByOr()
         {
-            Assert.That(names, Has.Exactly(3).EqualTo("Fred").Or.EqualTo("Charlie"));
+            Assert.That(Names, Has.Exactly(3).EqualTo("Fred").Or.EqualTo("Charlie"));
         }
 
         [Test]
@@ -76,20 +76,20 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly 2 items equal to \"Fred\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "1 item < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(2, Is.EqualTo("Fred"))));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(2, Is.EqualTo("Fred"))));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ExactlyFourItemsNoPredicate()
         {
-            Assert.That(names, new ExactCountConstraint(4));
+            Assert.That(Names, new ExactCountConstraint(4));
         }
 
         [Test]
         public void ExactlyFourItemsNoopNoPredicate()
         {
-            Assert.That(names, Has.Exactly(4).Items);
+            Assert.That(Names, Has.Exactly(4).Items);
         }
 
         [Test]
@@ -98,14 +98,14 @@ namespace NUnit.Framework.Constraints
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly one item" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "4 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(names, new ExactCountConstraint(1)));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1)));
             Assert.That(ex.Message, Is.EqualTo(expectedMessage));
         }
 
         [Test]
         public void ExactlyTwoItemsNoopMatch()
         {
-            Assert.That(names, Has.Exactly(2).Items.EqualTo("Charlie"));
+            Assert.That(Names, Has.Exactly(2).Items.EqualTo("Charlie"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/ExactlyOneConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactlyOneConstraintTests.cs
@@ -6,72 +6,72 @@ namespace NUnit.Framework.Constraints
 {
     public class ExactlyOneConstraintTests
     {
-        private static readonly IEnumerable<string> testCollectionLen0 = new List<string>();
-        private static readonly IEnumerable<string> testCollectionLen1 = new List<string> { "item" };
-        private static readonly IEnumerable<string> testCollectionLen2 = new List<string> { "item", "otherItem" };
-        private static readonly IEnumerable<string> testCollectionLen3 = new List<string> { "item", "item", "otherItem" };
+        private static readonly IEnumerable<string> TestCollectionLen0 = new List<string>();
+        private static readonly IEnumerable<string> TestCollectionLen1 = new List<string> { "item" };
+        private static readonly IEnumerable<string> TestCollectionLen2 = new List<string> { "item", "otherItem" };
+        private static readonly IEnumerable<string> TestCollectionLen3 = new List<string> { "item", "item", "otherItem" };
 
         [Test]
         public void ExactlyOneItemInCollection()
         {
-            Assert.That(testCollectionLen1, Has.One.Items);
+            Assert.That(TestCollectionLen1, Has.One.Items);
         }
 
         [Test]
         public void ExactlyOneItemMatches()
         {
-            Assert.That(testCollectionLen1, Has.One.EqualTo("item"));
+            Assert.That(TestCollectionLen1, Has.One.EqualTo("item"));
         }
 
         [Test]
         public void ExactlyOneItemDoesNotMatch()
         {
-            Assert.That(testCollectionLen1, Has.One.Not.EqualTo("notItem"));
+            Assert.That(TestCollectionLen1, Has.One.Not.EqualTo("notItem"));
         }
         [Test]
         public void ExactlyOneItemMustMatchButNoneInCollection()
         {
-            Assert.That(Has.One.EqualTo("item").ApplyTo(testCollectionLen0).IsSuccess, Is.False);
+            Assert.That(Has.One.EqualTo("item").ApplyTo(TestCollectionLen0).IsSuccess, Is.False);
         }
 
         [Test]
         public void ExactlyOneBlankConstraintWhereCollectionIsTwo()
         {
             Assert.Throws<AssertionException>(() =>
-                Assert.That(testCollectionLen2, Has.One.Items));
+                Assert.That(TestCollectionLen2, Has.One.Items));
         }
 
         [Test]
         public void ExactlyOneItemDoesNotMatchFromTwoElements()
         {
             Assert.Throws<AssertionException>(() =>
-                Assert.That(testCollectionLen2, Has.One.EqualTo("notItem")));
+                Assert.That(TestCollectionLen2, Has.One.EqualTo("notItem")));
         }
 
         [Test]
         public void ExactlyOneItemMustMatchButMultipleMatch()
         {
             Assert.Throws<AssertionException>(() =>
-                Assert.That(testCollectionLen3, Has.One.EqualTo("item")));
+                Assert.That(TestCollectionLen3, Has.One.EqualTo("item")));
         }
 
         [Test]
         public void ExactlyOneBlankConstraintWhereCollectionIsOne()
         {
-            Assert.That(testCollectionLen1, Has.One.Items);
+            Assert.That(TestCollectionLen1, Has.One.Items);
         }
 
         [Test]
         public void ExactlyOneConstraintMatchingWhereCollectionIsTwo()
         {
-            Assert.That(testCollectionLen2, Has.One.EqualTo("item"));
+            Assert.That(TestCollectionLen2, Has.One.EqualTo("item"));
         }
 
         [Test]
         public void ExactlyOneConstraintNotMatchingWhereCollectionIsTwo()
         {
            Assert.Throws<AssertionException>(() =>
-                Assert.That(testCollectionLen2, Has.One.EqualTo("blah")));
+                Assert.That(TestCollectionLen2, Has.One.EqualTo("blah")));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
+++ b/src/NUnitFramework/tests/Constraints/MsgUtilTests.cs
@@ -305,12 +305,12 @@ namespace NUnit.Framework.Constraints
         #endregion
         #region ClipString
 
-        private const string s52 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        private const string S52 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-        [TestCase(s52, 52, 0, s52, TestName="NoClippingNeeded")]
-        [TestCase(s52, 29, 0, "abcdefghijklmnopqrstuvwxyz...", TestName="ClipAtEnd")]
-        [TestCase(s52, 29, 26, "...ABCDEFGHIJKLMNOPQRSTUVWXYZ", TestName="ClipAtStart")]
-        [TestCase(s52, 28, 26, "...ABCDEFGHIJKLMNOPQRSTUV...", TestName="ClipAtStartAndEnd")]
+        [TestCase(S52, 52, 0, S52, TestName="NoClippingNeeded")]
+        [TestCase(S52, 29, 0, "abcdefghijklmnopqrstuvwxyz...", TestName="ClipAtEnd")]
+        [TestCase(S52, 29, 26, "...ABCDEFGHIJKLMNOPQRSTUVWXYZ", TestName="ClipAtStart")]
+        [TestCase(S52, 28, 26, "...ABCDEFGHIJKLMNOPQRSTUV...", TestName="ClipAtStartAndEnd")]
         public static void TestClipString(string input, int max, int start, string result)
         {
             System.Console.WriteLine("input=  \"{0}\"", input);
@@ -325,24 +325,24 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void ClipExpectedAndActual_StringsFitInLine()
         {
-            string eClip = s52;
+            string eClip = S52;
             string aClip = "abcde";
             MsgUtils.ClipExpectedAndActual(ref eClip, ref aClip, 52, 5);
-            Assert.That(eClip, Is.EqualTo(s52));
+            Assert.That(eClip, Is.EqualTo(S52));
             Assert.That(aClip, Is.EqualTo("abcde"));
 
-            eClip = s52;
+            eClip = S52;
             aClip = "abcdefghijklmno?qrstuvwxyz";
             MsgUtils.ClipExpectedAndActual(ref eClip, ref aClip, 52, 15);
-            Assert.That(eClip, Is.EqualTo(s52));
+            Assert.That(eClip, Is.EqualTo(S52));
             Assert.That(aClip, Is.EqualTo("abcdefghijklmno?qrstuvwxyz"));
         }
 
         [Test]
         public static void ClipExpectedAndActual_StringTailsFitInLine()
         {
-            string s1 = s52;
-            string s2 = s52.Replace('Z', '?');
+            string s1 = S52;
+            string s2 = S52.Replace('Z', '?');
             MsgUtils.ClipExpectedAndActual(ref s1, ref s2, 29, 51);
             Assert.That(s1, Is.EqualTo("...ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
         }
@@ -350,13 +350,13 @@ namespace NUnit.Framework.Constraints
         [Test]
         public static void ClipExpectedAndActual_StringsDoNotFitInLine()
         {
-            string s1 = s52;
+            string s1 = S52;
             string s2 = "abcdefghij";
             MsgUtils.ClipExpectedAndActual(ref s1, ref s2, 29, 10);
             Assert.That(s1, Is.EqualTo("abcdefghijklmnopqrstuvwxyz..."));
             Assert.That(s2, Is.EqualTo("abcdefghij"));
 
-            s1 = s52;
+            s1 = S52;
             s2 = "abcdefghijklmno?qrstuvwxyz";
             MsgUtils.ClipExpectedAndActual(ref s1, ref s2, 25, 15);
             Assert.That(s1, Is.EqualTo("...efghijklmnopqrstuvw..."));

--- a/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Constraints
 
             public ClassWithIComparable(int val)
             {
-                this._val = val;
+                _val = val;
             }
 
             public int CompareTo(object? x)
@@ -146,7 +146,7 @@ namespace NUnit.Framework.Constraints
 
             public ClassWithIComparableOfT(int val)
             {
-                this._val = val;
+                _val = val;
             }
 
             public int CompareTo(ClassWithIComparableOfT? other)

--- a/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitComparerTests.cs
@@ -7,12 +7,12 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class NUnitComparerTests
     {
-        private NUnitComparer comparer;
+        private NUnitComparer _comparer;
 
         [SetUp]
         public void SetUp()
         {
-            comparer = new NUnitComparer();
+            _comparer = new NUnitComparer();
         }
 
         [TestCase(4, 4)]
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)4)]
         public void EqualItems(object x, object y)
         {
-            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
+            Assert.That(_comparer.Compare(x, y), Is.EqualTo(0));
         }
 
         [TestCase(4, 2)]
@@ -50,8 +50,8 @@ namespace NUnit.Framework.Constraints
         {
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -63,8 +63,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -76,8 +76,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -89,8 +89,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -102,8 +102,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -115,8 +115,8 @@ namespace NUnit.Framework.Constraints
 
             Assert.Multiple(() =>
             {
-                Assert.That(comparer.Compare(greater, lesser), Is.GreaterThan(0));
-                Assert.That(comparer.Compare(lesser, greater), Is.LessThan(0));
+                Assert.That(_comparer.Compare(greater, lesser), Is.GreaterThan(0));
+                Assert.That(_comparer.Compare(lesser, greater), Is.LessThan(0));
             });
         }
 
@@ -124,17 +124,17 @@ namespace NUnit.Framework.Constraints
 
         private class ClassWithIComparable : IComparable
         {
-            private readonly int val;
+            private readonly int _val;
 
             public ClassWithIComparable(int val)
             {
-                this.val = val;
+                this._val = val;
             }
 
             public int CompareTo(object? x)
             {
                 if (x is ClassWithIComparable other)
-                    return val.CompareTo(other.val);
+                    return _val.CompareTo(other._val);
 
                 throw new ArgumentException();
             }
@@ -142,23 +142,23 @@ namespace NUnit.Framework.Constraints
 
         private class ClassWithIComparableOfT : IComparable<ClassWithIComparableOfT>, IComparable<int>
         {
-            private readonly int val;
+            private readonly int _val;
 
             public ClassWithIComparableOfT(int val)
             {
-                this.val = val;
+                this._val = val;
             }
 
             public int CompareTo(ClassWithIComparableOfT? other)
             {
                 if (other is null)
                     return 1;
-                return val.CompareTo(other.val);
+                return _val.CompareTo(other._val);
             }
 
             public int CompareTo(int other)
             {
-                return val.CompareTo(other);
+                return _val.CompareTo(other);
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -13,14 +13,14 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class NUnitEqualityComparerTests
     {
-        private Tolerance tolerance;
-        private NUnitEqualityComparer comparer;
+        private Tolerance _tolerance;
+        private NUnitEqualityComparer _comparer;
 
         [SetUp]
         public void Setup()
         {
-            tolerance = Tolerance.Default;
-            comparer = new NUnitEqualityComparer();
+            _tolerance = Tolerance.Default;
+            _comparer = new NUnitEqualityComparer();
         }
 
         [TestCase(4, 4)]
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)4)]
         public void EqualItems(object x, object y)
         {
-            Assert.That(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance));
         }
 
         [TestCase(4, 2)]
@@ -56,8 +56,8 @@ namespace NUnit.Framework.Constraints
         [TestCase(4, (char)2)]
         public void UnequalItems(object greater, object lesser)
         {
-            Assert.That(comparer.AreEqual(greater, lesser, ref tolerance), Is.False);
-            Assert.That(comparer.AreEqual(lesser, greater, ref tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(greater, lesser, ref _tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(lesser, greater, ref _tolerance), Is.False);
         }
 
         [TestCase(double.PositiveInfinity, double.PositiveInfinity)]
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Constraints
         [TestCase(float.NaN, float.NaN)]
         public void SpecialFloatingPointValuesCompareAsEqual(object x, object y)
         {
-            Assert.That(comparer.AreEqual(x, y, ref tolerance));
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Constraints
             {
                 var one = new DirectoryInfo(testDir.Directory.FullName);
                 var two = new DirectoryInfo(testDir.Directory.FullName);
-                Assert.That(comparer.AreEqual(one, two, ref tolerance));
+                Assert.That(_comparer.AreEqual(one, two, ref _tolerance));
             }
         }
 
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Constraints
             using (var one = new TestDirectory())
             using (var two = new TestDirectory())
             {
-                Assert.That(comparer.AreEqual(one, two, ref tolerance), Is.False);
+                Assert.That(_comparer.AreEqual(one, two, ref _tolerance), Is.False);
             }
         }
 
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Constraints
             object[] array = new object[1];
             array[0] = array;
 
-            Assert.That(comparer.AreEqual(array, array, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(array, array, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithoutEqualsOverridden x = new IEquatableWithoutEqualsOverridden(1);
             IEquatableWithoutEqualsOverridden y = new IEquatableWithoutEqualsOverridden(1);
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Constraints
 
             // y.Equals(x) is what gets actually called
             // TODO: This should work both ways
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace NUnit.Framework.Constraints
 
             // y.Equals(x) is what gets actually called
             // TODO: This should work both ways
-            Assert.That(comparer.AreEqual(y, x, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(y, x, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
             IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(1);
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Constraints
             IEquatableWithExplicitImplementation x = new IEquatableWithExplicitImplementation(1);
             IEquatableWithExplicitImplementation y = new IEquatableWithExplicitImplementation(2);
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.False);
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
         {
             NeverEqualIEquatable z = new NeverEqualIEquatable();
 
-            Assert.That(comparer.AreEqual(z, z, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(z, z, ref _tolerance), Is.True);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Framework.Constraints
             NeverEqualIEquatableWithOverriddenAlwaysTrueEquals x = new NeverEqualIEquatableWithOverriddenAlwaysTrueEquals();
             NeverEqualIEquatableWithOverriddenAlwaysTrueEquals y = new NeverEqualIEquatableWithOverriddenAlwaysTrueEquals();
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.False);
         }
 
         [Test]
@@ -174,10 +174,10 @@ namespace NUnit.Framework.Constraints
             var y = new EnumerableObject<int>(new[] { 5, 4, 3, 2, 1 }, 42);
             var z = new EnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 15);
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.True);
-            Assert.That(comparer.AreEqual(y, x, ref tolerance), Is.True);
-            Assert.That(comparer.AreEqual(x, z, ref tolerance), Is.False);
-            Assert.That(comparer.AreEqual(z, x, ref tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(y, x, ref _tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(x, z, ref _tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(z, x, ref _tolerance), Is.False);
 
             Assert.That(y, Is.EqualTo(x));
             Assert.That(x, Is.EqualTo(y));
@@ -188,16 +188,16 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void IEquatableIsIgnoredAndEnumerableEqualsUsedWithAsCollection()
         {
-            comparer.CompareAsCollection = true;
+            _comparer.CompareAsCollection = true;
 
             var x = new EquatableWithEnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 42);
             var y = new EnumerableObject<int>(new[] { 5, 4, 3, 2, 1 }, 42);
             var z = new EnumerableObject<int>(new[] { 1, 2, 3, 4, 5 }, 15);
 
-            Assert.That(comparer.AreEqual(x, y, ref tolerance), Is.False);
-            Assert.That(comparer.AreEqual(y, x, ref tolerance), Is.False);
-            Assert.That(comparer.AreEqual(x, z, ref tolerance), Is.True);
-            Assert.That(comparer.AreEqual(z, x, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(x, y, ref _tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(y, x, ref _tolerance), Is.False);
+            Assert.That(_comparer.AreEqual(x, z, ref _tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(z, x, ref _tolerance), Is.True);
 
             Assert.That(y, Is.Not.EqualTo(x).AsCollection);
             Assert.That(x, Is.Not.EqualTo(y).AsCollection);
@@ -284,7 +284,7 @@ namespace NUnit.Framework.Constraints
         public void IEnumeratorIsDisposed()
         {
             var enumeration = new EnumerableWithDisposeChecks<int>(new[] { 0, 1, 2, 3 });
-            Assert.That(comparer.AreEqual(enumeration, enumeration, ref tolerance), Is.True);
+            Assert.That(_comparer.AreEqual(enumeration, enumeration, ref _tolerance), Is.True);
             Assert.That(enumeration.EnumeratorsDisposed);
         }
 
@@ -320,7 +320,7 @@ namespace NUnit.Framework.Constraints
             var x = new[] { equalInstance1, equalInstance1 };
             var y = new[] { equalInstance2, equalInstance2 };
 
-            Assert.That(equalityComparer.AreEqual(x, y, ref tolerance), Is.True);
+            Assert.That(equalityComparer.AreEqual(x, y, ref _tolerance), Is.True);
         }
 
         private static IEnumerable<TestCaseData> GetRecursiveComparerTestCases()
@@ -357,20 +357,20 @@ namespace NUnit.Framework.Constraints
 
     internal class DetectRecursionComparer : EqualityAdapter
     {
-        private readonly int maxRecursion;
+        private readonly int _maxRecursion;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public DetectRecursionComparer(int maxRecursion)
         {
             var callerDepth = new StackTrace().FrameCount - 1;
-            this.maxRecursion = callerDepth + maxRecursion;
+            this._maxRecursion = callerDepth + maxRecursion;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public override bool CanCompare(object x, object y)
         {
             var currentDepth = new StackTrace().FrameCount - 1;
-            return currentDepth >= maxRecursion;
+            return currentDepth >= _maxRecursion;
         }
 
         public override bool AreEqual(object x, object y)
@@ -386,19 +386,19 @@ namespace NUnit.Framework.Constraints
 
     internal class EnumerableWithDisposeChecks<T> : IEnumerable<T>
     {
-        private readonly IEnumerable<T> data;
-        private readonly List<DisposableEnumerator<T>> enumerators = new List<DisposableEnumerator<T>>();
+        private readonly IEnumerable<T> _data;
+        private readonly List<DisposableEnumerator<T>> _enumerators = new List<DisposableEnumerator<T>>();
 
         public EnumerableWithDisposeChecks(T[] data)
         {
-            this.data = data;
+            this._data = data;
         }
 
         public bool EnumeratorsDisposed
         {
             get
             {
-                foreach (var disposableEnumerator in enumerators)
+                foreach (var disposableEnumerator in _enumerators)
                 {
                     if (!disposableEnumerator.Disposed)
                     {
@@ -411,8 +411,8 @@ namespace NUnit.Framework.Constraints
 
         public IEnumerator<T> GetEnumerator()
         {
-            var enumerator = new DisposableEnumerator<T>(data.GetEnumerator());
-            enumerators.Add(enumerator);
+            var enumerator = new DisposableEnumerator<T>(_data.GetEnumerator());
+            _enumerators.Add(enumerator);
             return enumerator;
         }
 
@@ -424,33 +424,33 @@ namespace NUnit.Framework.Constraints
 
     internal class DisposableEnumerator<T> : IEnumerator<T>
     {
-        private bool disposedValue = false;
-        private readonly IEnumerator<T> enumerator;
+        private bool _disposedValue = false;
+        private readonly IEnumerator<T> _enumerator;
 
         public DisposableEnumerator(IEnumerator<T> enumerator)
         {
-            this.enumerator = enumerator;
+            this._enumerator = enumerator;
         }
 
-        public bool Disposed => disposedValue;
+        public bool Disposed => _disposedValue;
 
-        public T Current => enumerator.Current;
+        public T Current => _enumerator.Current;
 
-        object? IEnumerator.Current => enumerator.Current;
+        object? IEnumerator.Current => _enumerator.Current;
 
         public bool MoveNext()
         {
-            return enumerator.MoveNext();
+            return _enumerator.MoveNext();
         }
 
         public void Reset()
         {
-            enumerator.Reset();
+            _enumerator.Reset();
         }
 
         public void Dispose()
         {
-            disposedValue = true;
+            _disposedValue = true;
         }
 
     }
@@ -475,16 +475,16 @@ namespace NUnit.Framework.Constraints
 
     public class Int32IEquatable : IEquatable<int>
     {
-        private readonly int value;
+        private readonly int _value;
 
         public Int32IEquatable(int value)
         {
-            this.value = value;
+            this._value = value;
         }
 
         public bool Equals(int other)
         {
-            return value.Equals(other);
+            return _value.Equals(other);
         }
     }
 
@@ -498,31 +498,31 @@ namespace NUnit.Framework.Constraints
 
     public class IEquatableWithoutEqualsOverridden : IEquatable<IEquatableWithoutEqualsOverridden>
     {
-        private readonly int value;
+        private readonly int _value;
 
         public IEquatableWithoutEqualsOverridden(int value)
         {
-            this.value = value;
+            this._value = value;
         }
 
         public bool Equals(IEquatableWithoutEqualsOverridden? other)
         {
-            return other is not null && value.Equals(other.value);
+            return other is not null && _value.Equals(other._value);
         }
     }
 
     public class IEquatableWithExplicitImplementation : IEquatable<IEquatableWithExplicitImplementation>
     {
-        private readonly int value;
+        private readonly int _value;
 
         public IEquatableWithExplicitImplementation(int value)
         {
-            this.value = value;
+            this._value = value;
         }
 
         bool IEquatable<IEquatableWithExplicitImplementation>.Equals(IEquatableWithExplicitImplementation? other)
         {
-            return other is not null && value.Equals(other.value);
+            return other is not null && _value.Equals(other._value);
         }
     }
 
@@ -581,11 +581,11 @@ namespace NUnit.Framework.Constraints
 
     public class EnumerableObject<T> : IEnumerable<T>
     {
-        private readonly IEnumerable<T> enumerable;
+        private readonly IEnumerable<T> _enumerable;
 
         public EnumerableObject(IEnumerable<T> enumerable, int someProperty)
         {
-            this.enumerable = enumerable;
+            this._enumerable = enumerable;
             SomeProperty = someProperty;
         }
 
@@ -595,7 +595,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            return enumerable.GetEnumerator();
+            return _enumerable.GetEnumerator();
         }
 
         /// <summary>Returns an enumerator that iterates through a collection.</summary>
@@ -608,11 +608,11 @@ namespace NUnit.Framework.Constraints
 
     public class EquatableWithEnumerableObject<T> : IEnumerable<T>, IEquatable<EnumerableObject<T>>
     {
-        private readonly IEnumerable<T> enumerable;
+        private readonly IEnumerable<T> _enumerable;
 
         public EquatableWithEnumerableObject(IEnumerable<T> enumerable, int otherProperty)
         {
-            this.enumerable = enumerable;
+            this._enumerable = enumerable;
             OtherProperty = otherProperty;
         }
 
@@ -622,7 +622,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            return enumerable.GetEnumerator();
+            return _enumerable.GetEnumerator();
         }
 
         /// <summary>Returns an enumerator that iterates through a collection.</summary>

--- a/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
@@ -363,7 +363,7 @@ namespace NUnit.Framework.Constraints
         public DetectRecursionComparer(int maxRecursion)
         {
             var callerDepth = new StackTrace().FrameCount - 1;
-            this._maxRecursion = callerDepth + maxRecursion;
+            _maxRecursion = callerDepth + maxRecursion;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -391,7 +391,7 @@ namespace NUnit.Framework.Constraints
 
         public EnumerableWithDisposeChecks(T[] data)
         {
-            this._data = data;
+            _data = data;
         }
 
         public bool EnumeratorsDisposed
@@ -429,7 +429,7 @@ namespace NUnit.Framework.Constraints
 
         public DisposableEnumerator(IEnumerator<T> enumerator)
         {
-            this._enumerator = enumerator;
+            _enumerator = enumerator;
         }
 
         public bool Disposed => _disposedValue;
@@ -479,7 +479,7 @@ namespace NUnit.Framework.Constraints
 
         public Int32IEquatable(int value)
         {
-            this._value = value;
+            _value = value;
         }
 
         public bool Equals(int other)
@@ -502,7 +502,7 @@ namespace NUnit.Framework.Constraints
 
         public IEquatableWithoutEqualsOverridden(int value)
         {
-            this._value = value;
+            _value = value;
         }
 
         public bool Equals(IEquatableWithoutEqualsOverridden? other)
@@ -517,7 +517,7 @@ namespace NUnit.Framework.Constraints
 
         public IEquatableWithExplicitImplementation(int value)
         {
-            this._value = value;
+            _value = value;
         }
 
         bool IEquatable<IEquatableWithExplicitImplementation>.Equals(IEquatableWithExplicitImplementation? other)
@@ -585,7 +585,7 @@ namespace NUnit.Framework.Constraints
 
         public EnumerableObject(IEnumerable<T> enumerable, int someProperty)
         {
-            this._enumerable = enumerable;
+            _enumerable = enumerable;
             SomeProperty = someProperty;
         }
 
@@ -612,7 +612,7 @@ namespace NUnit.Framework.Constraints
 
         public EquatableWithEnumerableObject(IEnumerable<T> enumerable, int otherProperty)
         {
-            this._enumerable = enumerable;
+            _enumerable = enumerable;
             OtherProperty = otherProperty;
         }
 

--- a/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class NoItemConstraintTests
     {
-        private readonly string NL = Environment.NewLine;
+        private static readonly string NL = Environment.NewLine;
 
         [Test]
         public void NoItemsAreNotNull()

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -7,14 +7,14 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class NumericsTests
     {
-        private Tolerance tenPercent, zeroTolerance, absoluteTolerance;
+        private Tolerance _tenPercent, _zeroTolerance, _absoluteTolerance;
 
         [SetUp]
         public void SetUp()
         {
-            absoluteTolerance = new Tolerance(0.1);
-            tenPercent = new Tolerance(10.0).Percent;
-            zeroTolerance = Tolerance.Exact;
+            _absoluteTolerance = new Tolerance(0.1);
+            _tenPercent = new Tolerance(10.0).Percent;
+            _zeroTolerance = Tolerance.Exact;
         }
 
         [TestCase(123456789)]
@@ -26,14 +26,14 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanMatchWithoutToleranceMode(object value)
         {
-            Assert.That(Numerics.AreEqual(value, value, ref zeroTolerance), Is.True);
+            Assert.That(Numerics.AreEqual(value, value, ref _zeroTolerance), Is.True);
         }
 
         // Separate test case because you can't use decimal in an attribute (24.1.3)
         [Test]
         public void CanMatchDecimalWithoutToleranceMode()
         {
-            Assert.That(Numerics.AreEqual(123m, 123m, ref zeroTolerance), Is.True);
+            Assert.That(Numerics.AreEqual(123m, 123m, ref _zeroTolerance), Is.True);
         }
 
         [TestCase((int)9500)]
@@ -51,36 +51,36 @@ namespace NUnit.Framework.Constraints
         [Test]
         public void CanMatchIntegralsWithPercentage(object value)
         {
-            Assert.That(Numerics.AreEqual(10000, value, ref tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000, value, ref _tenPercent), Is.True);
         }
 
         [Test]
         public void CanMatchDecimalWithPercentage()
         {
-            Assert.That(Numerics.AreEqual(10000m, 9500m, ref tenPercent), Is.True);
-            Assert.That(Numerics.AreEqual(10000m, 10000m, ref tenPercent), Is.True);
-            Assert.That(Numerics.AreEqual(10000m, 10500m, ref tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000m, 9500m, ref _tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000m, 10000m, ref _tenPercent), Is.True);
+            Assert.That(Numerics.AreEqual(10000m, 10500m, ref _tenPercent), Is.True);
         }
 
         [Test]
         public void CanCalculateAbsoluteDifference()
         {
-            Assert.That(Numerics.Difference(10000m, 9500m, absoluteTolerance.Mode), Is.EqualTo(500m));
-            Assert.That(Convert.ToDouble(Numerics.Difference(0.1, 0.05, absoluteTolerance.Mode)), Is.EqualTo(0.05).Within(0.00001));
-            Assert.That(Convert.ToDouble(Numerics.Difference(0.1, 0.15, absoluteTolerance.Mode)), Is.EqualTo(-0.05).Within(0.00001));
+            Assert.That(Numerics.Difference(10000m, 9500m, _absoluteTolerance.Mode), Is.EqualTo(500m));
+            Assert.That(Convert.ToDouble(Numerics.Difference(0.1, 0.05, _absoluteTolerance.Mode)), Is.EqualTo(0.05).Within(0.00001));
+            Assert.That(Convert.ToDouble(Numerics.Difference(0.1, 0.15, _absoluteTolerance.Mode)), Is.EqualTo(-0.05).Within(0.00001));
         }
 
         [Test]
         public void CanCalculatePercentDifference()
         {
-            Assert.That(Numerics.Difference(10000m, 8500m, tenPercent.Mode), Is.EqualTo(15));
-            Assert.That(Numerics.Difference(10000m, 11500m, tenPercent.Mode), Is.EqualTo(-15));
+            Assert.That(Numerics.Difference(10000m, 8500m, _tenPercent.Mode), Is.EqualTo(15));
+            Assert.That(Numerics.Difference(10000m, 11500m, _tenPercent.Mode), Is.EqualTo(-15));
         }
 
         [Test]
         public void DifferenceForNonNumericTypesReturnsNaN()
         {
-            Assert.That(Numerics.Difference(new object(), new object(), tenPercent.Mode), Is.EqualTo(double.NaN));
+            Assert.That(Numerics.Difference(new object(), new object(), _tenPercent.Mode), Is.EqualTo(double.NaN));
         }
 
         [Test]
@@ -165,19 +165,19 @@ namespace NUnit.Framework.Constraints
         [TestCase((ulong)11500)]
         public void FailsOnIntegralsOutsideOfPercentage(object value)
         {
-            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000, value, ref tenPercent), Is.True));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000, value, ref _tenPercent), Is.True));
         }
 
         [Test]
         public void FailsOnDecimalBelowPercentage()
         {
-            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 8500m, ref tenPercent), Is.True));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 8500m, ref _tenPercent), Is.True));
         }
 
         [Test]
         public void FailsOnDecimalAbovePercentage()
         {
-            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 11500m, ref tenPercent), Is.True));
+            Assert.Throws<AssertionException>(() => Assert.That(Numerics.AreEqual(10000m, 11500m, ref _tenPercent), Is.True));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeConstraintTests.cs
@@ -9,9 +9,9 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class RangeConstraintTest : ConstraintTestBase
     {
-        private readonly RangeConstraint rangeConstraint = new RangeConstraint(5, 42);
+        private readonly RangeConstraint _rangeConstraint = new RangeConstraint(5, 42);
 
-        protected override Constraint TheConstraint => rangeConstraint;
+        protected override Constraint TheConstraint => _rangeConstraint;
 
         [SetUp]
         public void SetUp()
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Constraints
         public void UsesProvidedIComparer()
         {
             var comparer = new ObjectComparer();
-            Assert.That(rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
+            Assert.That(_rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
             Assert.That(comparer.WasCalled, "Comparer was not called");
         }
 
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Constraints
         public void UsesProvidedGenericComparer()
         {
             var comparer = new GenericComparer<int>();
-            Assert.That(rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
+            Assert.That(_rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
             Assert.That(comparer.WasCalled, "Comparer was not called");
         }
 
@@ -50,7 +50,7 @@ namespace NUnit.Framework.Constraints
         public void UsesProvidedGenericComparison()
         {
             var comparer = new GenericComparison<int>();
-            Assert.That(rangeConstraint.Using(comparer.Delegate).ApplyTo(19).IsSuccess);
+            Assert.That(_rangeConstraint.Using(comparer.Delegate).ApplyTo(19).IsSuccess);
             Assert.That(comparer.WasCalled, "Comparer was not called");
         }
 
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
         public void UsesProvidedLambda()
         {
             Comparison<int> comparer = (x, y) => x.CompareTo(y);
-            Assert.That(rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
+            Assert.That(_rangeConstraint.Using(comparer).ApplyTo(19).IsSuccess);
         }
         [Test]
         public void ShouldThrowExceptionIfObjectHasNoComparer()

--- a/src/NUnitFramework/tests/Constraints/ReusableConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ReusableConstraintTests.cs
@@ -6,7 +6,7 @@ namespace NUnit.Framework.Constraints
     public class ReusableConstraintTests
     {
         [Datapoints]
-        public static readonly ReusableConstraint[] constraints = new ReusableConstraint[] {
+        public static readonly ReusableConstraint[] Constraints = new ReusableConstraint[] {
             Is.Not.Empty,
             Is.Not.Null,
             Has.Length.GreaterThan(3),

--- a/src/NUnitFramework/tests/Constraints/SameAsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/SameAsTest.cs
@@ -5,10 +5,10 @@ namespace NUnit.Framework.Constraints
     [TestFixture]
     public class SameAsTest : ConstraintTestBase
     {
-        private static readonly object obj1 = new object();
-        private static readonly object obj2 = new object();
+        private static readonly object Obj1 = new object();
+        private static readonly object Obj2 = new object();
 
-        protected override Constraint TheConstraint { get; } = new SameAsConstraint(obj1);
+        protected override Constraint TheConstraint { get; } = new SameAsConstraint(Obj1);
 
         [SetUp]
         public void SetUp()
@@ -18,10 +18,10 @@ namespace NUnit.Framework.Constraints
         }
 
 #pragma warning disable IDE0052 // Remove unread private members
-        private static readonly object[] SuccessData = new object[] { obj1 };
+        private static readonly object[] SuccessData = new object[] { Obj1 };
         private static readonly object[] FailureData = new object[]
         { 
-            new TestCaseData( obj2, "<System.Object>" ),
+            new TestCaseData( Obj2, "<System.Object>" ),
             new TestCaseData( 3, "3" ),
             new TestCaseData( "Hello", "\"Hello\"" )
         };

--- a/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework.Constraints
                 var newConstraint = subStringConstraint.Using(StringComparison.CurrentCultureIgnoreCase).IgnoreCase;
             });
 
-            var stringConstraint = (StringConstraint)new SubstringConstraint("hello"); ;
+            var stringConstraint = (StringConstraint)new SubstringConstraint("hello");
             Assert.DoesNotThrow(() =>
             {
                 var newConstraint = (SubstringConstraint)stringConstraint.IgnoreCase;

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -303,13 +303,13 @@ namespace NUnit.Framework.Constraints
             public override bool Equals(object? obj)
             {
                 if (obj is TestReferenceType_OverridesEquals other)
-                    return other.A == this.A;
+                    return other.A == A;
                 return false;
             }
 
             public override int GetHashCode()
             {
-                return this.A.GetHashCode();
+                return A.GetHashCode();
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -13,14 +13,14 @@ namespace NUnit.Framework.Internal
         [Test]
         public void GetNameForAssembly()
         {
-            var assemblyName = AssemblyHelper.GetAssemblyName(this.GetType().Assembly);
+            var assemblyName = AssemblyHelper.GetAssemblyName(GetType().Assembly);
             Assert.That(assemblyName.Name, Is.EqualTo(THIS_ASSEMBLY_NAME).IgnoreCase);
         }
 
         [Test]
         public void GetPathForAssembly()
         {
-            string path = AssemblyHelper.GetAssemblyPath(this.GetType().Assembly);
+            string path = AssemblyHelper.GetAssemblyPath(GetType().Assembly);
             Assert.That(Path.GetFileName(path), Is.EqualTo(THIS_ASSEMBLY_PATH).IgnoreCase);
 
             Assert.That(File.Exists(path));

--- a/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/CultureSettingAndDetectionTests.cs
@@ -13,32 +13,32 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class CultureSettingAndDetectionTests
     {
-        private readonly CultureDetector detector = new CultureDetector("fr-FR");
+        private readonly CultureDetector _detector = new CultureDetector("fr-FR");
 
         private void ExpectMatch( string culture )
         {
-            if ( !detector.IsCultureSupported( culture ) )
+            if ( !_detector.IsCultureSupported( culture ) )
                 Assert.Fail($"Failed to match \"{culture}\"");
         }
 
         private void ExpectMatch( CultureAttribute attr )
         {
-            if ( !detector.IsCultureSupported( attr ) )
+            if ( !_detector.IsCultureSupported( attr ) )
                 Assert.Fail($"Failed to match attribute with Include=\"{attr.Include}\",Exclude=\"{attr.Exclude}\"");
         }
 
         private void ExpectFailure( string culture )
         {
-            if ( detector.IsCultureSupported( culture ) )
+            if ( _detector.IsCultureSupported( culture ) )
                 Assert.Fail($"Should not match \"{culture}\"");
-            Assert.That( detector.Reason, Is.EqualTo("Only supported under culture " + culture));
+            Assert.That( _detector.Reason, Is.EqualTo("Only supported under culture " + culture));
         }
 
         private void ExpectFailure( CultureAttribute attr, string msg )
         {
-            if ( detector.IsCultureSupported( attr ) )
+            if ( _detector.IsCultureSupported( attr ) )
                 Assert.Fail($"Should not match attribute with Include=\"{attr.Include}\",Exclude=\"{attr.Exclude}\"");
-            Assert.That( detector.Reason, Is.EqualTo(msg));
+            Assert.That( _detector.Reason, Is.EqualTo(msg));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -110,9 +110,9 @@ namespace NUnit.Framework.Internal.Execution
             public void DequeueBlocking_Stop()
             {
                 var q = new EventQueue();
-                this._receivedEvents = 0;
-                this.RunProducerConsumer(q);
-                Assert.That(this._receivedEvents, Is.EqualTo(Events.Length + 1));
+                _receivedEvents = 0;
+                RunProducerConsumer(q);
+                Assert.That(_receivedEvents, Is.EqualTo(Events.Length + 1));
             }
 
             protected override void Producer(object? parameter)
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal.Execution
                 if (parameter is not EventQueue q)
                     throw new ArgumentException("Expected an EventQueue", nameof(parameter));
                 EnqueueEvents(q);
-                while (this._receivedEvents < Events.Length)
+                while (_receivedEvents < Events.Length)
                     Thread.Sleep(30);
 
                 q.Stop();
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Internal.Execution
                 do
                 {
                     e = q.Dequeue(true);
-                    this._receivedEvents++;
+                    _receivedEvents++;
                     Thread.MemoryBarrier();
                 }
                 while (e is not null);
@@ -229,12 +229,12 @@ namespace NUnit.Framework.Internal.Execution
 
             protected void RunProducerConsumer(object? parameter)
             {
-                this._myConsumerException = null;
-                Thread consumerThread = new Thread(this.ConsumerThreadWrapper);
+                _myConsumerException = null;
+                Thread consumerThread = new Thread(ConsumerThreadWrapper);
                 try
                 {
                     consumerThread.Start(parameter);
-                    this.Producer(parameter);
+                    Producer(parameter);
                     bool consumerStopped = consumerThread.Join(1000);
                     Assert.That(consumerStopped, Is.True);
                 }
@@ -245,7 +245,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
                 }
 
-                Assert.That(this._myConsumerException, Is.Null);
+                Assert.That(_myConsumerException, Is.Null);
             }
 
             protected abstract void Producer(object? parameter);
@@ -256,7 +256,7 @@ namespace NUnit.Framework.Internal.Execution
             {
                 try
                 {
-                    this.Consumer(parameter);
+                    Consumer(parameter);
                 }
 #if THREAD_ABORT
                 catch (System.Threading.ThreadAbortException)
@@ -266,7 +266,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
                 catch (Exception ex)
                 {
-                    this._myConsumerException = ex;
+                    _myConsumerException = ex;
                 }
             }
         }
@@ -282,10 +282,10 @@ namespace NUnit.Framework.Internal.Execution
 
             public EventProducer(EventQueue q, int id, bool delay)
             {
-                this._queue = q;
-                this.ProducerThread = new Thread(new ThreadStart(this.Produce));
-                this.ProducerThread.Name = this.GetType().FullName + id;
-                this._delay = delay;
+                _queue = q;
+                ProducerThread = new Thread(new ThreadStart(Produce));
+                ProducerThread.Name = GetType().FullName + id;
+                _delay = delay;
             }
 
             private void Produce()
@@ -296,18 +296,18 @@ namespace NUnit.Framework.Internal.Execution
                     DateTime start = DateTime.Now;
                     while (DateTime.Now - start <= TimeSpan.FromSeconds(3))
                     {
-                        this._queue.Enqueue(e);
-                        this.SentEventsCount++;
-                        this.MaxQueueLength = Math.Max(this._queue.Count, this.MaxQueueLength);
+                        _queue.Enqueue(e);
+                        SentEventsCount++;
+                        MaxQueueLength = Math.Max(_queue.Count, MaxQueueLength);
 
                         // without Sleep or with just a Sleep(0), the EventPump thread does not keep up and the queue gets very long
-                        if (this._delay)
+                        if (_delay)
                             Thread.Sleep(1);
                     }
                 }
                 catch (Exception ex)
                 {
-                    this.Exception = ex;
+                    Exception = ex;
                 }
             }
         }

--- a/src/NUnitFramework/tests/Internal/EventQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/EventQueueTests.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Internal.Execution
     [TestFixture]
     public class EventQueueTests
     {
-        private static readonly Event[] events =
+        private static readonly Event[] Events =
         {
             // These are all in violation of contract
             // However the code here doesn't use the argument.
@@ -31,23 +31,23 @@ namespace NUnit.Framework.Internal.Execution
 
         private static void EnqueueEvents(EventQueue q)
         {
-            foreach (Event e in events)
+            foreach (Event e in Events)
                 q.Enqueue(e);
         }
 
         private static void SendEvents(ITestListener listener)
         {
-            foreach (Event e in events)
+            foreach (Event e in Events)
                 e.Send(listener);
         }
 
         private static void VerifyQueue(EventQueue q)
         {
-            for (int index = 0; index < events.Length; index++)
+            for (int index = 0; index < Events.Length; index++)
             {
                 Event? e = q.Dequeue(false);
                 Assert.That(e, Is.Not.Null);
-                Assert.That(e.GetType(), Is.EqualTo(events[index].GetType()), $"Event {index}");
+                Assert.That(e.GetType(), Is.EqualTo(Events[index].GetType()), $"Event {index}");
             }
         }
 
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Internal.Execution
         [TestFixture]
         public class DequeueBlocking_StopTest : ProducerConsumerTest
         {
-            private volatile int receivedEvents;
+            private volatile int _receivedEvents;
 
             [Test]
 #if THREAD_ABORT
@@ -110,9 +110,9 @@ namespace NUnit.Framework.Internal.Execution
             public void DequeueBlocking_Stop()
             {
                 var q = new EventQueue();
-                this.receivedEvents = 0;
+                this._receivedEvents = 0;
                 this.RunProducerConsumer(q);
-                Assert.That(this.receivedEvents, Is.EqualTo(events.Length + 1));
+                Assert.That(this._receivedEvents, Is.EqualTo(Events.Length + 1));
             }
 
             protected override void Producer(object? parameter)
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal.Execution
                 if (parameter is not EventQueue q)
                     throw new ArgumentException("Expected an EventQueue", nameof(parameter));
                 EnqueueEvents(q);
-                while (this.receivedEvents < events.Length)
+                while (this._receivedEvents < Events.Length)
                     Thread.Sleep(30);
 
                 q.Stop();
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Internal.Execution
                 do
                 {
                     e = q.Dequeue(true);
-                    this.receivedEvents++;
+                    this._receivedEvents++;
                     Thread.MemoryBarrier();
                 }
                 while (e is not null);
@@ -205,10 +205,10 @@ namespace NUnit.Framework.Internal.Execution
 
                 int numberOfAsynchronousEvents = 0;
                 int sumOfAsynchronousQueueLength = 0;
-                const int Repetitions = 2;
-                for (int i = 0; i < Repetitions; i++)
+                const int repetitions = 2;
+                for (int i = 0; i < repetitions; i++)
                 {
-                    foreach (Event e in events)
+                    foreach (Event e in Events)
                     {
                         q.Enqueue(e);
 
@@ -225,11 +225,11 @@ namespace NUnit.Framework.Internal.Execution
 
         public abstract class ProducerConsumerTest
         {
-            private volatile Exception? myConsumerException;
+            private volatile Exception? _myConsumerException;
 
             protected void RunProducerConsumer(object? parameter)
             {
-                this.myConsumerException = null;
+                this._myConsumerException = null;
                 Thread consumerThread = new Thread(this.ConsumerThreadWrapper);
                 try
                 {
@@ -245,7 +245,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
                 }
 
-                Assert.That(this.myConsumerException, Is.Null);
+                Assert.That(this._myConsumerException, Is.Null);
             }
 
             protected abstract void Producer(object? parameter);
@@ -266,7 +266,7 @@ namespace NUnit.Framework.Internal.Execution
 #endif
                 catch (Exception ex)
                 {
-                    this.myConsumerException = ex;
+                    this._myConsumerException = ex;
                 }
             }
         }
@@ -277,15 +277,15 @@ namespace NUnit.Framework.Internal.Execution
             public int SentEventsCount;
             public int MaxQueueLength;
             public Exception? Exception;
-            private readonly EventQueue queue;
-            private readonly bool delay;
+            private readonly EventQueue _queue;
+            private readonly bool _delay;
 
             public EventProducer(EventQueue q, int id, bool delay)
             {
-                this.queue = q;
+                this._queue = q;
                 this.ProducerThread = new Thread(new ThreadStart(this.Produce));
                 this.ProducerThread.Name = this.GetType().FullName + id;
-                this.delay = delay;
+                this._delay = delay;
             }
 
             private void Produce()
@@ -296,12 +296,12 @@ namespace NUnit.Framework.Internal.Execution
                     DateTime start = DateTime.Now;
                     while (DateTime.Now - start <= TimeSpan.FromSeconds(3))
                     {
-                        this.queue.Enqueue(e);
+                        this._queue.Enqueue(e);
                         this.SentEventsCount++;
-                        this.MaxQueueLength = Math.Max(this.queue.Count, this.MaxQueueLength);
+                        this.MaxQueueLength = Math.Max(this._queue.Count, this.MaxQueueLength);
 
                         // without Sleep or with just a Sleep(0), the EventPump thread does not keep up and the queue gets very long
-                        if (this.delay)
+                        if (this._delay)
                             Thread.Sleep(1);
                     }
                 }

--- a/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/AndFilterTests.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void IsNotEmpty()
         {
-            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
+            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(DummyFixtureSuite.Id));
 
             Assert.That(filter.IsEmpty, Is.False);
         }
@@ -18,34 +18,34 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
+            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(DummyFixtureSuite.Id));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
+            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(DummyFixtureSuite.Id));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Pass(_dummyFixture));
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(filter.Pass(_anotherFixture), Is.False);
+            Assert.That(filter.Pass(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(_dummyFixture.Id));
+            var filter = new AndFilter(new CategoryFilter("Dummy"), new IdFilter(DummyFixtureSuite.Id));
 
-            Assert.That(filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -55,13 +55,13 @@ namespace NUnit.Framework.Internal.Filters
                 new NotFilter(
                     new CategoryFilter("Dummy")),
                 new NotFilter(
-                    new IdFilter(_dummyFixture.Id)));
+                    new IdFilter(DummyFixtureSuite.Id)));
 
-            Assert.That(filter.IsExplicitMatch(_topLevelSuite), Is.False);
-            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch(TopLevelSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(filter.Match(_anotherFixture), "4");
+            Assert.That(filter.Match(AnotherFixtureSuite), "4");
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal.Filters
             var filters = new List<MockTestFilter>();
             foreach (var inputBool in inputBooleans)
             {
-                var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
+                var strictFilter = new MockTestFilter(DummyFixtureSuite, matchFunction, inputBool);
                 Assert.That(ExecuteMatchFunction(strictFilter, matchFunction), Is.EqualTo(inputBool));
 
                 filters.Add(strictFilter);
@@ -122,11 +122,11 @@ namespace NUnit.Framework.Internal.Filters
             switch (matchFunction)
             {
                 case MockTestFilter.MatchFunction.IsExplicitMatch:
-                    return filter.IsExplicitMatch(_dummyFixture);
+                    return filter.IsExplicitMatch(DummyFixtureSuite);
                 case MockTestFilter.MatchFunction.Match:
-                    return filter.Match(_dummyFixture);
+                    return filter.Match(DummyFixtureSuite);
                 case MockTestFilter.MatchFunction.Pass:
-                    return filter.Pass(_dummyFixture);
+                    return filter.Pass(DummyFixtureSuite);
                 default:
                     throw new ArgumentException(
                         "Unexpected StrictIdFilterForTests.EqualValueFunction.", nameof(matchFunction));
@@ -137,22 +137,22 @@ namespace NUnit.Framework.Internal.Filters
         public void BuildFromXml()
         {
             TestFilter filter = TestFilter.FromXml(
-                $"<filter><and><cat>Dummy</cat><id>{_dummyFixture.Id}</id></and></filter>");
+                $"<filter><and><cat>Dummy</cat><id>{DummyFixtureSuite.Id}</id></and></filter>");
 
             Assert.That(filter, Is.TypeOf<AndFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void BuildFromXml_TopLevelDefaultsToAnd()
         {
             TestFilter filter = TestFilter.FromXml(
-                $"<filter><cat>Dummy</cat><id>{_dummyFixture.Id}</id></filter>");
+                $"<filter><cat>Dummy</cat><id>{DummyFixtureSuite.Id}</id></filter>");
 
             Assert.That(filter, Is.TypeOf<AndFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/CategoryFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/CategoryFilterTests.cs
@@ -21,28 +21,28 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture));
-            Assert.That(_filter.Match(_anotherFixture), Is.False);
+            Assert.That(_filter.Match(DummyFixtureSuite));
+            Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_topLevelSuite));
-            Assert.That(_filter.Pass(_dummyFixture));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(TopLevelSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(_filter.Pass(_anotherFixture), Is.False);
+            Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/ClassNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/ClassNameFilterTests.cs
@@ -22,28 +22,28 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture));
-            Assert.That(_filter.Match(_anotherFixture), Is.False);
+            Assert.That(_filter.Match(DummyFixtureSuite));
+            Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_topLevelSuite));
-            Assert.That(_filter.Pass(_dummyFixture));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(TopLevelSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(_filter.Pass(_anotherFixture), Is.False);
+            Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework.Interfaces;
 namespace NUnit.Framework.Internal.Filters {
     public class DeMorganOnFiltersTest : TestFilterTests
     {
-        private static readonly List<TestFilter[]> filterPairs;
+        private static readonly List<TestFilter[]> FilterPairs;
 
         static DeMorganOnFiltersTest()
         {
@@ -18,21 +18,21 @@ namespace NUnit.Framework.Internal.Filters {
                 new PropertyFilter("Priority", "Low")
             };
 
-            filterPairs = new List<TestFilter[]>();
+            FilterPairs = new List<TestFilter[]>();
             foreach (var part1 in filterParts)
             foreach (var part2 in filterParts)
             {
                 var and = new AndFilter(part1, new NotFilter(part2));
                 var or = new OrFilter(new NotFilter(part1), part2);
-                filterPairs.Add(new TestFilter[2] {new NotFilter(and), or});
-                filterPairs.Add(new TestFilter[2] {and, new NotFilter(or)});
+                FilterPairs.Add(new TestFilter[2] {new NotFilter(and), or});
+                FilterPairs.Add(new TestFilter[2] {and, new NotFilter(or)});
             }
         }
 
         private IEnumerable<ITest> GetTests()
         {
             var q = new Queue<ITest>();
-            q.Enqueue(_topLevelSuite);
+            q.Enqueue(TopLevelSuite);
             while (q.Count > 0)
             {
                 var test = q.Dequeue();
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal.Filters {
         }
 
         [Test]
-        [TestCaseSource(nameof(filterPairs))]
+        [TestCaseSource(nameof(FilterPairs))]
         public void DeMorganPassTests(TestFilter andFilter, TestFilter orFilter)
         {
 
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Internal.Filters {
         }
 
         [Test]
-        [TestCaseSource(nameof(filterPairs))]
+        [TestCaseSource(nameof(FilterPairs))]
         public void DeMorganMatchTests(TestFilter andFilter, TestFilter orFilter)
         {
             var disagreements = new List<string>();

--- a/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DeMorganOnFiltersTest.cs
@@ -20,12 +20,14 @@ namespace NUnit.Framework.Internal.Filters {
 
             FilterPairs = new List<TestFilter[]>();
             foreach (var part1 in filterParts)
-            foreach (var part2 in filterParts)
+            {
+                foreach (var part2 in filterParts)
             {
                 var and = new AndFilter(part1, new NotFilter(part2));
                 var or = new OrFilter(new NotFilter(part1), part2);
                 FilterPairs.Add(new TestFilter[2] {new NotFilter(and), or});
                 FilterPairs.Add(new TestFilter[2] {and, new NotFilter(or)});
+            }
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/DoubleNegativeFilterTests.cs
@@ -24,8 +24,8 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Match(_dummyFixture));
-                Assert.That(_filter.Match(_anotherFixture), Is.False);
+                Assert.That(_filter.Match(DummyFixtureSuite));
+                Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
             });
         }
 
@@ -34,11 +34,11 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Pass(_topLevelSuite));
-                Assert.That(_filter.Pass(_dummyFixture));
-                Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+                Assert.That(_filter.Pass(TopLevelSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-                Assert.That(_filter.Pass(_anotherFixture), Is.False);
+                Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
             });
         }
 
@@ -48,11 +48,11 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+                Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-                Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+                Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
             });
         }
     }

--- a/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/EmptyFilterTests.cs
@@ -23,25 +23,25 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchesAnything()
         {
-            Assert.That(TestFilter.Empty.Match(_dummyFixture));
-            Assert.That(TestFilter.Empty.Match(_anotherFixture));
-            Assert.That(TestFilter.Empty.Match(_yetAnotherFixture));
+            Assert.That(TestFilter.Empty.Match(DummyFixtureSuite));
+            Assert.That(TestFilter.Empty.Match(AnotherFixtureSuite));
+            Assert.That(TestFilter.Empty.Match(YetAnotherFixtureSuite));
         }
 
         [Test]
         public void PassesAnything()
         {
-            Assert.That(TestFilter.Empty.Match(_dummyFixture));
-            Assert.That(TestFilter.Empty.Match(_anotherFixture));
-            Assert.That(TestFilter.Empty.Match(_yetAnotherFixture));
+            Assert.That(TestFilter.Empty.Match(DummyFixtureSuite));
+            Assert.That(TestFilter.Empty.Match(AnotherFixtureSuite));
+            Assert.That(TestFilter.Empty.Match(YetAnotherFixtureSuite));
         }
 
         [Test]
         public void MatchesNothingExplicitly()
         {
-            Assert.That(TestFilter.Empty.IsExplicitMatch(_dummyFixture), Is.False);
-            Assert.That(TestFilter.Empty.IsExplicitMatch(_anotherFixture), Is.False);
-            Assert.That(TestFilter.Empty.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(TestFilter.Empty.IsExplicitMatch(DummyFixtureSuite), Is.False);
+            Assert.That(TestFilter.Empty.IsExplicitMatch(AnotherFixtureSuite), Is.False);
+            Assert.That(TestFilter.Empty.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/FullNameFilterTests.cs
@@ -24,8 +24,8 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Match(_dummyFixture));
-                Assert.That(_filter.Match(_anotherFixture), Is.False);
+                Assert.That(_filter.Match(DummyFixtureSuite));
+                Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
             });
         }
 
@@ -34,11 +34,11 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Pass(_topLevelSuite));
-                Assert.That(_filter.Pass(_dummyFixture));
-                Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+                Assert.That(_filter.Pass(TopLevelSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-                Assert.That(_filter.Pass(_anotherFixture), Is.False);
+                Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
             });
         }
 
@@ -48,11 +48,11 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+                Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-                Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+                Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
             });
         }
     }

--- a/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/IdFilterTests.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework.Internal.Filters
         [SetUp]
         public void CreateFilter()
         {
-            _filter = new IdFilter(_dummyFixture.Id);
+            _filter = new IdFilter(DummyFixtureSuite.Id);
         }
 
         [Test]
@@ -21,28 +21,28 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture));
-            Assert.That(_filter.Match(_anotherFixture), Is.False);
+            Assert.That(_filter.Match(DummyFixtureSuite));
+            Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_topLevelSuite));
-            Assert.That(_filter.Pass(_dummyFixture));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(TopLevelSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(_filter.Pass(_anotherFixture), Is.False);
+            Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/InFilterTests.cs
@@ -29,8 +29,8 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new FullNameFilter(ANOTHER_CLASS));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
 
             Assert.That(InFilter.TryOptimize(filter, out _), Is.False);
         }
@@ -66,8 +66,8 @@ namespace NUnit.Framework.Internal.Filters
                 $"<filter><or><test>{DUMMY_CLASS}</test><test>{ANOTHER_CLASS}</test></or></filter>");
 
             Assert.That(filter, Is.TypeOf<InFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
         }
         
         [Test]

--- a/src/NUnitFramework/tests/Internal/Filters/MethodNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MethodNameFilterTests.cs
@@ -24,8 +24,8 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Match(_dummyFixture.Tests[0]));
-                Assert.That(_filter.Match(_anotherFixture.Tests[0]));
+                Assert.That(_filter.Match(DummyFixtureSuite.Tests[0]));
+                Assert.That(_filter.Match(AnotherFixtureSuite.Tests[0]));
             });
         }
 
@@ -34,13 +34,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.Pass(_topLevelSuite));
-                Assert.That(_filter.Pass(_dummyFixture));
-                Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+                Assert.That(_filter.Pass(TopLevelSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite));
+                Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-                Assert.That(_filter.Pass(_anotherFixture));
-                Assert.That(_filter.Pass(_anotherFixture.Tests[0]));
-                Assert.That(_filter.Pass(_yetAnotherFixture), Is.False);
+                Assert.That(_filter.Pass(AnotherFixtureSuite));
+                Assert.That(_filter.Pass(AnotherFixtureSuite.Tests[0]));
+                Assert.That(_filter.Pass(YetAnotherFixtureSuite), Is.False);
             });
         }
 
@@ -49,10 +49,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-                Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]));
-                Assert.That(_filter.IsExplicitMatch(_anotherFixture));
+                Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+                Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]));
+                Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite));
             });
         }
     }

--- a/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/MultipleFilterTests.cs
@@ -11,17 +11,17 @@ namespace NUnit.Framework.Internal.Filters
                 new CategoryFilter("Dummy"),
                 new PropertyFilter("Priority", "High"));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite));
 
-            Assert.That(filter.Match(_anotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_explicitFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
+            Assert.That(filter.Match(ExplicitFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(ExplicitFixtureSuite), Is.False);
         }
 
         [Test]
@@ -29,17 +29,17 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("NotDummy"));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_anotherFixture));
-            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_yetAnotherFixture));
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_explicitFixture));
-            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
+            Assert.That(filter.Match(ExplicitFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(ExplicitFixtureSuite), Is.False);
         }
 
         [Test]
@@ -51,17 +51,17 @@ namespace NUnit.Framework.Internal.Filters
                     new PropertyFilter("Priority", "High"),
                     new PropertyFilter("Priority", "Low")));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_anotherFixture));
-            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_explicitFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
+            Assert.That(filter.Match(ExplicitFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(ExplicitFixtureSuite), Is.False);
         }
 
         [Test]
@@ -71,17 +71,17 @@ namespace NUnit.Framework.Internal.Filters
                 new CategoryFilter("Dummy"),
                 new NotFilter(new CategoryFilter("Dummy")));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite));
 
-            Assert.That(filter.Match(_anotherFixture));
-            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_yetAnotherFixture));
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_explicitFixture));
-            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
+            Assert.That(filter.Match(ExplicitFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(ExplicitFixtureSuite), Is.False);
         }
 
         [Test]
@@ -92,17 +92,17 @@ namespace NUnit.Framework.Internal.Filters
                     new NotFilter(
                         new NotFilter(new CategoryFilter("Dummy")))));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_anotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
 
-            Assert.That(filter.Match(_explicitFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch(_explicitFixture), Is.False);
+            Assert.That(filter.Match(ExplicitFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch(ExplicitFixtureSuite), Is.False);
         }
 
         [Test]
@@ -114,17 +114,17 @@ namespace NUnit.Framework.Internal.Filters
                         new CategoryFilter("Dummy")),
                     new MethodNameFilter("Test1")));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Match(_topLevelSuite), Is.False);
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Match(TopLevelSuite), Is.False);
 
-            Assert.That(filter.Pass(_fixtureWithMultipleTests));
-            Assert.That(filter.Match(_fixtureWithMultipleTests), Is.False);
+            Assert.That(filter.Pass(FixtureWithMultipleTestsSuite));
+            Assert.That(filter.Match(FixtureWithMultipleTestsSuite), Is.False);
 
-            var test1 = _fixtureWithMultipleTests.Tests[0];
+            var test1 = FixtureWithMultipleTestsSuite.Tests[0];
             Assert.That(filter.Pass(test1), Is.False);
             Assert.That(filter.Match(test1), Is.False);
 
-            var test2 = _fixtureWithMultipleTests.Tests[1];
+            var test2 = FixtureWithMultipleTestsSuite.Tests[1];
             Assert.That(filter.Pass(test2));
             Assert.That(filter.IsExplicitMatch(test2), Is.False);
             Assert.That(filter.Match(test2));
@@ -139,17 +139,17 @@ namespace NUnit.Framework.Internal.Filters
                         new CategoryFilter("Dummy")),
                     new MethodNameFilter("Test1")));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Match(_topLevelSuite));
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Match(TopLevelSuite));
 
-            Assert.That(filter.Pass(_fixtureWithMultipleTests));
-            Assert.That(filter.Match(_fixtureWithMultipleTests));
+            Assert.That(filter.Pass(FixtureWithMultipleTestsSuite));
+            Assert.That(filter.Match(FixtureWithMultipleTestsSuite));
 
-            var test1 = _fixtureWithMultipleTests.Tests[0];
+            var test1 = FixtureWithMultipleTestsSuite.Tests[0];
             Assert.That(filter.Pass(test1), Is.False);
             Assert.That(filter.Match(test1), Is.False);
 
-            var test2 = _fixtureWithMultipleTests.Tests[1];
+            var test2 = FixtureWithMultipleTestsSuite.Tests[1];
             Assert.That(filter.Pass(test2));
             Assert.That(filter.IsExplicitMatch(test2), Is.False);
             Assert.That(filter.Match(test2));

--- a/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/NamespaceFilterTests.cs
@@ -25,19 +25,19 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture.Tests[0]), Is.EqualTo(_expected));
+            Assert.That(_filter.Match(DummyFixtureSuite.Tests[0]), Is.EqualTo(_expected));
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_nestingFixture), Is.EqualTo(_expected));
-            Assert.That(_filter.Pass(_nestedFixture), Is.EqualTo(_expected));
-            Assert.That(_filter.Pass(_emptyNestedFixture), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(NestingFixtureSuite), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(NestedFixtureSuite), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(EmptyNestedFixtureSuite), Is.EqualTo(_expected));
 
-            Assert.That(_filter.Pass(_topLevelSuite), Is.EqualTo(_expected));
-            Assert.That(_filter.Pass(_dummyFixture), Is.EqualTo(_expected));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(TopLevelSuite), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(DummyFixtureSuite), Is.EqualTo(_expected));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]), Is.EqualTo(_expected));
         }
 
     }

--- a/src/NUnitFramework/tests/Internal/Filters/NotFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/NotFilterTests.cs
@@ -17,15 +17,15 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.That(filter.Match(_topLevelSuite), Is.True);
-            Assert.That(filter.Match(_dummyFixture), Is.False);
-            Assert.That(filter.Match(_dummyFixture.Tests[0]), Is.True);
+            Assert.That(filter.Match(TopLevelSuite), Is.True);
+            Assert.That(filter.Match(DummyFixtureSuite), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite.Tests[0]), Is.True);
 
-            Assert.That(filter.Match(_anotherFixture), Is.True);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.True);
 
-            Assert.That(filter.Match (_fixtureWithMultipleTests), Is.True);
-            Assert.That(filter.Match (_fixtureWithMultipleTests.Tests[0]), Is.True);
-            Assert.That(filter.Match (_fixtureWithMultipleTests.Tests[1]), Is.False);
+            Assert.That(filter.Match (FixtureWithMultipleTestsSuite), Is.True);
+            Assert.That(filter.Match (FixtureWithMultipleTestsSuite.Tests[0]), Is.True);
+            Assert.That(filter.Match (FixtureWithMultipleTestsSuite.Tests[1]), Is.False);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.That(filter.Pass(_topLevelSuite), Is.True);
-            Assert.That(filter.Pass(_dummyFixture), Is.False);
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(filter.Pass(TopLevelSuite), Is.True);
+            Assert.That(filter.Pass(DummyFixtureSuite), Is.False);
+            Assert.That(filter.Pass(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(filter.Pass(_anotherFixture), Is.True);
-            Assert.That(filter.Pass(_anotherFixture.Tests[0]), Is.True);
+            Assert.That(filter.Pass(AnotherFixtureSuite), Is.True);
+            Assert.That(filter.Pass(AnotherFixtureSuite.Tests[0]), Is.True);
 
-            Assert.That(filter.Pass (_fixtureWithMultipleTests), Is.True);
-            Assert.That(filter.Pass (_fixtureWithMultipleTests.Tests[0]), Is.True);
-            Assert.That(filter.Pass (_fixtureWithMultipleTests.Tests[1]), Is.False);
+            Assert.That(filter.Pass (FixtureWithMultipleTestsSuite), Is.True);
+            Assert.That(filter.Pass (FixtureWithMultipleTestsSuite.Tests[0]), Is.True);
+            Assert.That(filter.Pass (FixtureWithMultipleTestsSuite.Tests[1]), Is.False);
         }
 
         [Test]
@@ -50,12 +50,12 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new NotFilter(new CategoryFilter("Dummy"));
 
-            Assert.That(filter.IsExplicitMatch (_topLevelSuite), Is.False);
-            Assert.That(filter.IsExplicitMatch (_dummyFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch (_dummyFixture.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch (TopLevelSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch (DummyFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch (DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(filter.IsExplicitMatch (_anotherFixture), Is.False);
-            Assert.That(filter.IsExplicitMatch (_anotherFixture.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch (AnotherFixtureSuite), Is.False);
+            Assert.That(filter.IsExplicitMatch (AnotherFixtureSuite.Tests[0]), Is.False);
         }
 
         [Test]
@@ -65,8 +65,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><not><cat>Dummy</cat></not></filter>");
 
             Assert.That(filter, Is.TypeOf<NotFilter>());
-            Assert.That(filter.Match(_dummyFixture), Is.False);
-            Assert.That(filter.Match(_anotherFixture), Is.True);
+            Assert.That(filter.Match(DummyFixtureSuite), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.True);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/OrFilterTests.cs
@@ -28,10 +28,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new CategoryFilter("Another"));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -39,10 +39,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new FullNameFilter(ANOTHER_CLASS));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -50,9 +50,9 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new TestFilter[] {});
 
-            Assert.That(filter.Match(_dummyFixture), Is.False);
-            Assert.That(filter.Match(_anotherFixture), Is.False);
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite), Is.False);
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -60,10 +60,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS), new FullNameFilter(ANOTHER_CLASS));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -71,10 +71,10 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX, isRegex: true), new FullNameFilter(ANOTHER_CLASS_REGEX, isRegex: true));
 
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
 
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -82,13 +82,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new CategoryFilter("Another"));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Pass(_dummyFixture));
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]));
-            Assert.That(filter.Pass(_anotherFixture));
-            Assert.That(filter.Pass(_anotherFixture.Tests[0]));
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite.Tests[0]));
+            Assert.That(filter.Pass(AnotherFixtureSuite));
+            Assert.That(filter.Pass(AnotherFixtureSuite.Tests[0]));
 
-            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Pass(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -96,13 +96,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS), new FullNameFilter(ANOTHER_CLASS));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Pass(_dummyFixture));
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]));
-            Assert.That(filter.Pass(_anotherFixture));
-            Assert.That(filter.Pass(_anotherFixture.Tests[0]));
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite.Tests[0]));
+            Assert.That(filter.Pass(AnotherFixtureSuite));
+            Assert.That(filter.Pass(AnotherFixtureSuite.Tests[0]));
 
-            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Pass(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -110,13 +110,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new FullNameFilter(DUMMY_CLASS_REGEX, isRegex: true), new FullNameFilter(ANOTHER_CLASS_REGEX, isRegex: true));
 
-            Assert.That(filter.Pass(_topLevelSuite));
-            Assert.That(filter.Pass(_dummyFixture));
-            Assert.That(filter.Pass(_dummyFixture.Tests[0]));
-            Assert.That(filter.Pass(_anotherFixture));
-            Assert.That(filter.Pass(_anotherFixture.Tests[0]));
+            Assert.That(filter.Pass(TopLevelSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite));
+            Assert.That(filter.Pass(DummyFixtureSuite.Tests[0]));
+            Assert.That(filter.Pass(AnotherFixtureSuite));
+            Assert.That(filter.Pass(AnotherFixtureSuite.Tests[0]));
 
-            Assert.That(filter.Pass(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Pass(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -124,13 +124,13 @@ namespace NUnit.Framework.Internal.Filters
         {
             var filter = new OrFilter(new CategoryFilter("Dummy"), new CategoryFilter("Another"));
 
-            Assert.That(filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
-            Assert.That(filter.IsExplicitMatch(_anotherFixture));
-            Assert.That(filter.IsExplicitMatch(_anotherFixture.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite));
+            Assert.That(filter.IsExplicitMatch(AnotherFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace NUnit.Framework.Internal.Filters
             var filters = new List<MockTestFilter>();
             foreach (var inputBool in inputBooleans)
             {
-                var strictFilter = new MockTestFilter(_dummyFixture, matchFunction, inputBool);
+                var strictFilter = new MockTestFilter(DummyFixtureSuite, matchFunction, inputBool);
                 Assert.That(ExecuteMatchFunction(strictFilter, matchFunction), Is.EqualTo(inputBool));
 
                 filters.Add(strictFilter);
@@ -191,11 +191,11 @@ namespace NUnit.Framework.Internal.Filters
             switch (matchFunction)
             {
                 case MockTestFilter.MatchFunction.IsExplicitMatch:
-                    return filter.IsExplicitMatch(_dummyFixture);
+                    return filter.IsExplicitMatch(DummyFixtureSuite);
                 case MockTestFilter.MatchFunction.Match:
-                    return filter.Match(_dummyFixture);
+                    return filter.Match(DummyFixtureSuite);
                 case MockTestFilter.MatchFunction.Pass:
-                    return filter.Pass(_dummyFixture);
+                    return filter.Pass(DummyFixtureSuite);
                 default:
                     throw new ArgumentException(
                         "Unexpected StrictIdFilterForTests.EqualValueFunction.", nameof(matchFunction));
@@ -209,8 +209,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><or><cat>Dummy</cat><cat>Another</cat></or></filter>");
 
             Assert.That(filter, Is.TypeOf<OrFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
         }
 
         [Test]
@@ -220,8 +220,8 @@ namespace NUnit.Framework.Internal.Filters
                 $"<filter><or><test re=\"1\">{DUMMY_CLASS_REGEX}</test><test re=\"1\">{ANOTHER_CLASS_REGEX}</test></or></filter>");
 
             Assert.That(filter, Is.TypeOf<OrFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture));
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/PropertyFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/PropertyFilterTests.cs
@@ -22,31 +22,31 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture));
-            Assert.That(_filter.Match(_anotherFixture), Is.False);
-            Assert.That(_filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(_filter.Match(DummyFixtureSuite));
+            Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(_filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_topLevelSuite));
-            Assert.That(_filter.Pass(_dummyFixture));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(TopLevelSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(_filter.Pass(_anotherFixture), Is.False);
-            Assert.That(_filter.Pass(_yetAnotherFixture), Is.False);
+            Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
+            Assert.That(_filter.Pass(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
-            Assert.That(_filter.IsExplicitMatch(_yetAnotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
+            Assert.That(_filter.IsExplicitMatch(YetAnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterTests.cs
@@ -43,28 +43,28 @@ namespace NUnit.Framework.Internal.Filters
         public const string DUMMY_CLASS_REGEX = "NUnit.*\\+DummyFixture";
         public const string ANOTHER_CLASS_REGEX = "NUnit.*\\+AnotherFixture";
 
-        protected readonly TestSuite _dummyFixture = TestBuilder.MakeFixture(typeof(DummyFixture));
-        protected readonly TestSuite _anotherFixture = TestBuilder.MakeFixture(typeof(AnotherFixture));
-        protected readonly TestSuite _yetAnotherFixture = TestBuilder.MakeFixture(typeof(YetAnotherFixture));
-        protected readonly TestSuite _fixtureWithMultipleTests = TestBuilder.MakeFixture (typeof (FixtureWithMultipleTests));
-        protected readonly TestSuite _nestingFixture = TestBuilder.MakeFixture(typeof(NestingFixture));
-        protected readonly TestSuite _nestedFixture = TestBuilder.MakeFixture(typeof(NestingFixture.NestedFixture));
-        protected readonly TestSuite _emptyNestedFixture = TestBuilder.MakeFixture(typeof(NestingFixture.EmptyNestedFixture));
-        protected readonly TestSuite _topLevelSuite = new TestSuite("MySuite");
-        protected readonly TestSuite _explicitFixture = TestBuilder.MakeFixture(typeof(ExplicitFixture));
-        protected readonly TestSuite _specialFixture = TestBuilder.MakeFixture(typeof(SpecialCharactersFixture));
+        protected readonly TestSuite DummyFixtureSuite = TestBuilder.MakeFixture(typeof(DummyFixture));
+        protected readonly TestSuite AnotherFixtureSuite = TestBuilder.MakeFixture(typeof(AnotherFixture));
+        protected readonly TestSuite YetAnotherFixtureSuite = TestBuilder.MakeFixture(typeof(YetAnotherFixture));
+        protected readonly TestSuite FixtureWithMultipleTestsSuite = TestBuilder.MakeFixture (typeof (FixtureWithMultipleTests));
+        protected readonly TestSuite NestingFixtureSuite = TestBuilder.MakeFixture(typeof(NestingFixture));
+        protected readonly TestSuite NestedFixtureSuite = TestBuilder.MakeFixture(typeof(NestingFixture.NestedFixture));
+        protected readonly TestSuite EmptyNestedFixtureSuite = TestBuilder.MakeFixture(typeof(NestingFixture.EmptyNestedFixture));
+        protected readonly TestSuite TopLevelSuite = new TestSuite("MySuite");
+        protected readonly TestSuite ExplicitFixtureSuite = TestBuilder.MakeFixture(typeof(ExplicitFixture));
+        protected readonly TestSuite SpecialFixtureSuite = TestBuilder.MakeFixture(typeof(SpecialCharactersFixture));
 
         [OneTimeSetUp]
         public void SetUpSuite()
         {
-            _topLevelSuite.Add(_dummyFixture);
-            _topLevelSuite.Add(_anotherFixture);
-            _topLevelSuite.Add(_yetAnotherFixture);
-            _topLevelSuite.Add(_fixtureWithMultipleTests);
-            _topLevelSuite.Add(_nestingFixture);
+            TopLevelSuite.Add(DummyFixtureSuite);
+            TopLevelSuite.Add(AnotherFixtureSuite);
+            TopLevelSuite.Add(YetAnotherFixtureSuite);
+            TopLevelSuite.Add(FixtureWithMultipleTestsSuite);
+            TopLevelSuite.Add(NestingFixtureSuite);
 
-            _nestingFixture.Add(_nestedFixture);
-            _nestingFixture.Add(_emptyNestedFixture);
+            NestingFixtureSuite.Add(NestedFixtureSuite);
+            NestingFixtureSuite.Add(EmptyNestedFixtureSuite);
         }
 
         #region Fixtures Used by Tests

--- a/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestFilterXmlTests.cs
@@ -13,8 +13,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><class>" + TestFilterTests.DUMMY_CLASS + "</class></filter>");
 
             Assert.That(filter, Is.TypeOf<ClassNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -31,8 +31,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><class re='1'>Dummy</class></filter>");
 
             Assert.That(filter, Is.TypeOf<ClassNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -53,9 +53,9 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><method>Test</method></filter>");
 
             Assert.That(filter, Is.TypeOf<MethodNameFilter>());
-            Assert.That(filter.Match(_dummyFixture.Tests[0]));
-            Assert.That(filter.Match(_anotherFixture.Tests[0]));
-            Assert.That(filter.Match(_fixtureWithMultipleTests.Tests[0]), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite.Tests[0]));
+            Assert.That(filter.Match(AnotherFixtureSuite.Tests[0]));
+            Assert.That(filter.Match(FixtureWithMultipleTestsSuite.Tests[0]), Is.False);
         }
 
         [Test]
@@ -72,9 +72,9 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><method re='1'>T.st</method></filter>");
 
             Assert.That(filter, Is.TypeOf<MethodNameFilter>());
-            Assert.That(filter.Match(_dummyFixture.Tests[0]));
-            Assert.That(filter.Match(_anotherFixture.Tests[0]));
-            Assert.That(filter.Match(_fixtureWithMultipleTests.Tests[0]));
+            Assert.That(filter.Match(DummyFixtureSuite.Tests[0]));
+            Assert.That(filter.Match(AnotherFixtureSuite.Tests[0]));
+            Assert.That(filter.Match(FixtureWithMultipleTestsSuite.Tests[0]));
         }
 
         [Test]
@@ -95,8 +95,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><name>TestFilterTests+DummyFixture</name></filter>");
 
             Assert.That(filter, Is.TypeOf<TestNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -113,8 +113,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><name re='1'>Dummy</name></filter>");
 
             Assert.That(filter, Is.TypeOf<TestNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -135,8 +135,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><test>" + TestFilterTests.DUMMY_CLASS + "</test></filter>");
 
             Assert.That(filter, Is.TypeOf<FullNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -153,8 +153,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><test re='1'>Dummy</test></filter>");
 
             Assert.That(filter, Is.TypeOf<FullNameFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -175,8 +175,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><cat>Dummy</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -186,8 +186,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><cat>Special,Character-Fixture+!</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
-            Assert.That(filter.Match(_specialFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(SpecialFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -211,8 +211,8 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><cat re='1'>D.mmy</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -222,8 +222,8 @@ namespace NUnit.Framework.Internal.Filters
                 @"<filter><cat re='1'>Special,Character-Fixture\+!</cat></filter>");
 
             Assert.That(filter, Is.TypeOf<CategoryFilter>());
-            Assert.That(filter.Match(_specialFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(SpecialFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -251,9 +251,9 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><prop name='Priority'>High</prop></filter>");
 
             Assert.That(filter, Is.TypeOf<PropertyFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -270,9 +270,9 @@ namespace NUnit.Framework.Internal.Filters
                 "<filter><prop name='Author' re='1'>Charlie P</prop></filter>");
 
             Assert.That(filter, Is.TypeOf<PropertyFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
-            Assert.That(filter.Match(_yetAnotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
+            Assert.That(filter.Match(YetAnotherFixtureSuite), Is.False);
         }
 
         [Test]
@@ -290,11 +290,11 @@ namespace NUnit.Framework.Internal.Filters
         public void IdFilter_FromXml()
         {
             TestFilter filter = TestFilter.FromXml(
-                $"<filter><id>{_dummyFixture.Id}</id></filter>");
+                $"<filter><id>{DummyFixtureSuite.Id}</id></filter>");
 
             Assert.That(filter, Is.TypeOf<IdFilter>());
-            Assert.That(filter.Match(_dummyFixture));
-            Assert.That(filter.Match(_anotherFixture), Is.False);
+            Assert.That(filter.Match(DummyFixtureSuite));
+            Assert.That(filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/Filters/TestNameFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/TestNameFilterTests.cs
@@ -22,28 +22,28 @@ namespace NUnit.Framework.Internal.Filters
         [Test]
         public void MatchTest()
         {
-            Assert.That(_filter.Match(_dummyFixture));
-            Assert.That(_filter.Match(_anotherFixture), Is.False);
+            Assert.That(_filter.Match(DummyFixtureSuite));
+            Assert.That(_filter.Match(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void PassTest()
         {
-            Assert.That(_filter.Pass(_topLevelSuite));
-            Assert.That(_filter.Pass(_dummyFixture));
-            Assert.That(_filter.Pass(_dummyFixture.Tests[0]));
+            Assert.That(_filter.Pass(TopLevelSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite));
+            Assert.That(_filter.Pass(DummyFixtureSuite.Tests[0]));
 
-            Assert.That(_filter.Pass(_anotherFixture), Is.False);
+            Assert.That(_filter.Pass(AnotherFixtureSuite), Is.False);
         }
 
         [Test]
         public void ExplicitMatchTest()
         {
-            Assert.That(_filter.IsExplicitMatch(_topLevelSuite));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture));
-            Assert.That(_filter.IsExplicitMatch(_dummyFixture.Tests[0]), Is.False);
+            Assert.That(_filter.IsExplicitMatch(TopLevelSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite));
+            Assert.That(_filter.IsExplicitMatch(DummyFixtureSuite.Tests[0]), Is.False);
 
-            Assert.That(_filter.IsExplicitMatch(_anotherFixture), Is.False);
+            Assert.That(_filter.IsExplicitMatch(AnotherFixtureSuite), Is.False);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -39,8 +39,10 @@ namespace NUnit.Framework.Internal
             // Examine grandchildren - child is parameterized method suite
             var suiteResult = result.Children.ToArray()[0];
             foreach (var childResult in suiteResult.Children)
+            {
                 if (childResult.ResultState == ResultState.NotRunnable)
                     invalid++;
+            }
 
             Assert.That(invalid, Is.EqualTo(2), "Invalid count");
         }
@@ -98,8 +100,10 @@ namespace NUnit.Framework.Internal
             // Examine grandchildren - child is parameterized method suite
             var suiteResult = result.Children.ToArray()[0];
             foreach (var childResult in suiteResult.Children)
+            {
                 if (childResult.ResultState == ResultState.NotRunnable)
                     invalid++;
+            }
 
             Assert.That(invalid, Is.EqualTo(2), "Invalid count");
         }
@@ -150,8 +154,10 @@ namespace NUnit.Framework.Internal
             // Examine grandchildren - child is parameterized method suite
             var suiteResult = result.Children.ToArray()[0];
             foreach (var childResult in suiteResult.Children)
+            {
                 if (childResult.ResultState == ResultState.NotRunnable)
                     invalid++;
+            }
 
             Assert.That(invalid, Is.EqualTo(2), "Invalid count");
         }

--- a/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NUnitTestCaseBuilderTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Framework.Internal
             Assert.That(testCase.RunState, Is.EqualTo(expectedState));
         }
 
-        private readonly Type testNameFixtureType = typeof(TestNameFixture);
+        private readonly Type _testNameFixtureType = typeof(TestNameFixture);
 
         [TestCase(nameof(TestNameFixture.ImplicitNull), RunState.Runnable)]
         [TestCase(nameof(TestNameFixture.ExplicitNull), RunState.Runnable)]
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Internal
         [TestCase(nameof(TestNameFixture.ProperNameTest), RunState.Runnable)]
         public void TestNameTests(string methodName, RunState expectedState)
         {
-            var suite = TestBuilder.MakeParameterizedMethodSuite(testNameFixtureType, methodName);
+            var suite = TestBuilder.MakeParameterizedMethodSuite(_testNameFixtureType, methodName);
             var testCase = (Test)suite.Tests[0];
             Assert.That(testCase.RunState, Is.EqualTo(expectedState));
         }

--- a/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
@@ -145,11 +145,13 @@ namespace NUnit.Framework.Internal.Builders
             foreach (var name in names)
             {
                 foreach (var child in suite.Tests)
+                {
                     if (child.Name == name)
                     {
                         suite = child;
                         break;
                     }
+                }
 
                 if (suite.Name != name)
                 {

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -50,8 +50,10 @@ namespace NUnit.Framework.Internal
                 bool shouldPass = false;
 
                 foreach( string platform in expected )
+                {
                     if ( shouldPass = platform.ToLower() == testPlatform.ToLower() )
                         break;
+                }
 
                 bool didPass = helper.IsPlatformSupported( testPlatform );
 

--- a/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
+++ b/src/NUnitFramework/tests/Internal/PlatformDetectionTests.cs
@@ -10,11 +10,11 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class PlatformDetectionTests
     {
-        private static readonly PlatformHelper win95Helper = new PlatformHelper(
+        private static readonly PlatformHelper Win95Helper = new PlatformHelper(
             new OSPlatform( PlatformID.Win32Windows , new Version( 4, 0 ) ),
             new RuntimeFramework( RuntimeType.NetFramework, new Version( 1, 1, 4322, 0 ) ) );
 
-        private static readonly PlatformHelper winXPHelper = new PlatformHelper(
+        private static readonly PlatformHelper WinXPHelper = new PlatformHelper(
             new OSPlatform( PlatformID.Win32NT , new Version( 5,1 ) ),
             new RuntimeFramework( RuntimeType.NetFramework, new Version( 1, 1, 4322, 0 ) ) );
 
@@ -355,27 +355,27 @@ namespace NUnit.Framework.Internal
         [Test]
         public void DetectExactVersion()
         {
-            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322" ), Is.True);
-            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322.0" ), Is.True);
-            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4323.0" ), Is.False);
-            Assert.That( winXPHelper.IsPlatformSupported( "net-1.1.4322.1" ), Is.False);
+            Assert.That( WinXPHelper.IsPlatformSupported( "net-1.1.4322" ), Is.True);
+            Assert.That( WinXPHelper.IsPlatformSupported( "net-1.1.4322.0" ), Is.True);
+            Assert.That( WinXPHelper.IsPlatformSupported( "net-1.1.4323.0" ), Is.False);
+            Assert.That( WinXPHelper.IsPlatformSupported( "net-1.1.4322.1" ), Is.False);
         }
 
         [Test]
         public void ArrayOfPlatforms()
         {
             string[] platforms = new[] { "NT4", "Win2K", "WinXP" };
-            Assert.That( winXPHelper.IsPlatformSupported( platforms ), Is.True);
-            Assert.That( win95Helper.IsPlatformSupported( platforms ), Is.False);
+            Assert.That( WinXPHelper.IsPlatformSupported( platforms ), Is.True);
+            Assert.That( Win95Helper.IsPlatformSupported( platforms ), Is.False);
         }
 
         [Test]
         public void PlatformAttribute_Include()
         {
             PlatformAttribute attr = new PlatformAttribute( "Win2K,WinXP,NT4" );
-            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.True);
-            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
-            Assert.That(win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
+            Assert.That( WinXPHelper.IsPlatformSupported( attr ), Is.True);
+            Assert.That( Win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That(Win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
         }
 
         [Test]
@@ -383,9 +383,9 @@ namespace NUnit.Framework.Internal
         {
             PlatformAttribute attr = new PlatformAttribute();
             attr.Exclude = "Win2K,WinXP,NT4";
-            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.False);
-            Assert.That( winXPHelper.Reason, Is.EqualTo("Not supported on Win2K,WinXP,NT4"));
-            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.True);
+            Assert.That( WinXPHelper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( WinXPHelper.Reason, Is.EqualTo("Not supported on Win2K,WinXP,NT4"));
+            Assert.That( Win95Helper.IsPlatformSupported( attr ), Is.True);
         }
 
         [Test]
@@ -393,14 +393,14 @@ namespace NUnit.Framework.Internal
         {
             PlatformAttribute attr = new PlatformAttribute( "Win2K,WinXP,NT4" );
             attr.Exclude = "Mono";
-            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
-            Assert.That( win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
-            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.True);
+            Assert.That( Win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( Win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
+            Assert.That( WinXPHelper.IsPlatformSupported( attr ), Is.True);
             attr.Exclude = "Net";
-            Assert.That( win95Helper.IsPlatformSupported( attr ), Is.False);
-            Assert.That( win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
-            Assert.That( winXPHelper.IsPlatformSupported( attr ), Is.False);
-            Assert.That( winXPHelper.Reason, Is.EqualTo("Not supported on Net"));
+            Assert.That( Win95Helper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( Win95Helper.Reason, Is.EqualTo("Only supported on Win2K,WinXP,NT4"));
+            Assert.That( WinXPHelper.IsPlatformSupported( attr ), Is.False);
+            Assert.That( WinXPHelper.Reason, Is.EqualTo("Not supported on Net"));
         }
 
         [Test]
@@ -408,7 +408,7 @@ namespace NUnit.Framework.Internal
         {
             PlatformAttribute attr = new PlatformAttribute( "Net-1.0,Net11,Mono" );
             Assert.Throws<InvalidPlatformException>(
-                () => winXPHelper.IsPlatformSupported(attr),
+                () => WinXPHelper.IsPlatformSupported(attr),
                 "Invalid platform name Net11");
         }
 

--- a/src/NUnitFramework/tests/Internal/PropertyBagTests.cs
+++ b/src/NUnitFramework/tests/Internal/PropertyBagTests.cs
@@ -9,87 +9,87 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class PropertyBagTests
     {
-        private PropertyBag bag;
+        private PropertyBag _bag;
 
         [SetUp]
         public void SetUp()
         {
-            bag = new PropertyBag();
-            bag.Add("Answer", 42);
-            bag.Add("Tag", "bug");
-            bag.Add("Tag", "easy");
+            _bag = new PropertyBag();
+            _bag.Add("Answer", 42);
+            _bag.Add("Tag", "bug");
+            _bag.Add("Tag", "easy");
         }
 
         [Test]
         public void IndexGetsListOfValues()
         {
-            Assert.That(bag["Answer"], Has.Count.EqualTo(1));
-            Assert.That(bag["Answer"], Contains.Item(42));
+            Assert.That(_bag["Answer"], Has.Count.EqualTo(1));
+            Assert.That(_bag["Answer"], Contains.Item(42));
 
-            Assert.That(bag["Tag"], Has.Count.EqualTo(2));
-            Assert.That(bag["Tag"], Contains.Item("bug"));
-            Assert.That(bag["Tag"], Contains.Item("easy"));
+            Assert.That(_bag["Tag"], Has.Count.EqualTo(2));
+            Assert.That(_bag["Tag"], Contains.Item("bug"));
+            Assert.That(_bag["Tag"], Contains.Item("easy"));
         }
 
         [Test]
         public void IndexGetsEmptyListIfNameIsNotPresent()
         {
-            Assert.That(bag["Level"], Is.Empty);
+            Assert.That(_bag["Level"], Is.Empty);
         }
 
         [Test]
         public void IndexSetsListOfValues()
         {
-            bag["Zip"] = new[] {"junk", "more junk"};
-            Assert.That(bag["Zip"], Has.Count.EqualTo(2));
-            Assert.That(bag["Zip"], Contains.Item("junk"));
-            Assert.That(bag["Zip"], Contains.Item("more junk"));
+            _bag["Zip"] = new[] {"junk", "more junk"};
+            Assert.That(_bag["Zip"], Has.Count.EqualTo(2));
+            Assert.That(_bag["Zip"], Contains.Item("junk"));
+            Assert.That(_bag["Zip"], Contains.Item("more junk"));
         }
 
         [Test]
         public void AllKeysAreListed()
         {
-            Assert.That(bag.Keys, Has.Count.EqualTo(2));
-            Assert.That(bag.Keys, Has.Member("Answer"));
-            Assert.That(bag.Keys, Has.Member("Tag"));
+            Assert.That(_bag.Keys, Has.Count.EqualTo(2));
+            Assert.That(_bag.Keys, Has.Member("Answer"));
+            Assert.That(_bag.Keys, Has.Member("Tag"));
         }
 
         [Test]
         public void ContainsKey()
         {
-            Assert.That(bag.ContainsKey("Answer"));
-            Assert.That(bag.ContainsKey("Tag"));
-            Assert.That(bag.ContainsKey("Target"), Is.False);
+            Assert.That(_bag.ContainsKey("Answer"));
+            Assert.That(_bag.ContainsKey("Tag"));
+            Assert.That(_bag.ContainsKey("Target"), Is.False);
         }
 
         [Test]
         public void GetReturnsSingleValue()
         {
-            Assert.That(bag.Get("Answer"), Is.EqualTo(42));
-            Assert.That(bag.Get("Tag"), Is.EqualTo("bug"));
+            Assert.That(_bag.Get("Answer"), Is.EqualTo(42));
+            Assert.That(_bag.Get("Tag"), Is.EqualTo("bug"));
         }
 
         [Test]
         public void SetAddsNewSingleValue()
         {
-            bag.Set("Zip", "ZAP");
-            Assert.That(bag["Zip"], Has.Count.EqualTo(1));
-            Assert.That(bag["Zip"], Has.Member("ZAP"));
-            Assert.That(bag.Get("Zip"), Is.EqualTo("ZAP"));
+            _bag.Set("Zip", "ZAP");
+            Assert.That(_bag["Zip"], Has.Count.EqualTo(1));
+            Assert.That(_bag["Zip"], Has.Member("ZAP"));
+            Assert.That(_bag.Get("Zip"), Is.EqualTo("ZAP"));
         }
 
         [Test]
         public void SetReplacesOldValues()
         {
-            bag.Set("Tag", "ZAPPED");
-            Assert.That(bag["Tag"], Has.Count.EqualTo(1));
-            Assert.That(bag.Get("Tag"), Is.EqualTo("ZAPPED"));
+            _bag.Set("Tag", "ZAPPED");
+            Assert.That(_bag["Tag"], Has.Count.EqualTo(1));
+            Assert.That(_bag.Get("Tag"), Is.EqualTo("ZAPPED"));
         }
 
         [Test]
         public void XmlIsProducedCorrectly()
         {
-            TNode topNode = bag.ToXml(true);
+            TNode topNode = _bag.ToXml(true);
             Assert.That(topNode.Name, Is.EqualTo("properties"));
 
             string[] props = new string[topNode.ChildNodes.Count];
@@ -109,18 +109,18 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestNullPropertyValueIsntAdded()
         {
-            Assert.Throws<ArgumentNullException>(() => bag.Add("dontAddMe", null!));
-            Assert.That(bag.ContainsKey("dontAddMe"), Is.False);
+            Assert.Throws<ArgumentNullException>(() => _bag.Add("dontAddMe", null!));
+            Assert.That(_bag.ContainsKey("dontAddMe"), Is.False);
         }
 
         [Test]
         public void TestTryGet()
         {
-            Assert.That(bag.TryGet("Answer", 37), Is.EqualTo(42));
-            Assert.That(bag.TryGet("WrongAnswer", 37), Is.EqualTo(37));
+            Assert.That(_bag.TryGet("Answer", 37), Is.EqualTo(42));
+            Assert.That(_bag.TryGet("WrongAnswer", 37), Is.EqualTo(37));
 
-            Assert.That(bag.TryGet("Tag", "none"), Is.EqualTo("bug"));
-            Assert.That(bag.TryGet("Target", "netstandard"), Is.EqualTo("netstandard"));
+            Assert.That(_bag.TryGet("Tag", "none"), Is.EqualTo("bug"));
+            Assert.That(_bag.TryGet("Target", "netstandard"), Is.EqualTo("netstandard"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/RandomizerTests.cs
+++ b/src/NUnitFramework/tests/Internal/RandomizerTests.cs
@@ -689,7 +689,7 @@ namespace NUnit.Framework.Internal
             [Test]
             public static void ReturnsSameRandomizerForSameParameter()
             {
-                ParameterInfo p = testMethod1.GetParameters()[0];
+                ParameterInfo p = TestMethod1Info.GetParameters()[0];
                 var r1 = Randomizer.GetRandomizer(p);
                 var r2 = Randomizer.GetRandomizer(p);
                 Assert.That(r1, Is.SameAs(r2));
@@ -698,8 +698,8 @@ namespace NUnit.Framework.Internal
             [Test]
             public static void ReturnsSameRandomizerForDifferentParametersOfSameMethod()
             {
-                ParameterInfo p1 = testMethod1.GetParameters()[0];
-                ParameterInfo p2 = testMethod1.GetParameters()[1];
+                ParameterInfo p1 = TestMethod1Info.GetParameters()[0];
+                ParameterInfo p2 = TestMethod1Info.GetParameters()[1];
                 var r1 = Randomizer.GetRandomizer(p1);
                 var r2 = Randomizer.GetRandomizer(p2);
                 Assert.That(r1, Is.SameAs(r2));
@@ -708,26 +708,26 @@ namespace NUnit.Framework.Internal
             [Test]
             public static void ReturnsSameRandomizerForSameMethod()
             {
-                var r1 = Randomizer.GetRandomizer(testMethod1);
-                var r2 = Randomizer.GetRandomizer(testMethod1);
+                var r1 = Randomizer.GetRandomizer(TestMethod1Info);
+                var r2 = Randomizer.GetRandomizer(TestMethod1Info);
                 Assert.That(r1, Is.SameAs(r2));
             }
 
             [Test]
             public static void ReturnsDifferentRandomizersForDifferentMethods()
             {
-                var r1 = Randomizer.GetRandomizer(testMethod1);
-                var r2 = Randomizer.GetRandomizer(testMethod2);
+                var r1 = Randomizer.GetRandomizer(TestMethod1Info);
+                var r2 = Randomizer.GetRandomizer(TestMethod2Info);
                 Assert.That(r1, Is.Not.SameAs(r2));
             }
 
-            private static readonly MethodInfo testMethod1 =
+            private static readonly MethodInfo TestMethod1Info =
                 typeof(Repeatability).GetMethod(nameof(TestMethod1), BindingFlags.NonPublic | BindingFlags.Static)!;
             private static void TestMethod1(int x, int y)
             {
             }
 
-            private static readonly MethodInfo testMethod2 =
+            private static readonly MethodInfo TestMethod2Info =
                 typeof(Repeatability).GetMethod(nameof(TestMethod2), BindingFlags.NonPublic | BindingFlags.Static)!;
             private static void TestMethod2(int x, int y)
             {

--- a/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/AssertionResultTests.cs
@@ -10,13 +10,13 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Success, "Test passed!");
+            TestResult.SetResult(ResultState.Success, "Test passed!");
 
             RecordExpectedAssertions(
                 new AssertionResult(AssertionStatus.Passed, "Message 1", "Stack 1"),
                 new AssertionResult(AssertionStatus.Failed, "Message 2", "Stack 2"));
 
-            _suiteResult.AddResult(_testResult);
+            SuiteResult.AddResult(TestResult);
         }
 
         private readonly List<AssertionResult> _expectedAssertions = new List<AssertionResult>();
@@ -26,25 +26,25 @@ namespace NUnit.Framework.Internal.Results
             _expectedAssertions.AddRange(expectedAssertions);
 
             foreach (var assertion in _expectedAssertions)
-                _testResult.RecordAssertion(assertion);
+                TestResult.RecordAssertion(assertion);
         }
 
         [Test]
         public void TestResult_AssertionResults()
         {
-            Assert.That(_testResult.AssertionResults, Is.EqualTo(_expectedAssertions));
+            Assert.That(TestResult.AssertionResults, Is.EqualTo(_expectedAssertions));
         }
 
         [Test]
         public void SuiteResult_AssertionResults()
         {
-            Assert.That(_suiteResult.AssertionResults, Is.Empty);
+            Assert.That(SuiteResult.AssertionResults, Is.Empty);
         }
 
         [Test]
         public void TestResultXml_AssertionResults()
         {
-            TNode? assertionResults = _testResult.ToXml(true).SelectSingleNode("assertions");
+            TNode? assertionResults = TestResult.ToXml(true).SelectSingleNode("assertions");
 
             if (_expectedAssertions.Count == 0)
             {
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXml_AssertionResults()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
             Assert.That(suiteNode.SelectSingleNode("assertions"), Is.Null);
         }
     }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
@@ -11,8 +11,8 @@ namespace NUnit.Framework.Internal.Results
     {
         private IEnumerable<TestResult> TestResults => new[]
         {
-            _testResult,
-            _suiteResult
+            TestResult,
+            SuiteResult
         };
 
         private static IEnumerable<Action<TestResult, Exception>> RecordExceptionMethods => new Action<TestResult, Exception>[]

--- a/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
@@ -26,11 +26,13 @@ namespace NUnit.Framework.Internal.Results
         public void ThrowsForNullException()
         {
             foreach (var method in RecordExceptionMethods)
-            foreach (var result in TestResults)
+            {
+                foreach (var result in TestResults)
             {
                 Assert.That(
                     () => method.Invoke(result, null!),
                     Throws.ArgumentNullException.With.Property("ParamName").EqualTo("ex"));
+            }
             }
         }
 
@@ -46,10 +48,14 @@ namespace NUnit.Framework.Internal.Results
             };
 
             foreach (var method in RecordExceptionMethods)
-            foreach (var result in TestResults)
-            foreach (var exception in exceptions)
+            {
+                foreach (var result in TestResults)
+                {
+                    foreach (var exception in exceptions)
             {
                 method.Invoke(result, exception);
+            }
+                }
             }
         }
     }

--- a/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
@@ -104,10 +104,10 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Failure, _failureReason, _stackTrace);
-            _testResult.AssertCount = 3;
+            TestResult.SetResult(ResultState.Failure, _failureReason, _stackTrace);
+            TestResult.AssertCount = 3;
 
-            _suiteResult.AddResult(_testResult);
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -115,10 +115,10 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Failure));
-                Assert.That(_testResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(_testResult.Message, Is.EqualTo(_failureReason));
-                Assert.That(_testResult.StackTrace, Is.EqualTo(_stackTrace));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.Failure));
+                Assert.That(TestResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(TestResult.Message, Is.EqualTo(_failureReason));
+                Assert.That(TestResult.StackTrace, Is.EqualTo(_stackTrace));
             });
         }
 
@@ -127,25 +127,25 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
-                Assert.That(_suiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
-                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-                Assert.That(_suiteResult.StackTrace, Is.Null);
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(3));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(SuiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(SuiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(SuiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(SuiteResult.StackTrace, Is.Null);
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(3));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsFailure()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -162,8 +162,8 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultXmlNodeEscapesInvalidXmlCharacters()
         {
-            _testResult.SetResult(ResultState.Failure, "Invalid Characters: \u0001\u0008\u000b\u001f\ud800; Valid Characters: \u0009\u000a\u000d\u0020\ufffd\ud800\udc00");
-            TNode testNode = _testResult.ToXml(true);
+            TestResult.SetResult(ResultState.Failure, "Invalid Characters: \u0001\u0008\u000b\u001f\ud800; Valid Characters: \u0009\u000a\u000d\u0020\ufffd\ud800\udc00");
+            TNode testNode = TestResult.ToXml(true);
             TNode? failureNode = testNode.SelectSingleNode("failure");
 
             Assert.That(failureNode, Is.Not.Null, "No <failure> element found");
@@ -177,7 +177,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsFailure()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultGeneralTests.cs
@@ -24,105 +24,105 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _test.Properties.Set(PropertyNames.Description, TEST_DESCRIPTION);
-            _test.Properties.Set(PropertyNames.Category, TEST_CATEGORY);
-            _test.Properties.Set("Priority", TEST_PRIORITY);
+            Test.Properties.Set(PropertyNames.Description, TEST_DESCRIPTION);
+            Test.Properties.Set(PropertyNames.Category, TEST_CATEGORY);
+            Test.Properties.Set("Priority", TEST_PRIORITY);
 
-            _suite.Properties.Set(PropertyNames.Description, SUITE_DESCRIPTION);
-            _suite.Properties.Set(PropertyNames.Category, SUITE_CATEGORY);
-            _suite.Properties.Set("Level", SUITE_LEVEL);
+            Suite.Properties.Set(PropertyNames.Description, SUITE_DESCRIPTION);
+            Suite.Properties.Set(PropertyNames.Category, SUITE_CATEGORY);
+            Suite.Properties.Set("Level", SUITE_LEVEL);
 
-            _testResult.StartTime = EXPECTED_START;
-            _testResult.Duration = EXPECTED_DURATION;
-            _testResult.EndTime = EXPECTED_END;
+            TestResult.StartTime = EXPECTED_START;
+            TestResult.Duration = EXPECTED_DURATION;
+            TestResult.EndTime = EXPECTED_END;
 
-            _suiteResult.StartTime = EXPECTED_START;
-            _suiteResult.Duration = EXPECTED_DURATION;
-            _suiteResult.EndTime = EXPECTED_END;
+            SuiteResult.StartTime = EXPECTED_START;
+            SuiteResult.Duration = EXPECTED_DURATION;
+            SuiteResult.EndTime = EXPECTED_END;
         }
 
         [Test]
         public void TestResult_Identification()
         {
-            Assert.That(_testResult.Name, Is.EqualTo(_test.Name));
-            Assert.That(_testResult.FullName, Is.EqualTo(_test.FullName));
+            Assert.That(TestResult.Name, Is.EqualTo(Test.Name));
+            Assert.That(TestResult.FullName, Is.EqualTo(Test.FullName));
         }
 
         [Test]
         public void TestResult_Properties()
         {
-            Assert.That(_testResult.Test.Properties.Get(PropertyNames.Description), Is.EqualTo(TEST_DESCRIPTION));
-            Assert.That(_testResult.Test.Properties.Get(PropertyNames.Category), Is.EqualTo(TEST_CATEGORY));
-            Assert.That(_testResult.Test.Properties.Get("Priority"), Is.EqualTo(TEST_PRIORITY));
+            Assert.That(TestResult.Test.Properties.Get(PropertyNames.Description), Is.EqualTo(TEST_DESCRIPTION));
+            Assert.That(TestResult.Test.Properties.Get(PropertyNames.Category), Is.EqualTo(TEST_CATEGORY));
+            Assert.That(TestResult.Test.Properties.Get("Priority"), Is.EqualTo(TEST_PRIORITY));
         }
 
         [Test]
         public void TestResult_Duration()
         {
-            Assert.That(_testResult.StartTime, Is.EqualTo(EXPECTED_START));
-            Assert.That(_testResult.EndTime, Is.EqualTo(EXPECTED_END));
-            Assert.That(_testResult.Duration, Is.EqualTo(EXPECTED_DURATION));
+            Assert.That(TestResult.StartTime, Is.EqualTo(EXPECTED_START));
+            Assert.That(TestResult.EndTime, Is.EqualTo(EXPECTED_END));
+            Assert.That(TestResult.Duration, Is.EqualTo(EXPECTED_DURATION));
         }
 
         [Test]
         public void TestResult_MinimumDuration()
         {
             // Change duration to value less than minimum
-            _testResult.Duration = TestResult.MIN_DURATION - 0.000001d;
+            TestResult.Duration = TestResult.MIN_DURATION - 0.000001d;
 
-            Assert.That(_testResult.Duration, Is.EqualTo(TestResult.MIN_DURATION));
+            Assert.That(TestResult.Duration, Is.EqualTo(TestResult.MIN_DURATION));
         }
 
         [Test]
         public void SuiteResult_Identification()
         {
-            Assert.That(_suiteResult.Name, Is.EqualTo(_suite.Name));
-            Assert.That(_suiteResult.FullName, Is.EqualTo(_suite.FullName));
+            Assert.That(SuiteResult.Name, Is.EqualTo(Suite.Name));
+            Assert.That(SuiteResult.FullName, Is.EqualTo(Suite.FullName));
         }
 
         [Test]
         public void SuiteResult_Properties()
         {
-            Assert.That(_suiteResult.Test.Properties.Get(PropertyNames.Description), Is.EqualTo(SUITE_DESCRIPTION));
-            Assert.That(_suiteResult.Test.Properties.Get(PropertyNames.Category), Is.EqualTo(SUITE_CATEGORY));
-            Assert.That(_suiteResult.Test.Properties.Get("Level"), Is.EqualTo(SUITE_LEVEL));
+            Assert.That(SuiteResult.Test.Properties.Get(PropertyNames.Description), Is.EqualTo(SUITE_DESCRIPTION));
+            Assert.That(SuiteResult.Test.Properties.Get(PropertyNames.Category), Is.EqualTo(SUITE_CATEGORY));
+            Assert.That(SuiteResult.Test.Properties.Get("Level"), Is.EqualTo(SUITE_LEVEL));
         }
 
         [Test]
         public void SuiteResult_Duration()
         {
-            Assert.That(_suiteResult.StartTime, Is.EqualTo(EXPECTED_START));
-            Assert.That(_suiteResult.EndTime, Is.EqualTo(EXPECTED_END));
-            Assert.That(_suiteResult.Duration, Is.EqualTo(EXPECTED_DURATION));
+            Assert.That(SuiteResult.StartTime, Is.EqualTo(EXPECTED_START));
+            Assert.That(SuiteResult.EndTime, Is.EqualTo(EXPECTED_END));
+            Assert.That(SuiteResult.Duration, Is.EqualTo(EXPECTED_DURATION));
         }
 
         [Test]
         public void SuiteResult_MinimumDuration()
         {
             // Change duration to value less than minimum
-            _suiteResult.Duration = TestResult.MIN_DURATION - 0.000001d;
+            SuiteResult.Duration = TestResult.MIN_DURATION - 0.000001d;
 
-            Assert.That(_suiteResult.Duration, Is.EqualTo(TestResult.MIN_DURATION));
+            Assert.That(SuiteResult.Duration, Is.EqualTo(TestResult.MIN_DURATION));
         }
 
         [Test]
         public void TestResultXml_Identification()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
                 Assert.That(testNode.Attributes["id"], Is.Not.Null);
                 Assert.That(testNode.Name, Is.EqualTo("test-case"));
-                Assert.That(testNode.Attributes["name"], Is.EqualTo(_testResult.Name));
-                Assert.That(testNode.Attributes["fullname"], Is.EqualTo(_testResult.FullName));
+                Assert.That(testNode.Attributes["name"], Is.EqualTo(TestResult.Name));
+                Assert.That(testNode.Attributes["fullname"], Is.EqualTo(TestResult.FullName));
             });
         }
 
         [Test]
         public void TestResultXml_Properties()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultXml_NoChildren()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.That(testNode.SelectNodes("test-case"), Is.Empty);
         }
@@ -143,7 +143,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void TestResultXml_Duration()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -156,21 +156,21 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXml_Identification()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
                 Assert.That(suiteNode.Attributes["id"], Is.Not.Null);
                 Assert.That(suiteNode.Name, Is.EqualTo("test-suite"));
-                Assert.That(suiteNode.Attributes["name"], Is.EqualTo(_suiteResult.Name));
-                Assert.That(suiteNode.Attributes["fullname"], Is.EqualTo(_suiteResult.FullName));
+                Assert.That(suiteNode.Attributes["name"], Is.EqualTo(SuiteResult.Name));
+                Assert.That(suiteNode.Attributes["fullname"], Is.EqualTo(SuiteResult.FullName));
             });
         }
 
         [Test]
         public void SuiteResultXml_Properties()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -183,15 +183,15 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXml_Children()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
-            Assert.That(suiteNode.SelectNodes("test-case"), Has.Count.EqualTo(_suiteResult.Children.Count()));
+            Assert.That(suiteNode.SelectNodes("test-case"), Has.Count.EqualTo(SuiteResult.Children.Count()));
         }
 
         [Test]
         public void SuiteResultXml_Duration()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Ignored, _ignoreReason);
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Ignored, _ignoreReason);
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -56,8 +56,8 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Ignored));
-                Assert.That(_testResult.Message, Is.EqualTo(_ignoreReason));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.Ignored));
+                Assert.That(TestResult.Message, Is.EqualTo(_ignoreReason));
             });
         }
 
@@ -66,22 +66,22 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildIgnored));
-                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_IGNORE_MESSAGE));
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.ChildIgnored));
+                Assert.That(SuiteResult.Message, Is.EqualTo(TestResult.CHILD_IGNORE_MESSAGE));
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(0));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsIgnored()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsIgnored()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -47,8 +47,8 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Inconclusive, _inconclusiveReason);
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Inconclusive, _inconclusiveReason);
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -56,8 +56,8 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
-                Assert.That(_testResult.Message, Is.EqualTo(_inconclusiveReason));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
+                Assert.That(TestResult.Message, Is.EqualTo(_inconclusiveReason));
             });
         }
 
@@ -66,22 +66,22 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
-                Assert.That(_suiteResult.Message, Is.Null);
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
+                Assert.That(SuiteResult.Message, Is.Null);
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(0));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsInconclusive()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsInconclusive()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultMixedResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultMixedResultTests.cs
@@ -9,25 +9,25 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Success);
-            _testResult.AssertCount = 2;
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Success);
+            TestResult.AssertCount = 2;
+            SuiteResult.AddResult(TestResult);
 
-            _testResult.SetResult(ResultState.Failure, "message", "stack trace");
-            _testResult.AssertCount = 1;
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Failure, "message", "stack trace");
+            TestResult.AssertCount = 1;
+            SuiteResult.AddResult(TestResult);
 
-            _testResult.SetResult(ResultState.Success);
-            _testResult.AssertCount = 3;
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Success);
+            TestResult.AssertCount = 3;
+            SuiteResult.AddResult(TestResult);
 
-            _testResult.SetResult(ResultState.Inconclusive, "inconclusive reason", "stacktrace");
-            _testResult.AssertCount = 0;
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Inconclusive, "inconclusive reason", "stacktrace");
+            TestResult.AssertCount = 0;
+            SuiteResult.AddResult(TestResult);
 
-            _testResult.SetResult(ResultState.Warning, "message", "warning");
-            _testResult.AssertCount = 0;
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Warning, "message", "warning");
+            TestResult.AssertCount = 0;
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -35,25 +35,25 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
-                Assert.That(_suiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
-                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-                Assert.That(_suiteResult.StackTrace, Is.Null, "There should be no stacktrace");
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(5));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(2));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(6));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(SuiteResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(SuiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(SuiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(SuiteResult.StackTrace, Is.Null, "There should be no stacktrace");
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(5));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(2));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(6));
             });
         }
 
         [Test]
         public void SuiteResultXmlNodeIsFailure()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.That(suiteNode.Attributes["result"], Is.EqualTo("Failed"));
             TNode? failureNode = suiteNode.SelectSingleNode("failure");

--- a/src/NUnitFramework/tests/Internal/Results/TestResultNotRunnableTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultNotRunnableTests.cs
@@ -9,8 +9,8 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.NotRunnable, "bad test");
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.NotRunnable, "bad test");
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -18,8 +18,8 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.NotRunnable));
-                Assert.That(_testResult.Message, Is.EqualTo("bad test"));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.NotRunnable));
+                Assert.That(TestResult.Message, Is.EqualTo("bad test"));
             });
         }
 
@@ -28,23 +28,23 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
-                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
-                Assert.That(_suiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.ChildFailure));
+                Assert.That(SuiteResult.Message, Is.EqualTo(TestResult.CHILD_ERRORS_MESSAGE));
+                Assert.That(SuiteResult.ResultState.Site, Is.EqualTo(FailureSite.Child));
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(0));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsNotRunnable()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsFailure()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
@@ -49,10 +49,10 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Success, _successMessage);
-            _testResult.AssertCount = 2;
+            TestResult.SetResult(ResultState.Success, _successMessage);
+            TestResult.AssertCount = 2;
 
-            _suiteResult.AddResult(_testResult);
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -60,8 +60,8 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Success));
-                Assert.That(_testResult.Message, Is.EqualTo(_successMessage));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.Success));
+                Assert.That(TestResult.Message, Is.EqualTo(_successMessage));
             });
         }
 
@@ -70,21 +70,21 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.Success));
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(2));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.Success));
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(2));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsSuccess()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsSuccess()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultTests.cs
@@ -11,20 +11,20 @@ namespace NUnit.Framework.Internal.Results
     public abstract class TestResultTests
     {
         protected const string NonWhitespaceIgnoreReason = "because";
-        protected TestMethod _test;
-        protected TestResult _testResult;
+        protected TestMethod Test;
+        protected TestResult TestResult;
 
-        protected TestSuite _suite;
-        protected TestSuiteResult _suiteResult;
+        protected TestSuite Suite;
+        protected TestSuiteResult SuiteResult;
 
         [SetUp]
         public void SetUp()
         {
-            _test = new TestMethod(new MethodWrapper(typeof(DummySuite), "DummyMethod"));
-            _testResult = _test.MakeTestResult();
+            Test = new TestMethod(new MethodWrapper(typeof(DummySuite), "DummyMethod"));
+            TestResult = Test.MakeTestResult();
 
-            _suite = new TestSuite(typeof(DummySuite));
-            _suiteResult = (TestSuiteResult)_suite.MakeTestResult();
+            Suite = new TestSuite(typeof(DummySuite));
+            SuiteResult = (TestSuiteResult)Suite.MakeTestResult();
         }
 
         protected static void ReasonNodeExpectedValidation(TNode testNode, string reasonMessage)

--- a/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultWarningTests.cs
@@ -9,8 +9,8 @@ namespace NUnit.Framework.Internal.Results
         [SetUp]
         public void SimulateTestRun()
         {
-            _testResult.SetResult(ResultState.Warning, "Warning message");
-            _suiteResult.AddResult(_testResult);
+            TestResult.SetResult(ResultState.Warning, "Warning message");
+            SuiteResult.AddResult(TestResult);
         }
 
         [Test]
@@ -18,8 +18,8 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_testResult.ResultState, Is.EqualTo(ResultState.Warning));
-                Assert.That(_testResult.Message, Is.EqualTo("Warning message"));
+                Assert.That(TestResult.ResultState, Is.EqualTo(ResultState.Warning));
+                Assert.That(TestResult.Message, Is.EqualTo("Warning message"));
             });
         }
 
@@ -28,22 +28,22 @@ namespace NUnit.Framework.Internal.Results
         {
             Assert.Multiple(() =>
             {
-                Assert.That(_suiteResult.ResultState, Is.EqualTo(ResultState.ChildWarning));
-                Assert.That(_suiteResult.Message, Is.EqualTo(TestResult.CHILD_WARNINGS_MESSAGE));
-                Assert.That(_suiteResult.TotalCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.PassCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.FailCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.WarningCount, Is.EqualTo(1));
-                Assert.That(_suiteResult.SkipCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.InconclusiveCount, Is.EqualTo(0));
-                Assert.That(_suiteResult.AssertCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.ChildWarning));
+                Assert.That(SuiteResult.Message, Is.EqualTo(TestResult.CHILD_WARNINGS_MESSAGE));
+                Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.FailCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.WarningCount, Is.EqualTo(1));
+                Assert.That(SuiteResult.SkipCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.InconclusiveCount, Is.EqualTo(0));
+                Assert.That(SuiteResult.AssertCount, Is.EqualTo(0));
             });
         }
 
         [Test]
         public void TestResultXmlNodeIsWarning()
         {
-            TNode testNode = _testResult.ToXml(true);
+            TNode testNode = TestResult.ToXml(true);
 
             Assert.Multiple(() =>
             {
@@ -62,7 +62,7 @@ namespace NUnit.Framework.Internal.Results
         [Test]
         public void SuiteResultXmlNodeIsWarning()
         {
-            TNode suiteNode = _suiteResult.ToXml(true);
+            TNode suiteNode = SuiteResult.ToXml(true);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -8,9 +8,9 @@ namespace NUnit.Framework.Internal
     public class RuntimeFrameworkTests
     {
 #if NETCOREAPP
-        private static readonly RuntimeType currentRuntime = RuntimeType.NetCore;
+        private static readonly RuntimeType CurrentRuntime = RuntimeType.NetCore;
 #else
-        private static readonly RuntimeType currentRuntime =
+        private static readonly RuntimeType CurrentRuntime =
             Type.GetType("Mono.Runtime", false) is not null
                 ? RuntimeType.Mono
                 : RuntimeType.NetFramework;
@@ -22,13 +22,13 @@ namespace NUnit.Framework.Internal
             RuntimeFramework framework = RuntimeFramework.CurrentFramework;
             Assert.Multiple(() =>
             {
-                Assert.That(framework.Runtime, Is.EqualTo(currentRuntime), "#1");
+                Assert.That(framework.Runtime, Is.EqualTo(CurrentRuntime), "#1");
                 Assert.That(framework.ClrVersion, Is.EqualTo(Environment.Version), "#2");
             });
         }
 
         [Test]
-        [TestCaseSource(nameof(netcoreRuntimes))]
+        [TestCaseSource(nameof(NetcoreRuntimes))]
         public void SpecifyingNetCoreVersioningThrowsPlatformException(string netcoreRuntime)
         {
             PlatformHelper platformHelper = new PlatformHelper();
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal
             Assert.That(platformHelper.IsPlatformSupported("netcore"), Is.EqualTo(isNetCore));
         }
 
-        [TestCaseSource(nameof(frameworkData))]
+        [TestCaseSource(nameof(FrameworkTestData))]
         public void CanCreateUsingFrameworkVersion(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.Runtime, data.FrameworkVersion);
@@ -60,7 +60,7 @@ namespace NUnit.Framework.Internal
             });
         }
 
-        [TestCaseSource(nameof(frameworkData))]
+        [TestCaseSource(nameof(FrameworkTestData))]
         public void CanCreateUsingClrVersion(FrameworkData data)
         {
             Assume.That(data.FrameworkVersion.Major != 3, "#0");
@@ -77,7 +77,7 @@ namespace NUnit.Framework.Internal
             });
         }
 
-        [TestCaseSource(nameof(frameworkData))]
+        [TestCaseSource(nameof(FrameworkTestData))]
         public void CanParseRuntimeFramework(FrameworkData data)
         {
             RuntimeFramework framework = RuntimeFramework.Parse(data.Representation);
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Internal
             });
         }
 
-        [TestCaseSource(nameof(frameworkData))]
+        [TestCaseSource(nameof(FrameworkTestData))]
         public void CanDisplayFrameworkAsString(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.Runtime, data.FrameworkVersion);
@@ -99,13 +99,13 @@ namespace NUnit.Framework.Internal
             });
         }
 
-        [TestCaseSource(nameof(matchData))]
+        [TestCaseSource(nameof(MatchData))]
         public bool CanMatchRuntimes(RuntimeFramework f1, RuntimeFramework f2)
         {
             return f1.Supports(f2);
         }
 
-        internal static TestCaseData[] matchData = new TestCaseData[] {
+        internal static TestCaseData[] MatchData = new TestCaseData[] {
             new TestCaseData(
                 new RuntimeFramework(RuntimeType.NetFramework, new Version(3,5)),
                 new RuntimeFramework(RuntimeType.NetFramework, new Version(2,0)))
@@ -300,7 +300,7 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        internal static FrameworkData[] frameworkData = new FrameworkData[] {
+        internal static FrameworkData[] FrameworkTestData = new FrameworkData[] {
             new FrameworkData(RuntimeType.NetFramework, new Version(1,0), new Version(1,0,3705), "net-1.0", "Net 1.0"),
             new FrameworkData(RuntimeType.NetFramework, new Version(1,1), new Version(1,1,4322), "net-1.1", "Net 1.1"),
             new FrameworkData(RuntimeType.NetFramework, new Version(2,0), new Version(2,0,50727), "net-2.0", "Net 2.0"),
@@ -326,7 +326,7 @@ namespace NUnit.Framework.Internal
             new FrameworkData(RuntimeType.Any, RuntimeFramework.DefaultVersion, RuntimeFramework.DefaultVersion, "any", "Any")
         };
 
-        internal static string[] netcoreRuntimes = new string[] {
+        internal static string[] NetcoreRuntimes = new string[] {
             "netcore-1.0",
             "netcore-1.1",
             "netcore-2.0",

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -296,7 +296,7 @@ namespace NUnit.Framework.Internal
 
             public override string ToString()
             {
-                return $"<{this.Runtime},{this.FrameworkVersion},{this.ClrVersion}>";
+                return $"<{Runtime},{FrameworkVersion},{ClrVersion}>";
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpFixtureTests.cs
@@ -12,8 +12,8 @@ namespace NUnit.Framework.Internal
     public class SetUpFixtureTests
     {
         private static readonly string ASSEMBLY_PATH = AssemblyHelper.GetAssemblyPath(typeof(TestData.SetupFixture.Namespace1.SomeFixture).Assembly);
-        private ITestAssemblyBuilder builder;
-        private ITestAssemblyRunner runner;
+        private ITestAssemblyBuilder _builder;
+        private ITestAssemblyRunner _runner;
 
         #region SetUp
         [SetUp]
@@ -21,8 +21,8 @@ namespace NUnit.Framework.Internal
         {
             TestUtilities.SimpleEventRecorder.Clear();
 
-            builder = new DefaultTestAssemblyBuilder();
-            runner = new NUnitTestAssemblyRunner(builder);
+            _builder = new DefaultTestAssemblyBuilder();
+            _runner = new NUnitTestAssemblyRunner(_builder);
         }
         #endregion SetUp
 
@@ -39,8 +39,8 @@ namespace NUnit.Framework.Internal
             // No need for the overhead of parallel execution here
             options["NumberOfTestWorkers"] = 0;
 
-            if (runner.Load(ASSEMBLY_PATH, options) is not null)
-                return runner.Run(TestListener.NULL, filter);
+            if (_runner.Load(ASSEMBLY_PATH, options) is not null)
+                return _runner.Run(TestListener.NULL, filter);
 
             return null;
         }
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Internal
             {
                 ["LOAD"] = new[] { nameSpace }
             };
-            ITest? suite = builder.Build(ASSEMBLY_PATH, options);
+            ITest? suite = _builder.Build(ASSEMBLY_PATH, options);
 
             Assert.That(suite, Is.Not.Null);
             Assert.Multiple(() =>
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Internal
         public void AssemblySetUpFixtureFollowsAssemblyNodeInTree()
         {
             IDictionary<string, object> options = new Dictionary<string, object>();
-            var rootSuite = builder.Build(ASSEMBLY_PATH, options);
+            var rootSuite = _builder.Build(ASSEMBLY_PATH, options);
             Assert.That(rootSuite, Is.TypeOf<TestAssembly>());
             var setupFixture = rootSuite.Tests[0];
             Assert.That(setupFixture, Is.TypeOf<SetUpFixture>());
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Internal
             {
                 ["LOAD"] = new[] { nameSpace }
             };
-            ITest? suite = builder.Build(ASSEMBLY_PATH, options);
+            ITest? suite = _builder.Build(ASSEMBLY_PATH, options);
 
             Assert.That(suite, Is.Not.Null);
             Assert.Multiple(() =>

--- a/src/NUnitFramework/tests/Internal/StackFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/StackFilterTests.cs
@@ -11,26 +11,26 @@ namespace NUnit.Framework.Internal
 
         private static readonly string NL = Environment.NewLine;
 
-        private static readonly string shortTrace_Assert =
+        private static readonly string ShortTrace_Assert =
     @"   at NUnit.Framework.Assert.Fail(String message) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 56" + NL +
     @"   at NUnit.Framework.Assert.That(String label, Object actual, Matcher expectation, String message) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 50" + NL +
     @"   at NUnit.Framework.Assert.That(Object actual, Matcher expectation) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 19" + NL +
     @"   at NUnit.Tests.GreaterThanMatcherTest.MatchesGoodValue() in D:\Dev\NUnitLite\NUnitLiteTests\GreaterThanMatcherTest.cs:line 12" + NL;
 
-        private static readonly string shortTrace_Assume =
+        private static readonly string ShortTrace_Assume =
     @"   at NUnit.Framework.Assert.Fail(String message) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 56" + NL +
     @"   at NUnit.Framework.Assume.That(String label, Object actual, Matcher expectation, String message) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 50" + NL +
     @"   at NUnit.Framework.Assume.That(Object actual, Matcher expectation) in D:\Dev\NUnitLite\NUnitLite\Framework\Assert.cs:line 19" + NL +
     @"   at NUnit.Tests.GreaterThanMatcherTest.MatchesGoodValue() in D:\Dev\NUnitLite\NUnitLiteTests\GreaterThanMatcherTest.cs:line 12" + NL;
 
-        private static readonly string shortTrace_Result =
+        private static readonly string ShortTrace_Result =
     @"   at NUnit.Tests.GreaterThanMatcherTest.MatchesGoodValue() in D:\Dev\NUnitLite\NUnitLiteTests\GreaterThanMatcherTest.cs:line 12" + NL;
 
         // NOTE: In most cases, NUnit does not have to deal with traces
         // like this because the InnerException of a TargetInvocationException
         // only includes the methods called from the point of invocation.
         // However, in the compact framework, such long traces may arise.
-        private static readonly string longTrace =
+        private static readonly string LongTrace =
     @"   at NUnit.Framework.Assert.Fail(String message, Object[] args)" + NL +
     @"   at MyNamespace.MyAppsTests.AssertFailTest()" + NL +
     @"   at System.Reflection.RuntimeMethodInfo.InternalInvoke(RuntimeMethodInfo rtmi, Object obj, BindingFlags invokeAttr, Binder binder, Object parameters, CultureInfo culture, Boolean isBinderDefault, Assembly caller, Boolean verifyAccess, StackCrawlMark& stackMark)" + NL +
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Internal
     @"   at NUnitLite.Runner.ConsoleUI.Main(String[] args)" + NL +
     @"   at OpenNETCF.Linq.Demo.Program.Main(String[] args)" + NL;
 
-        private static readonly string longTrace_Result =
+        private static readonly string LongTrace_Result =
     @"   at MyNamespace.MyAppsTests.AssertFailTest()" + NL;
 
         #endregion
@@ -62,19 +62,19 @@ namespace NUnit.Framework.Internal
         [Test]
         public void FilterShortTraceWithAssert()
         {
-            Assert.That(StackFilter.DefaultFilter.Filter(shortTrace_Assert), Is.EqualTo(shortTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(ShortTrace_Assert), Is.EqualTo(ShortTrace_Result));
         }
 
         [Test]
         public void FilterShortTraceWithAssume_Trace1()
         {
-            Assert.That(StackFilter.DefaultFilter.Filter(shortTrace_Assume), Is.EqualTo(shortTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(ShortTrace_Assume), Is.EqualTo(ShortTrace_Result));
         }
 
         [Test]
         public void FilterLongTrace()
         {
-            Assert.That(StackFilter.DefaultFilter.Filter(longTrace), Is.EqualTo(longTrace_Result));
+            Assert.That(StackFilter.DefaultFilter.Filter(LongTrace), Is.EqualTo(LongTrace_Result));
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -25,10 +25,10 @@ namespace NUnit.Framework.Internal
         private TestExecutionContext _fixtureContext;
         private TestExecutionContext _setupContext;
         private ResultState _fixtureResult;
-        private string originalDirectory;
-        private CultureInfo originalCulture;
-        private CultureInfo originalUICulture;
-        private IPrincipal? originalPrincipal;
+        private string _originalDirectory;
+        private CultureInfo _originalCulture;
+        private CultureInfo _originalUICulture;
+        private IPrincipal? _originalPrincipal;
         private readonly DateTime _fixtureCreateTime = DateTime.UtcNow;
         private readonly long _fixtureCreateTicks = Stopwatch.GetTimestamp();
 
@@ -58,21 +58,21 @@ namespace NUnit.Framework.Internal
         {
             _setupContext = TestExecutionContext.CurrentContext;
 
-            originalDirectory = Directory.GetCurrentDirectory();
+            _originalDirectory = Directory.GetCurrentDirectory();
 
-            originalCulture = CultureInfo.CurrentCulture;
-            originalUICulture = CultureInfo.CurrentUICulture;
-            originalPrincipal = Thread.CurrentPrincipal;
+            _originalCulture = CultureInfo.CurrentCulture;
+            _originalUICulture = CultureInfo.CurrentUICulture;
+            _originalPrincipal = Thread.CurrentPrincipal;
         }
 
         [TearDown]
         public void Cleanup()
         {
-            Directory.SetCurrentDirectory(originalDirectory);
+            Directory.SetCurrentDirectory(_originalDirectory);
 
-            Thread.CurrentThread.CurrentCulture = originalCulture;
-            Thread.CurrentThread.CurrentUICulture = originalUICulture;
-            Thread.CurrentPrincipal = originalPrincipal;
+            Thread.CurrentThread.CurrentCulture = _originalCulture;
+            Thread.CurrentThread.CurrentUICulture = _originalUICulture;
+            Thread.CurrentPrincipal = _originalPrincipal;
 
             Assert.That(
                 TestExecutionContext.CurrentContext.CurrentTest.FullName,
@@ -715,19 +715,19 @@ namespace NUnit.Framework.Internal
             try
             {
                 CultureInfo otherCulture =
-                    new CultureInfo(originalCulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
+                    new CultureInfo(_originalCulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
                 context.CurrentCulture = otherCulture;
                 Assert.That(CultureInfo.CurrentCulture, Is.EqualTo(otherCulture), "Culture was not set");
                 Assert.That(context.CurrentCulture, Is.EqualTo(otherCulture), "Culture not in new context");
-                Assert.That(originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Original context should not change");
+                Assert.That(_originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.That(originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture was not restored");
-            Assert.That(originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Culture not in final context");
+            Assert.That(_originalCulture, Is.EqualTo(CultureInfo.CurrentCulture), "Culture was not restored");
+            Assert.That(_originalCulture, Is.EqualTo(_setupContext.CurrentCulture), "Culture not in final context");
         }
 
         [Test]
@@ -738,19 +738,19 @@ namespace NUnit.Framework.Internal
             try
             {
                 CultureInfo otherCulture =
-                    new CultureInfo(originalUICulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
+                    new CultureInfo(_originalUICulture.Name == "fr-FR" ? "en-GB" : "fr-FR");
                 context.CurrentUICulture = otherCulture;
                 Assert.That(CultureInfo.CurrentUICulture, Is.EqualTo(otherCulture), "UICulture was not set");
                 Assert.That(context.CurrentUICulture, Is.EqualTo(otherCulture), "UICulture not in new context");
-                Assert.That(originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "Original context should not change");
+                Assert.That(_originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.That(originalUICulture, Is.EqualTo(CultureInfo.CurrentUICulture), "UICulture was not restored");
-            Assert.That(originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "UICulture not in final context");
+            Assert.That(_originalUICulture, Is.EqualTo(CultureInfo.CurrentUICulture), "UICulture was not restored");
+            Assert.That(_originalUICulture, Is.EqualTo(_setupContext.CurrentUICulture), "UICulture not in final context");
         }
 
 #endregion
@@ -786,15 +786,15 @@ namespace NUnit.Framework.Internal
                 context.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
                 Assert.That(Thread.CurrentPrincipal?.Identity?.Name, Is.EqualTo("foo"), "Principal was not set");
                 Assert.That(context.CurrentPrincipal?.Identity?.Name, Is.EqualTo("foo"), "Principal not in new context");
-                Assert.That(originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Original context should not change");
+                Assert.That(_originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Original context should not change");
             }
             finally
             {
                 _setupContext.EstablishExecutionEnvironment();
             }
 
-            Assert.That(originalPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Principal was not restored");
-            Assert.That(originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Principal not in final context");
+            Assert.That(_originalPrincipal, Is.EqualTo(Thread.CurrentPrincipal), "Principal was not restored");
+            Assert.That(_originalPrincipal, Is.EqualTo(_setupContext.CurrentPrincipal), "Principal not in final context");
         }
 
 #endregion

--- a/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestMethodSignatureTests.cs
@@ -11,36 +11,36 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class TestMethodSignatureTests
     {
-        private static readonly Type fixtureType = typeof(TestMethodSignatureFixture);
+        private static readonly Type FixtureType = typeof(TestMethodSignatureFixture);
 
         [Test]
         public void InstanceTestMethodIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.InstanceTestMethod) );
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.InstanceTestMethod) );
         }
 
         [Test]
         public void StaticTestMethodIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethod) );
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.StaticTestMethod) );
         }
 
         [Test]
         public void TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithoutParametersWithArgumentsProvided));
+            TestAssert.ChildNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithoutParametersWithArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithArgumentsNotProvidedIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvided));
+            TestAssert.IsNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvided));
         }
 
         [Test]
         public void TestMethodHasAttributesAppliedCorrectlyEvenIfNotRunnable()
         {
-            var test = TestBuilder.MakeTestCase(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvidedAndExtraAttributes));
+            var test = TestBuilder.MakeTestCase(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsNotProvidedAndExtraAttributes));
             Assert.Multiple(() =>
             {
                 // NOTE: IgnoreAttribute has no effect, either on RunState or on the reason
@@ -54,91 +54,91 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestMethodWithArgumentsProvidedIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsProvided));
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongNumberOfArgumentsProvided));
+            TestAssert.ChildNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongNumberOfArgumentsProvided));
         }
 
         [Test]
         public void TestMethodWithWrongArgumentTypesProvidedGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongArgumentTypesProvided), ResultState.Error);
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithWrongArgumentTypesProvided), ResultState.Error);
         }
 
         [Test]
         public void StaticTestMethodWithArgumentsNotProvidedIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsNotProvided));
+            TestAssert.IsNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsNotProvided));
         }
 
         [Test]
         public void StaticTestMethodWithArgumentsProvidedIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsProvided));
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithArgumentsProvided));
         }
 
         [Test]
         public void StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable()
         {
-            TestAssert.ChildNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongNumberOfArgumentsProvided));
+            TestAssert.ChildNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongNumberOfArgumentsProvided));
         }
 
         [Test]
         public void StaticTestMethodWithWrongArgumentTypesProvidedGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongArgumentTypesProvided), ResultState.Error);
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.StaticTestMethodWithWrongArgumentTypesProvided), ResultState.Error);
         }
 
         [Test]
         public void TestMethodWithConvertibleArgumentsIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithConvertibleArguments));
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithConvertibleArguments));
         }
 
         [Test]
         public void TestMethodWithNonConvertibleArgumentsGivesError()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithNonConvertibleArguments), ResultState.Error);
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithNonConvertibleArguments), ResultState.Error);
         }
 
         [Test]
         public void ProtectedTestMethodIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, "ProtectedTestMethod");
+            TestAssert.IsNotRunnable(FixtureType, "ProtectedTestMethod");
         }
 
         [Test]
         public void PrivateTestMethodIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, "PrivateTestMethod");
+            TestAssert.IsNotRunnable(FixtureType, "PrivateTestMethod");
         }
 
         [Test]
         public void TestMethodWithReturnTypeIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithoutExpectedResult));
+            TestAssert.IsNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithoutExpectedResult));
         }
 
         [Test]
         public void TestMethodWithExpectedReturnTypeIsRunnable()
         {
-            TestAssert.IsRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithExpectedResult));
+            TestAssert.IsRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValue_WithExpectedResult));
         }
 
         [Test]
         public void TestMethodWithExpectedReturnAndArgumentsIsNotRunnable()
         {
-            TestAssert.IsNotRunnable(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValueAndArgs_WithExpectedResult));
+            TestAssert.IsNotRunnable(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithReturnValueAndArgs_WithExpectedResult));
         }
 
         [Test]
         public void TestMethodWithMultipleTestCasesExecutesMultipleTimes()
         {
-            ITestResult result = TestBuilder.RunParameterizedMethodSuite(fixtureType, nameof(TestMethodSignatureFixture.TestMethodWithMultipleTestCases));
+            ITestResult result = TestBuilder.RunParameterizedMethodSuite(FixtureType, nameof(TestMethodSignatureFixture.TestMethodWithMultipleTestCases));
 
             Assert.That( result.ResultState, Is.EqualTo(ResultState.Success) );
             ResultSummary summary = new ResultSummary(result);
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Internal
             string name = nameof(TestMethodSignatureFixture.TestMethodWithMultipleTestCases);
             string fullName = typeof (TestMethodSignatureFixture).FullName + "." + name;
 
-            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(fixtureType, name);
+            TestSuite suite = TestBuilder.MakeParameterizedMethodSuite(FixtureType, name);
             Assert.That(suite.TestCaseCount, Is.EqualTo(3));
 
             var names = new List<string>();
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Internal
         [Test]
         public void RunningTestsThroughFixtureGivesCorrectResults()
         {
-            ITestResult result = TestBuilder.RunTestFixture(fixtureType);
+            ITestResult result = TestBuilder.RunTestFixture(FixtureType);
             ResultSummary summary = new ResultSummary(result);
 
             Assert.That(

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -142,9 +142,13 @@ namespace NUnit.Framework.Internal
             {
                 var expectedProps = new List<string>();
                 foreach (string key in test.Properties.Keys)
+                {
                     foreach (object? value in test.Properties[key])
+                    {
                         if (value is not null)
                             expectedProps.Add(key + "=" + value);
+                    }
+                }
 
                 TNode? propsNode = topNode.SelectSingleNode("properties");
                 Assert.That(propsNode, Is.Not.Null);

--- a/src/NUnitFramework/tests/Internal/TestXmlTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestXmlTests.cs
@@ -9,37 +9,37 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class TestXmlTests
     {
-        private TestSuite testSuite;
-        private TestFixture testFixture;
-        private TestMethod testMethod;
+        private TestSuite _testSuite;
+        private TestFixture _testFixture;
+        private TestMethod _testMethod;
 
         [SetUp]
         public void SetUp()
         {
-            testMethod = new TestMethod(new MethodWrapper(typeof(DummyFixture), "DummyMethod"));
-            testMethod.Properties.Set(PropertyNames.Description, "Test description");
-            testMethod.Properties.Add(PropertyNames.Category, "Dubious");
-            testMethod.Properties.Set("Priority", "low");
+            _testMethod = new TestMethod(new MethodWrapper(typeof(DummyFixture), "DummyMethod"));
+            _testMethod.Properties.Set(PropertyNames.Description, "Test description");
+            _testMethod.Properties.Add(PropertyNames.Category, "Dubious");
+            _testMethod.Properties.Set("Priority", "low");
 
-            testFixture = new TestFixture(new TypeWrapper(typeof(DummyFixture)));
-            testFixture.Properties.Set(PropertyNames.Description, "Fixture description");
-            testFixture.Properties.Add(PropertyNames.Category, "Fast");
-            testFixture.Properties.Add("Value", 3);
+            _testFixture = new TestFixture(new TypeWrapper(typeof(DummyFixture)));
+            _testFixture.Properties.Set(PropertyNames.Description, "Fixture description");
+            _testFixture.Properties.Add(PropertyNames.Category, "Fast");
+            _testFixture.Properties.Add("Value", 3);
 
-            testFixture.Tests.Add(testMethod);
+            _testFixture.Tests.Add(_testMethod);
 
-            testSuite = new TestSuite(typeof(DummyFixture));
-            testSuite.Properties.Set(PropertyNames.Description, "Suite description");
+            _testSuite = new TestSuite(typeof(DummyFixture));
+            _testSuite.Properties.Set(PropertyNames.Description, "Suite description");
         }
 
         [Test]
         public void TestTypeTests()
         {
-            Assert.That(testMethod.TestType,
+            Assert.That(_testMethod.TestType,
                 Is.EqualTo("TestMethod"));
-            Assert.That(testFixture.TestType,
+            Assert.That(_testFixture.TestType,
                 Is.EqualTo("TestFixture"));
-            Assert.That(testSuite.TestType,
+            Assert.That(_testSuite.TestType,
                 Is.EqualTo("TestSuite"));
             Assert.That(new TestAssembly("junk").TestType,
                 Is.EqualTo("Assembly"));
@@ -57,47 +57,47 @@ namespace NUnit.Framework.Internal
         [Test]
         public void TestMethodToXml()
         {
-            CheckXmlForTest(testMethod, false);
+            CheckXmlForTest(_testMethod, false);
         }
 
         [Test]
         public void TestFixtureToXml()
         {
-            CheckXmlForTest(testFixture, false);
+            CheckXmlForTest(_testFixture, false);
         }
 
         [Test]
         public void TestFixtureToXml_Recursive()
         {
-            CheckXmlForTest(testFixture, true);
+            CheckXmlForTest(_testFixture, true);
         }
 
         [Test]
         public void TestSuiteToXml()
         {
-            CheckXmlForTest(testSuite, false);
+            CheckXmlForTest(_testSuite, false);
         }
 
         [Test]
         public void TestSuiteToXml_Recursive()
         {
-            CheckXmlForTest(testSuite, true);
+            CheckXmlForTest(_testSuite, true);
         }
 
         [Test]
         public void TestNameWithInvalidCharacter()
         {
-            testMethod.Name = "\u0001HappyFace";
+            _testMethod.Name = "\u0001HappyFace";
             // This throws if the name is not properly escaped
-            Assert.That(testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"\\u0001HappyFace\""));
+            Assert.That(_testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"\\u0001HappyFace\""));
         }
 
         [Test]
         public void TestNameWithInvalidCharacter_NonFirstPosition()
         {
-            testMethod.Name = "Happy\u0001Face";
+            _testMethod.Name = "Happy\u0001Face";
             // This throws if the name is not properly escaped
-            Assert.That(testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"Happy\\u0001Face\""));
+            Assert.That(_testMethod.ToXml(false).OuterXml, Contains.Substring("name=\"Happy\\u0001Face\""));
         }
 
         #region Helper Methods For Checking XML

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -9,12 +9,12 @@ namespace NUnit.Framework.Internal
     {
         private static readonly string NL = Environment.NewLine;
 
-        private TextMessageWriter writer;
+        private TextMessageWriter _writer;
 
         [SetUp]
         public void SetUp()
         {
-            writer = new TextMessageWriter();
+            _writer = new TextMessageWriter();
         }
 
         [Test]
@@ -23,8 +23,8 @@ namespace NUnit.Framework.Internal
             string s72 = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             string exp = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXY...";
 
-            writer.DisplayStringDifferences(s72, "abcde", 5, false, true);
-            string message = writer.ToString();
+            _writer.DisplayStringDifferences(s72, "abcde", 5, false, true);
+            string message = _writer.ToString();
             Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(exp) + NL +
                 TextMessageWriter.Pfx_Actual + Q("abcde") + NL +
@@ -36,8 +36,8 @@ namespace NUnit.Framework.Internal
         {
             string s72 = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
-            writer.DisplayStringDifferences(s72, "abcde", 5, false, false);
-            string message = writer.ToString();
+            _writer.DisplayStringDifferences(s72, "abcde", 5, false, false);
+            string message = _writer.ToString();
             Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(s72) + NL +
                 TextMessageWriter.Pfx_Actual + Q("abcde") + NL +
@@ -52,8 +52,8 @@ namespace NUnit.Framework.Internal
             expected = message = "here's an embedded zero \0, in me";
             expected = "  " + expected.Replace("\0", "\\0") + NL;
 
-            writer.WriteMessageLine(0, message, null);
-            message = writer.ToString();
+            _writer.WriteMessageLine(0, message, null);
+            message = _writer.ToString();
 
             Assert.That(message, Is.EqualTo(expected));
         }
@@ -67,8 +67,8 @@ namespace NUnit.Framework.Internal
             arg0 = "\0";
             expected = "  " + string.Format(message, arg0).Replace("\0", "\\0") + NL;
 
-            writer.WriteMessageLine(0, message, arg0);
-            message = writer.ToString();
+            _writer.WriteMessageLine(0, message, arg0);
+            message = _writer.ToString();
 
             Assert.That(message, Is.EqualTo(expected));
         }
@@ -80,8 +80,8 @@ namespace NUnit.Framework.Internal
 
             expected = message = "Here we have embedded control characters \b\f in the string!";
 
-            writer.WriteMessageLine(0, message, null);
-            message = writer.ToString();
+            _writer.WriteMessageLine(0, message, null);
+            message = _writer.ToString();
             expected = "  " + expected.Replace("\0", "\\0") + NL;
 
             Assert.That(message, Is.EqualTo(expected));

--- a/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.Framework.Internal
 
             public Dummy(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Internal
 
             public Dummy(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Internal
 
             public Dummy(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Internal
 
             public Dummy1(int value)
             {
-                this.Value = value;
+                Value = value;
             }
 
             public override string ToString()

--- a/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeNameDifferenceTests.cs
@@ -11,16 +11,16 @@ namespace NUnit.Framework.Internal
     {
         internal class Dummy
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
 
@@ -35,16 +35,16 @@ namespace NUnit.Framework.Internal
     {
         internal class Dummy
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
     }
@@ -99,31 +99,31 @@ namespace NUnit.Framework.Internal
 
         private class Dummy
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
 
         private class Dummy1
         {
-            internal readonly int value;
+            internal readonly int Value;
 
             public Dummy1(int value)
             {
-                this.value = value;
+                this.Value = value;
             }
 
             public override string ToString()
             {
-                return "Dummy " + value;
+                return "Dummy " + Value;
             }
         }
 

--- a/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
+++ b/src/NUnitFramework/tests/Internal/UniqueTestIdTests.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Internal
     [TestFixture]
     public class UniqueTestIdTests
     {
-        private readonly ConcurrentDictionary<string, string> IdHolder = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> _idHolder = new ConcurrentDictionary<string, string>();
         private static string ID => TestContext.CurrentContext.Test.ID;
 
         [TestCase(1)]
@@ -17,23 +17,23 @@ namespace NUnit.Framework.Internal
         [TestCase(4)]
         public void TestCase(int testCase)
         {
-            Assert.That(IdHolder, Does.Not.ContainKey(ID));
-            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         [TestCaseSource(nameof(SomeStrings))]
         public void TestCaseSource(string testCaseSourceData)
         {
-            Assert.That(IdHolder, Does.Not.ContainKey(ID));
-            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         [Repeat(5)]
         [Test]
         public void Repeat()
         {
-            Assert.That(IdHolder, Does.Not.ContainKey(ID));
-            IdHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
+            Assert.That(_idHolder, Does.Not.ContainKey(ID));
+            _idHolder.AddOrUpdate(ID, ID, (s, s1) => ID);
         }
 
         public static IEnumerable<string> SomeStrings => new List<string>

--- a/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
@@ -68,13 +68,17 @@ namespace NUnit.Framework.Internal.Execution
 
                 alive = 0;
                 foreach (var worker in workers)
+                {
                     if (worker.IsAlive)
                         alive++;
+                }
             }
 
             if (alive > 0)
+            {
                 foreach (var worker in workers)
                     Assert.That(worker.IsAlive, Is.False, "Worker thread {0} did not stop", worker.Name);
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Syntax/AfterTests.cs
+++ b/src/NUnitFramework/tests/Syntax/AfterTests.cs
@@ -87,16 +87,16 @@ namespace NUnit.Framework.Syntax
         [SetUp]
         public void InitializeValues()
         {
-            this.Flag = false;
-            this.Num = 0;
-            this.Ob1 = new object();
-            this.Ob2 = new object();
-            this.Ob3 = new object();
-            this.List = new List<object>();
-            this.List.Add(1);
-            this.List.Add(2);
-            this.List.Add(3);
-            this.Greeting = "hello";
+            Flag = false;
+            Num = 0;
+            Ob1 = new object();
+            Ob2 = new object();
+            Ob3 = new object();
+            List = new List<object>();
+            List.Add(1);
+            List.Add(2);
+            List.Add(3);
+            Greeting = "hello";
 
             new Thread(ModifyValuesAfterDelay).Start();
         }
@@ -105,12 +105,12 @@ namespace NUnit.Framework.Syntax
         {
             Thread.Sleep(100);
 
-            this.Flag = true;
-            this.Num = 1;
-            this.Ob1 = Ob2;
-            this.Ob3 = null;
-            this.List.Add(4);
-            this.Greeting += "world";
+            Flag = true;
+            Num = 1;
+            Ob1 = Ob2;
+            Ob3 = null;
+            List.Add(4);
+            Greeting += "world";
         }
     }
 

--- a/src/NUnitFramework/tests/Syntax/ArbitraryConstraintMatching.cs
+++ b/src/NUnitFramework/tests/Syntax/ArbitraryConstraintMatching.cs
@@ -9,27 +9,27 @@ namespace NUnit.Framework.Syntax
     [TestFixture]
     public class ArbitraryConstraintMatching
     {
-        private readonly Constraint custom = new CustomConstraint();
-        private readonly Constraint another = new AnotherConstraint();
+        private readonly Constraint _custom = new CustomConstraint();
+        private readonly Constraint _another = new AnotherConstraint();
 
         [Test]
         public void CanMatchCustomConstraint()
         {
-            IResolveConstraint constraint = new ConstraintExpression().Matches(custom);
+            IResolveConstraint constraint = new ConstraintExpression().Matches(_custom);
             Assert.That(constraint.Resolve().ToString(), Is.EqualTo("<custom>"));
         }
 
         [Test]
         public void CanMatchCustomConstraintAfterPrefix()
         {
-            IResolveConstraint constraint = Is.All.Matches(custom);
+            IResolveConstraint constraint = Is.All.Matches(_custom);
             Assert.That(constraint.Resolve().ToString(), Is.EqualTo("<all <custom>>"));
         }
 
         [Test]
         public void CanMatchCustomConstraintsUnderAndOperator()
         {
-            IResolveConstraint constraint = Is.All.Matches(custom).And.Matches(another);
+            IResolveConstraint constraint = Is.All.Matches(_custom).And.Matches(_another);
             Assert.That(constraint.Resolve().ToString(), Is.EqualTo("<all <and <custom> <another>>>")); 
         }
 

--- a/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
+++ b/src/NUnitFramework/tests/Syntax/InvalidCodeTests.cs
@@ -8,7 +8,7 @@ namespace NUnit.Framework.Syntax
     [TestFixture]
     public class InvalidCodeTests
     {
-        private static readonly string template1 =
+        private static readonly string Template1 =
 @"using System;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
@@ -30,7 +30,7 @@ class SomeClass
         [TestCase("Has.Some.Items")]
         public void CodeShouldNotCompile(string fragment)
         {
-            string code = template1.Replace("$FRAGMENT$", fragment);
+            string code = Template1.Replace("$FRAGMENT$", fragment);
             TestCompiler compiler = new TestCompiler(
                 new[] { "system.dll", "nunit.framework.dll" },
                 "test.dll");
@@ -39,7 +39,7 @@ class SomeClass
                 Assert.Fail("Code fragment \"" + fragment + "\" should not compile but it did");
         }
 
-        private static readonly string template2 =
+        private static readonly string Template2 =
 @"using System;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
@@ -60,7 +60,7 @@ class SomeClass
         [TestCase("Has.Exactly(5)")]
         public void CodeShouldNotCompileAsFinishedConstraint(string fragment)
         {
-            string code = template2.Replace("$FRAGMENT$", fragment);
+            string code = Template2.Replace("$FRAGMENT$", fragment);
             TestCompiler compiler = new TestCompiler(
                 new[] { "system.dll", "nunit.framework.dll" },
                 "test.dll");

--- a/src/NUnitFramework/tests/Syntax/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Syntax/PropertyTests.cs
@@ -81,20 +81,20 @@ namespace NUnit.Framework.Syntax
 
     public class PropertySyntaxVariations
     {
-        private readonly int[] ints = new int[] { 1, 2, 3 };
+        private readonly int[] _ints = new int[] { 1, 2, 3 };
 
         [Test]
         public void ExistenceTest()
         {
-            Assert.That(ints, Has.Property("Length"));
-            Assert.That(ints, Has.Length);
+            Assert.That(_ints, Has.Property("Length"));
+            Assert.That(_ints, Has.Length);
         }
 
         [Test]
         public void SeparateConstraintTest()
         {
-            Assert.That(ints, Has.Property("Length").EqualTo(3));
-            Assert.That(ints, Has.Length.EqualTo(3));
+            Assert.That(_ints, Has.Property("Length").EqualTo(3));
+            Assert.That(_ints, Has.Length.EqualTo(3));
         }
     }
 }

--- a/src/NUnitFramework/tests/Syntax/TestCompiler.cs
+++ b/src/NUnitFramework/tests/Syntax/TestCompiler.cs
@@ -7,7 +7,7 @@ namespace NUnit.Framework.Syntax
 {
     internal class TestCompiler
     {
-        private readonly Microsoft.CSharp.CSharpCodeProvider provider = new Microsoft.CSharp.CSharpCodeProvider();
+        private readonly Microsoft.CSharp.CSharpCodeProvider _provider = new Microsoft.CSharp.CSharpCodeProvider();
 
         public CompilerParameters Options { get; } = new CompilerParameters();
 
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Syntax
 
         public CompilerResults CompileCode( string code )
         {
-            return provider.CompileAssemblyFromSource( Options, code );
+            return _provider.CompileAssemblyFromSource( Options, code );
         }
     }
 }

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleEnumerable.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleEnumerable.cs
@@ -12,23 +12,23 @@ namespace NUnit.TestUtilities.Collections
     /// </summary>
     internal class SimpleEnumerable : IEnumerable
     {
-        private readonly List<object> contents = new List<object>();
+        private readonly List<object> _contents = new List<object>();
 
         public SimpleEnumerable(IEnumerable<object> source)
         {
-            this.contents = new List<object>(source);
+            this._contents = new List<object>(source);
         }
 
         public SimpleEnumerable(params object[] source)
         {
-            this.contents = new List<object>(source);
+            this._contents = new List<object>(source);
         }
 
         #region IEnumerable Members
 
         public IEnumerator GetEnumerator()
         {
-            return contents.GetEnumerator();
+            return _contents.GetEnumerator();
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleEnumerable.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleEnumerable.cs
@@ -16,12 +16,12 @@ namespace NUnit.TestUtilities.Collections
 
         public SimpleEnumerable(IEnumerable<object> source)
         {
-            this._contents = new List<object>(source);
+            _contents = new List<object>(source);
         }
 
         public SimpleEnumerable(params object[] source)
         {
-            this._contents = new List<object>(source);
+            _contents = new List<object>(source);
         }
 
         #region IEnumerable Members

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectCollection.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectCollection.cs
@@ -16,12 +16,12 @@ namespace NUnit.TestUtilities.Collections
 
         public SimpleObjectCollection(IEnumerable<object?> source)
         {
-            this._contents = new List<object?>(source);
+            _contents = new List<object?>(source);
         }
 
         public SimpleObjectCollection(params object?[] source)
         {
-            this._contents = new List<object?>(source);
+            _contents = new List<object?>(source);
         }
 
         #region ICollection Members

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectCollection.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectCollection.cs
@@ -12,30 +12,30 @@ namespace NUnit.TestUtilities.Collections
     /// </summary>
     internal class SimpleObjectCollection : ICollection
     {
-        private readonly List<object?> contents;
+        private readonly List<object?> _contents;
 
         public SimpleObjectCollection(IEnumerable<object?> source)
         {
-            this.contents = new List<object?>(source);
+            this._contents = new List<object?>(source);
         }
 
         public SimpleObjectCollection(params object?[] source)
         {
-            this.contents = new List<object?>(source);
+            this._contents = new List<object?>(source);
         }
 
         #region ICollection Members
 
         public void CopyTo(Array array, int index)
         {
-            ((ICollection)contents).CopyTo(array, index);
+            ((ICollection)_contents).CopyTo(array, index);
         }
 
-        public int Count => contents.Count;
+        public int Count => _contents.Count;
 
-        public bool IsSynchronized => ((ICollection)contents).IsSynchronized;
+        public bool IsSynchronized => ((ICollection)_contents).IsSynchronized;
 
-        public object SyncRoot => ((ICollection)contents).SyncRoot;
+        public object SyncRoot => ((ICollection)_contents).SyncRoot;
 
         #endregion
 
@@ -43,7 +43,7 @@ namespace NUnit.TestUtilities.Collections
 
         public IEnumerator GetEnumerator()
         {
-            return contents.GetEnumerator();
+            return _contents.GetEnumerator();
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
@@ -12,30 +12,30 @@ namespace NUnit.TestUtilities.Collections
     /// </summary>
     internal class SimpleObjectList : IList
     {
-        private readonly List<object?> contents;
+        private readonly List<object?> _contents;
 
         public SimpleObjectList(IEnumerable<object?> source)
         {
-            this.contents = new List<object?>(source);
+            this._contents = new List<object?>(source);
         }
 
         public SimpleObjectList(params object?[] source)
         {
-            this.contents = new List<object?>(source);
+            this._contents = new List<object?>(source);
         }
 
         #region ICollection Members
 
         public void CopyTo(Array array, int index)
         {
-            ((ICollection)contents).CopyTo(array, index);
+            ((ICollection)_contents).CopyTo(array, index);
         }
 
-        public int Count => contents.Count;
+        public int Count => _contents.Count;
 
-        public bool IsSynchronized => ((ICollection)contents).IsSynchronized;
+        public bool IsSynchronized => ((ICollection)_contents).IsSynchronized;
 
-        public object SyncRoot => ((ICollection)contents).SyncRoot;
+        public object SyncRoot => ((ICollection)_contents).SyncRoot;
 
         #endregion
 
@@ -43,7 +43,7 @@ namespace NUnit.TestUtilities.Collections
 
         public IEnumerator GetEnumerator()
         {
-            return contents.GetEnumerator();
+            return _contents.GetEnumerator();
         }
 
         #endregion
@@ -52,28 +52,28 @@ namespace NUnit.TestUtilities.Collections
 
         public int Add(object? value)
         {
-            contents.Add(value);
-            return contents.Count - 1;
+            _contents.Add(value);
+            return _contents.Count - 1;
         }
 
         public void Clear()
         {
-            contents.Clear();
+            _contents.Clear();
         }
 
         public bool Contains(object? value)
         {
-            return contents.Contains(value);
+            return _contents.Contains(value);
         }
 
         public int IndexOf(object? value)
         {
-            return contents.IndexOf(value);
+            return _contents.IndexOf(value);
         }
 
         public void Insert(int index, object? value)
         {
-            contents.Insert(index, value);
+            _contents.Insert(index, value);
         }
 
         public bool IsFixedSize => false;
@@ -82,18 +82,18 @@ namespace NUnit.TestUtilities.Collections
 
         public void Remove(object? value)
         {
-            contents.Remove(value);
+            _contents.Remove(value);
         }
 
         public void RemoveAt(int index)
         {
-            contents.RemoveAt(index);
+            _contents.RemoveAt(index);
         }
 
         public object? this[int index]
         {
-            get => contents[index];
-            set => contents[index] = value;
+            get => _contents[index];
+            set => _contents[index] = value;
         }
 
         #endregion

--- a/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Collections/SimpleObjectList.cs
@@ -16,12 +16,12 @@ namespace NUnit.TestUtilities.Collections
 
         public SimpleObjectList(IEnumerable<object?> source)
         {
-            this._contents = new List<object?>(source);
+            _contents = new List<object?>(source);
         }
 
         public SimpleObjectList(params object?[] source)
         {
-            this._contents = new List<object?>(source);
+            _contents = new List<object?>(source);
         }
 
         #region ICollection Members

--- a/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectToStringComparer.cs
+++ b/src/NUnitFramework/tests/TestUtilities/Comparers/ObjectToStringComparer.cs
@@ -26,7 +26,9 @@ namespace NUnit.TestUtilities.Comparers
                     return -1;
             }
             else if (yAsString is null)
+            {
                 return 1;
+            }
 
             if (int.TryParse(xAsString, out int intX) && int.TryParse(yAsString, out int intY))
             {

--- a/src/NUnitFramework/tests/TestUtilities/ResultSummary.cs
+++ b/src/NUnitFramework/tests/TestUtilities/ResultSummary.cs
@@ -10,23 +10,23 @@ namespace NUnit.TestUtilities
     /// </summary>
     public class ResultSummary
     {
-        private int resultCount = 0;
-        private int failureCount = 0;
-        private int successCount = 0;
-        private int inconclusiveCount = 0;
-        private int skipCount = 0;
+        private int _resultCount = 0;
+        private int _failureCount = 0;
+        private int _successCount = 0;
+        private int _inconclusiveCount = 0;
+        private int _skipCount = 0;
 
-        private readonly DateTime startTime = DateTime.MinValue;
-        private readonly DateTime endTime = DateTime.MaxValue;
-        private readonly double duration = 0.0d;
-        private readonly string name;
+        private readonly DateTime _startTime = DateTime.MinValue;
+        private readonly DateTime _endTime = DateTime.MaxValue;
+        private readonly double _duration = 0.0d;
+        private readonly string _name;
 
         public ResultSummary(ITestResult result)
         {
-            name = result.Name;
-            startTime = result.StartTime;
-            endTime = result.EndTime;
-            duration = result.Duration;
+            _name = result.Name;
+            _startTime = result.StartTime;
+            _endTime = result.EndTime;
+            _duration = result.Duration;
             Summarize(result);
         }
 
@@ -39,37 +39,37 @@ namespace NUnit.TestUtilities
             }
             else
             {
-                resultCount++;
+                _resultCount++;
 
                 switch (result.ResultState.Status)
                 {
                     case TestStatus.Passed:
-                        successCount++;
+                        _successCount++;
                         break;
                     case TestStatus.Failed:
-                        failureCount++;
+                        _failureCount++;
                         break;
                     case TestStatus.Inconclusive:
-                        inconclusiveCount++;
+                        _inconclusiveCount++;
                         break;
                     case TestStatus.Skipped:
                     default:
-                        skipCount++;
+                        _skipCount++;
                         break;
                 }
             }
         }
 
-        public string Name => name;
+        public string Name => _name;
 
-        public bool Success => failureCount == 0;
+        public bool Success => _failureCount == 0;
 
         /// <summary>
         /// Returns the number of test cases for which results
         /// have been summarized. Any tests excluded by use of
         /// Category or Explicit attributes are not counted.
         /// </summary>
-        public int ResultCount => resultCount;
+        public int ResultCount => _resultCount;
 
         /// <summary>
         /// Returns the number of test cases actually run, which
@@ -81,36 +81,36 @@ namespace NUnit.TestUtilities
         /// <summary>
         /// Returns the number of tests that passed
         /// </summary>
-        public int Passed => successCount;
+        public int Passed => _successCount;
 
         /// <summary>
         /// Returns the number of test cases that failed.
         /// </summary>
-        public int Failed => failureCount;
+        public int Failed => _failureCount;
 
         /// <summary>
         /// Returns the number of test cases that failed.
         /// </summary>
-        public int Inconclusive => inconclusiveCount;
+        public int Inconclusive => _inconclusiveCount;
 
         /// <summary>
         /// Returns the number of test cases that were skipped.
         /// </summary>
-        public int Skipped => skipCount;
+        public int Skipped => _skipCount;
 
         /// <summary>
         /// Gets the start time of the test run.
         /// </summary>
-        public DateTime StartTime => startTime;
+        public DateTime StartTime => _startTime;
 
         /// <summary>
         /// Gets the end time of the test run.
         /// </summary>
-        public DateTime EndTime => endTime;
+        public DateTime EndTime => _endTime;
 
         /// <summary>
         /// Gets the duration of the test run in seconds.
         /// </summary>
-        public double Duration => duration;
+        public double Duration => _duration;
     }
 }


### PR DESCRIPTION
Fixes #4380 

I also added a separate commit to enforce braces on multiline if/for statements but leave them optional on single line.
