### PR TITLE
Remove partial trust support

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Security;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
@@ -209,11 +208,6 @@ namespace NUnit.Framework.Api
             return result;
         }
 
-        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of
-        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the
-        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
-        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
-        [SecuritySafeCritical]
         private TestSuite BuildTestAssembly(Assembly assembly, string assemblyNameOrPath, IList<Test> fixtures)
         {
             TestSuite testAssembly = new TestAssembly(assembly, assemblyNameOrPath);

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Security;
 using System.Web.UI;
 using NUnit.Compatibility;
 using NUnit.Framework.Interfaces;
@@ -103,11 +102,6 @@ namespace NUnit.Framework.Api
             _testAssembly = assembly;
         }
 
-        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of
-        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the
-        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
-        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
-        [SecuritySafeCritical]
         [MemberNotNull(nameof(AssemblyNameOrPath), nameof(Settings))]
         private void Initialize(string assemblyNameOrPath, IDictionary settings)
         {

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -384,11 +384,6 @@ namespace NUnit.Framework.Api
         }
 
 #if NETFRAMEWORK
-        // This method invokes members on the 'System.Diagnostics.Process' class and must satisfy the link demand of
-        // the full-trust 'PermissionSetAttribute' on this class. Callers of this method have no influence on how the
-        // Process class is used, so we can safely satisfy the link demand with a 'SecuritySafeCriticalAttribute' rather
-        // than a 'SecurityCriticalAttribute' and allow use by security transparent callers.
-        [SecuritySafeCritical]
         private static void PauseBeforeRun()
         {
             using var process = Process.GetCurrentProcess();

--- a/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseSourceAttribute.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Security;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
@@ -140,7 +139,6 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        [SecuritySafeCritical]
         private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
         {
             List<ITestCaseData> data = new List<ITestCaseData>();

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Security;
 
 namespace NUnit.Compatibility
 {
@@ -13,7 +12,6 @@ namespace NUnit.Compatibility
         /// <summary>
         /// Obtains a lifetime service object to control the lifetime policy for this instance.
         /// </summary>
-        [SecurityCritical]  // Override of security critical method must be security critical itself
         public override object InitializeLifetimeService()
         {
             return null!;

--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Reflection;
-using System.Security;
 using System.Threading;
 
 namespace NUnit.Framework.Internal
@@ -63,7 +62,6 @@ namespace NUnit.Framework.Internal
             return null;
         }
 
-        [SecuritySafeCritical]
         private static void SetSynchronizationContext(SynchronizationContext? syncContext)
         {
             SynchronizationContext.SetSynchronizationContext(syncContext);

--- a/src/NUnitFramework/framework/Internal/ContextUtils.cs
+++ b/src/NUnitFramework/framework/Internal/ContextUtils.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Security;
 using System.Threading;
 
 namespace NUnit.Framework.Internal
@@ -20,7 +19,6 @@ namespace NUnit.Framework.Internal
             return returnValue!;
         }
 
-        [SecuritySafeCritical]
         public static void DoIsolated(ContextCallback callback, object? state)
         {
             var previousState = SandboxedThreadState.Capture();

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Security;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 
@@ -463,7 +462,6 @@ namespace NUnit.Framework.Internal.Execution
             _thread.Join();
         }
 
-        [SecuritySafeCritical]
         private void RunOnCurrentThread()
         {
             Context.CurrentTest = Test;

--- a/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
+++ b/src/NUnitFramework/framework/Internal/MessagePumpStrategy.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Security;
 using System.Threading;
 
 namespace NUnit.Framework.Internal
@@ -75,7 +74,6 @@ namespace NUnit.Framework.Internal
                 return context?.GetType().FullName == "System.Windows.Forms.WindowsFormsSynchronizationContext";
             }
 
-            [SecuritySafeCritical]
             public override void WaitForCompletion(AwaitAdapter awaiter)
             {
                 var context = SynchronizationContext.Current;

--- a/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitCallContext.cs
@@ -3,7 +3,6 @@
 #if NETFRAMEWORK
 using System;
 using System.Runtime.Remoting.Messaging;
-using System.Security;
 
 namespace NUnit.Framework.Internal
 {
@@ -17,16 +16,11 @@ namespace NUnit.Framework.Internal
         private readonly object _oldContext;
         public const string TestExecutionContextKey = "NUnit.Framework.TestExecutionContext";
 
-        // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
-        // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
-        // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
-        [SecuritySafeCritical]
         public NUnitCallContext()
         {
             _oldContext = CallContext.GetData(TestExecutionContextKey);
         }
 
-        [SecuritySafeCritical]
         public void Dispose()
         {
             if (_oldContext is null)

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -3,7 +3,6 @@
 using Microsoft.Win32;
 using System;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 
 namespace NUnit.Framework.Internal
@@ -11,10 +10,6 @@ namespace NUnit.Framework.Internal
     /// <summary>
     /// OSPlatform represents a particular operating system platform
     /// </summary>
-    // This class invokes security critical P/Invoke and 'System.Runtime.InteropServices.Marshal' methods.
-    // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
-    // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
-    [SecuritySafeCritical]
     public class OSPlatform
     {
         #region Static Members

--- a/src/NUnitFramework/framework/Internal/SandboxedThreadState.cs
+++ b/src/NUnitFramework/framework/Internal/SandboxedThreadState.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Globalization;
-using System.Security;
 using System.Threading;
 
 namespace NUnit.Framework.Internal
@@ -48,7 +47,6 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Restores the tracked state of the current thread to the previously captured state.
         /// </summary>
-        [SecurityCritical]
         public void Restore()
         {
             Thread.CurrentThread.CurrentCulture = Culture;

--- a/src/NUnitFramework/framework/Internal/TaskAwaitAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/TaskAwaitAdapter.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Security;
 using System.Threading.Tasks;
 
 namespace NUnit.Framework.Internal
@@ -40,7 +39,6 @@ namespace NUnit.Framework.Internal
 
             public override bool IsCompleted => _awaiter.IsCompleted;
 
-            [SecuritySafeCritical]
             public override void OnCompleted(Action action) => _awaiter.UnsafeOnCompleted(action);
 
             // Assumption that GetResult blocks until complete is only valid for System.Threading.Tasks.Task.
@@ -64,7 +62,6 @@ namespace NUnit.Framework.Internal
 
             public override bool IsCompleted => _awaiter.IsCompleted;
 
-            [SecuritySafeCritical]
             public override void OnCompleted(Action action) => _awaiter.UnsafeOnCompleted(action);
 
             // Assumption that GetResult blocks until complete is only valid for System.Threading.Tasks.Task.

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Security;
 using System.Security.Principal;
 using System.Threading;
 using NUnit.Compatibility;
@@ -146,10 +145,6 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public static TestExecutionContext CurrentContext
         {
-            // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
-            // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
-            // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
-            [SecuritySafeCritical]
             get
             {
                 var context = CallContext.GetData(NUnitCallContext.TestExecutionContextKey) as TestExecutionContext;
@@ -162,10 +157,6 @@ namespace NUnit.Framework.Internal
 
                 return context;
             }
-            // This method invokes security critical members on the 'System.Runtime.Remoting.Messaging.CallContext' class.
-            // Callers of this method have no influence on how these methods are used so we define a 'SecuritySafeCriticalAttribute'
-            // rather than a 'SecurityCriticalAttribute' to enable use by security transparent callers.
-            [SecuritySafeCritical]
             private set
             {
                 if (value is null)
@@ -407,11 +398,6 @@ namespace NUnit.Framework.Internal
         /// Note that we may be running on the same thread where the
         /// context was initially created or on a different thread.
         /// </summary>
-        [SecuritySafeCritical] // This gives partial trust code the ability to capture an existing
-                               // SynchronizationContext.Current and restore it at any time.
-                               // This simply unblocks us on .NET Framework and is not in the spirit
-                               // of partial trust. If we choose to make partial trust a design priority,
-                               // we’ll need to thoroughly review more than just this instance.
         public void EstablishExecutionEnvironment()
         {
             _sandboxedThreadState.Restore();
@@ -475,7 +461,6 @@ namespace NUnit.Framework.Internal
         /// Obtain lifetime service object
         /// </summary>
         /// <returns></returns>
-        [SecurityCritical]  // Override of security critical method must be security critical itself
         public override object InitializeLifetimeService()
         {
             return null!;

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -6,7 +6,6 @@ using System.Threading;
 #if THREAD_ABORT
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Security;
 #endif
 
 namespace NUnit.Framework.Internal
@@ -159,7 +158,6 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Captures the current thread's native id. If provided to <see cref="Kill(Thread,int)"/> later, allows the thread to be killed if it's in a message pump native blocking wait.
         /// </summary>
-        [SecuritySafeCritical]
         public static int GetCurrentThreadNativeId()
         {
             if (_isNotOnWindows) return 0;
@@ -180,7 +178,6 @@ namespace NUnit.Framework.Internal
         /// Sends a message to the thread to dislodge it from native code and allow a return to managed code, where a ThreadAbortException can be generated.
         /// The message is meaningless (WM_CLOSE without a window handle) but it will end any blocking message wait.
         /// </summary>
-        [SecuritySafeCritical]
         private static void PostThreadCloseMessage(int nativeId)
         {
             if (!PostThreadMessage(nativeId, WM.CLOSE, IntPtr.Zero, IntPtr.Zero))

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Security;
 
 [assembly: InternalsVisibleTo("nunit.framework.tests, PublicKey=002400000480000094" +
                               "000000060200000024000052534131000400000100010031eea" +
@@ -48,5 +47,3 @@ using System.Security;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(true)]
-
-[assembly: AllowPartiallyTrustedCallers]

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -32,19 +32,28 @@ namespace NUnit.Framework.Assertions
         [Test]
         public void AssertEqualityInLowTrustSandBox()
         {
-            _sandBox.Run(() => Assert.That(1, Is.EqualTo(1)));
+            Assert.That(
+                () => _sandBox.Run(() => Assert.That(1, Is.EqualTo(1))),
+                Throws.Exception.InstanceOf<MemberAccessException>()
+            );
         }
 
         [Test]
         public void AssertEqualityWithToleranceInLowTrustSandBox()
         {
-            _sandBox.Run(() => Assert.That(10.5, Is.EqualTo(10.5)));
+            Assert.That(
+                () => _sandBox.Run(() => Assert.That(10.5, Is.EqualTo(10.5))),
+                Throws.Exception.InstanceOf<MemberAccessException>()
+            );
         }
 
         [Test]
         public void AssertThrowsInLowTrustSandBox()
         {
-            _sandBox.Run(() => Assert.Throws<SecurityException>(() => new SecurityPermission(SecurityPermissionFlag.Infrastructure).Demand()));
+            Assert.That(
+                () => _sandBox.Run(() => Assert.Throws<SecurityException>(() => new SecurityPermission(SecurityPermissionFlag.Infrastructure).Demand())),
+                Throws.Exception.InstanceOf<MemberAccessException>()
+            );
         }
     }
 


### PR DESCRIPTION
Fixes #3301 

This largely was a find-remove of the following attributes usage and comments without much else needed. 
- `SecurityCriticalAttribute`
- `SecuritySafeCriticalAttribute`
- `AllowPartiallyTrustedCallers`

The `LowTrustFixture` tests were updated to now expect a `MemberAccessException` to be thrown as a way of verifying we continue to not support partial trust, though I'm on the fence about removing them outright.