### PR TITLE
Add type validation to regex constraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Constraints
         {
             string actualString = ConstraintUtils.RequireActual<string>(actual, nameof(actual), allowNull: false);
 
-            return new ConstraintResult(this, actual,_regex.IsMatch(actualString));
+            return new ConstraintResult(this, actual, _regex.IsMatch(actualString));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/RegexConstraint.cs
@@ -3,6 +3,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
+using NUnit.Framework.Internal;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -68,8 +70,9 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure.</returns>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            return new ConstraintResult(this, actual,
-                actual is string actualString && _regex.Match(actualString).Success);
+            string actualString = ConstraintUtils.RequireActual<string>(actual, nameof(actual), allowNull: false);
+
+            return new ConstraintResult(this, actual,_regex.IsMatch(actualString));
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
@@ -11,6 +11,17 @@ namespace NUnit.Framework.Tests.Constraints
         private static readonly string NL = Environment.NewLine;
 
         [Test]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", "NUnit2024", Justification = "Testing this negative case")]
+        public void RegexTypeMatches()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => Assert.That(1, Does.Match("[A-Z]")), Throws.ArgumentException);
+                Assert.That(() => Assert.That((string?)null, Does.Match("[A-Z]")), Throws.ArgumentException);
+            });
+        }
+
+        [Test]
         public void RegExMatchSucceeds()
         {
             const string testMatcher = "Make.*tests.*pass";

--- a/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/RegexConstraintTests.cs
@@ -11,13 +11,14 @@ namespace NUnit.Framework.Tests.Constraints
         private static readonly string NL = Environment.NewLine;
 
         [Test]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", "NUnit2024", Justification = "Testing this negative case")]
         public void RegexTypeMatches()
         {
             Assert.Multiple(() =>
             {
+#pragma warning disable NUnit2024 // Wrong actual type used with String Constraint
                 Assert.That(() => Assert.That(1, Does.Match("[A-Z]")), Throws.ArgumentException);
-                Assert.That(() => Assert.That((string?)null, Does.Match("[A-Z]")), Throws.ArgumentException);
+#pragma warning restore NUnit2024 // Wrong actual type used with String Constraint
+                Assert.That(() => Assert.That(default(string), Does.Match("[A-Z]")), Throws.ArgumentException);
             });
         }
 


### PR DESCRIPTION
Fixes #4484 
tests like
```csharp
Assert.That(1, Does.Not.Match("[A-Z]"));
Assert.That((string?)null, Does.Not.Match("[A-Z]"));
```
will no longer pass.

Bonus performance for converting `regex.Match(...).Success` to `regex.IsMatch(...)`