### PR TITLE
Remove myget from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,14 @@ build_script:
 # disable built-in tests.
 test: off
 
-deploy:
-  - provider: NuGet
-    server: https://www.myget.org/F/nunit/api/v2
-    api_key:
-      secure: wtAvJDVl2tfwiVcyLExFHLvZVfUWiQRHsfdHBFCNEATeCHo1Nd8JP642PfY8xhji
-    skip_symbols: true
-    on:
-      branch: master
+#deploy:
+#  - provider: NuGet
+#    server: https://www.myget.org/F/nunit/api/v2
+#    api_key:
+#      secure: wtAvJDVl2tfwiVcyLExFHLvZVfUWiQRHsfdHBFCNEATeCHo1Nd8JP642PfY8xhji
+#    skip_symbols: true
+#    on:
+#      branch: master
 
 # For PRs, skip the branch run and only run against the virtual PR merge.
 skip_branch_with_pr: true


### PR DESCRIPTION
Contributes to #4440 

Removes the myget deploy from appveyor build, since myget appears down. This will also help other PRs merge as the broken appveyor build blocks merging. This keeps the appveyor build itself in place since I don't seem to be able to remove it entirely from the checks.