### PR TITLE
DefaultTestCaseBuilder now looks for attributes in base class

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultTestCaseBuilder.cs
@@ -38,8 +38,8 @@ namespace NUnit.Framework.Internal.Builders
         /// <param name="method">An IMethodInfo for the method being used as a test method</param>
         public bool CanBuildFrom(IMethodInfo method)
         {
-            return method.IsDefined<ITestBuilder>(false)
-                || method.IsDefined<ISimpleTestBuilder>(false);
+            return method.IsDefined<ITestBuilder>(true)
+                || method.IsDefined<ISimpleTestBuilder>(true);
         }
 
         /// <summary>

--- a/src/NUnitFramework/testdata/DerivedClassWithTestsInBaseClass.cs
+++ b/src/NUnitFramework/testdata/DerivedClassWithTestsInBaseClass.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+    public sealed class DerivedClassWithTestsInBaseClass : BaseClassWithTests
+    {
+        public override void VirtualTestInBaseClass()
+        {
+            Assert.Pass("Derived Class");
+        }
+    }
+
+    public sealed class DerivedClassWithIgnoredTestsInBaseClass : BaseClassWithTests
+    {
+        [Ignore("Doesn't work in this derived class")]
+        public override void VirtualTestInBaseClass()
+        {
+            Assert.Fail("Should not have been called");
+        }
+    }
+
+    public class BaseClassWithTests : AbstractBaseClass
+    {
+        [Test]
+        public void TestInBaseClass()
+        {
+            Assert.Pass("Base Class");
+        }
+
+        public override void VirtualTestInBaseClass()
+        {
+            Assert.Pass("Base Class");
+        }
+    }
+
+    public abstract class AbstractBaseClass
+    {
+        [Test]
+        public abstract void VirtualTestInBaseClass();
+    }
+}

--- a/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/DefaultSuiteBuilderTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Linq;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
 using NUnit.TestData;
@@ -24,6 +26,82 @@ namespace NUnit.Framework.Tests.Internal
 
             Assert.That(suite, Is.Not.Null, "No test fixture was built");
             Assert.That(suite.Name, Is.EqualTo(nameof(ImpliedFixture)));
+        }
+
+        [Test]
+        public static void BuildFromAbstractBaseClassWithTestsReturnsFixture()
+        {
+            var suite = new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(typeof(AbstractBaseClass))) as TestFixture;
+
+            Assert.That(suite, Is.Not.Null, "No test fixture was built");
+            Assert.That(suite.Name, Is.EqualTo(nameof(AbstractBaseClass)));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.NotRunnable));
+
+            Assert.That(suite.TestCaseCount, Is.EqualTo(1));
+
+            ITest? testInDerivedClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.VirtualTestInBaseClass));
+            Assert.That(testInDerivedClass, Is.Not.Null);
+            Assert.That(testInDerivedClass.RunState, Is.EqualTo(RunState.NotRunnable));
+        }
+
+        [Test]
+        public static void BuildFromBaseClassWithTestsReturnsFixture()
+        {
+            var suite = new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(typeof(BaseClassWithTests))) as TestFixture;
+
+            Assert.That(suite, Is.Not.Null, "No test fixture was built");
+            Assert.That(suite.Name, Is.EqualTo(nameof(BaseClassWithTests)));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+
+            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
+
+            ITest? testInBaseClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.TestInBaseClass));
+            Assert.That(testInBaseClass, Is.Not.Null);
+            Assert.That(testInBaseClass.RunState, Is.EqualTo(RunState.Runnable));
+
+            ITest? testInDerivedClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.VirtualTestInBaseClass));
+            Assert.That(testInDerivedClass, Is.Not.Null);
+            Assert.That(testInDerivedClass.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
+        [Test]
+        public static void BuildFromDerivedClassWithTestsReturnsFixture()
+        {
+            var suite = new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(typeof(DerivedClassWithTestsInBaseClass))) as TestFixture;
+
+            Assert.That(suite, Is.Not.Null, "No test fixture was built");
+            Assert.That(suite.Name, Is.EqualTo(nameof(DerivedClassWithTestsInBaseClass)));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+
+            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
+
+            ITest? testInBaseClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.TestInBaseClass));
+            Assert.That(testInBaseClass, Is.Not.Null);
+            Assert.That(testInBaseClass.RunState, Is.EqualTo(RunState.Runnable));
+
+            ITest? testInDerivedClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.VirtualTestInBaseClass));
+            Assert.That(testInDerivedClass, Is.Not.Null);
+            Assert.That(testInDerivedClass.RunState, Is.EqualTo(RunState.Runnable));
+        }
+
+        [Test]
+        public static void BuildFromDerivedClassWithIgnoredTestsReturnsFixture()
+        {
+            var suite = new DefaultSuiteBuilder().BuildFrom(new TypeWrapper(typeof(DerivedClassWithIgnoredTestsInBaseClass))) as TestFixture;
+
+            Assert.That(suite, Is.Not.Null, "No test fixture was built");
+            Assert.That(suite.Name, Is.EqualTo(nameof(DerivedClassWithIgnoredTestsInBaseClass)));
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+
+            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
+
+            ITest? testInBaseClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.TestInBaseClass));
+            Assert.That(testInBaseClass, Is.Not.Null);
+            Assert.That(testInBaseClass.RunState, Is.EqualTo(RunState.Runnable));
+
+            ITest? testInDerivedClass = suite.Tests.SingleOrDefault(x => x.Name == nameof(BaseClassWithTests.VirtualTestInBaseClass));
+            Assert.That(testInDerivedClass, Is.Not.Null);
+            Assert.That(testInDerivedClass.RunState, Is.EqualTo(RunState.Ignored));
         }
     }
 }


### PR DESCRIPTION
Fixes #3274 
Fixes #3798 

Simple fix, ensure CanBuildFrom in DefaultTestCaseBuilder looks for attributes in the base class.