### PR TITLE
Unwrap TargetInvocationException

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -91,9 +91,7 @@ namespace NUnit.Framework.Internal.Builders
             }
             catch (Exception ex)
             {
-                if (ex is System.Reflection.TargetInvocationException)
-                    ex = ex.InnerException!;
-                var fixture = new TestFixture(typeInfo, ex);
+                var fixture = new TestFixture(typeInfo, ex.Unwrap());
 
                 return fixture;
             }

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 
@@ -17,6 +18,7 @@ namespace NUnit.Framework.Internal
         /// Rethrows an exception, preserving its stack trace
         /// </summary>
         /// <param name="exception">The exception to rethrow</param>
+        [DoesNotReturn]
         public static void Rethrow(Exception exception)
         {
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
@@ -190,6 +192,28 @@ namespace NUnit.Framework.Internal
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Unwraps the exception of type <see cref="TargetInvocationException"/> to its InnerException.
+        /// </summary>
+        /// <param name="exception">The exception to unwrap.</param>
+        /// <returns>The InnerException is available, otherwise the <paramref name="exception"/>.</returns>
+        public static Exception Unwrap(this Exception exception)
+        {
+            if (exception is NUnitException nUnitException &&
+                nUnitException.InnerException is not null)
+            {
+                exception = nUnitException.InnerException;
+            }
+
+            while (exception is TargetInvocationException targetInvocationException &&
+                targetInvocationException.InnerException is not null)
+            {
+                exception = targetInvocationException.InnerException;
+            }
+
+            return exception;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Reflection;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Extensions;
@@ -249,10 +248,7 @@ namespace NUnit.Framework.Internal.Execution
             }
             catch (Exception ex)
             {
-                if (ex is NUnitException || ex is TargetInvocationException)
-                    ex = ex.InnerException!;
-
-                Result.RecordException(ex, FailureSite.SetUp);
+                Result.RecordException(ex.Unwrap(), FailureSite.SetUp);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -255,7 +255,7 @@ namespace NUnit.Framework.Internal
             }
             catch (TargetInvocationException e)
             {
-                throw new NUnitException("Rethrown", e.InnerException);
+                throw new NUnitException("Rethrown", e.Unwrap());
             }
             catch (Exception e)
 #if THREAD_ABORT

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -6,7 +6,6 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using NUnit.Compatibility;
@@ -502,10 +501,7 @@ namespace NUnit.Framework.Internal
         {
             Guard.ArgumentNotNull(ex, nameof(ex));
 
-            if ((ex is NUnitException || ex is TargetInvocationException) && ex.InnerException is not null)
-                return ex.InnerException;
-
-            return ex;
+            return ex.Unwrap();
         }
 
         private struct ExceptionResult

--- a/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AdhocTestExecutionTests.cs
@@ -32,9 +32,7 @@ namespace NUnit.Framework.Tests.Assertions
             }
             catch (Exception ex)
             {
-                testException = ex is TargetInvocationException
-                    ? ex.InnerException
-                    : ex;
+                testException = ex.Unwrap();
             }
             finally
             {

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
 using System.Security.Policy;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Tests.Assertions
 {
@@ -176,9 +177,7 @@ namespace NUnit.Framework.Tests.Assertions
             }
             catch (Exception e)
             {
-                throw e is TargetInvocationException
-                    ? e.InnerException!
-                    : e;
+                throw e.Unwrap();
             }
         }
 
@@ -217,9 +216,7 @@ namespace NUnit.Framework.Tests.Assertions
                 }
                 catch (TargetInvocationException e)
                 {
-                    if (e.InnerException is null)
-                        throw;
-                    throw e.InnerException;
+                    throw e.Unwrap();
                 }
             }
         }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyConstraintTests.cs
@@ -136,6 +136,13 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void FailsWhenKeyIsNull()
+        {
+            Assert.That(() => Assert.That(new Dictionary<string, string>(), Does.ContainKey(null!)),
+                        Throws.TargetInvocationException.With.InnerException.InstanceOf<ArgumentNullException>());
+        }
+
+        [Test]
         public void ShouldCallContainsKeysMethodOnDictionary()
         {
             var dictionary = new TestDictionary(20);


### PR DESCRIPTION
Fixes #4481 

Code for 
```cshap
Assert.That(new Dictionary<string, string>(), Does.ContainKey(null!));
```

Now results in:
```
  Message: 
    System.ArgumentNullException : Value cannot be null. (Parameter 'key')

  Stack Trace: 
    Dictionary`2.FindValue(TKey key)
    Dictionary`2.ContainsKey(TKey key)
```

There are two methods in Reflect.cs ending in `WithTransparentExceptions`.
These are used in `Assert.Throws` and equivalents and were not modified to _unwrap_. 
Unwrapping all `InnerException`s would make it impossible to catch a `TargetInvocationException` thrown by user code.

This means that to validate that the `Does.ContainKey(null!)` throws an `ArgumentNullException` we
first have to test for the `TargetInvocationException`.
Beside testing NUnit, not many people will `Assert` an `Assert`.

```csharp
Assert.That(() => Assert.That(new Dictionary<string, string>(), Does.ContainKey(null!)),
            Throws.TargetInvocationException.With.InnerException.InstanceOf<ArgumentNullException>());
```

