### PR TITLE
Enable equality/inequality constraints against non-seekable steams

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -39,9 +39,12 @@ namespace NUnit.Framework.Constraints.Comparers
 
             try
             {
-                if (bothSeekable)
+                if (xStream.CanSeek)
                 {
                     binaryReaderExpected.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+                if (yStream.CanSeek)
+                {
                     binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
                 }
 
@@ -73,9 +76,12 @@ namespace NUnit.Framework.Constraints.Comparers
             }
             finally
             {
-                if (bothSeekable)
+                if (xStream.CanSeek)
                 {
                     xStream.Position = expectedPosition;
+                }
+                if (yStream.CanSeek)
+                {
                     yStream.Position = actualPosition;
                 }
             }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -54,8 +54,7 @@ namespace NUnit.Framework.Constraints.Comparers
                     readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
                     readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
 
-                    var actuallyRead = Math.Max(readExpected, readActual);
-                    for (int count = 0; count < actuallyRead; ++count)
+                    for (int count = 0; count < BUFFER_SIZE; ++count)
                     {
                         if (bufferExpected[count] != bufferActual[count])
                         {

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -45,8 +45,8 @@ namespace NUnit.Framework.Constraints.Comparers
                     binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
                 }
 
-                int readExpected = -1;
-                int readActual = -1;
+                int readExpected = 1;
+                int readActual = 1;
                 long readByte = 0;
 
                 while (readExpected > 0 && readActual > 0)
@@ -54,7 +54,8 @@ namespace NUnit.Framework.Constraints.Comparers
                     readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
                     readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
 
-                    for (int count = 0; count < BUFFER_SIZE; ++count)
+                    var actuallyRead = Math.Max(readExpected, readActual);
+                    for (int count = 0; count < actuallyRead; ++count)
                     {
                         if (bufferExpected[count] != bufferActual[count])
                         {

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -23,12 +23,10 @@ namespace NUnit.Framework.Constraints.Comparers
                 throw new ArgumentException("Stream is not readable", "expected");
             if (!yStream.CanRead)
                 throw new ArgumentException("Stream is not readable", "actual");
-            if (!xStream.CanSeek)
-                throw new ArgumentException("Stream is not seekable", "expected");
-            if (!yStream.CanSeek)
-                throw new ArgumentException("Stream is not seekable", "actual");
 
-            if (xStream.Length != yStream.Length) return false;
+            bool bothSeekable = xStream.CanSeek && yStream.CanSeek;
+
+            if (bothSeekable && xStream.Length != yStream.Length) return false;
 
             byte[] bufferExpected = new byte[BUFFER_SIZE];
             byte[] bufferActual = new byte[BUFFER_SIZE];
@@ -36,18 +34,25 @@ namespace NUnit.Framework.Constraints.Comparers
             BinaryReader binaryReaderExpected = new BinaryReader(xStream);
             BinaryReader binaryReaderActual = new BinaryReader(yStream);
 
-            long expectedPosition = xStream.Position;
-            long actualPosition = yStream.Position;
+            long expectedPosition = bothSeekable ? xStream.Position : default;
+            long actualPosition = bothSeekable ? yStream.Position : default;
 
             try
             {
-                binaryReaderExpected.BaseStream.Seek(0, SeekOrigin.Begin);
-                binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
-
-                for (long readByte = 0; readByte < xStream.Length; readByte += BUFFER_SIZE)
+                if (bothSeekable)
                 {
-                    binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
-                    binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
+                    binaryReaderExpected.BaseStream.Seek(0, SeekOrigin.Begin);
+                    binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                int readExpected = -1;
+                int readActual = -1;
+                long readByte = 0;
+
+                while (readExpected > 0 && readActual > 0)
+                {
+                    readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
+                    readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
 
                     for (int count = 0; count < BUFFER_SIZE; ++count)
                     {
@@ -63,12 +68,16 @@ namespace NUnit.Framework.Constraints.Comparers
                             return false;
                         }
                     }
+                    readByte += BUFFER_SIZE;
                 }
             }
             finally
             {
-                xStream.Position = expectedPosition;
-                yStream.Position = actualPosition;
+                if (bothSeekable)
+                {
+                    xStream.Position = expectedPosition;
+                    yStream.Position = actualPosition;
+                }
             }
 
             return true;

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -29,7 +29,7 @@ namespace NUnit.Framework.Constraints
         private static readonly string StreamsDiffer_2 =
             "Expected Stream length {0} but was {1}.";// Streams differ at offset {2}.";
         private static readonly string UnSeekableStreamsDiffer =
-            "Streams differ at offset {0}.";// Streams differ at offset {2}.";
+            "Streams differ at offset {0}.";
         private static readonly string CollectionType_1 =
             "Expected and actual are both {0}";
         private static readonly string CollectionType_2 =

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -28,6 +28,8 @@ namespace NUnit.Framework.Constraints
             "Stream lengths are both {0}. Streams differ at offset {1}.";
         private static readonly string StreamsDiffer_2 =
             "Expected Stream length {0} but was {1}.";// Streams differ at offset {2}.";
+        private static readonly string UnSeekableStreamsDiffer =
+            "Streams differ at offset {0}.";// Streams differ at offset {2}.";
         private static readonly string CollectionType_1 =
             "Expected and actual are both {0}";
         private static readonly string CollectionType_2 =
@@ -94,14 +96,21 @@ namespace NUnit.Framework.Constraints
         #region DisplayStreamDifferences
         private void DisplayStreamDifferences(MessageWriter writer, Stream expected, Stream actual, int depth)
         {
-            if (expected.Length == actual.Length)
+            if (expected.CanSeek && actual.CanSeek)
             {
-                long offset = _failurePoints[depth].Position;
-                writer.WriteMessageLine(StreamsDiffer_1, expected.Length, offset);
+                if (expected.Length == actual.Length)
+                {
+                    long offset = _failurePoints[depth].Position;
+                    writer.WriteMessageLine(StreamsDiffer_1, expected.Length, offset);
+                }
+                else
+                {
+                    writer.WriteMessageLine(StreamsDiffer_2, expected.Length, actual.Length);
+                }
             }
             else
             {
-                writer.WriteMessageLine(StreamsDiffer_2, expected.Length, actual.Length);
+                writer.WriteMessageLine(UnSeekableStreamsDiffer, _failurePoints[depth].Position);
             }
         }
         #endregion

--- a/src/NUnitFramework/nunit.framework.legacy.tests/FileAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/FileAssertTests.cs
@@ -56,16 +56,6 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex?.Message, Does.Contain("not readable"));
         }
 
-        [Test]
-        public void NonSeekableStreamGivesException()
-        {
-            using var tf1 = new TestFile("TestImage1.jpg");
-            using FileStream expected = tf1.File.OpenRead();
-            using var actual = new FakeStream();
-            var ex = Assert.Throws<ArgumentException>(() => FileAssert.AreEqual(expected, actual));
-            Assert.That(ex?.Message, Does.Contain("not seekable"));
-        }
-
         private class FakeStream : MemoryStream
         {
             public override bool CanSeek => false;

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -157,14 +157,6 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(expectedStream, Is.Not.EqualTo(actualStream));
             }
 
-            private static string GetString(Stream str)
-            {
-                using var ms = new MemoryStream();
-                str.CopyTo(ms);
-                var bytes = ms.ToArray();
-                return Encoding.UTF8.GetString(bytes);
-            }
-
             private static ZipArchive CreateZipArchive(string content)
             {
                 var archiveContents = new MemoryStream();

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -163,7 +163,6 @@ namespace NUnit.Framework.Tests.Constraints
                 str.CopyTo(ms);
                 var bytes = ms.ToArray();
                 return Encoding.UTF8.GetString(bytes);
-
             }
 
             private static ZipArchive CreateZipArchive(string content)


### PR DESCRIPTION
Fixes #4476 

Instead of using the stream's length as a stopping condition, we check that the amount of bytes read in the previous read operation is greater than 0.