### PR TITLE
Mark TimeoutAttribute Obsolete for non .NET Framework builds.

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs
@@ -12,6 +12,9 @@ namespace NUnit.Framework
     /// When applied to a class or assembly, the default timeout is set for all contained test methods.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+#if !NETFRAMEWORK
+    [Obsolete(".NET No longer supports aborting threads as it is not a safe thing to do. Update your tests to use CancelAfterAttribute instead")]
+#endif
     public class TimeoutAttribute : PropertyAttribute, IApplyToContext
     {
         private readonly int _timeout;

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -119,7 +119,11 @@ namespace NUnit.Framework.Internal.Commands
 
         private Task<TestResult> RunTestOnSeparateThread(TestExecutionContext context)
         {
-            return Task.Run(() => innerCommand.Execute(context));
+            var separateContext = new TestExecutionContext(context)
+            {
+                CurrentResult = context.CurrentTest.MakeTestResult()
+            };
+            return Task.Run(() => innerCommand.Execute(separateContext));
         }
 #endif
     }

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-#if THREAD_ABORT
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
 
 namespace NUnit.TestData
 {
+#if !NETFRAMEWORK
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
     [TestFixture]
     public class TimeoutFixture
     {
@@ -25,9 +28,9 @@ namespace NUnit.TestData
         }
 
         [Test, Timeout(50)]
-        public void InfiniteLoopWith50msTimeout()
+        public void VeryLongTestWith50msTimeout()
         {
-            Thread.Sleep(5000);
+            Thread.Sleep(2000);
         }
 
         [Test, Timeout(500)]
@@ -49,7 +52,7 @@ namespace NUnit.TestData
         [SetUp]
         public void SetUp2()
         {
-            Thread.Sleep(5000);
+            Thread.Sleep(2000);
         }
 
         [Test, Timeout(50)]
@@ -63,7 +66,7 @@ namespace NUnit.TestData
         [TearDown]
         public void TearDown2()
         {
-            Thread.Sleep(5000);
+            Thread.Sleep(2000);
         }
 
         [Test, Timeout(50)]
@@ -80,9 +83,9 @@ namespace NUnit.TestData
         {
         }
         [Test]
-        public void Test2WithInfiniteLoop()
+        public void Test2WithLongDuration()
         {
-            Thread.Sleep(5000);
+            Thread.Sleep(2000);
         }
         [Test]
         public void Test3()
@@ -106,4 +109,3 @@ namespace NUnit.TestData
         }
     }
 }
-#endif

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -291,7 +291,6 @@ namespace NUnit.Framework.Tests.Constraints
         private const int LARGE_COLLECTION_FAIL_TIME = 500;
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
         public void LargeIntCollectionsInSameOrder()
         {
             var actual = Enumerable.Range(0, SIZE);
@@ -306,10 +305,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
         public void LargeIntCollectionsInReversedOrder()
         {
             var actual = Enumerable.Range(0, SIZE);
@@ -324,10 +324,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
         public void LargeStringCollectionsInSameOrder()
         {
             var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
@@ -342,10 +343,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME * 2)]
         public void LargeStringCollectionsInReversedOrder()
         {
             var actual = Enumerable.Range(0, SIZE).Select(i => i.ToString()).ToList();
@@ -360,10 +362,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME * 2)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME * 2)]
         public void LargeStringCollection()
         {
             var actual = new StringCollection();
@@ -383,10 +386,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME * 2)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2598 - Is.Not.EquivalentTo is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
         public void LargeByteCollectionsNotEquivalent()
         {
             byte[] data = new byte[SIZE];
@@ -403,10 +407,11 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test(Description = "Issue #2598 - Is.Not.EquivalentTo is extremely slow")]
-        [Timeout(LARGE_COLLECTION_FAIL_TIME)]
         public void LargeByteCollectionsNotEquivalentAtEnd()
         {
             byte[] data = new byte[SIZE];
@@ -423,6 +428,8 @@ namespace NUnit.Framework.Tests.Constraints
             watch.Stop();
             if (watch.ElapsedMilliseconds > LARGE_COLLECTION_WARN_TIME)
                 Assert.Warn($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
+            if (watch.ElapsedMilliseconds > LARGE_COLLECTION_FAIL_TIME)
+                Assert.Fail($"{TestContext.CurrentContext.Test.MethodName} took {watch.ElapsedMilliseconds} ms.");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4297 

Align implementation/tests as much as possible.

Also marks the TimeoutAttribute obsolete for non-framework builds.
