### PR TITLE
Improve debugging experience

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -2,6 +2,8 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+
 using NUnit.Framework.Internal.Extensions;
 
 namespace NUnit.Framework.Constraints
@@ -11,6 +13,7 @@ namespace NUnit.Framework.Constraints
     public sealed class CollectionTally
     {
         /// <summary>The result of a <see cref="CollectionTally"/>.</summary>
+        [DebuggerDisplay("Missing = {MissingItems.Count}, Extra = {ExtraItems.Count}")]
         public sealed class CollectionTallyResult
         {
             /// <summary>Items that were not in the expected collection.</summary>

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -298,7 +298,7 @@ namespace NUnit.Framework.Constraints
         /// Tolerance.Range represents the range of values that match
         /// a specific tolerance, when applied to a specific value.
         /// </summary>
-        public struct Range
+        public readonly struct Range
         {
             /// <summary>
             /// The lower bound of the range

--- a/src/NUnitFramework/framework/Constraints/Tolerance.cs
+++ b/src/NUnitFramework/framework/Constraints/Tolerance.cs
@@ -321,5 +321,36 @@ namespace NUnit.Framework.Constraints
         }
 
         #endregion
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        public override string? ToString()
+        {
+            if (Amount == Exact.Amount && Mode == Exact.Mode)
+            {
+                return "Exact";
+            }
+            switch (Mode)
+            {
+                case ToleranceMode.Unset:
+                    return "Unset";
+
+                case ToleranceMode.Linear:
+                    return Amount.ToString();
+
+                case ToleranceMode.Percent:
+                    return Amount.ToString() + " Percent";
+
+                case ToleranceMode.Ulps:
+                    return Amount.ToString() + " Ulps";
+
+                default:
+                    return "Unknown"; // Unreachable without reflection
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -96,5 +96,20 @@ namespace NUnit.Framework.Tests.Constraints
         {
             Assert.That(Tolerance.Exact, Is.SameAs(Tolerance.Exact));
         }
+
+        [Test]
+        public void ToStringTests()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(Tolerance.Default.ToString(), Is.EqualTo("Unset"));
+                Assert.That(Tolerance.Exact.ToString(), Is.EqualTo("Exact"));
+                Assert.That(Is.EqualTo(5).Within(2).Tolerance.ToString(), Is.EqualTo("2"));
+                Assert.That(Is.EqualTo(5).Within(2).Ulps.Tolerance.ToString(), Is.EqualTo("2 Ulps"));
+                Assert.That(Is.EqualTo(5).Within(2).Percent.Tolerance.ToString(), Is.EqualTo("2 Percent"));
+                Assert.That(Is.EqualTo(5).Within(2).Seconds.Tolerance.ToString(), Is.EqualTo("00:00:02"));
+                Assert.That(Is.EqualTo(5).Within(2).Minutes.Tolerance.ToString(), Is.EqualTo("00:02:00"));
+            });
+        }
     }
 }


### PR DESCRIPTION
These changes make types more transparent when developing against them. Attached images show the results of these additions.

![image](https://github.com/nunit/nunit/assets/12619902/1aa8520b-4709-4529-bae3-7869eac86018)

![image](https://github.com/nunit/nunit/assets/12619902/e76e4151-288b-4c24-92da-a4ddb7e09bd1)

Since I noticed it, I made Tolerance.Range `readonly`.