### PR TITLE
Derive all runtimes in cake script from Directory.Build.props

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -64,7 +64,7 @@ var LibraryFrameworks = XmlPeek(DIRECTORY_BUILD_PROPS, "/Project/PropertyGroup/N
 var RuntimeFrameworks = XmlPeek(DIRECTORY_BUILD_PROPS, "/Project/PropertyGroup/NUnitRuntimeFrameworks").Split(';');
 
 var NetCoreTestRuntimes = RuntimeFrameworks.Where(s => !s.StartsWith("net4")).ToArray();
-var NetFrameworkTestRuntime = RuntimeFrameworks.Where(s => s.StartsWith("net4")).Single();
+var NetFrameworkTestRuntime = RuntimeFrameworks.Except(NetCoreTestRuntimes).Single();
 
 ///////////////////////////////////////////////////////////////////////////////
 // SETUP / TEARDOWN


### PR DESCRIPTION
As we have been talking about targeting different runtimes for tests or the framework distributable, I recall there having been an idea mentioned in a previous PR to simplify or outright infer some of the runtimes we target. I thought I would make an attempt at it to see thoughts.

The cake script currently loops over multiple netcore runtimes for tests but assumes there will only be one netfx runtime test target. I've left that assumption in place but it would be easy enough to change it to a set-based approach there too.