### PR TITLE
Issue2466 propagate stack trace to child result

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Internal.Execution
                                         case TestStatus.Skipped:
                                         case TestStatus.Inconclusive:
                                         case TestStatus.Failed:
-                                            SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message);
+                                            SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message, Result.StackTrace);
                                             break;
                                     }
                                 }
@@ -298,14 +298,14 @@ namespace NUnit.Framework.Internal.Execution
         private void SkipFixture(ResultState resultState, string message, string? stackTrace)
         {
             Result.SetResult(resultState.WithSite(FailureSite.SetUp), message, StackFilter.DefaultFilter.Filter(stackTrace));
-            SkipChildren(this, resultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + message);
+            SkipChildren(this, resultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + message, stackTrace);
         }
 
-        private void SkipChildren(CompositeWorkItem workItem, ResultState resultState, string message)
+        private void SkipChildren(CompositeWorkItem workItem, ResultState resultState, string message, string? stackTrace)
         {
             foreach (WorkItem child in workItem.Children)
             {
-                SetChildWorkItemSkippedResult(child.Result, resultState, message);
+                SetChildWorkItemSkippedResult(child.Result, resultState, message, stackTrace);
                 _suiteResult.AddResult(child.Result);
 
                 // Some runners may depend on getting the TestFinished event
@@ -313,13 +313,13 @@ namespace NUnit.Framework.Internal.Execution
                 Context.Listener.TestFinished(child.Result);
 
                 if (child is CompositeWorkItem item)
-                    SkipChildren(item, resultState, message);
+                    SkipChildren(item, resultState, message, stackTrace);
             }
         }
 
-        private void SetChildWorkItemSkippedResult(TestResult result, ResultState resultState, string message)
+        private void SetChildWorkItemSkippedResult(TestResult result, ResultState resultState, string message, string? stackTrace)
         {
-            result.SetResult(resultState, message);
+            result.SetResult(resultState, message, stackTrace);
             result.StartTime = Context.StartTime;
             result.EndTime = DateTime.UtcNow;
             result.Duration = Context.Duration;

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -127,6 +127,28 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void FailedSetUpStacktracePropogatesToTestResult()
+        {
+            SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
+            fixture.ThrowInBaseSetUp = true;
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.SetUp));
+            Assert.That(result.StackTrace, Is.Not.Null);
+            Assert.That(result.StackTrace, Does.Contain($"{nameof(SetUpAndTearDownFixture)}.{nameof(SetUpAndTearDownFixture.Init)}"));
+
+            Assert.That(result.HasChildren, Is.True);
+            foreach (var childResult in result.Children)
+            {
+                Assert.That(childResult.ResultState.Site, Is.EqualTo(FailureSite.Parent));
+                Assert.That(childResult.StackTrace, Is.EqualTo(result.StackTrace));
+            }
+
+            Assert.That(fixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(fixture.TearDownCount, Is.EqualTo(1));
+        }
+
+        [Test]
         public void StaticBaseSetUpCalledFirstAndTearDownCalledLast()
         {
             StaticSetUpAndTearDownFixture.SetUpCount = 0;


### PR DESCRIPTION
Fixes #2466 for master

* Ensure StackTrace of OneTimeSetUp is passed to child test results