### PR TITLE
Reduces allocations for TestResult.AddToXml

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -358,8 +358,9 @@ namespace NUnit.Framework.Internal
                     break;
             }
 
-            if (Output.Length > 0)
-                AddOutputElement(thisNode);
+            var outputContent = Output;
+            if (outputContent.Length > 0)
+                AddOutputElement(thisNode, outputContent);
 
             if (AssertionResults.Count > 0)
                 AddAssertionsElement(thisNode);
@@ -632,9 +633,9 @@ namespace NUnit.Framework.Internal
             return failureNode;
         }
 
-        private TNode AddOutputElement(TNode targetNode)
+        private TNode AddOutputElement(TNode targetNode, string outputContent)
         {
-            return targetNode.AddElementWithCDATA("output", Output);
+            return targetNode.AddElementWithCDATA("output", outputContent);
         }
 
         private TNode AddAssertionsElement(TNode targetNode)

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -493,8 +493,8 @@ namespace NUnit.Framework.Internal
                 message = Message + Environment.NewLine + message;
 
             string stackTrace = "--TearDown" + Environment.NewLine + ExceptionHelper.BuildStackTrace(ex);
-            if (StackTrace is not null)
-                stackTrace = StackTrace + Environment.NewLine + stackTrace;
+            if (StackTrace is { } stackTraceContent)
+                stackTrace = stackTraceContent + Environment.NewLine + stackTrace;
 
             SetResult(resultState, message, stackTrace);
         }
@@ -503,8 +503,8 @@ namespace NUnit.Framework.Internal
         {
             Guard.ArgumentNotNull(ex, nameof(ex));
 
-            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException is not null)
-                return ex.InnerException;
+            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException is { } innerException)
+                return innerException;
 
             return ex;
         }
@@ -646,10 +646,10 @@ namespace NUnit.Framework.Internal
             {
                 TNode assertionNode = assertionsNode.AddElement("assertion");
                 assertionNode.AddAttribute("result", assertion.Status.ToString());
-                if (assertion.Message is not null)
-                    assertionNode.AddElementWithCDATA("message", assertion.Message);
-                if (assertion.StackTrace is not null)
-                    assertionNode.AddElementWithCDATA("stack-trace", assertion.StackTrace);
+                if (assertion.Message is { } message)
+                    assertionNode.AddElementWithCDATA("message", message);
+                if (assertion.StackTrace is { } stackTrace)
+                    assertionNode.AddElementWithCDATA("stack-trace", stackTrace);
             }
 
             return assertionsNode;
@@ -688,8 +688,8 @@ namespace NUnit.Framework.Internal
 
                 attachmentNode.AddElement("filePath", attachment.FilePath);
 
-                if (attachment.Description is not null)
-                    attachmentNode.AddElementWithCDATA("description", attachment.Description);
+                if (attachment.Description is { } description)
+                    attachmentNode.AddElementWithCDATA("description", description);
             }
 
             return attachmentsNode;


### PR DESCRIPTION
Hi!

When `Output` is not empty there are two allocations of same string. This pull request eliminates it.
Also content of `Output` possibly may be changed between acquisitions of same lock on `OutWriter` twice, which can be misleading.
