### PR TITLE
Issue4413 caller argument expression

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,10 +7,6 @@ on:
       - release
       - 'v3.13-dev'
   pull_request:
-    branches:
-      - master
-      - release
-      - 'v3.13-dev'
 
 jobs:
   build-windows:
@@ -25,11 +21,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
-
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
 
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3
@@ -77,11 +68,6 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
-
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3
       with:
@@ -121,11 +107,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
-
-    - name: 🛠️ Setup .NET Core SDK 5.0.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '5.0.x'
 
     - name: 🛠️ Setup .NET Core SDK 6.0.x
       uses: actions/setup-dotnet@v3

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -118,14 +118,14 @@ Feature constants are defined in [Directory.Build.props](src/NUnitFramework/Dire
 - `THREAD_ABORT` enables timeouts and forcible cancellation
 
 Platform constants are defined by convention by the csproj SDK, one per target framework.
-For example, `NET462`, `NETSTANDARD2_0`, `NETCOREAPP2_1`, and so on.
+For example, `NET462`, `NETSTANDARD2_0`, `NET6_0`, and so on.
 It is most helpful to call out which platforms are the exception in rather than the rule
 in a given scenario. Keep in mind the effect the preprocessor would have on a newly added platform.
 
 For example, rather than this code:
 
 ```cs
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+#if NETSTANDARD2_0 || NET6_0
 // Something that .NET Framework can't do
 #endif
 ```

--- a/build.cake
+++ b/build.cake
@@ -50,6 +50,7 @@ var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
 var NUNITFRAMEWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
+var NUNITFRAMEWORKCLASSICTESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic.tests/bin/" + configuration + "/";
 var NUNITLITETESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunitlite.tests/bin/" + configuration + "/";
 var NUNITFRAMEWORKBIN = PROJECT_DIR + "src/NUnitFramework/framework/bin/" + configuration + "/";
 var NUNITFRAMEWORKCLASSICBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic/bin/" + configuration + "/";
@@ -63,6 +64,7 @@ var NUNITLITE_RUNNER_DLL = "nunitlite-runner.dll";
 
 // Test Assemblies
 var FRAMEWORK_TESTS = "nunit.framework.tests.dll";
+var FRAMEWORKCLASSIC_TESTS = "nunit.framework.classic.tests.dll";
 var EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE = "nunitlite-runner.exe";
 var EXECUTABLE_NUNITLITE_TESTS_EXE = "nunitlite.tests.exe";
 var EXECUTABLE_NUNITLITE_TESTS_DLL = "nunitlite.tests.dll";
@@ -182,7 +184,9 @@ Task("TestNetFramework")
         var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
         Information("Run tests for " + runtime + " in " + dir + "using runner");
         RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORK_TESTS, dir + "nunit.framework.tests.xml", runtime, ref ErrorDetail);
-        //RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
+        dir = NUNITFRAMEWORKCLASSICTESTSBIN + runtime + "/";
+        Information("Run classic tests for " + runtime + " in " + dir + "using runner");
+        RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORKCLASSIC_TESTS, dir + "nunit.framework.classic.tests.xml", runtime, ref ErrorDetail);
         dir = NUNITLITETESTSBIN + runtime + "/";
         Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS_EXE, dir, runtime, ref ErrorDetail);
@@ -204,6 +208,9 @@ foreach (var runtime in NetCoreTests)
             var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
             Information("Run tests for " + runtime + " in " + dir);
             RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORK_TESTS, runtime, GetResultXmlPath(FRAMEWORK_TESTS, runtime), ref ErrorDetail);
+            dir = NUNITFRAMEWORKCLASSICTESTSBIN + runtime + "/";
+            Information("Run classic tests for " + runtime + " in " + dir);
+            RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORKCLASSIC_TESTS, runtime, GetResultXmlPath(FRAMEWORKCLASSIC_TESTS, runtime), ref ErrorDetail);
             dir = NUNITLITETESTSBIN + runtime + "/";
             Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
             RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);

--- a/build.cake
+++ b/build.cake
@@ -31,15 +31,14 @@ var packageVersion = version + modifier + dbgSuffix;
 var LibraryFrameworks = new string[]
 {
     "net462",
-    "netstandard2.0"
+    "net6.0",
 };
 
 // Subset of NUnitRuntimeFrameworks in Directory.Build.props
 var NetCoreTests = new String[]
 {
-    "netcoreapp3.1",
     "net6.0",
-    "net7.0"
+    "net7.0",
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -50,7 +49,7 @@ var PROJECT_DIR = Context.Environment.WorkingDirectory.FullPath + "/";
 var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
-var NUNITFRAMWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
+var NUNITFRAMEWORKTESTSBIN = PROJECT_DIR + "src/NUnitFramework/tests/bin/" + configuration + "/";
 var NUNITLITETESTSBIN = PROJECT_DIR + "src/NUnitFramework/nunitlite.tests/bin/" + configuration + "/";
 var NUNITFRAMEWORKBIN = PROJECT_DIR + "src/NUnitFramework/framework/bin/" + configuration + "/";
 var NUNITFRAMEWORKCLASSICBIN = PROJECT_DIR + "src/NUnitFramework/nunit.framework.classic/bin/" + configuration + "/";
@@ -180,38 +179,38 @@ Task("TestNetFramework")
     .Does(() =>
     {
         var runtime = "net462";
-        var dir = NUNITFRAMWORKTESTSBIN + runtime + "/";
-        Information("Run tests for " + runtime + " in " + dir+"using runner");
+        var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
+        Information("Run tests for " + runtime + " in " + dir + "using runner");
         RunTest(dir + EXECUTABLE_NUNITLITE_TEST_RUNNER_EXE, dir, FRAMEWORK_TESTS, dir + "nunit.framework.tests.xml", runtime, ref ErrorDetail);
         //RunNUnitTests(dir, FRAMEWORK_TESTS, runtime, ref ErrorDetail);
         dir = NUNITLITETESTSBIN + runtime + "/";
-        Information("Run tests for " + runtime + " in " + dir+" for nunitlite.tests");
+        Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
         RunTest(dir + EXECUTABLE_NUNITLITE_TESTS_EXE, dir, runtime, ref ErrorDetail);
         PublishTestResults(runtime);
     });
 
-var testNetStandard20 = Task("TestNetStandard20")
-    .Description("Tests the .NET Standard 2.0 version of the framework");
+var testCore = Task("TestNetCore")
+    .Description("Tests the .NET Core (6.0+) version of the framework");
 
 foreach (var runtime in NetCoreTests)
 {
-    var task = Task("TestNetStandard20 on " + runtime)
-        .Description("Tests the .NET Standard 2.0 version of the framework on " + runtime)
+    var task = Task("TestNetCore on " + runtime)
+        .Description("Tests the .NET Core (6.0+) version of the framework on " + runtime)
         .WithCriteria(IsRunningOnWindows() || !runtime.EndsWith("windows"))
         .IsDependentOn("Build")
         .OnError(exception => { ErrorDetail.Add(exception.Message); })
         .Does(() =>
         {
-            var dir = NUNITFRAMWORKTESTSBIN + runtime + "/";
-              Information("Run tests for " + runtime + " in " + dir);
+            var dir = NUNITFRAMEWORKTESTSBIN + runtime + "/";
+            Information("Run tests for " + runtime + " in " + dir);
             RunDotnetCoreTests(dir + NUNITLITE_RUNNER_DLL, dir, FRAMEWORK_TESTS, runtime, GetResultXmlPath(FRAMEWORK_TESTS, runtime), ref ErrorDetail);
             dir = NUNITLITETESTSBIN + runtime + "/";
-            Information("Run tests for " + runtime + " in " + dir+" for nunitlite.tests");
+            Information("Run tests for " + runtime + " in " + dir + " for nunitlite.tests");
             RunDotnetCoreTests(dir + EXECUTABLE_NUNITLITE_TESTS_DLL, dir, runtime, ref ErrorDetail);
             PublishTestResults(runtime);
         });
 
-    testNetStandard20.IsDependentOn(task);
+    testCore.IsDependentOn(task);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -572,7 +571,7 @@ Task("Test")
     .Description("Builds and tests all versions of the framework")
     .IsDependentOn("Build")
     .IsDependentOn("TestNetFramework")
-    .IsDependentOn("TestNetStandard20");
+    .IsDependentOn("TestNetCore");
 
 Task("Package")
     .Description("Packages all versions of the framework")

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -26,9 +26,7 @@ Supported platforms:
     <copyright>Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License.</copyright>
     <dependencies>
       <group targetFramework="net462" />
-      <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
-      </group>
+      <group targetFramework="net6.0" />
     </dependencies>
   </metadata>
   <files>
@@ -43,12 +41,12 @@ Supported platforms:
     <file src="bin/net462/nunit.framework.classic.dll" target="lib\net462" />
     <file src="bin/net462/nunit.framework.classic.xml" target="lib\net462" />
     <file src="bin/net462/nunit.framework.classic.pdb" target="lib\net462" />
-    <file src="bin/netstandard2.0/nunit.framework.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.xml" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.pdb" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.xml" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunit.framework.classic.pdb" target="lib\netstandard2.0" />
+    <file src="bin/net6.0/nunit.framework.dll" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.xml" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.pdb" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.dll" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.xml" target="lib\net6.0" />
+    <file src="bin/net6.0/nunit.framework.classic.pdb" target="lib\net6.0" />
     <file src="..\..\nuget\framework\NUnit.props" target="build" />
   </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -33,13 +33,6 @@ How to use this package:
       <group targetFramework="net462">
         <dependency id="NUnit" version="[$version$]" />
       </group>
-      <group targetFramework="netstandard2.0">
-        <dependency id="NUnit" version="[$version$]" />
-        <dependency id="NETStandard.Library" version="2.0.0" />
-      </group>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="NUnit" version="[$version$]" />
-      </group>
       <group targetFramework="net6.0">
         <dependency id="NUnit" version="[$version$]" />
       </group>
@@ -55,12 +48,8 @@ How to use this package:
     <file src="..\..\nuget\icon.png" />
     <file src="bin/net462/nunitlite.dll" target="lib\net462" />
     <file src="bin/net462/nunitlite.pdb" target="lib\net462" />
-    <file src="bin/netstandard2.0/nunitlite.dll" target="lib\netstandard2.0" />
-    <file src="bin/netstandard2.0/nunitlite.pdb" target="lib\netstandard2.0" />
     <file src="bin/net462/nunitlite-runner.exe" target="tools\net462" />
     <file src="bin/net462/nunitlite-runner.pdb" target="tools\net462" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.dll" target="lib\netcoreapp3.1" />
-    <file src="bin/netcoreapp3.1/nunitlite-runner.pdb" target="lib\netcoreapp3.1" />
     <file src="bin/net6.0/nunitlite.dll" target="lib\net6.0" />
     <file src="bin/net6.0/nunitlite.pdb" target="lib\net6.0" />
     <file src="bin/net7.0/nunitlite.dll" target="lib\net7.0" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -13,12 +13,6 @@ using System.Reflection;
 #if DEBUG
 #if NET462
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2 Debug")]
-#elif NETSTANDARD2_0
-[assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
-#elif NETCOREAPP3_1
-[assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
-#elif NET5_0
-[assembly: AssemblyConfiguration(".NET 5.0 Debug")]
 #elif NET6_0
 [assembly: AssemblyConfiguration(".NET 6.0 Debug")]
 #elif NET7_0
@@ -29,12 +23,6 @@ using System.Reflection;
 #else
 #if NET462
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2")]
-#elif NETSTANDARD2_0
-[assembly: AssemblyConfiguration(".NET Standard 2.0")]
-#elif NETCOREAPP3_1
-[assembly: AssemblyConfiguration(".NET Core 3.1")]
-#elif NET5_0
-[assembly: AssemblyConfiguration(".NET 5.0")]
 #elif NET6_0
 [assembly: AssemblyConfiguration(".NET 6.0")]
 #elif NET7_0

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -15,8 +15,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2 Debug")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
-#elif NETCOREAPP2_1
-[assembly: AssemblyConfiguration(".NET Core 2.1 Debug")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1 Debug")]
 #elif NET5_0
@@ -33,8 +31,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET Framework 4.6.2")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyConfiguration(".NET Standard 2.0")]
-#elif NETCOREAPP2_1
-[assembly: AssemblyConfiguration(".NET Core 2.1")]
 #elif NETCOREAPP3_1
 [assembly: AssemblyConfiguration(".NET Core 3.1")]
 #elif NET5_0

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">10</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">11</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -6,8 +6,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-    <NUnitLibraryFrameworks>net462;netstandard2.0</NUnitLibraryFrameworks>
-    <NUnitRuntimeFrameworks>net462;netcoreapp3.1;net6.0;net7.0</NUnitRuntimeFrameworks>
+    <NUnitLibraryFrameworks>net462;net6.0</NUnitLibraryFrameworks>
+    <NUnitRuntimeFrameworks>net462;net6.0;net7.0</NUnitRuntimeFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--<OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>-->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">9</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">10</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -329,11 +329,7 @@ namespace NUnit.Framework.Api
 
             env.AddAttribute("framework-version", typeof(FrameworkController).Assembly.GetName().Version?.ToString() ?? "Unknown");
             env.AddAttribute("clr-version", Environment.Version.ToString());
-#if NETSTANDARD2_0
-            env.AddAttribute("os-version", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            env.AddAttribute("os-version", OSPlatform.CurrentPlatform.ToString());
-#endif
+            env.AddAttribute("os-version", OSPlatform.OSDescription);
             env.AddAttribute("platform", Environment.OSVersion.Platform.ToString());
             env.AddAttribute("cwd", Directory.GetCurrentDirectory());
             env.AddAttribute("machine-name", Environment.MachineName);

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework
 {
@@ -330,6 +331,20 @@ namespace NUnit.Framework
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(actual, expression, message, actualExpression, constraintExpression);
+        }
+
+        #endregion
+
+        #region Helper Method
+
+        private static void ReportFailure(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        {
+            MessageWriter writer = new TextMessageWriter(
+                ExtendedMessage($"{nameof(Assert)}.{nameof(Assert.That)}",
+                message, actualExpression, constraintExpression));
+            result.WriteMessageTo(writer);
+
+            ReportFailure(writer.ToString());
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -20,7 +20,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(bool condition, string? message)
+        public static void That(bool condition, NUnitString message)
+        {
+            That(condition, Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(bool condition, FormattableString message)
         {
             That(condition, Is.True, message);
         }
@@ -53,7 +63,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, string? message)
+        public static void That(Func<bool> condition, NUnitString message)
+        {
+            That(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(Func<bool> condition, FormattableString message)
         {
             That(condition.Invoke(), Is.True, message);
         }
@@ -99,14 +119,31 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         /// <summary>
@@ -149,7 +186,18 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, string? message)
+        public static void That(TestDelegate code, IResolveConstraint constraint, NUnitString message)
+        {
+            That((object)code, constraint, message);
+        }
+
+        /// <summary>
+        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">A TestDelegate to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That(TestDelegate code, IResolveConstraint constraint, FormattableString message)
         {
             That((object)code, constraint, message);
         }
@@ -191,14 +239,32 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
+        /// block.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            var constraint = expression.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -24,7 +24,8 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
         /// <param name="actualExpression"></param>
-        public static void That(bool condition, NUnitString message,
+        public static void That(bool condition,
+            NUnitString message = default,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             That(condition, Is.True, message, actualExpression, IsTrueExpression);
@@ -35,7 +36,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(bool condition, FormattableString message,
+        public static void That(bool condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -47,20 +49,9 @@ namespace NUnit.Framework
         /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void That(bool condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(condition, Is.True, string.Empty, actualExpression, IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<string?> getExceptionMessage,
+        public static void That(bool condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -77,7 +68,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, NUnitString message,
+        public static void That(Func<bool> condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -90,7 +82,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, FormattableString message,
+        public static void That(Func<bool> condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -102,20 +95,9 @@ namespace NUnit.Framework
         /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void That(Func<bool> condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(condition.Invoke(), Is.True, string.Empty, actualExpression, IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string?> getExceptionMessage,
+        public static void That(Func<bool> condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -133,23 +115,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(del, expr, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -170,7 +138,8 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -217,22 +186,9 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(code, constraint, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to a delegate. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="code">A TestDelegate to be executed</param>
-        /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, NUnitString message,
+        public static void That(TestDelegate code, IResolveConstraint constraint,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -247,7 +203,8 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, FormattableString message,
+        public static void That(TestDelegate code, IResolveConstraint constraint,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -262,7 +219,8 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, Func<string?> getExceptionMessage,
+        public static void That(TestDelegate code, IResolveConstraint constraint,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -284,24 +242,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(actual, expression, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
-        /// block.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -323,7 +266,8 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -371,22 +315,6 @@ namespace NUnit.Framework
         /// block. Used as a synonym for That in rare cases where a private setter causes a Visual Basic compilation
         /// error.
         /// </summary>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
-        public static void ByVal(object? actual, IResolveConstraint expression,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(actual, expression, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value. Returns without throwing an exception when inside a multiple assert
-        /// block. Used as a synonym for That in rare cases where a private setter causes a Visual Basic compilation
-        /// error.
-        /// </summary>
         /// <remarks>
         /// This method is provided for use by VB developers needing to test the value of properties with private
         /// setters.
@@ -394,7 +322,8 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void ByVal(object? actual, IResolveConstraint expression, string? message,
+        public static void ByVal(object? actual, IResolveConstraint expression,
+            string message = "",
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -5,6 +5,9 @@ using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
+// Disabled because of the CallerArgumentExpression attributes which are only for the compiler.
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+
 namespace NUnit.Framework
 {
     /// <summary>
@@ -39,9 +42,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That(bool condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition, Is.True, message, actualExpression, IsTrueExpression);
         }
@@ -53,9 +54,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(bool condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition, Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
         }
@@ -71,9 +70,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That(Func<bool> condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, message, actualExpression, IsTrueExpression);
         }
@@ -85,9 +82,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That(Func<bool> condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, message, actualExpression, IsTrueExpression);
         }
@@ -99,9 +94,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(Func<bool> condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
         }
@@ -119,10 +112,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -141,10 +132,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -165,10 +154,8 @@ namespace NUnit.Framework
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -190,10 +177,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That(TestDelegate code, IResolveConstraint constraint,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That((object)code, constraint, message, actualExpression, constraintExpression);
         }
@@ -206,10 +191,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That(TestDelegate code, IResolveConstraint constraint,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That((object)code, constraint, message, actualExpression, constraintExpression);
         }
@@ -222,10 +205,8 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(TestDelegate code, IResolveConstraint constraint,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That((object)code, constraint, getExceptionMessage, actualExpression, constraintExpression);
         }
@@ -246,10 +227,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(TActual actual, IResolveConstraint expression,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
@@ -269,10 +248,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(TActual actual, IResolveConstraint expression,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
@@ -294,10 +271,8 @@ namespace NUnit.Framework
             TActual actual,
             IResolveConstraint expression,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
@@ -325,10 +300,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void ByVal(object? actual, IResolveConstraint expression,
             string message = "",
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(actual, expression, message, actualExpression, constraintExpression);
         }

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework
@@ -13,6 +14,8 @@ namespace NUnit.Framework
     {
         #region Assert.That
 
+        internal const string IsTrueExpression = "Is.True";
+
         #region Boolean
 
         /// <summary>
@@ -20,9 +23,11 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(bool condition, NUnitString message)
+        /// <param name="actualExpression"></param>
+        public static void That(bool condition, NUnitString message,
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
-            That(condition, Is.True, message);
+            That(condition, Is.True, message, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
@@ -30,18 +35,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(bool condition, FormattableString message)
+        public static void That(bool condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, message);
+            That(condition, Is.True, message, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void That(bool condition)
+        public static void That(bool condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, string.Empty);
+            That(condition, Is.True, string.Empty, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
@@ -49,9 +60,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(bool condition, Func<string?> getExceptionMessage)
+        public static void That(bool condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, getExceptionMessage);
+            That(condition, Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
         }
 
         #endregion
@@ -63,9 +77,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, NUnitString message)
+        public static void That(Func<bool> condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, message);
+            That(condition.Invoke(), Is.True, message, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
@@ -73,18 +90,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, FormattableString message)
+        public static void That(Func<bool> condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, message);
+            That(condition.Invoke(), Is.True, message, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is true. Returns without throwing an exception when inside a multiple assert block.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void That(Func<bool> condition)
+        public static void That(Func<bool> condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, string.Empty);
+            That(condition.Invoke(), Is.True, string.Empty, actualExpression, IsTrueExpression);
         }
 
         /// <summary>
@@ -92,9 +115,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string?> getExceptionMessage)
+        public static void That(Func<bool> condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, getExceptionMessage);
+            That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
         }
 
         #endregion
@@ -107,9 +133,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(del, expr.Resolve(), string.Empty);
+            That(del, expr, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -119,14 +149,18 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -136,14 +170,18 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -156,14 +194,18 @@ namespace NUnit.Framework
         public static void That<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
-                ReportFailure(result, getExceptionMessage());
+                ReportFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -175,9 +217,13 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint)
+        public static void That(TestDelegate code, IResolveConstraint constraint,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(code, constraint, string.Empty);
+            That(code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -186,9 +232,13 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, NUnitString message)
+        public static void That(TestDelegate code, IResolveConstraint constraint, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That((object)code, constraint, message);
+            That((object)code, constraint, message, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -197,9 +247,13 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, FormattableString message)
+        public static void That(TestDelegate code, IResolveConstraint constraint, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That((object)code, constraint, message);
+            That((object)code, constraint, message, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -208,9 +262,13 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint, Func<string?> getExceptionMessage)
+        public static void That(TestDelegate code, IResolveConstraint constraint, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That((object)code, constraint, getExceptionMessage);
+            That((object)code, constraint, getExceptionMessage, actualExpression, constraintExpression);
         }
 
         #endregion
@@ -226,9 +284,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(actual, expression, string.Empty);
+            That(actual, expression, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -239,14 +301,18 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -257,14 +323,18 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -278,14 +348,18 @@ namespace NUnit.Framework
         public static void That<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
             IncrementAssertCount();
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
-                ReportFailure(result, getExceptionMessage());
+                ReportFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -299,9 +373,13 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void ByVal(object? actual, IResolveConstraint expression)
+        public static void ByVal(object? actual, IResolveConstraint expression,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(actual, expression, string.Empty);
+            That(actual, expression, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -316,9 +394,13 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void ByVal(object? actual, IResolveConstraint expression, string? message)
+        public static void ByVal(object? actual, IResolveConstraint expression, string? message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(actual, expression, message);
+            That(actual, expression, message, actualExpression, constraintExpression);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.ThatAsync.cs
+++ b/src/NUnitFramework/framework/Assert.ThatAsync.cs
@@ -29,7 +29,28 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, string? message)
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, NUnitString message)
+        {
+            try
+            {
+                await code();
+                Assert.That(() => { }, constraint, message);
+            }
+            catch (Exception ex)
+            {
+                var edi = ExceptionDispatchInfo.Capture(ex);
+                Assert.That(() => edi.Throw(), constraint, message);
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">An AsyncTestDelegate to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <returns>Awaitable.</returns>
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, FormattableString message)
         {
             try
             {
@@ -61,7 +82,28 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, string? message)
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, NUnitString message)
+        {
+            try
+            {
+                var result = await code();
+                Assert.That(() => result, constraint, message);
+            }
+            catch (Exception ex)
+            {
+                var edi = ExceptionDispatchInfo.Capture(ex);
+                Assert.That(() => edi.Throw(), constraint, message);
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">An async method to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <returns>Awaitable.</returns>
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, FormattableString message)
         {
             try
             {

--- a/src/NUnitFramework/framework/Assert.ThatAsync.cs
+++ b/src/NUnitFramework/framework/Assert.ThatAsync.cs
@@ -17,24 +17,10 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">An AsyncTestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
-        /// <returns>Awaitable.</returns>
-        public static Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            return ThatAsync(code, constraint, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="code">An AsyncTestDelegate to be executed</param>
-        /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, NUnitString message,
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -59,7 +45,8 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, FormattableString message,
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -82,24 +69,10 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">An async method to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
-        /// <returns>Awaitable.</returns>
-        public static Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            return ThatAsync(code, constraint, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="code">An async method to be executed</param>
-        /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, NUnitString message,
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
@@ -124,7 +97,8 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, FormattableString message,
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")

--- a/src/NUnitFramework/framework/Assert.ThatAsync.cs
+++ b/src/NUnitFramework/framework/Assert.ThatAsync.cs
@@ -4,6 +4,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using System;
 using NUnit.Framework.Constraints;
+using System.Runtime.CompilerServices;
 
 namespace NUnit.Framework
 {
@@ -17,9 +18,13 @@ namespace NUnit.Framework
         /// <param name="code">An AsyncTestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <returns>Awaitable.</returns>
-        public static Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint)
+        public static Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            return ThatAsync(code, constraint, string.Empty);
+            return ThatAsync(code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -29,17 +34,21 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, NUnitString message)
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             try
             {
                 await code();
-                Assert.That(() => { }, constraint, message);
+                Assert.That(() => { }, constraint, message, actualExpression, constraintExpression);
             }
             catch (Exception ex)
             {
                 var edi = ExceptionDispatchInfo.Capture(ex);
-                Assert.That(() => edi.Throw(), constraint, message);
+                Assert.That(() => edi.Throw(), constraint, message, actualExpression, constraintExpression);
             }
         }
 
@@ -50,17 +59,21 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, FormattableString message)
+        public static async Task ThatAsync(AsyncTestDelegate code, IResolveConstraint constraint, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             try
             {
                 await code();
-                Assert.That(() => { }, constraint, message);
+                Assert.That(() => { }, constraint, message, actualExpression, constraintExpression);
             }
             catch (Exception ex)
             {
                 var edi = ExceptionDispatchInfo.Capture(ex);
-                Assert.That(() => edi.Throw(), constraint, message);
+                Assert.That(() => edi.Throw(), constraint, message, actualExpression, constraintExpression);
             }
         }
 
@@ -70,30 +83,13 @@ namespace NUnit.Framework
         /// <param name="code">An async method to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <returns>Awaitable.</returns>
-        public static Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint)
+        public static Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            return ThatAsync(code, constraint, string.Empty);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
-        /// </summary>
-        /// <param name="code">An async method to be executed</param>
-        /// <param name="constraint">A Constraint expression to be applied</param>
-        /// <param name="message">The message that will be displayed on failure</param>
-        /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, NUnitString message)
-        {
-            try
-            {
-                var result = await code();
-                Assert.That(() => result, constraint, message);
-            }
-            catch (Exception ex)
-            {
-                var edi = ExceptionDispatchInfo.Capture(ex);
-                Assert.That(() => edi.Throw(), constraint, message);
-            }
+            return ThatAsync(code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -103,17 +99,46 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <returns>Awaitable.</returns>
-        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, FormattableString message)
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             try
             {
                 var result = await code();
-                Assert.That(() => result, constraint, message);
+                Assert.That(() => result, constraint, message, actualExpression, constraintExpression);
             }
             catch (Exception ex)
             {
                 var edi = ExceptionDispatchInfo.Capture(ex);
-                Assert.That(() => edi.Throw(), constraint, message);
+                Assert.That(() => edi.Throw(), constraint, message, actualExpression, constraintExpression);
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an async delegate. Returns without throwing an exception when inside a multiple assert block.
+        /// </summary>
+        /// <param name="code">An async method to be executed</param>
+        /// <param name="constraint">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        /// <returns>Awaitable.</returns>
+        public static async Task ThatAsync<T>(Func<Task<T>> code, IResolveConstraint constraint, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+        {
+            try
+            {
+                var result = await code();
+                Assert.That(() => result, constraint, message, actualExpression, constraintExpression);
+            }
+            catch (Exception ex)
+            {
+                var edi = ExceptionDispatchInfo.Capture(ex);
+                Assert.That(() => edi.Throw(), constraint, message, actualExpression, constraintExpression);
             }
         }
 

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -307,20 +306,12 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        internal static string? ExtendedMessage(string? message, string actualExpression, string constraintExpression)
+        internal static string? ExtendedMessage(string methodName, string? message, string actualExpression, string constraintExpression)
         {
-            string context = $"Assert.That({actualExpression}, {constraintExpression})";
+            string context = $"{methodName}({actualExpression}, {constraintExpression})";
             string extendedMessage = string.IsNullOrEmpty(message) ? context : $"{message}\n{context}";
 
             return extendedMessage;
-        }
-
-        private static void ReportFailure(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
-        {
-            MessageWriter writer = new TextMessageWriter(ExtendedMessage(message, actualExpression, constraintExpression));
-            result.WriteMessageTo(writer);
-
-            ReportFailure(writer.ToString());
         }
 
         private static void ReportFailure(string? message)

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -342,10 +342,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.StackTrace"/> throws, returns "SomeException was thrown by the
         /// Environment.StackTrace property." See also <see cref="ExceptionExtensions.GetStackTraceWithoutThrowing"/>.
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         private static string GetEnvironmentStackTraceWithoutThrowing()
         {
             try

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -309,15 +309,12 @@ namespace NUnit.Framework
 
         internal static string? ExtendedMessage(string? message, string actualExpression, string constraintExpression)
         {
-#if DEBUG
-            return message;
-#else
             string context = $"Assert.That({actualExpression}, {constraintExpression})";
             string extendedMessage = string.IsNullOrEmpty(message) ? context : $"{message}\n{context}";
 
             return extendedMessage;
-#endif
         }
+
         private static void ReportFailure(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
         {
             MessageWriter writer = new TextMessageWriter(ExtendedMessage(message, actualExpression, constraintExpression));

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -306,7 +306,7 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        internal static string? ExtendedMessage(string methodName, string? message, string actualExpression, string constraintExpression)
+        internal static string ExtendedMessage(string methodName, string? message, string actualExpression, string constraintExpression)
         {
             string context = $"{methodName}({actualExpression}, {constraintExpression})";
             string extendedMessage = string.IsNullOrEmpty(message) ? context : $"{message}\n{context}";

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -306,9 +306,21 @@ namespace NUnit.Framework
         #endregion
 
         #region Helper Methods
-        private static void ReportFailure(ConstraintResult result, string? message)
+
+        internal static string? ExtendedMessage(string? message, string actualExpression, string constraintExpression)
         {
-            MessageWriter writer = new TextMessageWriter(message);
+#if DEBUG
+            return message;
+#else
+            string context = $"Assert.That({actualExpression}, {constraintExpression})";
+            string extendedMessage = string.IsNullOrEmpty(message) ? context : $"{message}\n{context}";
+
+            return extendedMessage;
+#endif
+        }
+        private static void ReportFailure(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        {
+            MessageWriter writer = new TextMessageWriter(ExtendedMessage(message, actualExpression, constraintExpression));
             result.WriteMessageTo(writer);
 
             ReportFailure(writer.ToString());
@@ -357,6 +369,6 @@ namespace NUnit.Framework
         private static void IncrementAssertCount()
             => TestExecutionContext.CurrentContext.IncrementAssertCount();
 
-        #endregion
+#endregion
     }
 }

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -7,6 +7,9 @@ using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
+// Disabled because of the CallerArgumentExpression attributes which are only for the compiler.
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+
 namespace NUnit.Framework
 {
     /// <summary>
@@ -61,10 +64,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -85,10 +86,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -111,10 +110,8 @@ namespace NUnit.Framework
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -139,9 +136,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That([DoesNotReturnIf(false)] bool condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition, Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -154,9 +149,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That([DoesNotReturnIf(false)] bool condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition, Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -169,9 +162,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That([DoesNotReturnIf(false)] bool condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -188,9 +179,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That(Func<bool> condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -203,9 +192,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void That(Func<bool> condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -218,9 +205,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(Func<bool> condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -241,10 +226,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(TActual actual, IResolveConstraint expression,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -267,10 +250,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(TActual actual, IResolveConstraint expression,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -295,10 +276,8 @@ namespace NUnit.Framework
             TActual actual,
             IResolveConstraint expression,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
@@ -57,9 +58,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(del, expr.Resolve(), string.Empty);
+            That(del, expr, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -70,7 +75,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -78,7 +87,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportInconclusive(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -89,7 +98,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -97,12 +110,12 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                ReportFailure(result, message.ToString());
+                ReportInconclusive(result, message.ToString(), actualExpression, constraintExpression);
         }
 
-        private static void ReportFailure(ConstraintResult result, string? message)
+        private static void ReportInconclusive(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
         {
-            MessageWriter writer = new TextMessageWriter(message);
+            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
             result.WriteMessageTo(writer);
             throw new InconclusiveException(writer.ToString());
         }
@@ -118,7 +131,11 @@ namespace NUnit.Framework
         public static void That<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -127,7 +144,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
             if (!result.IsSuccess)
             {
-                throw new InconclusiveException(getExceptionMessage());
+                ReportInconclusive(result, getExceptionMessage(), actualExpression, constraintExpression);
             }
         }
 
@@ -141,9 +158,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, NUnitString message)
+        public static void That([DoesNotReturnIf(false)] bool condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, message);
+            That(condition, Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -152,9 +172,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, FormattableString message)
+        public static void That([DoesNotReturnIf(false)] bool condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, message);
+            That(condition, Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -162,9 +185,12 @@ namespace NUnit.Framework
         /// method throws an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void That([DoesNotReturnIf(false)] bool condition)
+        public static void That([DoesNotReturnIf(false)] bool condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True);
+            That(condition, Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -173,9 +199,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, Func<string?> getExceptionMessage)
+        public static void That([DoesNotReturnIf(false)] bool condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition, Is.True, getExceptionMessage);
+            That(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -188,9 +217,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, NUnitString message)
+        public static void That(Func<bool> condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, message);
+            That(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -199,9 +231,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, FormattableString message)
+        public static void That(Func<bool> condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, message);
+            That(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -209,9 +244,12 @@ namespace NUnit.Framework
         /// an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void That(Func<bool> condition)
+        public static void That(Func<bool> condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True);
+            That(condition.Invoke(), Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -220,9 +258,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string?> getExceptionMessage)
+        public static void That(Func<bool> condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(condition.Invoke(), Is.True, getExceptionMessage);
+            That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -235,9 +276,13 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A ThrowsConstraint used in the test</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint)
+        public static void That(TestDelegate code, IResolveConstraint constraint,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That((object)code, constraint);
+            That((object)code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         #endregion
@@ -253,9 +298,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            That(actual, expression, string.Empty);
+            That(actual, expression, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -266,7 +315,11 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -275,9 +328,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
             {
-                MessageWriter writer = new TextMessageWriter(message.ToString());
-                result.WriteMessageTo(writer);
-                throw new InconclusiveException(writer.ToString());
+                ReportInconclusive(result, message.ToString(), actualExpression, constraintExpression);
             }
         }
 
@@ -289,7 +340,11 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -298,9 +353,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
             {
-                MessageWriter writer = new TextMessageWriter(message.ToString());
-                result.WriteMessageTo(writer);
-                throw new InconclusiveException(writer.ToString());
+                ReportInconclusive(result, message.ToString(), actualExpression, constraintExpression);
             }
         }
 
@@ -315,7 +368,11 @@ namespace NUnit.Framework
         public static void That<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             CheckMultipleAssertLevel();
 
@@ -324,7 +381,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
             {
-                throw new InconclusiveException(getExceptionMessage());
+                ReportInconclusive(result, getExceptionMessage(), actualExpression, constraintExpression);
             }
         }
 

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -58,24 +58,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
         public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(del, expr, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an InconclusiveException on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
-        /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -98,7 +83,8 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -111,13 +97,6 @@ namespace NUnit.Framework
 
             if (!result.IsSuccess)
                 ReportInconclusive(result, message.ToString(), actualExpression, constraintExpression);
-        }
-
-        private static void ReportInconclusive(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
-        {
-            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
-            result.WriteMessageTo(writer);
-            throw new InconclusiveException(writer.ToString());
         }
 
         /// <summary>
@@ -158,7 +137,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, NUnitString message,
+        public static void That([DoesNotReturnIf(false)] bool condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -172,7 +152,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, FormattableString message,
+        public static void That([DoesNotReturnIf(false)] bool condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -181,25 +162,13 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Asserts that a condition is true. If the condition is false, the
-        /// method throws an <see cref="InconclusiveException"/>.
-        /// </summary>
-        /// <param name="condition">The evaluated condition</param>
-        public static void That([DoesNotReturnIf(false)] bool condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(condition, Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
         /// Asserts that a condition is true. If the condition is false, the method throws
         /// an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, Func<string?> getExceptionMessage,
+        public static void That([DoesNotReturnIf(false)] bool condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -217,7 +186,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, NUnitString message,
+        public static void That(Func<bool> condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -231,7 +201,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, FormattableString message,
+        public static void That(Func<bool> condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -244,45 +215,14 @@ namespace NUnit.Framework
         /// an <see cref="InconclusiveException"/>.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void That(Func<bool> condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(condition.Invoke(), Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false, the method throws
-        /// an <see cref="InconclusiveException"/>.
-        /// </summary>
-        /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void That(Func<bool> condition, Func<string?> getExceptionMessage,
+        public static void That(Func<bool> condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
-        }
-
-        #endregion
-
-        #region TestDelegate
-
-        /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
-        /// </summary>
-        /// <param name="code">A TestDelegate to be executed</param>
-        /// <param name="constraint">A ThrowsConstraint used in the test</param>
-        public static void That(TestDelegate code, IResolveConstraint constraint,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That((object)code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         #endregion
@@ -298,24 +238,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            That(actual, expression, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and throwing an InconclusiveException on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -340,7 +265,8 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+        public static void That<TActual>(TActual actual, IResolveConstraint expression,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -393,6 +319,13 @@ namespace NUnit.Framework
         {
             if (TestExecutionContext.CurrentContext.MultipleAssertLevel > 0)
                 throw new Exception("Assume.That may not be used in a multiple assertion block.");
+        }
+
+        private static void ReportInconclusive(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        {
+            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
+            result.WriteMessageTo(writer);
+            throw new InconclusiveException(writer.ToString());
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -323,7 +323,9 @@ namespace NUnit.Framework
 
         private static void ReportInconclusive(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
         {
-            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
+            MessageWriter writer = new TextMessageWriter(
+                Assert.ExtendedMessage($"{nameof(Assume)}.{nameof(Assume.That)}",
+                message, actualExpression, constraintExpression));
             result.WriteMessageTo(writer);
             throw new InconclusiveException(writer.ToString());
         }

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -70,7 +70,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             CheckMultipleAssertLevel();
 
@@ -78,7 +78,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                ReportFailure(result, message);
+                ReportFailure(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            CheckMultipleAssertLevel();
+
+            var constraint = expr.Resolve();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                ReportFailure(result, message.ToString());
         }
 
         private static void ReportFailure(ConstraintResult result, string? message)
@@ -122,7 +141,18 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That([DoesNotReturnIf(false)] bool condition, string? message)
+        public static void That([DoesNotReturnIf(false)] bool condition, NUnitString message)
+        {
+            That(condition, Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That([DoesNotReturnIf(false)] bool condition, FormattableString message)
         {
             That(condition, Is.True, message);
         }
@@ -158,7 +188,18 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void That(Func<bool> condition, string? message)
+        public static void That(Func<bool> condition, NUnitString message)
+        {
+            That(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, the method throws
+        /// an <see cref="InconclusiveException"/>.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void That(Func<bool> condition, FormattableString message)
         {
             That(condition.Invoke(), Is.True, message);
         }
@@ -225,7 +266,7 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void That<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
             CheckMultipleAssertLevel();
 
@@ -234,7 +275,30 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
             if (!result.IsSuccess)
             {
-                MessageWriter writer = new TextMessageWriter(message);
+                MessageWriter writer = new TextMessageWriter(message.ToString());
+                result.WriteMessageTo(writer);
+                throw new InconclusiveException(writer.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and throwing an InconclusiveException on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void That<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            CheckMultipleAssertLevel();
+
+            var constraint = expression.Resolve();
+
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+            {
+                MessageWriter writer = new TextMessageWriter(message.ToString());
                 result.WriteMessageTo(writer);
                 throw new InconclusiveException(writer.ToString());
             }

--- a/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
+++ b/src/NUnitFramework/framework/Compatibility/LongLivedMarshalByRefObject.cs
@@ -12,6 +12,9 @@ namespace NUnit.Compatibility
         /// <summary>
         /// Obtains a lifetime service object to control the lifetime policy for this instance.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [Obsolete("Preventing throwing PlatformNotSupportedException")]
+#endif
         public override object InitializeLifetimeService()
         {
             return null!;

--- a/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/BinarySerializableConstraint.cs
@@ -36,11 +36,15 @@ namespace NUnit.Framework.Constraints
 
             try
             {
+                // 'BinaryFormatter serialization is obsolete and should not be used.
+                // See https://aka.ms/binaryformatter for more information.'
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                 _serializer.Serialize(stream, actual);
 
                 stream.Seek(0, SeekOrigin.Begin);
 
                 succeeded = _serializer.Deserialize(stream) is not null;
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
             catch (SerializationException)
             {

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -94,7 +94,9 @@ namespace NUnit.Framework.Constraints
             AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsValueTuple, GetValueFromValueTuple) ?? next(val));
         }
 
+#if NETFRAMEWORK
         [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
+#endif
         private static string FormatValueWithoutThrowing(object? val)
         {
             string? asString;

--- a/src/NUnitFramework/framework/ExceptionExtensions.cs
+++ b/src/NUnitFramework/framework/ExceptionExtensions.cs
@@ -11,10 +11,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.StackTrace"/> throws, returns "SomeException was thrown by the Exception.StackTrace
         /// property." See also <see cref="Assert.GetEnvironmentStackTraceWithoutThrowing"/>.
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static string? GetStackTraceWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));
@@ -33,10 +29,6 @@ namespace NUnit.Framework
         /// If <see cref="Exception.Message"/> throws, returns "SomeException was thrown by the Exception.Message
         /// property."
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static string GetMessageWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));
@@ -54,10 +46,6 @@ namespace NUnit.Framework
         /// <summary>
         /// If <see cref="Exception.Data"/> throws, returns "SomeException was thrown by the Exception.Data property."
         /// </summary>
-        // https://github.com/dotnet/coreclr/issues/19698 is also currently present in .NET Framework 4.7 and 4.8. A
-        // race condition between threads reading the same PDB file to obtain file and line info for a stack trace
-        // results in AccessViolationException when the stack trace is accessed even indirectly e.g. Exception.ToString.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
         public static Result<IDictionary> GetDataWithoutThrowing(this Exception exception)
         {
             if (exception is null) throw new ArgumentNullException(nameof(exception));

--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -51,8 +51,8 @@ namespace NUnit.Framework.Interfaces
         {
             var hashCode = -783279553;
             hashCode = hashCode * -1521134295 + Status.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(StackTrace);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message ?? string.Empty);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(StackTrace ?? string.Empty);
             return hashCode;
         }
 

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -3,7 +3,7 @@
 using System;
 using System.IO;
 using System.Reflection;
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
 using System.Runtime.Loader;
 #endif
 
@@ -29,10 +29,16 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
+#if NETFRAMEWORK
+            // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location 
+            // .NET Framework only: 
+            // If the loaded file was shadow-copied, the location is that of the file after being shadow-copied.
+            // To get the location before the file has been shadow-copied, use the CodeBase property.
             string? codeBase = assembly.CodeBase;
 
             if (codeBase is not null && IsFileUri(codeBase))
                 return GetAssemblyPathFromCodeBase(codeBase);
+#endif
 
             return assembly.Location;
         }
@@ -69,7 +75,7 @@ namespace NUnit.Framework.Internal
 
         #region Load
 
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
         private sealed class ReflectionAssemblyLoader
         {
             private static ReflectionAssemblyLoader? _instance;

--- a/src/NUnitFramework/framework/Internal/CallerArgumentExpressionAttribute.cs
+++ b/src/NUnitFramework/framework/Internal/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,30 @@
+#if !NET6_0_OR_GREATER
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that a parameter captures the expression passed for another parameter as a string.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute"/> class.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter whose expression should be captured as a string.</param>
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        /// <summary>
+        /// Gets the name of the parameter whose expression should be captured as a string.
+        /// </summary>
+        public string ParameterName { get; }
+    }
+}
+
+#endif

--- a/src/NUnitFramework/framework/Internal/CallerArgumentExpressionAttribute.cs
+++ b/src/NUnitFramework/framework/Internal/CallerArgumentExpressionAttribute.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.CompilerServices
     /// Indicates that a parameter captures the expression passed for another parameter as a string.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public sealed class CallerArgumentExpressionAttribute : Attribute
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute"/> class.

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -36,6 +36,12 @@ namespace NUnit.Framework.Internal.Execution
 
             if (topLevelWorkItem.TargetApartment != ApartmentState.Unknown)
             {
+#if NET6_0_OR_GREATER
+                if (OperatingSystem.IsWindows())
+                    _runnerThread.SetApartmentState(topLevelWorkItem.TargetApartment);
+                else
+                    topLevelWorkItem.MarkNotRunnable("Apartment state cannot be set on this platform.");
+#else
                 try
                 {
                     _runnerThread.SetApartmentState(topLevelWorkItem.TargetApartment);
@@ -44,6 +50,7 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     topLevelWorkItem.MarkNotRunnable("Apartment state cannot be set on this platform.");
                 }
+#endif
             }
 
             _runnerThread.Start(topLevelWorkItem);

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -134,6 +134,10 @@ namespace NUnit.Framework.Internal.Execution
                 Name = Name
             };
 
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+                _workerThread.SetApartmentState(WorkQueue.TargetApartment);
+#else
             try
             {
                 _workerThread.SetApartmentState(WorkQueue.TargetApartment);
@@ -141,6 +145,7 @@ namespace NUnit.Framework.Internal.Execution
             catch (PlatformNotSupportedException)
             {
             }
+#endif
 
             Log.Info("{0} starting on thread [{1}]", Name, _workerThread.ManagedThreadId);
             _workerThread.Start();

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -445,6 +445,20 @@ namespace NUnit.Framework.Internal.Execution
                 RunOnCurrentThread();
             });
 
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+            {
+                _thread.SetApartmentState(apartment);
+            }
+            else
+            {
+                const string msg = "Apartment state cannot be set on this platform.";
+                Log.Error(msg);
+                Result.SetResult(ResultState.Skipped, msg);
+                WorkItemComplete();
+                return;
+            }
+#else
             try
             {
                 _thread.SetApartmentState(apartment);
@@ -457,6 +471,7 @@ namespace NUnit.Framework.Internal.Execution
                 WorkItemComplete();
                 return;
             }
+#endif
 
             _thread.Start();
             _thread.Join();

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 
 namespace NUnit.Framework.Internal
 {
@@ -182,7 +181,9 @@ namespace NUnit.Framework.Internal
         /// <param name="fixture">The object on which to invoke the method</param>
         /// <param name="args">The argument list for the method</param>
         /// <returns>The return value from the invoked method</returns>
-        [HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions.
+#if NETFRAMEWORK
+        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions] //put here to handle C++ exceptions.
+#endif
         public static object? InvokeMethod(MethodInfo method, object? fixture, params object?[]? args)
         {
             try

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Internal
                 major = 0;
                 minor = 0;
             }
-            else /* It's windows */
+            else /* It's .net framework */
 #if NETSTANDARD2_0
             {
                 minor = 5;

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -455,19 +455,6 @@ namespace NUnit.Framework.Internal
 
         #endregion
 
-        #region InitializeLifetimeService
-
-        /// <summary>
-        /// Obtain lifetime service object
-        /// </summary>
-        /// <returns></returns>
-        public override object InitializeLifetimeService()
-        {
-            return null!;
-        }
-
-        #endregion
-
         #region Nested IsolatedContext Class
 
         /// <summary>

--- a/src/NUnitFramework/framework/NUnitString.cs
+++ b/src/NUnitFramework/framework/NUnitString.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// A class to allow postponing the actual formatting of interpolated strings.
+    /// </summary>
+    /// <remarks>
+    /// This class is needed as the compiler prefers to call a <see cref="string"/> overload
+    /// vs a <see cref="FormattableString"/> overload.
+    /// https://www.damirscorner.com/blog/posts/20180921-FormattableStringAsMethodParameter.html
+    /// </remarks>
+    public readonly struct NUnitString
+    {
+        private readonly string? _message;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NUnitString"/> class.
+        /// </summary>
+        /// <param name="message">The message formattable to hold.</param>
+        public NUnitString(string? message)
+        {
+            _message = message;
+        }
+
+        /// <summary>
+        /// Implicit conversion from a <see cref="FormattableString"/> to a <see cref="NUnitString"/>.
+        /// </summary>
+        /// <remarks>
+        /// Should never be called. It only exists for the compiler.
+        /// </remarks>
+        /// <param name="formattableMessage">The message formattable to hold.</param>
+        [Obsolete("This only exists for the compiler")]
+        public static implicit operator NUnitString(FormattableString formattableMessage)
+            => throw new NotImplementedException();
+
+        /// <summary>
+        /// Implicit conversion from a <see cref="string"/> to a <see cref="NUnitString"/>.
+        /// </summary>
+        /// <param name="message">The message formattable to hold.</param>
+        public static implicit operator NUnitString(string? message) => new(message);
+
+        /// <inheritdoc/>
+        public override string? ToString() => _message;
+    }
+}

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -38,14 +38,8 @@ using System.Runtime.CompilerServices;
 
 #if NET462
 [assembly: AssemblyTitle("NUnit Framework (.NET Framework 4.6.2)")]
-#elif NETSTANDARD2_0
-[assembly: AssemblyTitle("NUnit Framework (.NET Standard 2.0)")]
 #elif NET6_0
-#if WINDOWS
 [assembly: AssemblyTitle("NUnit Framework (.NET 6.0)")]
-#else
-[assembly: AssemblyTitle("NUnit Framework (.NET 6.0-windows)")]
-#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/framework/Properties/AssemblyInfo.cs
@@ -40,6 +40,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnit Framework (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnit Framework (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnit Framework (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnit Framework (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -69,7 +69,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = expr.Resolve();
 
@@ -77,7 +77,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message);
+                IssueWarning(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and issuing a warning on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = expr.Resolve();
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                IssueWarning(result, message.ToString());
         }
 
         private static void IssueWarning(ConstraintResult result, string? message)
@@ -118,9 +137,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, string? message)
+        public static void Unless(bool condition, NUnitString message)
         {
-            Unless(condition, Is.True, () => message);
+            Unless(condition, Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, a warning is issued.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void Unless(bool condition, FormattableString message)
+        {
+            Unless(condition, Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -151,7 +180,17 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, string? message)
+        public static void Unless(Func<bool> condition, NUnitString message)
+        {
+            Unless(condition.Invoke(), Is.True, message);
+        }
+
+        /// <summary>
+        /// Asserts that a condition is true. If the condition is false, a warning is issued.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void Unless(Func<bool> condition, FormattableString message)
         {
             Unless(condition.Invoke(), Is.True, message);
         }
@@ -214,9 +253,22 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
-            Unless(actual, expression, () => message);
+            Unless(actual, expression, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// is satisfied and issuing a warning on failure.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            Unless(actual, expression, () => message.ToString());
         }
 
         /// <summary>
@@ -269,7 +321,7 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, string? message)
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -277,7 +329,26 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message);
+                IssueWarning(result, message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// fails and issuing a warning on success.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
+        /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        {
+            var constraint = new NotConstraint(expr.Resolve());
+
+            IncrementAssertCount();
+            var result = constraint.ApplyTo(del);
+
+            if (!result.IsSuccess)
+                IssueWarning(result, message.ToString());
         }
 
         /// <summary>
@@ -311,9 +382,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, string? message)
+        public static void If(bool condition, NUnitString message)
         {
-            If(condition, Is.True, () => message);
+            If(condition, Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is false. If the condition is true, a warning is issued.
+        /// </summary>
+        /// <param name="condition">The evaluated condition</param>
+        /// <param name="message">The message to display if the condition is false</param>
+        public static void If(bool condition, FormattableString message)
+        {
+            If(condition, Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -344,9 +425,19 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, string? message)
+        public static void If(Func<bool> condition, NUnitString message)
         {
-            If(condition.Invoke(), Is.True, () => message);
+            If(condition.Invoke(), Is.True, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Asserts that a condition is false. If the condition is true a warning is issued.
+        /// </summary>
+        /// <param name="condition">A lambda that returns a Boolean</param>
+        /// <param name="message">The message to display if the condition is true</param>
+        public static void If(Func<bool> condition, FormattableString message)
+        {
+            If(condition.Invoke(), Is.True, () => message.ToString());
         }
 
         /// <summary>
@@ -392,9 +483,22 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, string? message)
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
         {
-            If(actual, expression, () => message);
+            If(actual, expression, () => message.ToString());
+        }
+
+        /// <summary>
+        /// Apply a constraint to an actual value, succeeding if the constraint
+        /// fails and issuing a warning if it succeeds.
+        /// </summary>
+        /// <typeparam name="TActual">The Type being compared.</typeparam>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expression">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        {
+            If(actual, expression, () => message.ToString());
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
@@ -56,9 +57,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(del, expr.Resolve(), string.Empty);
+            Unless(del, expr, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -69,7 +74,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -77,7 +86,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString());
+                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -88,7 +97,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -96,12 +109,12 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString());
+                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
         }
 
-        private static void IssueWarning(ConstraintResult result, string? message)
+        private static void IssueWarning(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
         {
-            MessageWriter writer = new TextMessageWriter(message);
+            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
             result.WriteMessageTo(writer);
             Assert.Warn(writer.ToString());
         }
@@ -117,7 +130,11 @@ namespace NUnit.Framework
         public static void Unless<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -125,7 +142,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage());
+                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -137,9 +154,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, NUnitString message)
+        public static void Unless(bool condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition, Is.True, () => message.ToString());
+            Unless(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -147,18 +167,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, FormattableString message)
+        public static void Unless(bool condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition, Is.True, () => message.ToString());
+            Unless(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false, a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void Unless(bool condition)
+        public static void Unless(bool condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition, Is.True, () => string.Empty);
+            Unless(condition, Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -166,9 +192,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void Unless(bool condition, Func<string?> getExceptionMessage)
+        public static void Unless(bool condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition, Is.True, getExceptionMessage);
+            Unless(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -180,9 +209,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, NUnitString message)
+        public static void Unless(Func<bool> condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition.Invoke(), Is.True, message);
+            Unless(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -190,18 +222,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, FormattableString message)
+        public static void Unless(Func<bool> condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition.Invoke(), Is.True, message);
+            Unless(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is true. If the condition is false, a warning is issued.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void Unless(Func<bool> condition)
+        public static void Unless(Func<bool> condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition.Invoke(), Is.True, string.Empty);
+            Unless(condition.Invoke(), Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -209,9 +247,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void Unless(Func<bool> condition, Func<string?> getExceptionMessage)
+        public static void Unless(Func<bool> condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(condition.Invoke(), Is.True, getExceptionMessage);
+            Unless(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -224,9 +265,13 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="code">A TestDelegate to be executed</param>
         /// <param name="constraint">A Constraint expression to be applied</param>
-        public static void Unless(TestDelegate code, IResolveConstraint constraint)
+        public static void Unless(TestDelegate code, IResolveConstraint constraint,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless((object)code, constraint);
+            Unless((object)code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         #endregion
@@ -240,9 +285,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression)
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(actual, expression, string.Empty);
+            Unless(actual, expression, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -253,9 +302,13 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(actual, expression, () => message.ToString());
+            Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -266,9 +319,13 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            Unless(actual, expression, () => message.ToString());
+            Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -282,7 +339,11 @@ namespace NUnit.Framework
         public static void Unless<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
@@ -290,7 +351,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage());
+                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -308,9 +369,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr)
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(del, expr.Resolve(), string.Empty);
+            If(del, expr, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -321,7 +386,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message)
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -329,7 +398,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString());
+                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -340,7 +409,11 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message)
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -348,7 +421,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString());
+                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -362,7 +435,11 @@ namespace NUnit.Framework
         public static void If<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -370,7 +447,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage());
+                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -382,9 +459,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, NUnitString message)
+        public static void If(bool condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition, Is.True, () => message.ToString());
+            If(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -392,18 +472,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, FormattableString message)
+        public static void If(bool condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition, Is.True, () => message.ToString());
+            If(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is false. If the condition is true, a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void If(bool condition)
+        public static void If(bool condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition, Is.True, () => string.Empty);
+            If(condition, Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -411,9 +497,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void If(bool condition, Func<string?> getExceptionMessage)
+        public static void If(bool condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition, Is.True, getExceptionMessage);
+            If(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -425,9 +514,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, NUnitString message)
+        public static void If(Func<bool> condition, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition.Invoke(), Is.True, () => message.ToString());
+            If(condition.Invoke(), Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -435,18 +527,24 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, FormattableString message)
+        public static void If(Func<bool> condition, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition.Invoke(), Is.True, () => message.ToString());
+            If(condition.Invoke(), Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
         /// Asserts that a condition is false. If the condition is true a warning is issued.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void If(Func<bool> condition)
+        public static void If(Func<bool> condition,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition.Invoke(), Is.True, () => string.Empty);
+            If(condition.Invoke(), Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
         }
 
         /// <summary>
@@ -454,9 +552,12 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void If(Func<bool> condition, Func<string?> getExceptionMessage)
+        public static void If(Func<bool> condition, Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(condition.Invoke(), Is.True, getExceptionMessage);
+            If(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
 
         #endregion
@@ -470,9 +571,13 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression)
+        public static void If<TActual>(TActual actual, IResolveConstraint expression,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(actual, expression, string.Empty);
+            If(actual, expression, string.Empty, actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -483,9 +588,13 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, NUnitString message)
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(actual, expression, () => message.ToString());
+            If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -496,9 +605,13 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, FormattableString message)
+        public static void If<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
-            If(actual, expression, () => message.ToString());
+            If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -512,7 +625,11 @@ namespace NUnit.Framework
         public static void If<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage)
+            Func<string?> getExceptionMessage,
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
+            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expression.Resolve());
 
@@ -520,7 +637,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage());
+                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -6,6 +6,9 @@ using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
+// Disabled because of the CallerArgumentExpression attributes which are only for the compiler.
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+
 namespace NUnit.Framework
 {
     /// <summary>
@@ -60,10 +63,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -84,10 +85,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -110,10 +109,8 @@ namespace NUnit.Framework
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expr.Resolve();
 
@@ -135,9 +132,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void Unless(bool condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -149,9 +144,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void Unless(bool condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -163,9 +156,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(bool condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -181,9 +172,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void Unless(Func<bool> condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -195,9 +184,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void Unless(Func<bool> condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition.Invoke(), Is.True, message, actualExpression, Assert.IsTrueExpression);
         }
@@ -209,9 +196,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(Func<bool> condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -230,10 +215,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
@@ -248,10 +231,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
@@ -268,10 +249,8 @@ namespace NUnit.Framework
             TActual actual,
             IResolveConstraint expression,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = expression.Resolve();
 
@@ -300,10 +279,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -324,10 +301,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -350,10 +325,8 @@ namespace NUnit.Framework
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expr.Resolve());
 
@@ -375,9 +348,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void If(bool condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -389,9 +360,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is false</param>
         public static void If(bool condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition, Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -403,9 +372,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(bool condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -421,9 +388,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is true</param>
         public static void If(Func<bool> condition,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition.Invoke(), Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -435,9 +400,7 @@ namespace NUnit.Framework
         /// <param name="message">The message to display if the condition is true</param>
         public static void If(Func<bool> condition,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition.Invoke(), Is.True, () => message.ToString(), actualExpression, Assert.IsTrueExpression);
         }
@@ -449,9 +412,7 @@ namespace NUnit.Framework
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(Func<bool> condition,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
         }
@@ -470,10 +431,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void If<TActual>(TActual actual, IResolveConstraint expression,
             NUnitString message = default,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
@@ -488,10 +447,8 @@ namespace NUnit.Framework
         /// <param name="message">The message that will be displayed on failure</param>
         public static void If<TActual>(TActual actual, IResolveConstraint expression,
             FormattableString message,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
         }
@@ -508,10 +465,8 @@ namespace NUnit.Framework
             TActual actual,
             IResolveConstraint expression,
             Func<string?> getExceptionMessage,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             var constraint = new NotConstraint(expression.Resolve());
 

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(Unless), message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(Unless), message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(Unless), getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -279,7 +279,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(Unless), getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -311,7 +311,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(If), message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(If), message.ToString(), actualExpression, constraintExpression);
         }
 
         /// <summary>
@@ -361,7 +361,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(del);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(If), getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -519,7 +519,7 @@ namespace NUnit.Framework
             var result = constraint.ApplyTo(actual);
 
             if (!result.IsSuccess)
-                IssueWarning(result, getExceptionMessage(), actualExpression, constraintExpression);
+                IssueWarning(result, nameof(If), getExceptionMessage(), actualExpression, constraintExpression);
         }
 
         #endregion
@@ -533,9 +533,10 @@ namespace NUnit.Framework
             TestExecutionContext.CurrentContext.IncrementAssertCount();
         }
 
-        private static void IssueWarning(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        private static void IssueWarning(ConstraintResult result, string method, string? message, string actualExpression, string constraintExpression)
         {
-            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
+            MessageWriter writer = new TextMessageWriter(
+                Assert.ExtendedMessage($"{nameof(Warn)}.{method}", message, actualExpression, constraintExpression));
             result.WriteMessageTo(writer);
             Assert.Warn(writer.ToString());
         }

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -57,24 +57,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
+        /// <param name="message">The message that will be displayed on failure</param>
         public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            Unless(del, expr, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and issuing a warning on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
-        /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -97,7 +82,8 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+        public static void Unless<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -110,13 +96,6 @@ namespace NUnit.Framework
 
             if (!result.IsSuccess)
                 IssueWarning(result, message.ToString(), actualExpression, constraintExpression);
-        }
-
-        private static void IssueWarning(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
-        {
-            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
-            result.WriteMessageTo(writer);
-            Assert.Warn(writer.ToString());
         }
 
         /// <summary>
@@ -154,7 +133,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, NUnitString message,
+        public static void Unless(bool condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -167,7 +147,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(bool condition, FormattableString message,
+        public static void Unless(bool condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -179,20 +160,9 @@ namespace NUnit.Framework
         /// Asserts that a condition is true. If the condition is false, a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void Unless(bool condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            Unless(condition, Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false, a warning is issued.
-        /// </summary>
-        /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void Unless(bool condition, Func<string?> getExceptionMessage,
+        public static void Unless(bool condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -209,7 +179,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, NUnitString message,
+        public static void Unless(Func<bool> condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -222,7 +193,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void Unless(Func<bool> condition, FormattableString message,
+        public static void Unless(Func<bool> condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -234,44 +206,14 @@ namespace NUnit.Framework
         /// Asserts that a condition is true. If the condition is false, a warning is issued.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void Unless(Func<bool> condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            Unless(condition.Invoke(), Is.True, string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is true. If the condition is false, a warning is issued.
-        /// </summary>
-        /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void Unless(Func<bool> condition, Func<string?> getExceptionMessage,
+        public static void Unless(Func<bool> condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         {
             Unless(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
-        }
-
-        #endregion
-
-        #region TestDelegate
-
-        /// <summary>
-        /// Asserts that the code represented by a delegate throws an exception
-        /// that satisfies the constraint provided.
-        /// </summary>
-        /// <param name="code">A TestDelegate to be executed</param>
-        /// <param name="constraint">A Constraint expression to be applied</param>
-        public static void Unless(TestDelegate code, IResolveConstraint constraint,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(code))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            Unless((object)code, constraint, string.Empty, actualExpression, constraintExpression);
         }
 
         #endregion
@@ -285,24 +227,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            Unless(actual, expression, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// is satisfied and issuing a warning on failure.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -319,7 +246,8 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void Unless<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+        public static void Unless<TActual>(TActual actual, IResolveConstraint expression,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -369,24 +297,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(del))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            If(del, expr, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// fails and issuing a warning on success.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
-        /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, NUnitString message,
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -409,7 +322,8 @@ namespace NUnit.Framework
         /// <param name="del">An ActualValueDelegate returning the value to be tested</param>
         /// <param name="expr">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr, FormattableString message,
+        public static void If<TActual>(ActualValueDelegate<TActual> del, IResolveConstraint expr,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
@@ -459,7 +373,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, NUnitString message,
+        public static void If(bool condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -472,7 +387,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display if the condition is false</param>
-        public static void If(bool condition, FormattableString message,
+        public static void If(bool condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -484,20 +400,9 @@ namespace NUnit.Framework
         /// Asserts that a condition is false. If the condition is true, a warning is issued.
         /// </summary>
         /// <param name="condition">The evaluated condition</param>
-        public static void If(bool condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            If(condition, Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is false. If the condition is true, a warning is issued.
-        /// </summary>
-        /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void If(bool condition, Func<string?> getExceptionMessage,
+        public static void If(bool condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -514,7 +419,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, NUnitString message,
+        public static void If(Func<bool> condition,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -527,7 +433,8 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="message">The message to display if the condition is true</param>
-        public static void If(Func<bool> condition, FormattableString message,
+        public static void If(Func<bool> condition,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -539,20 +446,9 @@ namespace NUnit.Framework
         /// Asserts that a condition is false. If the condition is true a warning is issued.
         /// </summary>
         /// <param name="condition">A lambda that returns a Boolean</param>
-        public static void If(Func<bool> condition,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            If(condition.Invoke(), Is.True, () => string.Empty, actualExpression, Assert.IsTrueExpression);
-        }
-
-        /// <summary>
-        /// Asserts that a condition is false. If the condition is true a warning is issued.
-        /// </summary>
-        /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
-        public static void If(Func<bool> condition, Func<string?> getExceptionMessage,
+        public static void If(Func<bool> condition,
+            Func<string?> getExceptionMessage,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
@@ -571,24 +467,9 @@ namespace NUnit.Framework
         /// <typeparam name="TActual">The Type being compared.</typeparam>
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression,
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-            [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
-            [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
-#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-        {
-            If(actual, expression, string.Empty, actualExpression, constraintExpression);
-        }
-
-        /// <summary>
-        /// Apply a constraint to an actual value, succeeding if the constraint
-        /// fails and issuing a warning if it succeeds.
-        /// </summary>
-        /// <typeparam name="TActual">The Type being compared.</typeparam>
-        /// <param name="actual">The actual value to test</param>
-        /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, NUnitString message,
+        public static void If<TActual>(TActual actual, IResolveConstraint expression,
+            NUnitString message = default,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -605,7 +486,8 @@ namespace NUnit.Framework
         /// <param name="actual">The actual value to test</param>
         /// <param name="expression">A Constraint expression to be applied</param>
         /// <param name="message">The message that will be displayed on failure</param>
-        public static void If<TActual>(TActual actual, IResolveConstraint expression, FormattableString message,
+        public static void If<TActual>(TActual actual, IResolveConstraint expression,
+            FormattableString message,
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
@@ -649,6 +531,13 @@ namespace NUnit.Framework
         private static void IncrementAssertCount()
         {
             TestExecutionContext.CurrentContext.IncrementAssertCount();
+        }
+
+        private static void IssueWarning(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        {
+            MessageWriter writer = new TextMessageWriter(Assert.ExtendedMessage(message, actualExpression, constraintExpression));
+            result.WriteMessageTo(writer);
+            Assert.Warn(writer.ToString());
         }
 
         #endregion

--- a/src/NUnitFramework/nunit.framework.classic.tests/AssertEqualsTests.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/AssertEqualsTests.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  -----------^" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(expected, junitString));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  " + double.NaN + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(1.234, double.NaN, 0.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  1.234d" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(double.NaN, 1.234, 0.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  1.23d" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(double.PositiveInfinity, 1.23, 0.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  " + double.NegativeInfinity + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(double.PositiveInfinity, double.NegativeInfinity, 0.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  " + double.NegativeInfinity + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(float.PositiveInfinity, float.NegativeInfinity, (float)0.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -358,7 +358,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  " + nameof(MyEnum.A) + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(MyEnum.C, actual));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message,Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -379,7 +379,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  2005-06-01 00:00:00" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.AreEqual(dt1, dt2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -392,7 +392,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  1914-06-28 12:00:00.0000666" + Environment.NewLine;
 
             Framework.Assert.That(() => Assert.AreEqual(dt1, dt2),
-                Throws.InstanceOf<AssertionException>().With.Message.EqualTo(expectedMessage));
+                Throws.InstanceOf<AssertionException>().With.Message.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/CollectionAssertTest.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/CollectionAssertTest.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  First non-matching item at index [2]:  <System.Object>" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreInstancesOfType(collection, typeof(string)));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
         #endregion
 
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  First non-matching item at index [1]:  null" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreNotNull(collection));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
         #endregion
 
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Not unique items: < \"x\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", "y", "x")));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NUnit.Framework.Classic.Tests
 
             var ex = Framework.Assert.Throws<AssertionException>(
                 () => CollectionAssert.AllItemsAreUnique(new SimpleObjectCollection("x", null, "y", null, "z")));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Not unique items: < \"x\", \"y\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Extra:    < \"a\" >";
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreEqual(set1, set2, new TestComparer()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  -----------^" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreEqual(set1, set2, new TestComparer()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -359,7 +359,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Extra (1): < \"x\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreEquivalent(set1, set2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -375,7 +375,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Extra (1): < \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreEquivalent(set1, set2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -415,7 +415,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreNotEqual(set1, set2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -467,7 +467,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"x\", \"z\", \"y\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreNotEquivalent(set1, set2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -505,7 +505,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.Contains(list, "a"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -518,7 +518,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.Contains(collection, "a"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -531,7 +531,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  <empty>" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.Contains(list, "x"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -544,7 +544,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  <empty>" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.Contains(ca, "x"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -587,7 +587,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"x\", \"y\", \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.DoesNotContain(list, "y"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
         #endregion
 
@@ -614,7 +614,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Extra items: < \"x\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.IsSubsetOf(set1, set2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -650,7 +650,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  < \"y\", \"z\" >" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.IsNotSubsetOf(set2, set1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -683,7 +683,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Ordering breaks at index [2]:  \"y\"" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.IsOrdered(list));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -774,7 +774,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  But was:  (1, 2, 4)" + Environment.NewLine;
 
             var ex = Framework.Assert.Throws<AssertionException>(() => CollectionAssert.AreEqual(set1, set2, new TestComparer()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/ConditionAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/ConditionAssertTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: True" + Environment.NewLine +
                 "  But was:  False" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsTrue(false));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [TestCase(false, "  But was:  False")]
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: True" + Environment.NewLine +
                 expectedButWas + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsTrue(actual));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: False" + Environment.NewLine +
                 "  But was:  True" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsFalse(true));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [TestCase(true, "  But was:  True")]
@@ -74,7 +74,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: False" + Environment.NewLine +
                 expectedButWas + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsFalse(actual));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: null" + Environment.NewLine +
                 "  But was:  \"S1\"" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNull(s1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not null" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotNull(null));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: NaN" + Environment.NewLine +
                 "  But was:  10.0d" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNaN(10.0));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: <empty>" + Environment.NewLine +
                 "  But was:  \"Hi!\"" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsEmpty("Hi!"));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: <empty>" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsEmpty(default));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: <empty>" + Environment.NewLine +
                 "  But was:  < 1, 2, 3 >" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsEmpty(new[] { 1, 2, 3 }));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: <empty>" + Environment.NewLine +
                 "  But was:  < 1, 2, 3 >" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsEmpty(new[] { 1, 2, 3 }));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not <empty>" + Environment.NewLine +
                 "  But was:  <string.Empty>" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(string.Empty));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not <empty>" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(Array.Empty<int>()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not <empty>" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(Enumerable.Empty<int>()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -232,7 +232,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not <empty>" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(new ArrayList()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: not <empty>" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.IsNotEmpty(new Hashtable()));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/nunit.framework.classic.tests/DirectoryAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/DirectoryAssertTests.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Tests.Assertions
                 string.Format("  Expected: <{0}>{2}  But was:  <{1}>{2}",
                     expected.FullName, actual.FullName, Environment.NewLine);
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.AreEqual(expected, actual));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         #endregion
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Tests.Assertions
                 actual.FullName,
                 Environment.NewLine);
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.AreNotEqual(expected, actual));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         #endregion
@@ -125,14 +125,14 @@ namespace NUnit.Framework.Tests.Assertions
         public void ExistsFailsWhenDirectoryInfoDoesNotExist()
         {
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(new DirectoryInfo(BAD_DIRECTORY)));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: directory exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: directory exists"));
         }
 
         [Test]
         public void ExistsFailsWhenStringDoesNotExist()
         {
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(BAD_DIRECTORY));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: directory exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: directory exists"));
         }
 
         [Test]
@@ -164,14 +164,14 @@ namespace NUnit.Framework.Tests.Assertions
         public void DoesNotExistFailsWhenDirectoryInfoExists()
         {
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.DoesNotExist(_goodDir1.Directory));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: not directory exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: not directory exists"));
         }
 
         [Test]
         public void DoesNotExistFailsWhenStringExists()
         {
             var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.DoesNotExist(_goodDir1.ToString()));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: not directory exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: not directory exists"));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/FileAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/FileAssertTests.cs
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  But was:  null" + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreEqual(expected, null));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Tests.Assertions
                 string.Format("  Expected Stream length {0} but was {1}." + Environment.NewLine,
                     tf1.File.Length, tf2.File.Length);
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreEqual(expected, actual));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NUnit.Framework.Tests.Assertions
                 string.Format("  Expected Stream length {0} but was {1}." + Environment.NewLine,
                     expectedTestFile.File.Length, actualTestFile.File.Length);
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreEqual(expectedTestFile.File, actualTestFile.File));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace NUnit.Framework.Tests.Assertions
                 string.Format("  Expected Stream length {0} but was {1}." + Environment.NewLine,
                     expectedTestFile.File.Length, actualTestFile.File.Length);
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreEqual(expectedTestFile.File.FullName, actualTestFile.File.FullName));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Framework.Tests.Assertions
                 tf1.FileLength,
                 tf1.OffsetOf('!'));
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreEqual(tf1.File.FullName, tf2.File.FullName));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
         #endregion
 
@@ -226,7 +226,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not equal to null" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreNotEqual(expected, actual));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -240,7 +240,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not equal to <System.IO.FileStream>" + Environment.NewLine +
                 "  But was:  <System.IO.FileStream>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreNotEqual(expected, actual));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not equal to <System.IO.FileStream>" + Environment.NewLine +
                 "  But was:  <System.IO.FileStream>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreNotEqual(expectedTestFile.File, actualTestFile.File));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -263,7 +263,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not equal to <System.IO.FileStream>" + Environment.NewLine +
                 "  But was:  <System.IO.FileStream>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreNotEqual(tf1.File.FullName, tf1.File.FullName));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -275,7 +275,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not equal to <System.IO.FileStream>" + Environment.NewLine +
                 "  But was:  <System.IO.FileStream>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.AreNotEqual(tf1.File.FullName, tf2.File.FullName));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
         #endregion
 
@@ -301,21 +301,21 @@ namespace NUnit.Framework.Tests.Assertions
         public void ExistsFailsWhenFileInfoDoesNotExist()
         {
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.Exists(new FileInfo(BadFile)));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: file exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: file exists"));
         }
 
         [Test]
         public void ExistsFailsWhenStringDoesNotExist()
         {
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.Exists(BadFile));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: file exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: file exists"));
         }
 
         [Test]
         public void ExistsFailsWhenFileInfoIsNull()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => Classic.FileAssert.Exists(default(FileInfo)!));
-            Assert.That(ex?.Message, Does.StartWith("The actual value must be a non-null string or FileInfo"));
+            Assert.That(ex?.Message, Does.Contain("The actual value must be a non-null string or FileInfo"));
         }
 
         [Test]
@@ -341,7 +341,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             using var tf1 = new TestFile("TestText1.txt");
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.DoesNotExist(tf1.File));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: not file exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: not file exists"));
         }
 
         [Test]
@@ -349,7 +349,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             using var tf1 = new TestFile("TestText1.txt");
             var ex = Assert.Throws<AssertionException>(() => Classic.FileAssert.DoesNotExist(tf1.File.FullName));
-            Assert.That(ex?.Message, Does.StartWith("  Expected: not file exists"));
+            Assert.That(ex?.Message, Does.Contain("  Expected: not file exists"));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/GreaterEqualFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/GreaterEqualFixture.cs
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than or equal to 5" + Environment.NewLine +
                 "  But was:  4" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(_i2, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than or equal to Ignored" + Environment.NewLine +
                 "  But was:  Explicit" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.GreaterOrEqual(_e1, _e2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/GreaterFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/GreaterFixture.cs
@@ -97,7 +97,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than 5" + Environment.NewLine +
                 "  But was:  5" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Greater(_i1, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than 5" + Environment.NewLine +
                 "  But was:  4" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Greater(_i2, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than Ignored" + Environment.NewLine +
                 "  But was:  Explicit" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Greater(_e1, _e2));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: greater than 99" + Environment.NewLine +
                 "  But was:  7" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Greater(7, 99));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/nunit.framework.classic.tests/LessEqualFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/LessEqualFixture.cs
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than or equal to 5" + Environment.NewLine +
                 "  But was:  8" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.LessOrEqual(_i2, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than or equal to Explicit" + Environment.NewLine +
                 "  But was:  Ignored" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.LessOrEqual(_e2, _e1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than or equal to 4" + Environment.NewLine +
                 "  But was:  9" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.LessOrEqual(9, 4));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/nunit.framework.classic.tests/LessFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/LessFixture.cs
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than 5" + Environment.NewLine +
                 "  But was:  5" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Less(_i1, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than 5" + Environment.NewLine +
                 "  But was:  8" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Less(_i2, _i1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace NUnit.Framework.Classic.Tests
                 "  Expected: less than Explicit" + Environment.NewLine +
                 "  But was:  Ignored" + Environment.NewLine;
             var ex = Framework.Assert.Throws<AssertionException>(() => Assert.Less(_e2, _e1));
-            Framework.Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Framework.Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/NotEqualFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/NotEqualFixture.cs
@@ -21,7 +21,7 @@ namespace NUnit.Framework.Tests.ClassicAssertions
                 "  Expected: not equal to 5" + Environment.NewLine +
                 "  But was:  5" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.Assert.AreNotEqual(5, 5));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace NUnit.Framework.Tests.ClassicAssertions
                 "  Expected: not equal to null" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.Assert.AreNotEqual(null, null));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Tests.ClassicAssertions
                 "  Expected: not equal to < 1, 2, 3 >" + Environment.NewLine +
                 "  But was:  < 1, 2, 3 >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.Assert.AreNotEqual(new object[] { 1, 2, 3 }, new object[] { 1, 2, 3 }));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/NotSameFixture.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/NotSameFixture.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Tests.ClassicAssertions
                 "  Expected: not same as \"S1\"" + Environment.NewLine +
                 "  But was:  \"S1\"" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.Assert.AreNotSame(_s1, _s1));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic.tests/StringAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.classic.tests/StringAssertTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Expected + "String containing \"abc\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "\"abxcdxbc\"" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.StringAssert.Contains("abc", "abxcdxbc"));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Expected + "String starting with \"xyz\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "\"abcxyz\"" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.StringAssert.StartsWith("xyz", "abcxyz"));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Expected + "String ending with \"xyz\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "\"abcdef\"" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.StringAssert.EndsWith("xyz", "abcdef"));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace NUnit.Framework.Tests.Assertions
                 + TextMessageWriter.Pfx_Actual + "\"NAMES\"" + Environment.NewLine
                 + "  ---------------^" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.StringAssert.AreEqualIgnoringCase("Name", "NAMES"));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Expected + "String matching \"a?b*c\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "\"12ab456\"" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.StringAssert.IsMatch("a?b*c", "12ab456"));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.classic/Assert.Types.cs
+++ b/src/NUnitFramework/nunit.framework.classic/Assert.Types.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Classic
         public static void IsAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
         {
             var msg = ConvertMessageWithArgs(message, args);
-            That(actual, Is.AssignableFrom(expected), msg);
+            That(actual, Is.AssignableFrom(expected), (NUnitString)msg);
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunit.framework.classic/Assert.Types.cs
+++ b/src/NUnitFramework/nunit.framework.classic/Assert.Types.cs
@@ -18,8 +18,7 @@ namespace NUnit.Framework.Classic
         /// <param name="args">Array of objects to be used in formatting the message</param>
         public static void IsAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
         {
-            var msg = ConvertMessageWithArgs(message, args);
-            That(actual, Is.AssignableFrom(expected), (NUnitString)msg);
+            That(actual, Is.AssignableFrom(expected), () => ConvertMessageWithArgs(message, args));
         }
 
         /// <summary>

--- a/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
@@ -38,14 +38,8 @@ using System.Runtime.CompilerServices;
 
 #if NET462
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET Framework 4.6.2)")]
-#elif NETSTANDARD2_0
-[assembly: AssemblyTitle("NUnit Framework Classic (.NET Standard 2.0)")]
 #elif NET6_0
-#if WINDOWS
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0)")]
-#else
-[assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0-windows)")]
-#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunit.framework.classic/Properties/AssemblyInfo.cs
@@ -40,6 +40,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnit Framework Classic (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnit Framework Classic (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -526,7 +526,9 @@ namespace NUnit.Options
 
         public string OptionName => _option;
 
+#if !NET6_0_OR_GREATER
         [SecurityPermission(SecurityAction.LinkDemand, SerializationFormatter = true)]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -96,13 +96,8 @@ namespace NUnitLite
                                            assemblyName.Version.ToString());
             _xmlWriter.WriteAttributeString("clr-version",
                 Environment.Version.ToString());
-#if NETSTANDARD2_0
             _xmlWriter.WriteAttributeString("os-version",
-                                           System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            _xmlWriter.WriteAttributeString("os-version",
-                                           OSPlatform.CurrentPlatform.ToString());
-#endif
+                                           OSPlatform.OSDescription);
             _xmlWriter.WriteAttributeString("platform",
                 Environment.OSVersion.Platform.ToString());
             _xmlWriter.WriteAttributeString("cwd",

--- a/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
@@ -15,6 +15,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 4.6.2)")]
 #elif NETSTANDARD2_0
 [assembly: AssemblyTitle("NUnitLite Runner (.NET Standard 2.0)")]
+#elif NET6_0
+#if WINDOWS
+[assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0)")]
+#else
+[assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0-windows)")]
+#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
+++ b/src/NUnitFramework/nunitlite/Properties/AssemblyInfo.cs
@@ -13,14 +13,8 @@ using System.Runtime.CompilerServices;
 
 #if NET462
 [assembly: AssemblyTitle("NUnitLite Runner (.NET Framework 4.6.2)")]
-#elif NETSTANDARD2_0
-[assembly: AssemblyTitle("NUnitLite Runner (.NET Standard 2.0)")]
 #elif NET6_0
-#if WINDOWS
 [assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0)")]
-#else
-[assembly: AssemblyTitle("NUnitLite Runner (.NET 6.0-windows)")]
-#endif
 #else
 #error Missing AssemblyTitle attribute for this target.
 #endif

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -144,11 +144,7 @@ namespace NUnitLite
         public void DisplayRuntimeEnvironment()
         {
             WriteSectionHeader("Runtime Environment");
-#if NETSTANDARD2_0
-            Writer.WriteLabelLine("   OS Version: ", System.Runtime.InteropServices.RuntimeInformation.OSDescription);
-#else
-            Writer.WriteLabelLine("   OS Version: ", OSPlatform.CurrentPlatform);
-#endif
+            Writer.WriteLabelLine("   OS Version: ", OSPlatform.OSDescription);
             Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
             Writer.WriteLine();
         }

--- a/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
@@ -25,7 +25,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected is <System.Int32[4]>, actual is <System.Int32[2,2]>" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Missing:  < 4, 5 >";
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Extra:    < 4, 5, 6... >";
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "5" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "3" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "0" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "4" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "0" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Tests.Assertions
 #pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
 #pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "0" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected).AsCollection));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Tests.Assertions
                 TextMessageWriter.Pfx_Actual + "0" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected).AsCollection));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -205,7 +205,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  ------------^" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  ------------^" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -239,7 +239,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  But was:  3" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected).AsCollection));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -257,7 +257,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  ------------^" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(array2, Is.EqualTo(array1)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertPolarityTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertPolarityTests.cs
@@ -103,7 +103,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: greater than 0" + Environment.NewLine +
                 "  But was:  -1" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(_i2, Is.Positive));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: less than 0" + Environment.NewLine +
                 "  But was:  1" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(_i1, Is.Negative));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -235,6 +235,32 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
         }
 
+        [Test]
+        public void OnlyFailingAssertion_FormatsString()
+        {
+            const string text = "String was formatted";
+            var formatCounter = new FormatCounter();
+
+            Assert.That(1 + 1, Is.EqualTo(2), $"{text} {formatCounter}");
+            Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(0), "The interpolated string should not have been evaluated");
+
+            Assert.That(() => Assert.That(1 + 1, Is.Not.EqualTo(2), $"{text} {formatCounter}"),
+                Throws.InstanceOf<AssertionException>().With.Message.Contains(text));
+
+            Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(1), "The interpolated string should have been evaluated once");
+        }
+
+        private sealed class FormatCounter
+        {
+            public int NumberOfToStringCalls { get; private set; }
+
+            public override string ToString()
+            {
+                NumberOfToStringCalls++;
+                return string.Empty;
+            }
+        }
+
         private int ReturnsFive()
         {
             return 5;

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -104,6 +104,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, "message"));
             Assert.That(ex?.Message, Does.Contain("message"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(2 + 2 == 5, Is.True)"));
         }
 
         [Test]
@@ -112,6 +113,7 @@ namespace NUnit.Framework.Tests.Assertions
             string GetExceptionMessage() => "Not Equal to 4";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2 == 5, GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("Not Equal to 4"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(2 + 2 == 5, Is.True)"));
         }
 #pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
 
@@ -126,6 +128,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2, Is.EqualTo(5), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -134,6 +137,7 @@ namespace NUnit.Framework.Tests.Assertions
             string GetExceptionMessage() => "error";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(2 + 2, Is.EqualTo(5), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -147,6 +151,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(() => 2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -155,6 +160,7 @@ namespace NUnit.Framework.Tests.Assertions
             string GetExceptionMessage() => "error";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(() => 2 + 2, Is.EqualTo(5), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(() => 2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -168,6 +174,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(ReturnsFive, Is.EqualTo(4), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(ReturnsFive, Is.EqualTo(4))"));
         }
 
         [Test]
@@ -176,6 +183,7 @@ namespace NUnit.Framework.Tests.Assertions
             string GetExceptionMessage() => "error";
             var ex = Assert.Throws<AssertionException>(() => Assert.That(ReturnsFive, Is.EqualTo(4), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(ReturnsFive, Is.EqualTo(4))"));
         }
 
         [Test]
@@ -232,6 +240,7 @@ namespace NUnit.Framework.Tests.Assertions
 
             // Assert
             Assert.That(ex?.Message, Does.Contain("Func was called"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(1 + 1 == 1, Is.True)"));
             Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
         }
 
@@ -245,7 +254,10 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(0), "The interpolated string should not have been evaluated");
 
             Assert.That(() => Assert.That(1 + 1, Is.Not.EqualTo(2), $"{text} {formatCounter}"),
-                Throws.InstanceOf<AssertionException>().With.Message.Contains(text));
+                Throws.InstanceOf<AssertionException>()
+                    .With.Message.Contains(text).
+                    And
+                    .With.Message.Contains("Assert.That(1 + 1, Is.Not.EqualTo(2)"));
 
             Assert.That(formatCounter.NumberOfToStringCalls, Is.EqualTo(1), "The interpolated string should have been evaluated once");
         }
@@ -329,6 +341,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(() => false, "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assert.That(() => false, Is.True)"));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsAsyncTests.cs
@@ -140,7 +140,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNothing));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Is.EqualTo(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine));
 
@@ -152,7 +152,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceException));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
 
@@ -164,7 +164,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsNullReferenceExceptionAsync));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
 
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemException));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
 
@@ -188,7 +188,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<ArgumentException>(AsyncTestDelegates.ThrowsSystemExceptionAsync));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
         }
@@ -198,7 +198,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentException));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: myMessage"));
 
@@ -210,7 +210,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = CatchException(() => Assert.ThrowsAsync<Exception>(AsyncTestDelegates.ThrowsArgumentExceptionAsync));
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: myMessage"));
         }

--- a/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThrowsTests.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework.Tests.Assertions
                 Assert.Throws<ArgumentException>(TestDelegates.ThrowsNothing));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Is.EqualTo(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  null" + Environment.NewLine));
 
@@ -131,7 +131,7 @@ namespace NUnit.Framework.Tests.Assertions
                 Assert.Throws<ArgumentException>(TestDelegates.ThrowsNullReferenceException));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
 
@@ -145,7 +145,7 @@ namespace NUnit.Framework.Tests.Assertions
                 Assert.Throws<ArgumentException>(TestDelegates.ThrowsSystemException));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.Exception: my message" + Environment.NewLine));
 
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Tests.Assertions
                 Assert.Throws<Exception>(TestDelegates.ThrowsArgumentException));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex!.Message, Does.StartWith(
+            Assert.That(ex!.Message, Does.Contain(
                 "  Expected: <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: myMessage"));
 

--- a/src/NUnitFramework/tests/Assertions/AssertZeroTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertZeroTests.cs
@@ -91,7 +91,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: 0" + Environment.NewLine +
                 "  But was:  1234" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(_i2, Is.Zero));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssumeThatTests.cs
@@ -117,14 +117,16 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, "message"));
             Assert.That(ex?.Message, Does.Contain("message"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(2 + 2 == 5, Is.True)"));
         }
 
         [Test]
         public void FailureThrowsInconclusiveException_BooleanWithMessageStringFunc()
         {
             string GetExceptionMessage() => "got 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, (Func<string>)GetExceptionMessage));
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2 == 5, GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("got 5"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(2 + 2 == 5, Is.True)"));
         }
 
         [Test]
@@ -138,14 +140,16 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, "message"));
             Assert.That(ex?.Message, Does.Contain("message"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(() => 2 + 2 == 5, Is.True)"));
         }
 
         [Test]
         public void FailureThrowsInconclusiveException_BooleanLambdaWithMessageStringFunc()
         {
             string GetExceptionMessage() => "got 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, (Func<string>)GetExceptionMessage));
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2 == 5, GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("got 5"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(() => 2 + 2 == 5, Is.True)"));
         }
 
         [Test]
@@ -159,14 +163,16 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
         public void FailureThrowsInconclusiveException_ActualAndConstraintWithMessageStringFunc()
         {
             string GetExceptionMessage() => "Should be 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), (Func<string>)GetExceptionMessage));
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(2 + 2, Is.EqualTo(5), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("Should be 5"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -180,14 +186,16 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(() => 2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
         public void FailureThrowsInconclusiveException_ActualLambdaAndConstraintWithMessageStringFunc()
         {
             string GetExceptionMessage() => "Should be 5";
-            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), (Func<string>)GetExceptionMessage));
+            var ex = Assert.Throws<InconclusiveException>(() => Assume.That(() => 2 + 2, Is.EqualTo(5), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("Should be 5"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(() => 2 + 2, Is.EqualTo(5))"));
         }
 
         [Test]
@@ -201,6 +209,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var ex = Assert.Throws<InconclusiveException>(() => Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), "Error"));
             Assert.That(ex?.Message, Does.Contain("Error"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4))"));
         }
 
         [Test]
@@ -210,6 +219,7 @@ namespace NUnit.Framework.Tests.Assertions
             var ex = Assert.Throws<InconclusiveException>(
                 () => Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4), GetExceptionMessage));
             Assert.That(ex?.Message, Does.Contain("Should be 4"));
+            Assert.That(ex?.Message, Does.Contain("Assume.That(new ActualValueDelegate<int>(ReturnsFive), Is.EqualTo(4))"));
         }
 
         [Test]
@@ -250,6 +260,7 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.Multiple(() =>
             {
                 Assert.That(ex?.Message, Does.Contain("Func was called"));
+                Assert.That(ex?.Message, Does.Contain("Assume.That(1 + 1 == 1, Is.True)"));
                 Assert.That(funcWasCalled, "The getExceptionMessage function was not called when it should have been.");
             });
         }

--- a/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
+++ b/src/NUnitFramework/tests/Assertions/ListContentsTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
                 "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(TestArray, Has.Some.EqualTo("def")));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
                 "  But was:  <empty>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Array.Empty<object>(), Has.Some.EqualTo("def")));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: some item equal to \"def\"" + Environment.NewLine +
                 "  But was:  < \"abc\", 123, \"xyz\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(new SimpleObjectList(TestArray), Has.Some.EqualTo("def")));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/SameFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/SameFixture.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: same as <System.Exception: one>" + Environment.NewLine +
                 "  But was:  <System.Exception: two>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(ex2, Is.SameAs(ex1)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Tests.Assertions
 #pragma warning disable NUnit2040 // Non-reference types for SameAs constraint
             var ex = Assert.Throws<AssertionException>(() => Assert.That(index, Is.SameAs(index)));
 #pragma warning restore NUnit2040 // Non-reference types for SameAs constraint
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
+++ b/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: <System.Int32>" + Environment.NewLine +
                 "  But was:  <System.String>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That("Hello", Is.TypeOf(typeof(int))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: instance of <System.Int32>" + Environment.NewLine +
                 "  But was:  <System.String>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That("abc123", Is.InstanceOf(typeof(int))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not instance of <System.Exception>" + Environment.NewLine +
                 "  But was:  <System.ArgumentException: Value does not fall within the expected range.>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Classic.Assert.IsNotInstanceOf(typeof(Exception), new ArgumentException()));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test()]
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: assignable from <System.Int32[,]>" + Environment.NewLine +
                 "  But was:  <System.Int32[]>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(array10, Is.AssignableFrom(array2.GetType())));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test()]
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Tests.Assertions
                 "  Expected: not assignable from <System.Int32[]>" + Environment.NewLine +
                 "  But was:  <System.Int32[]>" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(array10, Is.Not.AssignableFrom(array2.GetType())));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -92,6 +92,7 @@ namespace NUnit.Framework.Tests.Assertions
         public void WarningFails(string methodName, string? expectedMessage)
         {
             var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
+            string expectedMethodName = methodName.Contains("WarnUnless") ? "Warn.Unless" : "Warn.If";
 
             Assert.Multiple(() =>
             {
@@ -106,9 +107,10 @@ namespace NUnit.Framework.Tests.Assertions
             string? stackTrace = result.AssertionResults[0].StackTrace;
             Assert.That(stackTrace, Is.Not.Null, "StackTrace should not be null");
             Assert.That(stackTrace, Does.Contain("WarningFixture"));
-            Assert.That(stackTrace!.Split(new[] { '\n' }), Has.Length.LessThan(3));
+            Assert.That(stackTrace.Split(new[] { '\n' }), Has.Length.LessThan(3));
             Assert.That(result.Message, Is.Not.Null, "Result Message should not be null");
-            Assert.That(result.Message, Contains.Substring(message!), "Result message should contain assertion message");
+            Assert.That(result.Message, Contains.Substring(message), "Result message should contain assertion message");
+            Assert.That(result.Message, Contains.Substring(expectedMethodName), "Result message should contain assert method name");
 
             if (expectedMessage is not null)
             {

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Tests.Attributes
             attr.ApplyToTest(fixture);
 
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), (NUnitString)result.Message);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
 
             BaseLifeCycle.VerifyInstancePerTestCase(3);
         }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework.Tests.Attributes
             attr.ApplyToTest(fixture);
 
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), (NUnitString)result.Message);
 
             BaseLifeCycle.VerifyInstancePerTestCase(3);
         }

--- a/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AllItemsConstraintTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
                 "  First non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new NotConstraint(new EqualConstraint(null)))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< 12, 27, 19, 32, 107, 99, 26 >" + NL +
                 "  First non-matching item at index [4]:  107" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new RangeConstraint(10, 100))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< 'a', \"b\", 'c' >" + NL +
                 "  First non-matching item at index [1]:  \"b\"" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new AllItemsConstraint(new InstanceOfTypeConstraint(typeof(char)))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Tests.Constraints
             IEnumerable<int> actual = expected.Take(2);
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(
+            Assert.That(ex?.Message, Does.Contain(
                 $"  Expected is {MsgUtils.GetTypeRepresentation(expected)}, actual is {MsgUtils.GetTypeRepresentation(actual)}" + Environment.NewLine +
                 "  Values differ at index [2]" + Environment.NewLine +
                 "  Missing:  < 3, ... >"));
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Tests.Constraints
             ICollection actual = new SimpleObjectCollection(1, 5, 3);
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.EqualTo(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(
+            Assert.That(ex?.Message, Does.Contain(
                 "  Expected is <System.Int32[3]>, actual is <NUnit.Framework.Tests.TestUtilities.Collections.SimpleObjectCollection> with 3 elements" + Environment.NewLine +
                 "  Values differ at index [1]" + Environment.NewLine +
                 TextMessageWriter.Pfx_Expected + "2" + Environment.NewLine +

--- a/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionOrderedConstraintTests.cs
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Tests.Constraints
                 "  Ordering breaks at index [2]:  \"y\"" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(new[] { "x", "z", "y" }, Is.Ordered));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Tests.Constraints
                 "  Ordering breaks at index [91]:  91" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actual, Is.Ordered));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "\"abc\"" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actualString, Does.Contain(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "\"abc\"" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actualString, Does.Contain(expected).IgnoreCase));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< \"a\", \"b\" >" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actualItems, Does.Contain(expected)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< \"a\", \"b\" >" + NL;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(actualItems, Does.Contain(expected).IgnoreCase));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -244,7 +244,7 @@ namespace NUnit.Framework.Tests.Constraints
                 "  Missing (1): < 3 >" + Environment.NewLine +
                 "  Extra (1): < 1 >" + Environment.NewLine;
 
-            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            Assert.That(exception.Message, Does.Contain(expectedMessage));
         }
 
         private static int _setValuesDelay;

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -835,7 +835,7 @@ namespace NUnit.Framework.Tests.Constraints
 #pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
             var ex = Assert.Throws<AssertionException>(() => Assert.That(new IntPtr(0), Is.EqualTo(0)));
 #pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
-            Assert.That("  Expected: 0 (Int32)" + NL + "  But was:  0 (IntPtr)" + NL, Is.EqualTo(ex.Message));
+            Assert.That(ex?.Message, Does.Contain("  Expected: 0 (Int32)" + NL + "  But was:  0 (IntPtr)" + NL));
         }
 
         private class Dummy
@@ -898,14 +898,14 @@ namespace NUnit.Framework.Tests.Constraints
                 "  Expected: <Dummy 12> (EqualConstraintTests+DummyGenericClass`1[EqualConstraintTests+Dummy])" + Environment.NewLine +
                 "  But was:  <Dummy 12> (EqualConstraintTests+DummyGenericClass`1[EqualConstraintTests+Dummy1])" + Environment.NewLine;
 
-            Assert.That(ex?.Message, Is.EqualTo(expectedMsg));
+            Assert.That(ex?.Message, Does.Contain(expectedMsg));
         }
 
         [Test]
         public void SameValueAndTypeButDifferentReferenceShowNotShowTypeDifference()
         {
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Is.Zero, Is.EqualTo(Is.Zero)));
-            Assert.That("  Expected: <<equal 0>>" + NL + "  But was:  <<equal 0>>" + NL, Is.EqualTo(ex.Message));
+            Assert.That(ex?.Message, Does.Contain("  Expected: <<equal 0>>" + NL + "  But was:  <<equal 0>>" + NL));
         }
 
         [Test, TestCaseSource(nameof(DifferentTypeSameValueTestData))]

--- a/src/NUnitFramework/tests/Constraints/EqualTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualTest.cs
@@ -75,6 +75,7 @@ namespace NUnit.Framework.Tests.Constraints
             StringReader rdr = new StringReader(ex.Message);
             /* skip */
             rdr.ReadLine();
+            rdr.ReadLine(); // Skip actualExpression, constraintExpression string
             string? expected = rdr.ReadLine();
             Assert.That(expected, Is.Not.Null);
             if (expected.Length > 11)

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Expected + "no item equal to \"Charlie\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(0, Is.EqualTo("Charlie"))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Expected + "exactly one item equal to \"Charlie\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1, Is.EqualTo("Charlie"))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Expected + "exactly 2 items equal to \"Fred\"" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "1 item < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(2, Is.EqualTo("Fred"))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Expected + "exactly one item" + Environment.NewLine +
                 TextMessageWriter.Pfx_Actual + "4 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace NUnit.Framework.Tests.Constraints
                 + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(longElementList, Has.Exactly(5).Items));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Tests.Constraints
                 + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(longElementList, Has.Exactly(10).Items));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/IndexerConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/IndexerConstraintTests.cs
@@ -52,7 +52,7 @@ namespace NUnit.Framework.Tests.Constraints
             var tester = new IndexerTester();
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(tester, Has.ItemAt(4, 2).EqualTo("Second indexer")));
-            Assert.That(ex?.Message, Is.EqualTo(expectedErrorMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedErrorMessage));
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Tests.Constraints
             var tester = new IndexerTester();
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(tester, Has.No.ItemAt(string.Empty).EqualTo("Second indexer")));
-            Assert.That(ex?.Message, Is.EqualTo(expectedErrorMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedErrorMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NoItemConstraintTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Tests.Constraints
                 TextMessageWriter.Pfx_Actual + "< 1, \"hello\", null, 3 >" + NL +
                 "  First non-matching item at index [2]:  null" + NL;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(c, new NoItemConstraint(Is.Null)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/RangeTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RangeTests.cs
@@ -25,7 +25,7 @@ namespace NUnit.Framework.Tests.Constraints
 
             Assert.That(
                 new TestDelegate(FailingInRangeMethod),
-                Throws.TypeOf(typeof(AssertionException)).With.Message.EqualTo(expectedMessage));
+                Throws.TypeOf(typeof(AssertionException)).With.Message.Contains(expectedMessage));
         }
 
         private void FailingInRangeMethod()
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Tests.Constraints
 
             Assert.That(
                 new TestDelegate(FailingNotInRangeMethod),
-                Throws.TypeOf(typeof(AssertionException)).With.Message.EqualTo(expectedMessage));
+                Throws.TypeOf(typeof(AssertionException)).With.Message.Contains(expectedMessage));
         }
 
         private void FailingNotInRangeMethod()

--- a/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
@@ -59,10 +59,10 @@ namespace NUnit.Framework.Tests.Constraints
             const string testPhrase = "Make your tests fail before passing!";
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(testPhrase, Does.Match(testMatcher)));
-            Assert.That(ex?.Message, Is.EqualTo(expectedErrorMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedErrorMessage));
 
             ex = Assert.Throws<AssertionException>(() => Assert.That(testPhrase, Does.Match(new Regex(testMatcher))));
-            Assert.That(ex?.Message, Is.EqualTo(expectedErrorMessage));
+            Assert.That(ex?.Message, Does.Contain(expectedErrorMessage));
         }
     }
 }

--- a/src/NUnitFramework/tests/Extensions.cs
+++ b/src/NUnitFramework/tests/Extensions.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Tests
         {
             if (result is null) throw new ArgumentNullException(nameof(result));
 
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), (NUnitString)result.Message);
         }
     }
 }

--- a/src/NUnitFramework/tests/Extensions.cs
+++ b/src/NUnitFramework/tests/Extensions.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Tests
         {
             if (result is null) throw new ArgumentNullException(nameof(result));
 
-            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), (NUnitString)result.Message);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
         }
     }
 }

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -119,7 +119,7 @@ namespace NUnit.Framework.Tests.Internal
 
             Assert.That(ex is null); // Careful not to pass ex to Assert.That and crash the test run rather than failing
 
-            Assert.That(result, Has.Property("Message").StartWith(
+            Assert.That(result, Has.Property("Message").Contains(
                 "  Expected: null" + Environment.NewLine
                 + "  But was:  <! RecursivelyThrowingException was thrown by RecursivelyThrowingException.ToString() !>"));
         }
@@ -134,7 +134,7 @@ namespace NUnit.Framework.Tests.Internal
 
             Assert.That(ex is null); // Careful not to pass ex to Assert.That and crash the test run rather than failing
 
-            Assert.That(result, Has.Property("Message").StartWith(
+            Assert.That(result, Has.Property("Message").Contains(
                 "  Expected: <! RecursivelyThrowingException was thrown by RecursivelyThrowingException.ToString() !>" + Environment.NewLine
                 + "  But was:  null"));
         }

--- a/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Tests.Syntax
                 Assert.That(TestDelegates.ThrowsNullReferenceException, Throws.TypeOf<ArgumentException>()));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex?.Message, Does.StartWith(
+            Assert.That(ex?.Message, Does.Contain(
                 "  Expected: <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
         }
@@ -135,7 +135,7 @@ namespace NUnit.Framework.Tests.Syntax
                 Assert.That(TestDelegates.ThrowsNullReferenceException, Throws.InstanceOf<ArgumentException>()));
 
             Assert.That(ex, Is.Not.Null);
-            Assert.That(ex?.Message, Does.StartWith(
+            Assert.That(ex?.Message, Does.Contain(
                 "  Expected: instance of <System.ArgumentException>" + Environment.NewLine +
                 "  But was:  <System.NullReferenceException: my message" + Environment.NewLine));
         }


### PR DESCRIPTION
@OsirisTerje I see a problem, the compiler cannot distinguish between:

```csharp
Assert.That(actual, constraint, [CAE] string actualExpression =  "", [CAE] string constraintExpression =  "")
{}
Assert.That(actual, constraint, string? message, [CAE] string actualExpression =  "", [CAE] string constraintExpression = "")
{}
```
When calling it like:
```
Assert.That(actual, constraint, message)
```

Because it matches both.
