### PR TITLE
Issue #4423 Chaining multiple collection with index 

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Operators/BinaryOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/BinaryOperator.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Constraints
         /// Gets the left precedence of the operator
         /// </summary>
         public override int LeftPrecedence =>
-            RightContext is CollectionOperator || RightContext is ExactCountOperator
+            RightContext is CollectionOperator || RightContext is ExactCountOperator || RightContext is IndexerOperator
                 ? base.LeftPrecedence + 10
                 : base.LeftPrecedence;
 

--- a/src/NUnitFramework/tests/Constraints/IndexerConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/IndexerConstraintTests.cs
@@ -22,6 +22,18 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(tester, Has.ItemAt(1, 2).EqualTo("Third indexer"));
             Assert.That(tester, Has.No.ItemAt(string.Empty).EqualTo("Third indexer"));
         }
+        
+        [Test]
+        public void IndexerOperatorOnRightSideOfAndOperator()
+        {
+            var items = new ClassWithName[]
+            {
+                new("Name 1"),
+            };
+
+            Assert.That(items, Has.Exactly(1).Items
+                                  .And.ItemAt(0).Property(nameof(ClassWithName.Name)).EqualTo("Name 1"));
+        }
 
         [Test]
         public void CanMatchArrayEquality()
@@ -166,6 +178,15 @@ namespace NUnit.Framework.Tests.Constraints
 
         private class DerivedClassWithoutNamedIndexer : ClassHidingBaseNamedIndexer
         {
+        }
+        
+        private class ClassWithName
+        {
+            public ClassWithName(string name)
+            {
+                this.Name = name;
+            }
+            public string Name { get; }
         }
     }
 }


### PR DESCRIPTION
Fixes #4423 for master

First Error: _System.InvalidOperationException : Stack empty_ We've addressed the "Stack empty" error. The issue was with how certain operators were being processed. To fix it, we adjusted the LeftPrecedence when we encounter an IndexerOperator.
Explanation:  in the function `ReduceOperatorStack` the `And `will not be reduced with the `IndexerOperator`. This will then fail in `NUnit.Framework.Constraints.ConstraintBuilder.Resolve` for the `BinaryOperator.Reduce ` because it tries to pop the stack two times and will then fail.

Second Error:  _Default indexer accepting arguments < 0 > was not found on SomeTests+SomeStuff_ We believe this isn't a real error. It looks like @azygis is trying to access a collection in a specific way. He's currently using a collection of SomeStuff, but it seems he should be using a collection that contains other collections of SomeStuff.