### PR TITLE
Add string syntax attributes

### DIFF
--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -39,9 +39,7 @@ namespace NUnit.Framework
         /// property set which will appear in the test results.
         /// </remarks>
         /// <exception cref="FormatException">The string does not contain a valid string representation of a date and time.</exception>
-#if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)]
-#endif
+        [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
         [DisallowNull]
         public string? Until
         {

--- a/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/IgnoreAttribute.cs
@@ -39,6 +39,9 @@ namespace NUnit.Framework
         /// property set which will appear in the test results.
         /// </remarks>
         /// <exception cref="FormatException">The string does not contain a valid string representation of a date and time.</exception>
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)]
+#endif
         [DisallowNull]
         public string? Until
         {

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -266,9 +266,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Gets and sets the ignore until date for this test case.
         /// </summary>
-#if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)]
-#endif
+        [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
         [DisallowNull]
         public string? Until
         {

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -266,6 +266,9 @@ namespace NUnit.Framework
         /// <summary>
         /// Gets and sets the ignore until date for this test case.
         /// </summary>
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)]
+#endif
         [DisallowNull]
         public string? Until
         {

--- a/src/NUnitFramework/framework/Compatibility/StringSyntaxAttribute.cs
+++ b/src/NUnitFramework/framework/Compatibility/StringSyntaxAttribute.cs
@@ -1,0 +1,77 @@
+#if !NET7_0_OR_GREATER
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies the syntax used in a string.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class StringSyntaxAttribute : Attribute
+    {
+        /// <summary>The syntax identifier for strings containing composite formats for string formatting.</summary>
+        public const string CompositeFormat = nameof(CompositeFormat);
+
+        /// <summary>The syntax identifier for strings containing date format specifiers.</summary>
+        public const string DateOnlyFormat = nameof(DateOnlyFormat);
+
+        /// <summary>The syntax identifier for strings containing date and time format specifiers.</summary>
+        public const string DateTimeFormat = nameof(DateTimeFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="Enum"/> format specifiers.</summary>
+        public const string EnumFormat = nameof(EnumFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="Guid"/> format specifiers.</summary>
+        public const string GuidFormat = nameof(GuidFormat);
+
+        /// <summary>The syntax identifier for strings containing JavaScript Object Notation (JSON).</summary>
+        public const string Json = nameof(Json);
+
+        /// <summary>The syntax identifier for strings containing numeric format specifiers.</summary>
+        public const string NumericFormat = nameof(NumericFormat);
+
+        /// <summary>The syntax identifier for strings containing regular expressions.</summary>
+        public const string Regex = nameof(Regex);
+
+        /// <summary>The syntax identifier for strings containing time format specifiers.</summary>
+        public const string TimeOnlyFormat = nameof(TimeOnlyFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="TimeSpan"/> format specifiers.</summary>
+        public const string TimeSpanFormat = nameof(TimeSpanFormat);
+
+        /// <summary>The syntax identifier for strings containing URIs.</summary>
+        public const string Uri = nameof(Uri);
+
+        /// <summary>The syntax identifier for strings containing XML.</summary>
+        public const string Xml = nameof(Xml);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringSyntaxAttribute"/> class with the identifier of the syntax used.
+        /// </summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        public StringSyntaxAttribute(string syntax)
+        {
+            Syntax = syntax;
+            Arguments = Array.Empty<object?>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringSyntaxAttribute"/> class with the identifier of the syntax used.
+        /// </summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+        public StringSyntaxAttribute(string syntax, params object?[] arguments)
+        {
+            Syntax = syntax;
+            Arguments = arguments;
+        }
+
+        /// <summary>Gets the identifier of the syntax used.</summary>
+        public string Syntax { get; }
+
+        /// <summary>Gets optional arguments associated with the specific syntax employed.</summary>
+        public object?[] Arguments { get; }
+    }
+}
+
+#endif

--- a/src/NUnitFramework/framework/Compatibility/StringSyntaxAttribute.cs
+++ b/src/NUnitFramework/framework/Compatibility/StringSyntaxAttribute.cs
@@ -1,7 +1,6 @@
-#if !NET7_0_OR_GREATER
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+#if !NET7_0_OR_GREATER
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -768,7 +768,11 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public RegexConstraint Match(string pattern)
+        public RegexConstraint Match(
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+#endif
+            string pattern)
         {
             return (RegexConstraint)Append(new RegexConstraint(pattern));
         }
@@ -786,7 +790,11 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public RegexConstraint Matches(string pattern)
+        public RegexConstraint Matches(
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+#endif
+            string pattern)
         {
             return (RegexConstraint)Append(new RegexConstraint(pattern));
         }

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -770,7 +770,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Match(
 #if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
 #endif
             string pattern)
         {

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace NUnit.Framework.Constraints
@@ -768,11 +769,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public RegexConstraint Match(
-#if NET7_0_OR_GREATER
-            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
-#endif
-            string pattern)
+        public RegexConstraint Match([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
         {
             return (RegexConstraint)Append(new RegexConstraint(pattern));
         }
@@ -790,11 +787,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public RegexConstraint Matches(
-#if NET7_0_OR_GREATER
-            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
-#endif
-            string pattern)
+        public RegexConstraint Matches([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
         {
             return (RegexConstraint)Append(new RegexConstraint(pattern));
         }

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -792,7 +792,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Matches(
 #if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
 #endif
             string pattern)
         {

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace NUnit.Framework.Constraints
@@ -34,11 +35,7 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="RegexConstraint"/> class.
         /// </summary>
         /// <param name="pattern">The pattern.</param>
-        public RegexConstraint(
-#if NET7_0_OR_GREATER
-            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
-#endif
-            string pattern) : base(pattern)
+        public RegexConstraint([StringSyntax(StringSyntaxAttribute.Regex)] string pattern) : base(pattern)
         {
             _regex = new Regex(pattern);
         }

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="pattern">The pattern.</param>
         public RegexConstraint(
 #if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
 #endif
             string pattern) : base(pattern)
         {

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -34,7 +34,11 @@ namespace NUnit.Framework.Constraints
         /// Initializes a new instance of the <see cref="RegexConstraint"/> class.
         /// </summary>
         /// <param name="pattern">The pattern.</param>
-        public RegexConstraint(string pattern) : base(pattern)
+        public RegexConstraint(
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+#endif
+            string pattern) : base(pattern)
         {
             _regex = new Regex(pattern);
         }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -111,7 +111,7 @@ namespace NUnit.Framework
         /// </summary>
         public static RegexConstraint Match(
 #if NET7_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
 #endif
             string pattern)
         {

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -109,7 +109,11 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public static RegexConstraint Match(string pattern)
+        public static RegexConstraint Match(
+#if NET7_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
+#endif
+            string pattern)
         {
             return new RegexConstraint(pattern);
         }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using NUnit.Framework.Constraints;
 
@@ -109,11 +110,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
-        public static RegexConstraint Match(
-#if NET7_0_OR_GREATER
-            [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)]
-#endif
-            string pattern)
+        public static RegexConstraint Match([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
         {
             return new RegexConstraint(pattern);
         }


### PR DESCRIPTION
fixes #4433

This allows IDEs to add DateTime and Regex syntax highlighting when available (.NET 7+)