### PR TITLE
Add the ability to use params arguments properly when using a parametrised test fixture

### DIFF
--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -98,8 +98,9 @@ namespace NUnit.Framework.Internal
                         {
                             throw new InvalidTestFixtureException(type.FullName + " params argument did not have an element type");
                         }
-                        int paramsOffset = ctor.GetParameters().Length - 1;
-                        var paramArray = Array.CreateInstance(elementType, argTypes.Length - ctor.GetParameters().Length + 1);
+
+                        int paramsOffset = parameterInfos.Length - 1;
+                        var paramArray = Array.CreateInstance(elementType, argTypes.Length - parameterInfos.Length + 1);
                         for (int i = 0; i < paramArray.Length; i++)
                         {
                             paramArray.SetValue(arguments[i + paramsOffset], i);

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -86,7 +86,7 @@ namespace NUnit.Framework.Internal
                 ParameterInfo parameterInfo = parameterInfos.Last();
                 if (parameterInfo.HasAttribute<ParamArrayAttribute>(false))
                 {
-                    if (arguments.Length == parameterInfos.Length 
+                    if (arguments.Length == parameterInfos.Length
                         && parameterInfo.ParameterType.IsAssignableFrom(arguments[parameterInfos.Length - 1]?.GetType()))
                     {
                         // Don't convert arguments as there was already an array we could use.
@@ -144,11 +144,11 @@ namespace NUnit.Framework.Internal
         /// </summary>
         internal static bool ParametersMatch(this ParameterInfo[] pinfos, Type?[] ptypes)
         {
-            bool hasParamsArgument = pinfos.Length > 0 && pinfos[pinfos.Length -1].HasAttribute<ParamArrayAttribute>(false);
+            bool hasParamsArgument = pinfos.Length > 0 && pinfos[pinfos.Length - 1].HasAttribute<ParamArrayAttribute>(false);
 
             if (hasParamsArgument)
             {
-                if (ptypes.Length < pinfos.Length -1)
+                if (ptypes.Length < pinfos.Length - 1)
                     return false;
             }
             else

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Internal
                     if (elementType is not null)
                     {
                         bool allParamArgsMatched = true;
-                        for (int j = i; j < ptypes.Length; j++)
+                        for (int j = i; j < ptypes.Length && allParamArgsMatched; j++)
                         {
                             if (!ptypes[j].CanImplicitlyConvertTo(elementType))
                             {

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -106,7 +106,6 @@ namespace NUnit.Framework.Internal
                         }
                         arguments = arguments.Take(parameterInfos.Length - 1).Concat(new object[] { paramArray }).ToArray();
                     }
-
                 }
             }
 

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -252,6 +252,32 @@ namespace NUnit.TestData.TestFixtureSourceData
         };
     }
 
+    [TestFixture]
+    [TestFixtureSource(nameof(MyData))]
+    public class TestFixtureSourceMayUseParamsArguments
+    {
+        public TestFixtureSourceMayUseParamsArguments(params int[] parameters)
+        {
+            Parameters = parameters;
+        }
+
+        public int[] Parameters { get; }
+
+        [Test]
+        public void Test()
+        {
+            Assert.That(Parameters, Is.Not.Null);
+            for (int i = 0; i < Parameters.Length; i++)
+                Assert.That(Parameters[i], Is.EqualTo(i + 1));
+        }
+        public static IEnumerable MyData()
+        {
+            yield return new object[] { 1, 2, 3 };
+            yield return new object[] { };
+            yield return new object[] { new int[] { 1, 2, 3, 4 } };
+        }
+    }
+
     [TestFixtureSource(nameof(IgnoredData))]
     public class IndividualInstancesMayBeIgnored : TestFixtureSourceTest
     {

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -270,7 +270,7 @@ namespace NUnit.TestData.TestFixtureSourceData
             for (int i = 0; i < Parameters.Length; i++)
                 Assert.That(Parameters[i], Is.EqualTo(i + 1));
         }
-        public static IEnumerable MyData()
+        private static IEnumerable MyData()
         {
             yield return new object[] { 1, 2, 3 };
             yield return new object[] { };

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -210,6 +210,7 @@ namespace NUnit.Framework.Tests.Attributes
     [TestFixture("Zero")]
     [TestFixture("One", 1)]
     [TestFixture("Many", 1,2,3,4)]
+    [TestFixture(1.5,8.2)]
     public class ParameterizedTestFixtureWithParamsArgument
     {
         public ParameterizedTestFixtureWithParamsArgument(string name, params int[] parameterValues)
@@ -218,8 +219,14 @@ namespace NUnit.Framework.Tests.Attributes
             ParameterValues = parameterValues;
         }
 
-        public string Name { get; }
+        public ParameterizedTestFixtureWithParamsArgument(params double[] parameterDoubleValues)
+        {
+            ParameterDoubleValues = parameterDoubleValues;
+        }
+        
+        public string? Name { get; }
         public int[] ParameterValues { get; }
+        public double[] ParameterDoubleValues { get; }
 
         [Test]
         public void CheckParametersPassedInAsExpected()
@@ -232,10 +239,13 @@ namespace NUnit.Framework.Tests.Attributes
             {
                 Assert.That(ParameterValues, Is.EqualTo(new[] {1}));
             }
-            else
+            else if (Name == "Many")
             {
                 Assert.That(ParameterValues, Is.EqualTo(new[] { 1, 2, 3, 4 }));
-
+            }
+            else if (Name is null)
+            {
+                Assert.That(ParameterDoubleValues, Is.EqualTo(new object[] { 1.5, 8.2 }));
             }
         }
     }

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -218,7 +217,7 @@ namespace NUnit.Framework.Tests.Attributes
         private static IEnumerable SourceData()
         {
             yield return new object[] { "Many", 1, 2, 3, 4 };
-            yield return new object[] { new double[] { 1.5, 8.2} };
+            yield return new object[] { new double[] { 1.5, 8.2 } };
         }
 
         public ParameterizedTestFixtureWithParamsArgument(string name, params int[] parameterValues)
@@ -231,7 +230,7 @@ namespace NUnit.Framework.Tests.Attributes
         {
             ParameterDoubleValues = parameterDoubleValues;
         }
-        
+
         public string? Name { get; }
         public int[]? ParameterValues { get; }
         public double[]? ParameterDoubleValues { get; }
@@ -245,7 +244,7 @@ namespace NUnit.Framework.Tests.Attributes
             }
             else if (Name == "One")
             {
-                Assert.That(ParameterValues, Is.EqualTo(new[] {1}));
+                Assert.That(ParameterValues, Is.EqualTo(new[] { 1 }));
             }
             else if (Name == "Many")
             {

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -215,9 +215,7 @@ namespace NUnit.Framework.Tests.Attributes
     [TestFixtureSource(nameof(SourceData))]
     public class ParameterizedTestFixtureWithParamsArgument
     {
-#pragma warning disable NUnit1028 // The non-test method is public
-        public static IEnumerable SourceData()
-#pragma warning restore NUnit1028 // The non-test method is public
+        private static IEnumerable SourceData()
         {
             yield return new object[] { "Many", 1, 2, 3, 4 };
             yield return new object[] { new double[] { 1.5, 8.2} };

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -203,6 +204,39 @@ namespace NUnit.Framework.Tests.Attributes
         public void MakeSureTypeIsInSystemNamespace()
         {
             Assert.That(_someType.Namespace, Is.EqualTo("System"));
+        }
+    }
+
+    [TestFixture("Zero")]
+    [TestFixture("One", 1)]
+    [TestFixture("Many", 1,2,3,4)]
+    public class ParameterizedTestFixtureWithParamsArgument
+    {
+        public ParameterizedTestFixtureWithParamsArgument(string name, params int[] parameterValues)
+        {
+            Name = name;
+            ParameterValues = parameterValues;
+        }
+
+        public string Name { get; }
+        public int[] ParameterValues { get; }
+
+        [Test]
+        public void CheckParametersPassedInAsExpected()
+        {
+            if (Name == "Zero")
+            {
+                Assert.That(ParameterValues, Is.Empty);
+            }
+            else if (Name == "One")
+            {
+                Assert.That(ParameterValues, Is.EqualTo(new[] {1}));
+            }
+            else
+            {
+                Assert.That(ParameterValues, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -209,10 +210,19 @@ namespace NUnit.Framework.Tests.Attributes
 
     [TestFixture("Zero")]
     [TestFixture("One", 1)]
-    [TestFixture("Many", 1,2,3,4)]
-    [TestFixture(1.5,8.2)]
+    [TestFixture("Many", 1, 2, 3, 4)]
+    [TestFixture(1.5, 8.2)]
+    [TestFixtureSource(nameof(SourceData))]
     public class ParameterizedTestFixtureWithParamsArgument
     {
+#pragma warning disable NUnit1028 // The non-test method is public
+        public static IEnumerable SourceData()
+#pragma warning restore NUnit1028 // The non-test method is public
+        {
+            yield return new object[] { "Many", 1, 2, 3, 4 };
+            yield return new object[] { new double[] { 1.5, 8.2} };
+        }
+
         public ParameterizedTestFixtureWithParamsArgument(string name, params int[] parameterValues)
         {
             Name = name;
@@ -225,8 +235,8 @@ namespace NUnit.Framework.Tests.Attributes
         }
         
         public string? Name { get; }
-        public int[] ParameterValues { get; }
-        public double[] ParameterDoubleValues { get; }
+        public int[]? ParameterValues { get; }
+        public double[]? ParameterDoubleValues { get; }
 
         [Test]
         public void CheckParametersPassedInAsExpected()

--- a/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
@@ -69,6 +69,20 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void CanSpecifyParametrizedTestFixturesWithParamsArgs()
+        {
+            TestSuite suite = TestBuilder.MakeFixture(typeof(TestFixtureSourceMayUseParamsArguments));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[0].RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[1].RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(suite.Tests[2].RunState, Is.EqualTo(RunState.Runnable));
+            });
+        }
+
+        [Test]
         public void CanMarkIndividualFixturesExplicit()
         {
             TestSuite suite = TestBuilder.MakeFixture(typeof(IndividualInstancesMayBeExplicit));


### PR DESCRIPTION
Added some tests for this and made the methods that call the constructors on TestFixtures able to allow params arguments. This doesn't really address the duplication with similar code for calling test methods but that didn't seem particularly quick to also fix as part of this.

Fixes #1459 