### PR TITLE
Added PropertiesComparer

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NUnit MyGet Feed" value="https://www.myget.org/F/nunit/api/v3/index.json" />
+    <!-- <add key="NUnit MyGet Feed" value="https://www.myget.org/F/nunit/api/v3/index.json" /> -->
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Framework.Constraints.Comparers
+{
+    /// <summary>
+    /// Comparator for a type that overrides Equals
+    /// </summary>
+    internal static class EqualsComparer
+    {
+        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        {
+            if (equalityComparer.CompareAsCollection && state.TopLevelComparison)
+                return null;
+            if (tolerance is not null && tolerance.HasVariance)
+                return null;
+
+            Type xType = x.GetType();
+
+            if (OverridesEqualsObject(xType))
+                return x.Equals(y);
+
+            return null;
+        }
+
+        private static readonly Type[] EqualsObjectParameterTypes = { typeof(object) };
+
+        private static bool OverridesEqualsObject(Type type)
+        {
+            // Check for Equals(object) override
+            var equalsObject = type.GetMethod(nameof(type.Equals), BindingFlags.Instance | BindingFlags.Public,
+                                  null, EqualsObjectParameterTypes, null);
+            return equalsObject is not null && equalsObject.DeclaringType != typeof(object);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -65,9 +65,9 @@ namespace NUnit.Framework.Constraints.Comparers
             return implementations;
         }
 
-        private static bool InvokeFirstIEquatableEqualsSecond(object first, object second, MethodInfo? equals)
+        private static bool InvokeFirstIEquatableEqualsSecond(object first, object second, MethodInfo equals)
         {
-            return equals is not null && (bool)equals.Invoke(first, new[] { second })!;
+            return (bool)equals.Invoke(first, new[] { second })!;
         }
 
         private readonly struct EquatableMethodImpl

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Framework.Constraints.Comparers
+{
+    /// <summary>
+    /// Comparator for two instances of the same type, comparing each property.
+    /// </summary>
+    internal static class PropertiesComparer
+    {
+        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        {
+            Type xType = x.GetType();
+            Type yType = y.GetType();
+
+            if (xType != yType)
+            {
+                return null;
+            }
+
+            PropertyInfo[] properties = xType.GetProperties();
+            foreach (var property in properties)
+            {
+                object? xPropertyValue = property.GetValue(x, null);
+                object? yPropertyValue = property.GetValue(y, null);
+                if (!equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, state.PushComparison(x, y)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -17,10 +17,21 @@ namespace NUnit.Framework.Constraints.Comparers
 
             if (xType != yType)
             {
-                return null;
+                return null; // Both operands need to be the same type.
             }
 
-            PropertyInfo[] properties = xType.GetProperties();
+            if (xType.IsPrimitive)
+            {
+                // We should never get here if the order in NUnitEqualityComparer is correct.
+                return null; // We don't do built-in value types
+            }
+
+            PropertyInfo[] properties = xType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            if (properties.Length == 0)
+            {
+                return null;    // We can't compare if there are no properties.
+            }
+
             foreach (var property in properties)
             {
                 object? xPropertyValue = property.GetValue(x, null);

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -49,6 +49,7 @@ namespace NUnit.Framework.Constraints
             StructuralComparer.Equal,
             EquatablesComparer.Equal,
             EnumerablesComparer.Equal,
+            PropertiesComparer.Equal,
         };
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -49,6 +49,7 @@ namespace NUnit.Framework.Constraints
             StructuralComparer.Equal,
             EquatablesComparer.Equal,
             EnumerablesComparer.Equal,
+            EqualsComparer.Equal,
             PropertiesComparer.Equal,
         };
 

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -343,5 +343,43 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex?.Message, Does.Contain("Error"));
             Assert.That(ex?.Message, Does.Contain("Assert.That(() => false, Is.True)"));
         }
+
+        [Test]
+        public void AssertThatEqualsWithClass()
+        {
+            var zero = new SomeClass(0, 0.0, string.Empty, null);
+            var instance = new SomeClass(1, 1.1, "1.1", zero);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new SomeClass(1, 1.1, "1.1", zero), Is.EqualTo(instance));
+                Assert.That(new SomeClass(1, 1.2, "1.1", zero), Is.EqualTo(instance).Within(0.1));
+                Assert.That(new SomeClass(1, 1.1, "1.1", null), Is.Not.EqualTo(instance));
+                Assert.That(new SomeClass(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance));
+                Assert.That(new SomeClass(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new SomeClass(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance));
+            });
+        }
+
+        private sealed class SomeClass
+        {
+            public SomeClass(int valueA, double valueB, string valueC, SomeClass? chained)
+            {
+                ValueA = valueA;
+                ValueB = valueB;
+                ValueC = valueC;
+                Chained = chained;
+            }
+
+            public int ValueA { get; }
+            public double ValueB { get; }
+            public string ValueC { get; }
+            public SomeClass? Chained { get; }
+
+            public override string ToString()
+            {
+                return $"{ValueA} {ValueB} '{ValueC}' [{Chained}]";
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -107,7 +107,8 @@ namespace NUnit.Framework.Tests.Constraints
 
             Assert.That(integerTypes, equalsConstraint);
 
-            Assert.That(equalsConstraint.Tolerance, Is.Not.EqualTo(originalTolerance));
+            Assert.That(equalsConstraint.Tolerance, Is.Not.SameAs(originalTolerance));
+            Assert.That(equalsConstraint.Tolerance.Amount, Is.Not.EqualTo(originalTolerance.Amount).Within(0.0));
             Assert.That(equalsConstraint.Tolerance.Mode, Is.Not.EqualTo(originalTolerance.Mode));
         }
 


### PR DESCRIPTION
Fixes #4394 

We constantly have to make special Validate methods or implement IEquatable on classes that should not be comparable.
However we want to be able to compare them in NUnit, e.g. to check if serialization roundtrips.