### PR TITLE
Add PartitionFilter to run a subset of tests based off a hash/partition key

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/PartitionFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PartitionFilter.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    /// <summary>
+    /// PartitionFilter filter matches a subset of tests based upon a chosen partition number and partition count
+    ///
+    /// This is helpful when you may want to run a subset of tests (eg, across 3 machines - or partitions), each with a separately assigned partition number and fixed partition count
+    /// </summary>
+    internal sealed class PartitionFilter : TestFilter
+    {
+        /// <summary>
+        /// The matching partition number (between 1 and Partition Count, inclusive) this filter should match on
+        /// </summary>
+        public uint PartitionNumber { get; private set; }
+
+        /// <summary>
+        /// The number of partitions available to use when assigning a matching partition number for each test this filter should match on
+        /// </summary>
+        public uint PartitionCount { get; private set; }
+
+        /// <summary>
+        /// Construct a PartitionFilter that matches tests that have the assigned partition number from the total partition count
+        /// </summary>
+        /// <param name="partitionNumber">The partition number this filter will recognize and match on.</param>
+        /// <param name="partitionCount">The total number of partitions that should be configured when assigning each test to a partition number.</param>
+        public PartitionFilter(uint partitionNumber, uint partitionCount)
+        {
+            PartitionNumber = partitionNumber;
+            PartitionCount = partitionCount;
+        }
+
+        /// <summary>
+        /// Create a new PartitionFilter from the provided string value, or return false if the value could not be parsed
+        /// </summary>
+        /// <param name="value">The partition value (eg, 1/10 to indicate partition 1 of 10)</param>
+        /// <param name="partitionFilter">The created PartitionFilter if the parsing succeeded</param>
+        /// <returns>True on successful parsing, or False if there is an error</returns>
+        public static bool TryCreate(string value, out PartitionFilter partitionFilter)
+        {
+            // Split our numberWithCount into two parts, such that "1/10" becomes PartitionNumber 1, PartitionCount 10
+            string[] parts = value.Split('/');
+
+            // Parts must be exactly 2, and be in the format of "number/count"
+            if (parts.Length == 2 && uint.TryParse(parts[0], out uint number) && uint.TryParse(parts[1], out uint count)) {
+                // Number must be between 1 and Count, inclusive
+                // Return a new PartitionFilter with the parsed values
+                if (number >= 1 && number <= count)
+                {
+                    partitionFilter = new PartitionFilter(number, count);
+                    return true;
+                }
+            }
+
+            // Could not parse partition information
+            partitionFilter = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Match a test against a single value.
+        /// </summary>
+        public override bool Match(ITest test)
+        {
+            // Do not match a test Suite, only match individual tests
+            if (test.IsSuite)
+                return false;
+
+            // Calculate the partition number for the provided Test
+            var partitionForTest = ComputePartitionNumber(test);
+
+            // Return a match if the calculated partition number matches our configured Partition Number
+            return partitionForTest == PartitionNumber;
+        }
+
+        /// <summary>
+        /// Adds a PartitionFilter XML node to the provided parentNode
+        /// </summary>
+        /// <param name="parentNode">Parent node</param>
+        /// <param name="recursive">True if recursive</param>
+        /// <returns>The added XML node</returns>
+        public override TNode AddToXml(TNode parentNode, bool recursive)
+        {
+            return parentNode.AddElement("partition", $"{PartitionNumber}/{PartitionCount}");
+        }
+
+        /// <summary>
+        /// Computes the Partition Number that has been assigned to the provided ITest value (based upon the configured Partition Count)
+        /// </summary>
+        /// <param name="value">A partition value between 1 and PartitionCount, inclusive</param>
+        /// <returns>A partition value between 1 and PartitionCount, inclusive</returns>
+        public uint ComputePartitionNumber(ITest value)
+        {
+            return ComputeHashValue(value.FullName) % PartitionCount + 1;
+        }
+
+        /// <summary>
+        /// Computes an unsigned integer hash value based upon the provided string
+        /// </summary>
+        private static uint ComputeHashValue(string name)
+        {
+            using var hashAlgorithm = SHA256.Create();
+
+            // SHA256 ComputeHash will return 32 bytes, we will use the first 4 bytes of that to convert to an unsigned integer
+            var hashValue = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(name));
+
+            return BitConverter.ToUInt32(hashValue, 0);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -228,6 +228,11 @@ namespace NUnit.Framework.Internal
                     if (name != null)
                         return new PropertyFilter(name, node.Value) { IsRegex = isRegex };
                     break;
+
+                case "partition":
+                    if (PartitionFilter.TryCreate(node.Value, out var partitionFilter))
+                        return partitionFilter;
+                    break;
             }
 
             throw new ArgumentException("Invalid filter element: " + node.Name, "xmlNode");

--- a/src/NUnitFramework/tests/Internal/Filters/PartitionFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/PartitionFilterTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Filters
+{
+    public class PartitionFilterTests : TestFilterTests
+    {
+        private PartitionFilter _filter;
+        private ITest _testMatchingPartition;
+        private ITest _testNotMatchingPartition;
+
+        [SetUp]
+        public void CreateFilter()
+        {
+            // Configure a new PartitionFilter with the provided partition count and number
+            _filter = new PartitionFilter(7, 10);
+
+            _testMatchingPartition = _fixtureWithMultipleTests.Tests[1];
+            _testNotMatchingPartition = _fixtureWithMultipleTests.Tests[0];
+        }
+
+        [Test]
+        public void IsNotEmpty()
+        {
+            Assert.That(_filter.IsEmpty, Is.False);
+        }
+
+        [Test]
+        public void MatchTest()
+        {
+            // Validate
+            Assert.That(_filter.ComputePartitionNumber(_testMatchingPartition), Is.EqualTo(7));
+            Assert.That(_filter.ComputePartitionNumber(_testNotMatchingPartition), Is.EqualTo(8));
+
+            // Assert
+            Assert.That(_filter.Match(_testMatchingPartition), Is.True);
+            Assert.That(_filter.Match(_testNotMatchingPartition), Is.False);
+        }
+
+        [Test]
+        public void PassTest()
+        {
+            // This test fixture contains both one matching and one non-matching test
+            // The fixture should therefore pass as True because one of the child tests are a match
+            Assert.That(_filter.Pass(_fixtureWithMultipleTests), Is.True);
+
+            // Validate that our matching and non-matching tests return the correct Pass result
+            Assert.That(_filter.Pass(_testMatchingPartition), Is.True);
+            Assert.That(_filter.Pass(_testNotMatchingPartition), Is.False);
+
+            // This other test fixture has no matching tests for this partition number
+            Assert.That(_filter.Pass(_specialFixture), Is.False);
+        }
+
+        [Test]
+        public void ExplicitMatchTest()
+        {
+            // Top level TestFixture should always Pass
+            Assert.That(_filter.IsExplicitMatch(_fixtureWithMultipleTests));
+
+            // Assert
+            Assert.That(_filter.IsExplicitMatch(_testMatchingPartition), Is.True);
+            Assert.That(_filter.IsExplicitMatch(_testNotMatchingPartition), Is.False);
+        }
+
+        [Test]
+        public void FromXml()
+        {
+            TestFilter filter = TestFilter.FromXml(@"<filter><partition>7/10</partition></filter>");
+
+            Assert.That(filter, Is.TypeOf<PartitionFilter>());
+
+            var partitionFilter = (PartitionFilter)filter;
+            Assert.That(partitionFilter.PartitionNumber, Is.EqualTo(7));
+            Assert.That(partitionFilter.PartitionCount, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void ToXml()
+        {
+            Assert.That(_filter.ToXml(false).OuterXml, Is.EqualTo(@"<partition>7/10</partition>"));
+        }
+    }
+}


### PR DESCRIPTION
# Overview
Added a new filter, PartitionFilter, that allows you to filter to a subset of arbitrary tests based on a partition number and count.

This is helpful when you may want to run a subset of tests (eg, across 3 machines - or partitions), each with a separately assigned partition number and fixed partition count

Fixes #4391 