### PR TITLE
All Assert messages must be non-null

### DIFF
--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestSnippet delegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Exception? ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string message, params object?[]? args)
         {
             Exception? caughtException = null;
             try
@@ -54,7 +54,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Exception? ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object?[]? args)
         {
             return ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -82,7 +82,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
+        public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object?[]? args) where TActual : Exception
         {
             return (TActual?)ThrowsAsync(typeof(TActual), code, message, args);
         }
@@ -109,7 +109,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? CatchAsync(AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Exception? CatchAsync(AsyncTestDelegate code, string message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
         }
@@ -132,7 +132,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string? message, params object?[]? args)
+        public static Exception? CatchAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object?[]? args)
         {
             return ThrowsAsync(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -159,7 +159,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code, string? message, params object?[]? args) where TActual : Exception
+        public static TActual? CatchAsync<TActual>(AsyncTestDelegate code, string message, params object?[]? args) where TActual : Exception
         {
             return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
         }
@@ -184,7 +184,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void DoesNotThrowAsync(AsyncTestDelegate code, string? message, params object?[]? args)
+        public static void DoesNotThrowAsync(AsyncTestDelegate code, string message, params object?[]? args)
         {
             Assert.That(code, new ThrowsNothingConstraint(), () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestSnippet delegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? Throws(IResolveConstraint expression, TestDelegate code, string? message, params object?[]? args)
+        public static Exception? Throws(IResolveConstraint expression, TestDelegate code, string message, params object?[]? args)
         {
             Exception? caughtException = null;
 
@@ -60,7 +60,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? Throws(Type expectedExceptionType, TestDelegate code, string? message, params object?[]? args)
+        public static Exception? Throws(Type expectedExceptionType, TestDelegate code, string message, params object?[]? args)
         {
             return Throws(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -88,7 +88,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? Throws<TActual>(TestDelegate code, string? message, params object?[]? args) where TActual : Exception
+        public static TActual? Throws<TActual>(TestDelegate code, string message, params object?[]? args) where TActual : Exception
         {
             return (TActual?)Throws(typeof(TActual), code, message, args);
         }
@@ -114,7 +114,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? Catch(TestDelegate code, string? message, params object?[]? args)
+        public static Exception? Catch(TestDelegate code, string message, params object?[]? args)
         {
             return Throws(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
         }
@@ -137,7 +137,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static Exception? Catch(Type expectedExceptionType, TestDelegate code, string? message, params object?[]? args)
+        public static Exception? Catch(Type expectedExceptionType, TestDelegate code, string message, params object?[]? args)
         {
             return Throws(new InstanceOfTypeConstraint(expectedExceptionType), code, message, args);
         }
@@ -163,7 +163,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static TActual? Catch<TActual>(TestDelegate code, string? message, params object?[]? args) where TActual : System.Exception
+        public static TActual? Catch<TActual>(TestDelegate code, string message, params object?[]? args) where TActual : System.Exception
         {
             return (TActual?)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
         }
@@ -188,7 +188,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         /// <param name="message">The message that will be displayed on failure</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void DoesNotThrow(TestDelegate code, string? message, params object?[]? args)
+        public static void DoesNotThrow(TestDelegate code, string message, params object?[]? args)
         {
             Assert.That(code, new ThrowsNothingConstraint(), () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -53,7 +53,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(bool condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             That(condition, Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
@@ -93,7 +93,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(Func<bool> condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, IsTrueExpression);
@@ -153,7 +153,7 @@ namespace NUnit.Framework
         public static void That<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
@@ -204,7 +204,7 @@ namespace NUnit.Framework
         /// <param name="constraint">A Constraint expression to be applied</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(TestDelegate code, IResolveConstraint constraint,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(constraint))] string constraintExpression = "")
         {
@@ -270,7 +270,7 @@ namespace NUnit.Framework
         public static void That<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
@@ -310,7 +310,7 @@ namespace NUnit.Framework
 
         #region Helper Method
 
-        private static void ReportFailure(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        private static void ReportFailure(ConstraintResult result, string message, string actualExpression, string constraintExpression)
         {
             MessageWriter writer = new TextMessageWriter(
                 ExtendedMessage($"{nameof(Assert)}.{nameof(Assert.That)}",

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -88,12 +88,11 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         [DoesNotReturn]
-        public static void Pass(string? message)
+        public static void Pass(string message)
         {
             // If we are in a multiple assert block, this is an error
             if (TestExecutionContext.CurrentContext.MultipleAssertLevel > 0)
                 throw new Exception("Assert.Pass may not be used in a multiple assertion block.");
-            message ??= string.Empty;
             throw new SuccessException(message);
         }
 
@@ -117,9 +116,8 @@ namespace NUnit.Framework
         /// exception when inside a multiple assert block.
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
-        public static void Fail(string? message)
+        public static void Fail(string message)
         {
-            message ??= string.Empty;
             ReportFailure(message);
         }
 
@@ -139,9 +137,8 @@ namespace NUnit.Framework
         /// Issues a warning using the message and arguments provided.
         /// </summary>
         /// <param name="message">The message to display.</param>
-        public static void Warn(string? message)
+        public static void Warn(string message)
         {
-            message ??= string.Empty;
             IssueWarning(message);
         }
 
@@ -155,7 +152,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="AssertionException"/> with.</param>
         [DoesNotReturn]
-        public static void Ignore(string? message)
+        public static void Ignore(string message)
         {
             // If we are in a multiple assert block, this is an error
             if (TestExecutionContext.CurrentContext.MultipleAssertLevel > 0)
@@ -184,7 +181,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="message">The message to initialize the <see cref="InconclusiveException"/> with.</param>
         [DoesNotReturn]
-        public static void Inconclusive(string? message)
+        public static void Inconclusive(string message)
         {
             // If we are in a multiple assert block, this is an error
             if (TestExecutionContext.CurrentContext.MultipleAssertLevel > 0)
@@ -306,7 +303,7 @@ namespace NUnit.Framework
 
         #region Helper Methods
 
-        internal static string ExtendedMessage(string methodName, string? message, string actualExpression, string constraintExpression)
+        internal static string ExtendedMessage(string methodName, string message, string actualExpression, string constraintExpression)
         {
             string context = $"{methodName}({actualExpression}, {constraintExpression})";
             string extendedMessage = string.IsNullOrEmpty(message) ? context : $"{message}\n{context}";
@@ -314,7 +311,7 @@ namespace NUnit.Framework
             return extendedMessage;
         }
 
-        private static void ReportFailure(string? message)
+        private static void ReportFailure(string message)
         {
             // Record the failure in an <assertion> element
             var result = TestExecutionContext.CurrentContext.CurrentResult;
@@ -326,7 +323,7 @@ namespace NUnit.Framework
                 throw new AssertionException(result.Message);
         }
 
-        private static void IssueWarning(string? message)
+        private static void IssueWarning(string message)
         {
             var result = TestExecutionContext.CurrentContext.CurrentResult;
             result.RecordAssertion(AssertionStatus.Warning, message, GetStackTrace());

--- a/src/NUnitFramework/framework/AssertBase.cs
+++ b/src/NUnitFramework/framework/AssertBase.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Check if message comes with args, and convert that to a formatted string
         /// </summary>
-        protected static string? ConvertMessageWithArgs(string? message, object?[]? args)
-            => message is null ? null : (args is null || args.Length == 0) ? message : string.Format(message, args);
+        protected static string ConvertMessageWithArgs(string message, object?[]? args)
+            => (args is null || args.Length == 0) ? message : string.Format(message, args);
     }
 }

--- a/src/NUnitFramework/framework/Assume.cs
+++ b/src/NUnitFramework/framework/Assume.cs
@@ -109,7 +109,7 @@ namespace NUnit.Framework
         public static void That<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
@@ -161,7 +161,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That([DoesNotReturnIf(false)] bool condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             That(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -204,7 +204,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void That(Func<bool> condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             That(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -275,7 +275,7 @@ namespace NUnit.Framework
         public static void That<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
@@ -300,7 +300,7 @@ namespace NUnit.Framework
                 throw new Exception("Assume.That may not be used in a multiple assertion block.");
         }
 
-        private static void ReportInconclusive(ConstraintResult result, string? message, string actualExpression, string constraintExpression)
+        private static void ReportInconclusive(ConstraintResult result, string message, string actualExpression, string constraintExpression)
         {
             MessageWriter writer = new TextMessageWriter(
                 Assert.ExtendedMessage($"{nameof(Assume)}.{nameof(Assume.That)}",

--- a/src/NUnitFramework/framework/Exceptions/AssertionException.cs
+++ b/src/NUnitFramework/framework/Exceptions/AssertionException.cs
@@ -14,14 +14,14 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        public AssertionException(string? message) : base(message)
+        public AssertionException(string message) : base(message)
         { }
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public AssertionException(string? message, Exception? inner) :
+        public AssertionException(string message, Exception? inner) :
             base(message, inner)
         { }
 

--- a/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
+++ b/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
@@ -13,14 +13,14 @@ namespace NUnit.Framework
     public class IgnoreException : ResultStateException
     {
         /// <param name="message"></param>
-        public IgnoreException(string? message) : base(message)
+        public IgnoreException(string message) : base(message)
         { }
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public IgnoreException(string? message, Exception? inner) :
+        public IgnoreException(string message, Exception? inner) :
             base(message, inner)
         { }
 

--- a/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
+++ b/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        public InconclusiveException(string? message)
+        public InconclusiveException(string message)
             : base(message)
         { }
 
@@ -22,7 +22,7 @@ namespace NUnit.Framework
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public InconclusiveException(string? message, Exception? inner)
+        public InconclusiveException(string message, Exception? inner)
             :
             base(message, inner)
         { }

--- a/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
+++ b/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework
         /// internally by NUnit but is provided to facilitate debugging.
         /// </param>
         public MultipleAssertException(ITestResult testResult)
-            : base(testResult?.Message)
+            : base(testResult.Message)
         {
             Guard.ArgumentNotNull(testResult, "testResult");
             TestResult = testResult;

--- a/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
+++ b/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
@@ -14,14 +14,14 @@ namespace NUnit.Framework
     {
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
-        protected ResultStateException(string? message) : base(message)
+        protected ResultStateException(string message) : base(message)
         { }
 
         /// <param name="message">The error message that explains
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public ResultStateException(string? message, Exception? inner) :
+        public ResultStateException(string message, Exception? inner) :
             base(message, inner)
         { }
 

--- a/src/NUnitFramework/framework/Exceptions/SuccessException.cs
+++ b/src/NUnitFramework/framework/Exceptions/SuccessException.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework
     public class SuccessException : ResultStateException
     {
         /// <param name="message"></param>
-        public SuccessException(string? message)
+        public SuccessException(string message)
             : base(message)
         { }
 
@@ -21,7 +21,7 @@ namespace NUnit.Framework
         /// the reason for the exception</param>
         /// <param name="inner">The exception that caused the
         /// current exception</param>
-        public SuccessException(string? message, Exception? inner)
+        public SuccessException(string message, Exception? inner)
             :
             base(message, inner)
         { }

--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework.Interfaces
         /// <summary>
         /// Construct an AssertionResult
         /// </summary>
-        public AssertionResult(AssertionStatus status, string? message, string? stackTrace)
+        public AssertionResult(AssertionStatus status, string message, string? stackTrace)
         {
             Status = status;
             Message = message;
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Interfaces
         public AssertionStatus Status { get; }
 
         /// <summary>The message produced by the assertion, or null</summary>
-        public string? Message { get; }
+        public string Message { get; }
 
         /// <summary>The stack trace associated with the assertion, or null</summary>
         public string? StackTrace { get; }
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Interfaces
         {
             var hashCode = -783279553;
             hashCode = hashCode * -1521134295 + Status.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message ?? string.Empty);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
             hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(StackTrace ?? string.Empty);
             return hashCode;
         }

--- a/src/NUnitFramework/framework/Interfaces/ITestResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/ITestResult.cs
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Interfaces
         /// Gets the message associated with a test
         /// failure or with not running the test
         /// </summary>
-        string? Message
+        string Message
         {
             get;
         }

--- a/src/NUnitFramework/framework/Internal/Commands/SkipCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SkipCommand.cs
@@ -47,9 +47,9 @@ namespace NUnit.Framework.Internal.Commands
             return testResult;
         }
 
-        private string? GetSkipReason()
+        private string GetSkipReason()
         {
-            return (string?)Test.Properties.Get(PropertyNames.SkipReason);
+            return (string?)Test.Properties.Get(PropertyNames.SkipReason) ?? string.Empty;
         }
 
         private string? GetProviderStackTrace()

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -295,7 +295,7 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private void SkipFixture(ResultState resultState, string? message, string? stackTrace)
+        private void SkipFixture(ResultState resultState, string message, string? stackTrace)
         {
             Result.SetResult(resultState.WithSite(FailureSite.SetUp), message, StackFilter.DefaultFilter.Filter(stackTrace));
             SkipChildren(this, resultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + message);
@@ -336,9 +336,9 @@ namespace NUnit.Framework.Internal.Execution
             _teardownCommand?.Execute(Context);
         }
 
-        private string? GetSkipReason()
+        private string GetSkipReason()
         {
-            return (string?)Test.Properties.Get(PropertyNames.SkipReason);
+            return (string?)Test.Properties.Get(PropertyNames.SkipReason) ?? string.Empty;
         }
 
         private string? GetProviderStackTrace()

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Internal
         /// <param name="level">The indentation level of the message</param>
         /// <param name="message">The message to be written</param>
         /// <param name="args">Any arguments used in formatting the message</param>
-        public override void WriteMessageLine(int level, string? message, params object?[]? args)
+        public override void WriteMessageLine(int level, string message, params object?[]? args)
         {
             if (message is not null)
             {

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Internal
         protected int InternalAssertCount;
 
         private ResultState _resultState;
-        private string? _message;
+        private string _message;
         private string? _stackTrace;
 
         private readonly List<AssertionResult> _assertionResults = new();
@@ -80,6 +80,7 @@ namespace NUnit.Framework.Internal
         {
             Test = test;
             _resultState = ResultState.Inconclusive;
+            _message = string.Empty;
 
             OutWriter = TextWriter.Synchronized(new StringWriter(_output));
         }
@@ -161,7 +162,7 @@ namespace NUnit.Framework.Internal
         /// Gets the message associated with a test
         /// failure or with not running the test
         /// </summary>
-        public string? Message
+        public string Message
         {
             get
             {
@@ -349,7 +350,7 @@ namespace NUnit.Framework.Internal
                 case TestStatus.Passed:
                 case TestStatus.Inconclusive:
                 case TestStatus.Warning:
-                    if (Message is not null && Message.Trim().Length > 0)
+                    if (!string.IsNullOrWhiteSpace(Message))
                     {
                         TNode reasonNode = thisNode.AddElement("reason");
                         reasonNode.AddElementWithCDATA("message", Message);
@@ -399,7 +400,7 @@ namespace NUnit.Framework.Internal
         /// <param name="resultState">The ResultState to use in the result</param>
         public void SetResult(ResultState resultState)
         {
-            SetResult(resultState, null, null);
+            SetResult(resultState, string.Empty, null);
         }
 
         /// <summary>
@@ -407,7 +408,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         /// <param name="resultState">The ResultState to use in the result</param>
         /// <param name="message">A message associated with the result state</param>
-        public void SetResult(ResultState resultState, string? message)
+        public void SetResult(ResultState resultState, string message)
         {
             SetResult(resultState, message, null);
         }
@@ -418,7 +419,7 @@ namespace NUnit.Framework.Internal
         /// <param name="resultState">The ResultState to use in the result</param>
         /// <param name="message">A message associated with the result state</param>
         /// <param name="stackTrace">Stack trace giving the location of the command</param>
-        public void SetResult(ResultState resultState, string? message, string? stackTrace)
+        public void SetResult(ResultState resultState, string message, string? stackTrace)
         {
             RwLock.EnterWriteLock();
             try
@@ -487,7 +488,7 @@ namespace NUnit.Framework.Internal
                 resultState = resultState.WithSite(FailureSite.TearDown);
 
             string message = "TearDown : " + ExceptionHelper.BuildMessage(ex);
-            if (Message is not null)
+            if (!string.IsNullOrEmpty(Message))
                 message = Message + Environment.NewLine + message;
 
             string stackTrace = "--TearDown" + Environment.NewLine + ExceptionHelper.BuildStackTrace(ex);
@@ -576,7 +577,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Record an assertion result
         /// </summary>
-        public void RecordAssertion(AssertionStatus status, string? message, string? stackTrace)
+        public void RecordAssertion(AssertionStatus status, string message, string? stackTrace)
         {
             RecordAssertion(new AssertionResult(status, message, stackTrace));
         }
@@ -584,7 +585,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Record an assertion result
         /// </summary>
-        public void RecordAssertion(AssertionStatus status, string? message)
+        public void RecordAssertion(AssertionStatus status, string message)
         {
             RecordAssertion(status, message, null);
         }
@@ -622,10 +623,10 @@ namespace NUnit.Framework.Internal
         {
             TNode failureNode = targetNode.AddElement("failure");
 
-            if (Message is not null && Message.Trim().Length > 0)
+            if (!string.IsNullOrWhiteSpace(Message))
                 failureNode.AddElementWithCDATA("message", Message);
 
-            if (StackTrace is not null && StackTrace.Trim().Length > 0)
+            if (!string.IsNullOrWhiteSpace(StackTrace))
                 failureNode.AddElementWithCDATA("stack-trace", StackTrace);
 
             return failureNode;

--- a/src/NUnitFramework/framework/NUnitString.cs
+++ b/src/NUnitFramework/framework/NUnitString.cs
@@ -14,13 +14,14 @@ namespace NUnit.Framework
     /// </remarks>
     public readonly struct NUnitString
     {
+        // Keep as nullable, as default(NUnitString) will set this to null.
         private readonly string? _message;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitString"/> class.
         /// </summary>
         /// <param name="message">The message formattable to hold.</param>
-        public NUnitString(string? message)
+        public NUnitString(string message)
         {
             _message = message;
         }
@@ -40,9 +41,9 @@ namespace NUnit.Framework
         /// Implicit conversion from a <see cref="string"/> to a <see cref="NUnitString"/>.
         /// </summary>
         /// <param name="message">The message formattable to hold.</param>
-        public static implicit operator NUnitString(string? message) => new(message);
+        public static implicit operator NUnitString(string message) => new(message);
 
         /// <inheritdoc/>
-        public override string? ToString() => _message;
+        public override string ToString() => _message ?? string.Empty;
     }
 }

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -422,7 +422,7 @@ namespace NUnit.Framework
             /// Gets the message associated with a test
             /// failure or with not running the test
             /// </summary>
-            public string? Message => _result.Message;
+            public string Message => _result.Message;
 
             /// <summary>
             /// Gets any stack trace associated with an

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -108,7 +108,7 @@ namespace NUnit.Framework
         public static void Unless<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
@@ -155,7 +155,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(bool condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             Unless(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -195,7 +195,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void Unless(Func<bool> condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             Unless(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -248,7 +248,7 @@ namespace NUnit.Framework
         public static void Unless<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
@@ -324,7 +324,7 @@ namespace NUnit.Framework
         public static void If<TActual>(
             ActualValueDelegate<TActual> del,
             IResolveConstraint expr,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(del))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
@@ -371,7 +371,7 @@ namespace NUnit.Framework
         /// <param name="condition">The evaluated condition</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(bool condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             If(condition, Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -411,7 +411,7 @@ namespace NUnit.Framework
         /// <param name="condition">A lambda that returns a Boolean</param>
         /// <param name="getExceptionMessage">A function to build the message included with the Exception</param>
         public static void If(Func<bool> condition,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(condition))] string actualExpression = "")
         {
             If(condition.Invoke(), Is.True, getExceptionMessage, actualExpression, Assert.IsTrueExpression);
@@ -464,7 +464,7 @@ namespace NUnit.Framework
         public static void If<TActual>(
             TActual actual,
             IResolveConstraint expression,
-            Func<string?> getExceptionMessage,
+            Func<string> getExceptionMessage,
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
@@ -488,7 +488,7 @@ namespace NUnit.Framework
             TestExecutionContext.CurrentContext.IncrementAssertCount();
         }
 
-        private static void IssueWarning(ConstraintResult result, string method, string? message, string actualExpression, string constraintExpression)
+        private static void IssueWarning(ConstraintResult result, string method, string message, string actualExpression, string constraintExpression)
         {
             MessageWriter writer = new TextMessageWriter(
                 Assert.ExtendedMessage($"{nameof(Warn)}.{method}", message, actualExpression, constraintExpression));

--- a/src/NUnitFramework/nunit.framework.legacy/Assert.Conditions.cs
+++ b/src/NUnitFramework/nunit.framework.legacy/Assert.Conditions.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void True(bool? condition, string? message, params object?[]? args)
+        public static void True(bool? condition, string message, params object?[]? args)
         {
             That(condition, Is.True, () => ConvertMessageWithArgs(message, args));
         }
@@ -27,7 +27,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void True(bool condition, string? message, params object?[]? args)
+        public static void True(bool condition, string message, params object?[]? args)
         {
             That(condition, Is.True, () => ConvertMessageWithArgs(message, args));
         }
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsTrue(bool? condition, string? message, params object?[]? args)
+        public static void IsTrue(bool? condition, string message, params object?[]? args)
         {
             That(condition, Is.True, () => ConvertMessageWithArgs(message, args));
         }
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsTrue(bool condition, string? message, params object?[]? args)
+        public static void IsTrue(bool condition, string message, params object?[]? args)
         {
             That(condition, Is.True, () => ConvertMessageWithArgs(message, args));
         }
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void False(bool? condition, string? message, params object?[]? args)
+        public static void False(bool? condition, string message, params object?[]? args)
         {
             That(condition, Is.False, () => ConvertMessageWithArgs(message, args));
         }
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void False(bool condition, string? message, params object?[]? args)
+        public static void False(bool condition, string message, params object?[]? args)
         {
             That(condition, Is.False, () => ConvertMessageWithArgs(message, args));
         }
@@ -144,7 +144,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsFalse(bool? condition, string? message, params object?[]? args)
+        public static void IsFalse(bool? condition, string message, params object?[]? args)
         {
             That(condition, Is.False, () => ConvertMessageWithArgs(message, args));
         }
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="condition">The evaluated condition</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsFalse(bool condition, string? message, params object?[]? args)
+        public static void IsFalse(bool condition, string message, params object?[]? args)
         {
             That(condition, Is.False, () => ConvertMessageWithArgs(message, args));
         }
@@ -192,7 +192,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotNull(object? anObject, string? message, params object?[]? args)
+        public static void NotNull(object? anObject, string message, params object?[]? args)
         {
             That(anObject, Is.Not.Null, () => ConvertMessageWithArgs(message, args));
         }
@@ -214,7 +214,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotNull(object? anObject, string? message, params object?[]? args)
+        public static void IsNotNull(object? anObject, string message, params object?[]? args)
         {
             That(anObject, Is.Not.Null, () => ConvertMessageWithArgs(message, args));
         }
@@ -240,7 +240,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Null(object? anObject, string? message, params object?[]? args)
+        public static void Null(object? anObject, string message, params object?[]? args)
         {
             That(anObject, Is.Null, () => ConvertMessageWithArgs(message, args));
         }
@@ -262,7 +262,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="anObject">The object that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNull(object? anObject, string? message, params object?[]? args)
+        public static void IsNull(object? anObject, string message, params object?[]? args)
         {
             That(anObject, Is.Null, () => ConvertMessageWithArgs(message, args));
         }
@@ -288,7 +288,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNaN(double aDouble, string? message, params object?[]? args)
+        public static void IsNaN(double aDouble, string message, params object?[]? args)
         {
             That(aDouble, Is.NaN, () => ConvertMessageWithArgs(message, args));
         }
@@ -310,7 +310,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="aDouble">The value that is to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNaN(double? aDouble, string? message, params object?[]? args)
+        public static void IsNaN(double? aDouble, string message, params object?[]? args)
         {
             That(aDouble, Is.NaN, () => ConvertMessageWithArgs(message, args));
         }
@@ -337,7 +337,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsEmpty(string? aString, string? message, params object?[]? args)
+        public static void IsEmpty(string? aString, string message, params object?[]? args)
         {
             That(aString, new EmptyStringConstraint(), () => ConvertMessageWithArgs(message, args));
         }
@@ -362,7 +362,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsEmpty(IEnumerable collection, string? message, params object?[]? args)
+        public static void IsEmpty(IEnumerable collection, string message, params object?[]? args)
         {
             That(collection, new EmptyCollectionConstraint(), () => ConvertMessageWithArgs(message, args));
         }
@@ -392,7 +392,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotEmpty(string? aString, string? message, params object?[]? args)
+        public static void IsNotEmpty(string? aString, string message, params object?[]? args)
         {
             That(aString, Is.Not.Empty, () => ConvertMessageWithArgs(message, args));
         }
@@ -418,7 +418,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="collection">An array, list or other collection implementing ICollection</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotEmpty(IEnumerable collection, string? message, params object?[]? args)
+        public static void IsNotEmpty(IEnumerable collection, string message, params object?[]? args)
         {
             That(collection, Is.Not.Empty, () => ConvertMessageWithArgs(message, args));
         }
@@ -456,7 +456,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(int actual, string? message, params object?[]? args)
+        public static void Zero(int actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -484,7 +484,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Zero(uint actual, string? message, params object?[]? args)
+        public static void Zero(uint actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -508,7 +508,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(long actual, string? message, params object?[]? args)
+        public static void Zero(long actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -536,7 +536,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Zero(ulong actual, string? message, params object?[]? args)
+        public static void Zero(ulong actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -560,7 +560,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(decimal actual, string? message, params object?[]? args)
+        public static void Zero(decimal actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -584,7 +584,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(double actual, string? message, params object?[]? args)
+        public static void Zero(double actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -608,7 +608,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Zero(float actual, string? message, params object?[]? args)
+        public static void Zero(float actual, string message, params object?[]? args)
         {
             That(actual, Is.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -636,7 +636,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(int actual, string? message, params object?[]? args)
+        public static void NotZero(int actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -664,7 +664,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void NotZero(uint actual, string? message, params object?[]? args)
+        public static void NotZero(uint actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -688,7 +688,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(long actual, string? message, params object?[]? args)
+        public static void NotZero(long actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -716,7 +716,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void NotZero(ulong actual, string? message, params object?[]? args)
+        public static void NotZero(ulong actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -740,7 +740,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(decimal actual, string? message, params object?[]? args)
+        public static void NotZero(decimal actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -764,7 +764,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(double actual, string? message, params object?[]? args)
+        public static void NotZero(double actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -788,7 +788,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void NotZero(float actual, string? message, params object?[]? args)
+        public static void NotZero(float actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.Zero, () => ConvertMessageWithArgs(message, args));
         }
@@ -816,7 +816,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(int actual, string? message, params object?[]? args)
+        public static void Positive(int actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -844,7 +844,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Positive(uint actual, string? message, params object?[]? args)
+        public static void Positive(uint actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -868,7 +868,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(long actual, string? message, params object?[]? args)
+        public static void Positive(long actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -896,7 +896,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Positive(ulong actual, string? message, params object?[]? args)
+        public static void Positive(ulong actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -922,7 +922,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(decimal actual, string? message, params object?[]? args)
+        public static void Positive(decimal actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -947,7 +947,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(double actual, string? message, params object?[]? args)
+        public static void Positive(double actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -971,7 +971,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Positive(float actual, string? message, params object?[]? args)
+        public static void Positive(float actual, string message, params object?[]? args)
         {
             That(actual, Is.Positive, () => ConvertMessageWithArgs(message, args));
         }
@@ -999,7 +999,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(int actual, string? message, params object?[]? args)
+        public static void Negative(int actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1027,7 +1027,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Negative(uint actual, string? message, params object?[]? args)
+        public static void Negative(uint actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1051,7 +1051,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(long actual, string? message, params object?[]? args)
+        public static void Negative(long actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1079,7 +1079,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
         [CLSCompliant(false)]
-        public static void Negative(ulong actual, string? message, params object?[]? args)
+        public static void Negative(ulong actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1105,7 +1105,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(decimal actual, string? message, params object?[]? args)
+        public static void Negative(decimal actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1131,7 +1131,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(double actual, string? message, params object?[]? args)
+        public static void Negative(double actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }
@@ -1155,7 +1155,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The number to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Negative(float actual, string? message, params object?[]? args)
+        public static void Negative(float actual, string message, params object?[]? args)
         {
             That(actual, Is.Negative, () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/nunit.framework.legacy/Assert.Contains.cs
+++ b/src/NUnitFramework/nunit.framework.legacy/Assert.Contains.cs
@@ -15,7 +15,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The collection to be examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void Contains(object? expected, ICollection? actual, string? message, params object?[]? args)
+        public static void Contains(object? expected, ICollection? actual, string message, params object?[]? args)
         {
             That(actual, new SomeItemsConstraint(new EqualConstraint(expected)), () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/nunit.framework.legacy/Assert.Equality.cs
+++ b/src/NUnitFramework/nunit.framework.legacy/Assert.Equality.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(double expected, double actual, double delta, string? message,
+        public static void AreEqual(double expected, double actual, double delta, string message,
             params object?[]? args)
         {
             AssertDoublesAreEqual(expected, actual, delta, message, args);
@@ -32,7 +32,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="delta">The maximum acceptable difference between the the expected and the actual</param>
         public static void AreEqual(double expected, double actual, double delta)
         {
-            AssertDoublesAreEqual(expected, actual, delta, null, null);
+            AssertDoublesAreEqual(expected, actual, delta, string.Empty, null);
         }
 
         #endregion
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreEqual(object? expected, object? actual, string? message, params object?[]? args)
+        public static void AreEqual(object? expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.EqualTo(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -82,7 +82,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual value</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreNotEqual(object? expected, object? actual, string? message, params object?[]? args)
+        public static void AreNotEqual(object? expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.EqualTo(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -113,7 +113,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual object</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreSame(object? expected, object? actual, string? message, params object?[]? args)
+        public static void AreSame(object? expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.SameAs(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual object</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void AreNotSame(object? expected, object? actual, string? message, params object?[]? args)
+        public static void AreNotSame(object? expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.SameAs(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -171,7 +171,7 @@ namespace NUnit.Framework.Legacy
         /// the expected and the actual</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        protected static void AssertDoublesAreEqual(double expected, double actual, double delta, string? message,
+        protected static void AssertDoublesAreEqual(double expected, double actual, double delta, string message,
             object?[]? args)
         {
             if (double.IsNaN(expected) || double.IsInfinity(expected))

--- a/src/NUnitFramework/nunit.framework.legacy/Assert.Types.cs
+++ b/src/NUnitFramework/nunit.framework.legacy/Assert.Types.cs
@@ -16,7 +16,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
+        public static void IsAssignableFrom(Type expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.AssignableFrom(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsAssignableFrom<TExpected>(object? actual, string? message, params object?[]? args)
+        public static void IsAssignableFrom<TExpected>(object? actual, string message, params object?[]? args)
         {
             That(actual, Is.AssignableFrom(typeof(TExpected)), () => ConvertMessageWithArgs(message, args));
         }
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotAssignableFrom(Type expected, object? actual, string? message, params object?[]? args)
+        public static void IsNotAssignableFrom(Type expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.AssignableFrom(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object under examination</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotAssignableFrom<TExpected>(object? actual, string? message, params object?[]? args)
+        public static void IsNotAssignableFrom<TExpected>(object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.AssignableFrom(typeof(TExpected)), () => ConvertMessageWithArgs(message, args));
         }
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsInstanceOf(Type expected, object? actual, string? message, params object?[]? args)
+        public static void IsInstanceOf(Type expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.InstanceOf(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsInstanceOf<TExpected>(object? actual, string? message, params object?[]? args)
+        public static void IsInstanceOf<TExpected>(object? actual, string message, params object?[]? args)
         {
             That(actual, Is.InstanceOf(typeof(TExpected)), () => ConvertMessageWithArgs(message, args));
         }
@@ -184,7 +184,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotInstanceOf(Type expected, object? actual, string? message, params object?[]? args)
+        public static void IsNotInstanceOf(Type expected, object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.InstanceOf(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -212,7 +212,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The object being examined</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
-        public static void IsNotInstanceOf<TExpected>(object? actual, string? message, params object?[]? args)
+        public static void IsNotInstanceOf<TExpected>(object? actual, string message, params object?[]? args)
         {
             That(actual, Is.Not.InstanceOf(typeof(TExpected)), () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/nunit.framework.legacy/FileAssert.cs
+++ b/src/NUnitFramework/nunit.framework.legacy/FileAssert.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual Stream</param>
         /// <param name="message">The message to display if Streams are not equal</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreEqual(Stream? expected, Stream? actual, string? message, params object?[]? args)
+        public static void AreEqual(Stream? expected, Stream? actual, string message, params object?[]? args)
         {
             Framework.Assert.That(actual, Is.EqualTo(expected), () => ConvertMessageWithArgs(message, args));
         }
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Legacy
         /// <param name="actual">The actual Stream</param>
         /// <param name="message">The message to be displayed when the two Stream are the same.</param>
         /// <param name="args">Arguments to be used in formatting the message</param>
-        public static void AreNotEqual(Stream? expected, Stream? actual, string? message, params object?[]? args)
+        public static void AreNotEqual(Stream? expected, Stream? actual, string message, params object?[]? args)
         {
             Framework.Assert.That(actual, Is.Not.EqualTo(expected), () => ConvertMessageWithArgs(message, args));
         }

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -121,7 +121,7 @@ namespace NUnitLite
             switch (result.ResultState.Status)
             {
                 case TestStatus.Skipped:
-                    if (result.Message is not null)
+                    if (!string.IsNullOrEmpty(result.Message))
                         WriteReasonElement(result.Message);
                     break;
                 case TestStatus.Failed:

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -153,7 +153,7 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(currentResult.AssertionResults, Has.Count.EqualTo(previousFailureCount));
 
             // If we get this far, the test is good so we should clean up the context from the intentional failure above
-            currentResult.SetResult(ResultState.Inconclusive, null, null);
+            currentResult.SetResult(ResultState.Inconclusive, string.Empty, null);
             currentResult.AssertionResults.Clear();
         }
     }

--- a/src/NUnitFramework/tests/Assertions/WarningTests.cs
+++ b/src/NUnitFramework/tests/Assertions/WarningTests.cs
@@ -235,7 +235,6 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var result = TestBuilder.RunTestCase(typeof(WarningFixture), methodName);
             if (result.FailCount != 0 &&
-                result.Message is not null &&
                 result.Message.StartsWith(typeof(PlatformNotSupportedException).FullName()))
             {
                 return; // BeginInvoke causes PlatformNotSupportedException on .NET Core

--- a/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultFailureTests.cs
@@ -42,10 +42,10 @@ namespace NUnit.Framework.Tests.Internal.Results
         }
     }
 
-    public class TestResultFailureWithNullReasonAndStackTraceGivenTests : TestResultFailureTests
+    public class TestResultFailureWithEmptyReasonAndNullStackTraceGivenTests : TestResultFailureTests
     {
-        public TestResultFailureWithNullReasonAndStackTraceGivenTests()
-            : base(null,
+        public TestResultFailureWithEmptyReasonAndNullStackTraceGivenTests()
+            : base(string.Empty,
                   null,
                   FailureNodeExistsAndIsNotNull,
                   MessageNodeDoesNotExist,
@@ -83,13 +83,13 @@ namespace NUnit.Framework.Tests.Internal.Results
         protected const string NonWhitespaceFailureMessage = "message";
         protected const string NonWhitespaceFailureStackTrace = "stack_trace";
 
-        private readonly string? _failureReason;
+        private readonly string _failureReason;
         private readonly string? _stackTrace;
         private readonly Func<TNode, TNode> _xmlFailureNodeValidation;
         private readonly Action<TNode> _xmlMessageNodeValidation;
         private readonly Action<TNode> _xmlStackTraceNodeValidation;
 
-        protected TestResultFailureTests(string? failureReason,
+        protected TestResultFailureTests(string failureReason,
             string? stackTrace,
             Func<TNode, TNode> xmlFailureNodeValidation,
             Action<TNode> xmlMessageNodeValidation,

--- a/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultIgnoredTests.cs
@@ -13,13 +13,6 @@ namespace NUnit.Framework.Tests.Internal.Results
         }
     }
 
-    public class TestResultIgnoredWithNullReasonGivenTests : TestResultIgnoredTests
-    {
-        public TestResultIgnoredWithNullReasonGivenTests() : base(null, NoReasonNodeExpectedValidation)
-        {
-        }
-    }
-
     public class TestResultIgnoredWithEmptyReasonGivenTests : TestResultIgnoredTests
     {
         public TestResultIgnoredWithEmptyReasonGivenTests() : base(string.Empty, NoReasonNodeExpectedValidation)
@@ -36,10 +29,10 @@ namespace NUnit.Framework.Tests.Internal.Results
 
     public abstract class TestResultIgnoredTests : TestResultTests
     {
-        private readonly string? _ignoreReason;
+        private readonly string _ignoreReason;
         private readonly Action<TNode> _xmlReasonNodeValidation;
 
-        protected TestResultIgnoredTests(string? ignoreReason, Action<TNode> xmlReasonNodeValidation)
+        protected TestResultIgnoredTests(string ignoreReason, Action<TNode> xmlReasonNodeValidation)
         {
             _ignoreReason = ignoreReason;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;

--- a/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultInconclusiveTests.cs
@@ -12,13 +12,6 @@ namespace NUnit.Framework.Tests.Internal.Results
         }
     }
 
-    public class TestResultInconclusiveWithNullReasonGivenTests : TestResultInconclusiveTests
-    {
-        public TestResultInconclusiveWithNullReasonGivenTests() : base(null, NoReasonNodeExpectedValidation)
-        {
-        }
-    }
-
     public class TestResultInconclusiveWithEmptyReasonGivenTests : TestResultInconclusiveTests
     {
         public TestResultInconclusiveWithEmptyReasonGivenTests() : base(string.Empty, NoReasonNodeExpectedValidation)
@@ -35,12 +28,12 @@ namespace NUnit.Framework.Tests.Internal.Results
 
     public abstract class TestResultInconclusiveTests : TestResultTests
     {
-        private readonly string? _inconclusiveReason;
+        private readonly string _inconclusiveReason;
         private readonly Action<TNode> _xmlReasonNodeValidation;
 
-        protected TestResultInconclusiveTests(string? ignoreReason, Action<TNode> xmlReasonNodeValidation)
+        protected TestResultInconclusiveTests(string inconclusiveReason, Action<TNode> xmlReasonNodeValidation)
         {
-            _inconclusiveReason = ignoreReason;
+            _inconclusiveReason = inconclusiveReason;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;
         }
 
@@ -67,7 +60,7 @@ namespace NUnit.Framework.Tests.Internal.Results
             Assert.Multiple(() =>
             {
                 Assert.That(SuiteResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
-                Assert.That(SuiteResult.Message, Is.Null);
+                Assert.That(SuiteResult.Message, Is.Empty);
                 Assert.That(SuiteResult.TotalCount, Is.EqualTo(1));
                 Assert.That(SuiteResult.PassCount, Is.EqualTo(0));
                 Assert.That(SuiteResult.FailCount, Is.EqualTo(0));

--- a/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultSuccessTests.cs
@@ -12,13 +12,6 @@ namespace NUnit.Framework.Tests.Internal.Results
         }
     }
 
-    public class TestResultSuccessWithNullReasonGivenTests : TestResultSuccessTests
-    {
-        public TestResultSuccessWithNullReasonGivenTests() : base(null, NoReasonNodeExpectedValidation)
-        {
-        }
-    }
-
     public class TestResultSuccessWithEmptyReasonGivenTests : TestResultSuccessTests
     {
         public TestResultSuccessWithEmptyReasonGivenTests() : base(string.Empty, NoReasonNodeExpectedValidation)
@@ -35,14 +28,14 @@ namespace NUnit.Framework.Tests.Internal.Results
 
     public abstract class TestResultSuccessTests : TestResultTests
     {
-        private readonly string? _successMessage;
+        private readonly string _successMessage;
         private readonly Action<TNode> _xmlReasonNodeValidation;
 
         public const string TestPassedReason = "Test passed!";
 
-        protected TestResultSuccessTests(string? ignoreReason, Action<TNode> xmlReasonNodeValidation)
+        protected TestResultSuccessTests(string successMessage, Action<TNode> xmlReasonNodeValidation)
         {
-            _successMessage = ignoreReason;
+            _successMessage = successMessage;
             _xmlReasonNodeValidation = xmlReasonNodeValidation;
         }
 


### PR DESCRIPTION
Fixes #4432 

We need to use `NUnitString = default` for the cases where the user does not specify an error.
This will call the `struct` hidden default constructor that initializes all fields with null.
Although the user cannot specify a null string (as there is no converter for it), the compiler can.