### PR TITLE
Issue4421 all target frameworks

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,10 +7,6 @@ on:
       - release
       - 'v3.13-dev'
   pull_request:
-    branches:
-      - master
-      - release
-      - 'v3.13-dev'
 
 jobs:
   build-windows:
@@ -25,11 +21,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
-
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
 
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3
@@ -77,11 +68,6 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
-
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3
       with:
@@ -121,11 +107,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
-
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
 
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -118,14 +118,14 @@ Feature constants are defined in [Directory.Build.props](src/NUnitFramework/Dire
 - `THREAD_ABORT` enables timeouts and forcible cancellation
 
 Platform constants are defined by convention by the csproj SDK, one per target framework.
-For example, `NET462`, `NETSTANDARD2_0`, `NETCOREAPP2_1`, and so on.
+For example, `NET462`, `NETSTANDARD2_0`, `NET6_0`, and so on.
 It is most helpful to call out which platforms are the exception in rather than the rule
 in a given scenario. Keep in mind the effect the preprocessor would have on a newly added platform.
 
 For example, rather than this code:
 
 ```cs
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+#if NETSTANDARD2_0 || NET6_0
 // Something that .NET Framework can't do
 #endif
 ```

--- a/build.cake
+++ b/build.cake
@@ -50,6 +50,7 @@ var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
 var NUNITFRAMEWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
+var NUNITFRAMEWORKCLASSICTESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic.tests/bin/" + configuration + "/";
 var NUNITLITETESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunitlite.tests/bin/" + configuration + "/";
 var NUNITFRAMEWORKBIN = PROJECT_DIR + "src/NUnitFramework/framework/bin/" + configuration + "/";
 var NUNITFRAMEWORKCLASSICBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic/bin/" + configuration + "/";
@@ -63,6 +64,7 @@ var NUNITLITE_RUNNER_DLL = "nunitlite-runner.dll";
 
 // Test Assemblies
 var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
+var FRAMEWORKCLASSIC_TESTS = "nunit.framework.classic.tests.dll";
 var EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE = "nunitlite-runner.exe";
 var EXECUTABLE_NUNITLITE_TESTS_EXE = "nunitlite.tests.exe";
 var EXECUTABLE_NUNITLITE_TESTS_DLL = "nunitlite.tests.dll";
@@ -182,7 +184,9 @@ Task("TestNetFramework")
         var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
         Information("Run tests for " + runtime + " in " + dir + "using runner");
         RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORK_TESTS, dir + "nunit.framework.tests.xml", runtime, ref ErrorDetail);
-        //RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        dir = NUNITFRAMEWORKCLASSICTESTSBIN + runtime + "/";
+        Information("Run classic tests for " + runtime + " in " + dir + "using runner");
+        RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORKCLASSIC_TESTS, dir + "nunit.framework.classic.tests.xml", runtime, ref ErrorDetail);
         dir = NUNITLITETESTSBIN + runtime + "/";
         Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS_EXE, dir, runtime, ref ErrorDetail);
@@ -204,6 +208,9 @@ foreach (var runtime in NetCoreTests)
             var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
             Information("Run tests for " + runtime + " in " + dir);
             RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORK_TESTS, runtime, GetResultXmlPath(FRAMEWORK_TESTS, runtime), ref ErrorDetail);
+            dir = NUNITFRAMEWORKCLASSICTESTSBIN + runtime + "/";
+            Information("Run classic tests for " + runtime + " in " + dir);
+            RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORKCLASSIC_TESTS, runtime, GetResultXmlPath(FRAMEWORKCLASSIC_TESTS, runtime), ref ErrorDetail);
             dir = NUNITLITETESTSBIN + runtime + "/";
             Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
             RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);

--- a/build.cake
+++ b/build.cake
@@ -31,15 +31,14 @@ var packageVersion = version + modifier + dbgSuffix;
 var LibraryFrameworks = new string[]
 {
     "net462",
-    "netstandard2.0"
+    "net6.0",
 };
 
 // Subset of NUnitRuntimeFrameworks in Directory.Build.props
 var NetCoreTests = new String[]
 {
-    "netcoreapp3.1",
     "net6.0",
-    "net7.0"
+    "net7.0",
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -50,7 +49,7 @@ var PROJECT_DIR = Context.Environment.WorkingDirectory.FullPath + "/";
 var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
-var NUNITFRAMWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
+var NUNITFRAMEWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
 var NUNITLITETESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunitlite.tests/bin/" + configuration + "/";
 var NUNITFRAMEWORKBIN = PROJECT_DIR + "src/NUnitFramework/framework/bin/" + configuration + "/";
 var NUNITFRAMEWORKCLASSICBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic/bin/" + configuration + "/";
@@ -180,38 +179,38 @@ Task("TestNetFramework")
     .Does(() =>
     {
         var runtime = "net462";
-        var dir = NUNITFRAMWORKTESTSBIN + runtime + "/";
-        Information("Run tests for " + runtime + " in " + dir+"using runner");
+        var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
+        Information("Run tests for " + runtime + " in " + dir + "using runner");
         RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORK_TESTS, dir + "nunit.framework.tests.xml", runtime, ref ErrorDetail);
         //RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         dir = NUNITLITETESTSBIN + runtime + "/";
-        Information("Run tests for " + runtime + " in " + dir+" for nunitlite.tests");
+        Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS_EXE, dir, runtime, ref ErrorDetail);
         PublishTestResults(runtime);
     });
 
-var testNetStandard20 = Task("TestNetStandard20")
-    .Description("Tests the .NET Standard 2.0 version of the framework");
+var testCore = Task("TestNetCore")
+    .Description("Tests the .NET Core (6.0+) version of the framework");
 
 foreach (var runtime in NetCoreTests)
 {
-    var task = Task("TestNetStandard20 on " + runtime)
-        .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
+    var task = Task("TestNetCore on " + runtime)
+        .Description("Tests the .NET Core (6.0+) version of the framework on " + runtime)
         .WithCriteria(IsRunningOnWindows() || !runtime.EndsWith("windows"))
         .IsDependentOn("Build")
         .OnError(exception => { ErrorDetail.Add(exception.Message); })
         .Does(() =>
         {
-            var dir = NUNITFRAMWORKTESTSBIN + runtime + "/";
-              Information("Run tests for " + runtime + " in " + dir);
+            var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
+            Information("Run tests for " + runtime + " in " + dir);
             RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORK_TESTS, runtime, GetResultXmlPath(FRAMEWORK_TESTS, runtime), ref ErrorDetail);
             dir = NUNITLITETESTSBIN + runtime + "/";
-            Information("Run tests for " + runtime + " in " + dir+" for nunitlite.tests");
+            Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
             RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);
             PublishTestResults(runtime);
         });
 
-    testNetStandard20.IsDependentOn(task);
+    testCore.IsDependentOn(task);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -572,7 +571,7 @@ Task("Test")
     .Description("Builds and tests all versions of the framework")
     .IsDependentOn("Build")
     .IsDependentOn("TestNetFramework")
-    .IsDependentOn("TestNetStandard20");
+    .IsDependentOn("TestNetCore");
 
 Task("Package")
     .Description("Packages all versions of the framework")

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -26,9 +26,7 @@ Supported platforms:
     <copyright>Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License.</copyright>
     <dependencies>
       <group targetFramework="net462" />
-      <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
-      </group>
+      <group targetFramework="net6.0" />
     </dependencies>
   </metadata>
   <files>
@@ -43,12 +41,12 @@ Supported platforms:
     <file src="bin/net462/nunit.framework.classic.dll" target="lib\net462" />
     <file src="bin/net462/nunit.framework.classic.xml" target="lib\net462" />
     <file src="bin/net462/nunit.framework.classic.pdb" target="lib\net462" />
-    <file src="bin/netstandard2.0/nunit.framework.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.xml" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.pdb" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.xml" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.pdb" target="lib\netstandard2.0" />
+    <file src="bin/net6.0/nunit.framework.dll" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.xml" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.pdb" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.dll" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.xml" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.pdb" target="lib\net6.0" />
     <file src="..\..\nuget\framework\NUnit.props" target="build" />
   </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -33,13 +33,6 @@ How to use this package:
       <group targetFramework="net462">
         <dependency id="NUnit" version="[$version$]" />
       </group>
-      <group targetFramework="netstandard2.0">
-        <dependency id="NUnit" version="[$version$]" />
-        <dependency id="NETStandard.Library" version="2.0.0" />
-      </group>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="NUnit" version="[$version$]" />
-      </group>
       <group targetFramework="net6.0">
         <dependency id="NUnit" version="[$version$]" />
       </group>
@@ -55,12 +48,8 @@ How to use this package:
     <file src="..\..\nuget\icon.png" />
     <file src="bin/net462/nunitlite.dll" target="lib\net462" />
     <file src="bin/net462/nunitlite.pdb" target="lib\net462" />
-    <file src="bin/netstandard2.0/nunitlite.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunitlite.pdb" target="lib\netstandard2.0" />
     <file src="bin/net462/nunitlite-runner.exe" target="tools\net462" />
     <file src="bin/net462/nunitlite-runner.pdb" target="tools\net462" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="lib\netcoreapp3.1" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="lib\netcoreapp3.1" />
     <file src="bin/net6.0/nunitlite.dll" target="lib\net6.0" />
     <file src="bin/net6.0/nunitlite.pdb" target="lib\net6.0" />
     <file src="bin/net7.0/nunitlite.dll" target="lib\net7.0" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -15,8 +15,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2 Debug")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
-#elif NETCOREAPP2_1
-[assembly: AssemblyConfiguration(".NET Core 2.1 Debug")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
 #elif NET5_0
@@ -33,8 +31,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyConfiguration(".NET Standard 2.0")]
-#elif NETCOREAPP2_1
-[assembly: AssemblyConfiguration(".NET Core 2.1")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1")]
 #elif NET5_0

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -6,8 +6,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-    <NUnitLibraryFrameworks>net462;netstandard2.0</NUnitLibraryFrameworks>
-    <NUnitRuntimeFrameworks>net462;netcoreapp3.1;net6.0;net7.0</NUnitRuntimeFrameworks>
+    <NUnitLibraryFrameworks>net462;net6.0</NUnitLibraryFrameworks>
+    <NUnitRuntimeFrameworks>net462;net6.0;net7.0</NUnitRuntimeFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--<OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>-->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">9</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">10</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -329,11 +329,7 @@ namespace NUnit.Framework.Api
 
             env.AddAttribute("framework-version", typeof(FrameworkController).Assembly.GetName().Version?.ToString() ?? "Unknown");
             env.AddAttribute("clr-version", Environment.Version.ToString());
-#if NETSTANDARD2_0
-            env.AddAttribute("os-version", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            env.AddAttribute("os-version", OSPlatform.CurrentPlatform.ToString());
-#endif
+            env.AddAttribute("os-version", OSPlatform.OSDescription);
             env.AddAttribute("platform", Environment.OSVersion.Platform.ToString());
             env.AddAttribute("cwd", Directory.GetCurrentDirectory());
             env.AddAttribute("machine-name", Environment.MachineName);

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -20,7 +20,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(bool condition, string? message)
+        public static void That(bool condition, NUnitString message)
+        {
+            That(condition, Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(bool condition, FormattableString message)
         {
             That(condition, Is.True, message);
         }
@@ -53,7 +63,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, string? message)
+        public static void That(Func<bool> condition, NUnitString message)
+        {
+            That(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(Func<bool> condition, FormattableString message)
         {
             That(condition.Invoke(), Is.True, message);
         }
@@ -99,14 +119,31 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         /// <summary>
@@ -149,7 +186,18 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, string? message)
+        public static void That(TestDelegate code, IResolveConstraint constraint, NUnitString message)
+        {
+            That((object)code, constraint, message);
+        }
+
+        /// <summary>
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">A TestDelegate to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That(TestDelegate code, IResolveConstraint constraint, FormattableString message)
         {
             That((object)code, constraint, message);
         }
@@ -191,14 +239,32 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            var constraint = expression.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.ThatAsync.cs
+++ b/src/NUnitFramework/framework/Assert.ThatAsync.cs
@@ -29,7 +29,28 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, string? message)
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, NUnitString message)
+        {
+            try
+            {
+                await code();
+                Assert.That(() => { }, constraint, message);
+            }
+            catch (Exception ex)
+            {
+                var edi = ExceptionDispatchInfo.Capture(ex);
+                Assert.That(() => edi.Throw(), constraint, message);
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">An AsyncTestDelegate to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <returns>Awaitable.</returns>
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, FormattableString message)
         {
             try
             {
@@ -61,7 +82,28 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, string? message)
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, NUnitString message)
+        {
+            try
+            {
+                var result = await code();
+                Assert.That(() => result, constraint, message);
+            }
+            catch (Exception ex)
+            {
+                var edi = ExceptionDispatchInfo.Capture(ex);
+                Assert.That(() => edi.Throw(), constraint, message);
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">An async method to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <returns>Awaitable.</returns>
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, FormattableString message)
         {
             try
             {

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -342,10 +342,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.StackTrace"/> throws, returns "SomeException was thrown by the
         /// Environment.StackTrace property." See also <see cref="ExceptionExtensions.GetStackTraceWithoutThrowing"/>.
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         private static string GetEnvironmentStackTraceWithoutThrowing()
         {
             try

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             CheckMultipleAssertLevel();
 
@@ -78,7 +78,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            CheckMultipleAssertLevel();
+
+            var constraint = expr.Resolve();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         private static void ReportFailure(ConstraintResult result, string? message)
@@ -122,7 +141,18 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, string? message)
+        public static void That([DoesNotReturnIf(false)] bool condition, NUnitString message)
+        {
+            That(condition, Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That([DoesNotReturnIf(false)] bool condition, FormattableString message)
         {
             That(condition, Is.True, message);
         }
@@ -158,7 +188,18 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, string? message)
+        public static void That(Func<bool> condition, NUnitString message)
+        {
+            That(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(Func<bool> condition, FormattableString message)
         {
             That(condition.Invoke(), Is.True, message);
         }
@@ -225,7 +266,7 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
             CheckMultipleAssertLevel();
 
@@ -234,7 +275,30 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
             {
-                MessageWriter writer = new TextMessageWriter(message);
+                MessageWriter writer = new TextMessageWriter(message.ToString());
+                result.WriteMessageTo(writer);
+                throw new InconclusiveException(writer.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            CheckMultipleAssertLevel();
+
+            var constraint = expression.Resolve();
+
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                MessageWriter writer = new TextMessageWriter(message.ToString());
                 result.WriteMessageTo(writer);
                 throw new InconclusiveException(writer.ToString());
             }

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -12,6 +12,9 @@ namespace NUnit.Compatibility
         /// <summary>
         /// Obtains a lifetime service object to control the lifetime policy for this instance.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [Obsolete("Preventing throwing PlatformNotSupportedException")]
+#endif
         public override object InitializeLifetimeService()
         {
             return null!;

--- a/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
@@ -36,11 +36,15 @@ namespace NUnit.Framework.Constraints
 
             try
             {
+                // 'BinaryFormatter serialization is obsolete and should not be used.
+                // See https://aka.ms/binaryformatter for more information.'
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                 _serializer.Serialize(stream, actual);
 
                 stream.Seek(0, SeekOrigin.Begin);
 
                 succeeded = _serializer.Deserialize(stream) is not null;
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
             catch (SerializationException)
             {

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -94,7 +94,9 @@ namespace NUnit.Framework.Constraints
             AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsValueTuple, GetValueFromValueTuple) ?? next(val));
         }
 
+#if NETFRAMEWORK
         [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
+#endif
         private static string FormatValueWithoutThrowing(object? val)
         {
             string? asString;

--- a/src/NUnitFramework/framework/ExceptionExtensions.cs
+++ b/src/NUnitFramework/framework/ExceptionExtensions.cs
@@ -11,10 +11,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.StackTrace"/> throws, returns "SomeException was thrown by the Exception.StackTrace
         /// property." See also <see cref="Assert.GetEnvironmentStackTraceWithoutThrowing"/>.
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static string? GetStackTraceWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));
@@ -33,10 +29,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.Message"/> throws, returns "SomeException was thrown by the Exception.Message
         /// property."
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static string GetMessageWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));
@@ -54,10 +46,6 @@ namespace NUnit.Framework
         /// <summary>
         /// If <see cref="Exception.Data"/> throws, returns "SomeException was thrown by the Exception.Data property."
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static Result<IDictionary> GetDataWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));

--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -51,8 +51,8 @@ namespace NUnit.Framework.Interfaces
         {
             var hashCode = -783279553;
             hashCode = hashCode * -1521134295 + Status.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(StackTrace);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message ?? string.Empty);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(StackTrace ?? string.Empty);
             return hashCode;
         }
 

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -3,7 +3,7 @@
 using System;
 using System.IO;
 using System.Reflection;
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
 using System.Runtime.Loader;
 #endif
 
@@ -29,10 +29,16 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
+#if NETFRAMEWORK
+            // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location 
+            // .NET Framework only: 
+            // If the loaded file was shadow-copied, the location is that of the file after being shadow-copied.
+            // To get the location before the file has been shadow-copied, use the CodeBase property.
             string? codeBase = assembly.CodeBase;
 
             if (codeBase is not null && IsFileUri(codeBase))
                 return GetAssemblyPathFromCodeBase(codeBase);
+#endif
 
             return assembly.Location;
         }
@@ -69,7 +75,7 @@ namespace NUnit.Framework.Internal
 
         #region Load
 
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
         private sealed class ReflectionAssemblyLoader
         {
             private static ReflectionAssemblyLoader? _instance;

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -36,6 +36,12 @@ namespace NUnit.Framework.Internal.Execution
 
             if (topLevelWorkItem.TargetApartment != ApartmentState.Unknown)
             {
+#if NET6_0_OR_GREATER
+                if (OperatingSystem.IsWindows())
+                    _runnerThread.SetApartmentState(topLevelWorkItem.TargetApartment);
+                else
+                    topLevelWorkItem.MarkNotRunnable("Apartment state cannot be set on this platform.");
+#else
                 try
                 {
                     _runnerThread.SetApartmentState(topLevelWorkItem.TargetApartment);
@@ -44,6 +50,7 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     topLevelWorkItem.MarkNotRunnable("Apartment state cannot be set on this platform.");
                 }
+#endif
             }
 
             _runnerThread.Start(topLevelWorkItem);

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -134,6 +134,10 @@ namespace NUnit.Framework.Internal.Execution
                 Name = Name
             };
 
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+                _workerThread.SetApartmentState(WorkQueue.TargetApartment);
+#else
             try
             {
                 _workerThread.SetApartmentState(WorkQueue.TargetApartment);
@@ -141,6 +145,7 @@ namespace NUnit.Framework.Internal.Execution
             catch (PlatformNotSupportedException)
             {
             }
+#endif
 
             Log.Info("{0} starting on thread [{1}]", Name, _workerThread.ManagedThreadId);
             _workerThread.Start();

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -445,6 +445,20 @@ namespace NUnit.Framework.Internal.Execution
                 RunOnCurrentThread();
             });
 
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+            {
+                _thread.SetApartmentState(apartment);
+            }
+            else
+            {
+                const string msg = "Apartment state cannot be set on this platform.";
+                Log.Error(msg);
+                Result.SetResult(ResultState.Skipped, msg);
+                WorkItemComplete();
+                return;
+            }
+#else
             try
             {
                 _thread.SetApartmentState(apartment);
@@ -457,6 +471,7 @@ namespace NUnit.Framework.Internal.Execution
                 WorkItemComplete();
                 return;
             }
+#endif
 
             _thread.Start();
             _thread.Join();

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 
 namespace NUnit.Framework.Internal
 {
@@ -182,7 +181,9 @@ namespace NUnit.Framework.Internal
         /// <param name="fixture">The object on which to invoke the method</param>
         /// <param name="args">The argument list for the method</param>
         /// <returns>The return value from the invoked method</returns>
-        [HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions.
+#if NETFRAMEWORK
+        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions.
+#endif
         public static object? InvokeMethod(MethodInfo method, object? fixture, params object?[]? args)
         {
             try

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
                 major = 0;
                 minor = 0;
             }
-            else /* It's windows */
+            else /* It's .net framework */
 #if NETSTANDARD2_0
             {
                 minor = 5;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -455,19 +455,6 @@ namespace NUnit.Framework.Internal
 
         #endregion
 
-        #region InitializeLifetimeService
-
-        /// <summary>
-        /// Obtain lifetime service object
-        /// </summary>
-        /// <returns></returns>
-        public override object InitializeLifetimeService()
-        {
-            return null!;
-        }
-
-        #endregion
-
         #region Nested IsolatedContext Class
 
         /// <summary>

--- a/src/NUnitFramework/framework/NUnitString.cs
+++ b/src/NUnitFramework/framework/NUnitString.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// A class to allow postponing the actual formatting of interpolated strings.
+    /// </summary>
+    /// <remarks>
+    /// This class is needed as the compiler prefers to call a <see cref="string"/> overload
+    /// vs a <see cref="FormattableString"/> overload.
+    /// https://www.damirscorner.com/blog/posts/20180921-FormattableStringAsMethodParameter.html
+    /// </remarks>
+    public readonly struct NUnitString
+    {
+        private readonly string? _message;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NUnitString"/> class.
+        /// </summary>
+        /// <param name="message">The message formattable to hold.</param>
+        public NUnitString(string? message)
+        {
+            _message = message;
+        }
+
+        /// <summary>
+        /// Implicit conversion from a <see cref="FormattableString"/> to a <see cref="NUnitString"/>.
+        /// </summary>
+        /// <remarks>
+        /// Should never be called. It only exists for the compiler.
+        /// </remarks>
+        /// <param name="formattableMessage">The message formattable to hold.</param>
+        [Obsolete("This only exists for the compiler")]
+        public static implicit operator NUnitString(FormattableString formattableMessage)
+            => throw new NotImplementedException();
+
+        /// <summary>
+        /// Implicit conversion from a <see cref="string"/> to a <see cref="NUnitString"/>.
+        /// </summary>
+        /// <param name="message">The message formattable to hold.</param>
+        public static implicit operator NUnitString(string? message) => new(message);
+
+        /// <inheritdoc/>
+        public override string? ToString() => _message;
+    }
+}

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -40,6 +40,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnit Framework (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnit Framework (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnit Framework (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnit Framework (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = expr.Resolve();
 
@@ -77,7 +77,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message);
+                IssueWarning(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and issuing a warning on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                IssueWarning(result, message.ToString());
         }
 
         private static void IssueWarning(ConstraintResult result, string? message)
@@ -118,9 +137,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, string? message)
+        public static void Unless(bool condition, NUnitString message)
         {
-            Unless(condition, Is.True, () => message);
+            Unless(condition, Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, a warning is issued.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void Unless(bool condition, FormattableString message)
+        {
+            Unless(condition, Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -151,7 +180,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, string? message)
+        public static void Unless(Func<bool> condition, NUnitString message)
+        {
+            Unless(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, a warning is issued.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void Unless(Func<bool> condition, FormattableString message)
         {
             Unless(condition.Invoke(), Is.True, message);
         }
@@ -214,9 +253,22 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
-            Unless(actual, expression, () => message);
+            Unless(actual, expression, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and issuing a warning on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            Unless(actual, expression, () => message.ToString());
         }
 
         /// <summary>
@@ -269,7 +321,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -277,7 +329,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message);
+                IssueWarning(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// fails and issuing a warning on success.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = new NotConstraint(expr.Resolve());
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                IssueWarning(result, message.ToString());
         }
 
         /// <summary>
@@ -311,9 +382,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, string? message)
+        public static void If(bool condition, NUnitString message)
         {
-            If(condition, Is.True, () => message);
+            If(condition, Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is false. If the condition is true, a warning is issued.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void If(bool condition, FormattableString message)
+        {
+            If(condition, Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -344,9 +425,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, string? message)
+        public static void If(Func<bool> condition, NUnitString message)
         {
-            If(condition.Invoke(), Is.True, () => message);
+            If(condition.Invoke(), Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is false. If the condition is true a warning is issued.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is true</param>
+        public static void If(Func<bool> condition, FormattableString message)
+        {
+            If(condition.Invoke(), Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -392,9 +483,22 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
-            If(actual, expression, () => message);
+            If(actual, expression, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// fails and issuing a warning if it succeeds.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            If(actual, expression, () => message.ToString());
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
@@ -40,6 +40,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -526,7 +526,9 @@ namespace NUnit.Options
 
         public string OptionName => _option;
 
+#if !NET6_0_OR_GREATER
         [SecurityPermission(SecurityAction.LinkDemand, SerializationFormatter = true)]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -96,13 +96,8 @@ namespace NUnitLite
                                            assemblyName.Version.ToString());
             _xmlWriter.WriteAttributeString("clr-version",
                 Environment.Version.ToString());
-#if NETSTANDARD2_0
             _xmlWriter.WriteAttributeString("os-version",
-                                           System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            _xmlWriter.WriteAttributeString("os-version",
-                                           OSPlatform.CurrentPlatform.ToString());
-#endif
+                                           OSPlatform.OSDescription);
             _xmlWriter.WriteAttributeString("platform",
                 Environment.OSVersion.Platform.ToString());
             _xmlWriter.WriteAttributeString("cwd",

--- a/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
@@ -15,6 +15,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnitLite Runner (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -144,11 +144,7 @@ namespace NUnitLite
         public void DisplayRuntimeEnvironment()
         {
             WriteSectionHeader("Runtime Environment");
-#if NETSTANDARD2_0
-            Writer.WriteLabelLine("   OS Version: ", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);
-#endif
+            Writer.WriteLabelLine("   OS Version: ", OSPlatform.OSDescription);
             Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
             Writer.WriteLine();
         }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -235,6 +235,32 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
         }
 
+        [Test]
+        public void OnlyFailingAssertion_FormatsString()
+        {
+            const string text = "String was formatted";
+            var formatCounter = new FormatCounter();
+
+            Assert.That(1 + 1, Is.EqualTo(2), $"{text} {formatCounter}");
+            Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(0), "The interpolated string should not have been evaluated");
+
+            Assert.That(() => Assert.That(1 + 1, Is.Not.EqualTo(2), $"{text} {formatCounter}"),
+                Throws.InstanceOf<AssertionException>().With.Message.Contains(text));
+
+            Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(1), "The interpolated string should have been evaluated once");
+        }
+
+        private sealed class FormatCounter
+        {
+            public int NumberOfToStringCalls { get; private set; }
+
+            public override string ToString()
+            {
+                NumberOfToStringCalls++;
+                return string.Empty;
+            }
+        }
+
         private int ReturnsFive()
         {
             return 5;


### PR DESCRIPTION
Also fixed #4421 

This version defers formatting interpolatable string to until the test fails for all frameworks.
It adds an overload to all `Assert`, `Assume`, `Warn` methods with a `FormattableString` parameter.
Code like:
```csharp
Assert.That(1 + 1, Is.EqualTo(2), $"{text} {formatCounter}");
```
Gets compiled into:
```csharp
Assert.That(2, Is.EqualTo(2), FormattableStringFactory.Create("{0} {1}", "String was formatted", formatCounter));
```

This works even for .NET 4.6.2

For a  .NET6 specific solution see (#4428). I'm not sure if that is worth it.