### PR TITLE
Tolerance is not supported for IEquatable types

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
@@ -9,10 +9,10 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class ArraysComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (!x.GetType().IsArray || !y.GetType().IsArray || equalityComparer.CompareAsCollection)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
             Array xArray = (Array)x;
             Array yArray = (Array)y;
@@ -20,12 +20,12 @@ namespace NUnit.Framework.Constraints.Comparers
             int rank = xArray.Rank;
 
             if (rank != yArray.Rank)
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
 
             for (int r = 1; r < rank; r++)
             {
                 if (xArray.GetLength(r) != yArray.GetLength(r))
-                    return false;
+                    return EqualMethodResult.ComparedNotEqual;
             }
 
             return EnumerablesComparer.Equal(xArray, yArray, ref tolerance, state, equalityComparer);

--- a/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
@@ -9,10 +9,10 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class DateTimeOffsetsComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (x is not DateTimeOffset xOffset || y is not DateTimeOffset yOffset)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
             bool result;
 
@@ -30,7 +30,8 @@ namespace NUnit.Framework.Constraints.Comparers
                 result = xOffset.Offset == yOffset.Offset;
             }
 
-            return result;
+            return result ?
+                EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -9,26 +9,28 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class DictionariesComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (x is not IDictionary xDictionary || y is not IDictionary yDictionary)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
             if (xDictionary.Count != yDictionary.Count)
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
 
             CollectionTally tally = new CollectionTally(equalityComparer, xDictionary.Keys);
             tally.TryRemove(yDictionary.Keys);
             if ((tally.Result.MissingItems.Count > 0) || (tally.Result.ExtraItems.Count > 0))
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
 
+            ComparisonState comparisonState = state.PushComparison(x, y);
             foreach (object key in xDictionary.Keys)
             {
-                if (!equalityComparer.AreEqual(xDictionary[key], yDictionary[key], ref tolerance, state.PushComparison(x, y)))
-                    return false;
+                EqualMethodResult result = equalityComparer.AreEqual(xDictionary[key], yDictionary[key], ref tolerance, comparisonState);
+                if (result != EqualMethodResult.ComparedEqual)
+                    return result;
             }
 
-            return true;
+            return EqualMethodResult.ComparedEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionaryEntriesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionaryEntriesComparer.cs
@@ -9,15 +9,18 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class DictionaryEntriesComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             // Issue #70 - EquivalentTo isn't compatible with IgnoreCase for dictionaries
             if (x is not DictionaryEntry xDictionaryEntry || y is not DictionaryEntry yDictionaryEntry)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
+            ComparisonState comparisonState = state.PushComparison(x, y);
             var keyTolerance = Tolerance.Exact;
-            return equalityComparer.AreEqual(xDictionaryEntry.Key, yDictionaryEntry.Key, ref keyTolerance, state.PushComparison(x, y))
-                && equalityComparer.AreEqual(xDictionaryEntry.Value, yDictionaryEntry.Value, ref tolerance, state.PushComparison(x, y));
+            EqualMethodResult result = equalityComparer.AreEqual(xDictionaryEntry.Key, yDictionaryEntry.Key, ref keyTolerance, comparisonState);
+            if (result == EqualMethodResult.ComparedEqual)
+                result = equalityComparer.AreEqual(xDictionaryEntry.Value, yDictionaryEntry.Value, ref tolerance, comparisonState);
+            return result;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/DirectoriesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DirectoriesComparer.cs
@@ -9,21 +9,25 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class DirectoriesComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (x is not DirectoryInfo xDirectoryInfo || y is not DirectoryInfo yDirectoryInfo)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
+
+            if (tolerance.HasVariance)
+                return EqualMethodResult.ToleranceNotSupported;
 
             // Do quick compares first
             if (xDirectoryInfo.Attributes != yDirectoryInfo.Attributes ||
                 xDirectoryInfo.CreationTime != yDirectoryInfo.CreationTime ||
                 xDirectoryInfo.LastAccessTime != yDirectoryInfo.LastAccessTime)
             {
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
             }
 
             // TODO: Find a cleaner way to do this
-            return new SamePathConstraint(xDirectoryInfo.FullName).ApplyTo(yDirectoryInfo.FullName).IsSuccess;
+            return new SamePathConstraint(xDirectoryInfo.FullName).ApplyTo(yDirectoryInfo.FullName).IsSuccess ?
+                EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/EnumComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EnumComparer.cs
@@ -1,26 +1,23 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+
 namespace NUnit.Framework.Constraints.Comparers
 {
     /// <summary>
-    /// Comparator for two <see cref="char"/>s.
+    /// Comparator for two <see cref="Enum"/>s.
     /// </summary>
-    internal static class CharsComparer
+    internal static class EnumComparer
     {
         public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
-            if (x is not char xChar || y is not char yChar)
+            if (x is not Enum xEnum || y is not Enum yEnum)
                 return EqualMethodResult.TypesNotSupported;
 
             if (tolerance.HasVariance)
                 return EqualMethodResult.ToleranceNotSupported;
 
-            bool caseInsensitive = equalityComparer.IgnoreCase;
-
-            char c1 = caseInsensitive ? char.ToLower(xChar) : xChar;
-            char c2 = caseInsensitive ? char.ToLower(yChar) : yChar;
-
-            return c1 == c2 ?
+            return xEnum.Equals(yEnum) ?
                 EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }
     }

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualMethodResult.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualMethodResult.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Constraints.Comparers
+{
+    /// <summary>
+    /// Result of the Equal comparison method.
+    /// </summary>
+    internal enum EqualMethodResult
+    {
+        /// <summary>
+        /// Method does not support the instances being compared.
+        /// </summary>
+        TypesNotSupported,
+
+        /// <summary>
+        /// Method is appropriate for the data types, but doesn't support the specified tolerance.
+        /// </summary>
+        ToleranceNotSupported,
+
+        /// <summary>
+        /// Method is appropriate and the items are considered equal.
+        /// </summary>
+        ComparedEqual,
+
+        /// <summary>
+        /// Method is appropriate and the items are consisdered different.
+        /// </summary>
+        ComparedNotEqual
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
@@ -7,12 +7,13 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class NumericsComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (!Numerics.IsNumericType(x) || !Numerics.IsNumericType(y))
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
-            return Numerics.AreEqual(x, y, ref tolerance);
+            return Numerics.AreEqual(x, y, ref tolerance) ?
+                EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -10,39 +10,76 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class PropertiesComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             Type xType = x.GetType();
             Type yType = y.GetType();
 
             if (xType != yType)
             {
-                return null; // Both operands need to be the same type.
+                // Both operands need to be the same type.
+                return EqualMethodResult.TypesNotSupported;
             }
 
             if (xType.IsPrimitive)
             {
                 // We should never get here if the order in NUnitEqualityComparer is correct.
-                return null; // We don't do built-in value types
+                // We don't do built-in value types
+                return EqualMethodResult.TypesNotSupported;
             }
 
             PropertyInfo[] properties = xType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
-            if (properties.Length == 0)
+            if (properties.Length == 0 || properties.Length >= 32)
             {
-                return null;    // We can't compare if there are no properties.
+                // We can't compare if there are no (or too many) properties.
+                return EqualMethodResult.TypesNotSupported;
             }
 
-            foreach (var property in properties)
+            ComparisonState comparisonState = state.PushComparison(x, y);
+
+            uint redoWithoutTolerance = 0x0;
+            if (tolerance.HasVariance)
             {
-                object? xPropertyValue = property.GetValue(x, null);
-                object? yPropertyValue = property.GetValue(y, null);
-                if (!equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, state.PushComparison(x, y)))
+                for (int i = 0; i < properties.Length; i++)
                 {
-                    return false;
+                    PropertyInfo property = properties[i];
+                    object? xPropertyValue = property.GetValue(x, null);
+                    object? yPropertyValue = property.GetValue(y, null);
+
+                    EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, comparisonState);
+                    if (result == EqualMethodResult.ComparedNotEqual)
+                        return result;
+                    if (result == EqualMethodResult.ToleranceNotSupported)
+                        redoWithoutTolerance |= 1U << i;
+                }
+
+                if (redoWithoutTolerance == (1U << properties.Length) - 1)
+                    return EqualMethodResult.ToleranceNotSupported;
+            }
+            else
+            {
+                redoWithoutTolerance = (1U << properties.Length) - 1;
+            }
+
+            if (redoWithoutTolerance != 0)
+            {
+                Tolerance noTolerance = Tolerance.Exact;
+                for (int i = 0; i < properties.Length; i++)
+                {
+                    if ((redoWithoutTolerance & (1U << i)) != 0)
+                    {
+                        PropertyInfo property = properties[i];
+                        object? xPropertyValue = property.GetValue(x, null);
+                        object? yPropertyValue = property.GetValue(y, null);
+
+                        EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref noTolerance, comparisonState);
+                        if (result == EqualMethodResult.ComparedNotEqual)
+                            return result;
+                    }
                 }
             }
 
-            return true;
+            return EqualMethodResult.ComparedEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -12,13 +12,16 @@ namespace NUnit.Framework.Constraints.Comparers
     {
         private const int BUFFER_SIZE = 4096;
 
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (x is not Stream xStream || y is not Stream yStream)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
+
+            if (tolerance.HasVariance)
+                return EqualMethodResult.ToleranceNotSupported;
 
             if (xStream == yStream)
-                return true;
+                return EqualMethodResult.ComparedEqual;
 
             if (!xStream.CanRead)
                 throw new ArgumentException("Stream is not readable", "expected");
@@ -28,7 +31,7 @@ namespace NUnit.Framework.Constraints.Comparers
             bool bothSeekable = xStream.CanSeek && yStream.CanSeek;
 
             if (bothSeekable && xStream.Length != yStream.Length)
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
 
             byte[] bufferExpected = new byte[BUFFER_SIZE];
             byte[] bufferActual = new byte[BUFFER_SIZE];
@@ -70,7 +73,7 @@ namespace NUnit.Framework.Constraints.Comparers
                             fp.ActualHasData = true;
                             fp.ActualValue = bufferActual[count];
                             equalityComparer.FailurePoints.Insert(0, fp);
-                            return false;
+                            return EqualMethodResult.ComparedNotEqual;
                         }
                     }
                     readByte += BUFFER_SIZE;
@@ -88,7 +91,7 @@ namespace NUnit.Framework.Constraints.Comparers
                 }
             }
 
-            return true;
+            return EqualMethodResult.ComparedEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
@@ -9,13 +9,17 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class StringsComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (x is not string xString || y is not string yString)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
+
+            if (tolerance.HasVariance)
+                return EqualMethodResult.ToleranceNotSupported;
 
             var stringComparison = equalityComparer.IgnoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
-            return xString.Equals(yString, stringComparison);
+            return xString.Equals(yString, stringComparison) ?
+                EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StructuralComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StructuralComparer.cs
@@ -9,10 +9,10 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class StructuralComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (equalityComparer.CompareAsCollection && state.TopLevelComparison)
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
             if (x is IStructuralEquatable xEquatable && y is IStructuralEquatable yEquatable)
             {
@@ -28,10 +28,11 @@ namespace NUnit.Framework.Constraints.Comparers
                 // Keep all the refs up to date
                 tolerance = equalityComparison.Tolerance;
 
-                return xResult || yResult;
+                return xResult || yResult ?
+                    EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
             }
 
-            return null;
+            return EqualMethodResult.TypesNotSupported;
         }
 
         private sealed class NUnitEqualityComparison : IEqualityComparer

--- a/src/NUnitFramework/framework/Constraints/Comparers/TimeSpanToleranceComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TimeSpanToleranceComparer.cs
@@ -9,18 +9,24 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class TimeSpanToleranceComparer
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
             if (tolerance?.Amount is TimeSpan amount)
             {
-                if (x is DateTime xDateTime && y is DateTime yDateTime)
-                    return (xDateTime - yDateTime).Duration() <= amount;
+                bool result;
 
-                if (x is TimeSpan xTimeSpan && y is TimeSpan yTimeSpan)
-                    return (xTimeSpan - yTimeSpan).Duration() <= amount;
+                if (x is DateTime xDateTime && y is DateTime yDateTime)
+                    result = (xDateTime - yDateTime).Duration() <= amount;
+                else if (x is TimeSpan xTimeSpan && y is TimeSpan yTimeSpan)
+                    result = (xTimeSpan - yTimeSpan).Duration() <= amount;
+                else
+                    return EqualMethodResult.TypesNotSupported;
+
+                return result ?
+                    EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
             }
 
-            return null;
+            return EqualMethodResult.TypesNotSupported;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/TupleComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TupleComparer.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Constraints.Comparers
             return type.GetProperty(propertyName)?.GetValue(obj, null);
         }
 
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
             => TupleComparerBase.Equal(x, y, ref tolerance, state, equalityComparer, IsCorrectType, GetValue);
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
@@ -9,32 +9,65 @@ namespace NUnit.Framework.Constraints.Comparers
     /// </summary>
     internal static class TupleComparerBase
     {
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer,
-                                  Func<Type, bool> isCorrectType, Func<Type, string, object, object?> getValue)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer,
+                                              Func<Type, bool> isCorrectType, Func<Type, string, object, object?> getValue)
         {
             Type xType = x.GetType();
             Type yType = y.GetType();
 
             if (!isCorrectType(xType) || !isCorrectType(yType))
-                return null;
+                return EqualMethodResult.TypesNotSupported;
 
             int numberOfGenericArgs = xType.GetGenericArguments().Length;
 
             if (numberOfGenericArgs != yType.GetGenericArguments().Length)
-                return false;
+                return EqualMethodResult.ComparedNotEqual;
 
-            for (int i = 0; i < numberOfGenericArgs; i++)
+            ComparisonState comparisonState = state.PushComparison(x, y);
+
+            uint redoWithoutTolerance = 0x0;
+            if (tolerance.HasVariance)
             {
-                string propertyName = i < 7 ? "Item" + (i + 1) : "Rest";
-                object? xItem = getValue(xType, propertyName, x);
-                object? yItem = getValue(yType, propertyName, y);
+                for (int i = 0; i < numberOfGenericArgs; i++)
+                {
+                    string propertyName = i < 7 ? "Item" + (i + 1) : "Rest";
+                    object? xItem = getValue(xType, propertyName, x);
+                    object? yItem = getValue(yType, propertyName, y);
 
-                bool comparison = equalityComparer.AreEqual(xItem, yItem, ref tolerance, state.PushComparison(x, y));
-                if (!comparison)
-                    return false;
+                    EqualMethodResult result = equalityComparer.AreEqual(xItem, yItem, ref tolerance, comparisonState);
+                    if (result == EqualMethodResult.ComparedNotEqual)
+                        return result;
+                    if (result == EqualMethodResult.ToleranceNotSupported)
+                        redoWithoutTolerance |= 1U << i;
+                }
+
+                if (redoWithoutTolerance == (1U << numberOfGenericArgs) - 1)
+                    return EqualMethodResult.ToleranceNotSupported;
+            }
+            else
+            {
+                redoWithoutTolerance = (1U << numberOfGenericArgs) - 1;
             }
 
-            return true;
+            if (redoWithoutTolerance != 0)
+            {
+                Tolerance noTolerance = Tolerance.Exact;
+                for (int i = 0; i < numberOfGenericArgs; i++)
+                {
+                    if ((redoWithoutTolerance & (1U << i)) != 0)
+                    {
+                        string propertyName = i < 7 ? "Item" + (i + 1) : "Rest";
+                        object? xItem = getValue(xType, propertyName, x);
+                        object? yItem = getValue(yType, propertyName, y);
+
+                        EqualMethodResult result = equalityComparer.AreEqual(xItem, yItem, ref noTolerance, comparisonState);
+                        if (result == EqualMethodResult.ComparedNotEqual)
+                            return result;
+                    }
+                }
+            }
+
+            return EqualMethodResult.ComparedEqual;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/ValueTupleComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ValueTupleComparer.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Constraints.Comparers
             return type.GetField(propertyName)?.GetValue(obj);
         }
 
-        public static bool? Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
             => TupleComparerBase.Equal(x, y, ref tolerance, state, equalityComparer, IsCorrectType, GetValue);
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -344,26 +344,37 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex?.Message, Does.Contain("Assert.That(() => false, Is.True)"));
         }
 
-        [Test]
-        public void AssertThatEqualsWithClass()
+        [TestCase("Hello", "World")]
+        [TestCase('A', 'B')]
+        [TestCase(false, true)]
+        [TestCase(SomeEnum.One, SomeEnum.Two)]
+        public void AssertThatWithTypesNotSupportingTolerance(object? x, object? y)
         {
-            var zero = new SomeClass(0, 0.0, string.Empty, null);
-            var instance = new SomeClass(1, 1.1, "1.1", zero);
+            Assert.That(() => Assert.That(x, Is.EqualTo(y).Within(0.1)),
+                        Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+        }
+
+        [Test]
+        public void AssertThatEqualsWithClassWithSomeToleranceAwareMembers()
+        {
+            var zero = new ClassWithSomeToleranceAwareMembers(0, 0.0, string.Empty, null);
+            var instance = new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", zero);
 
             Assert.Multiple(() =>
             {
-                Assert.That(new SomeClass(1, 1.1, "1.1", zero), Is.EqualTo(instance));
-                Assert.That(new SomeClass(1, 1.2, "1.1", zero), Is.EqualTo(instance).Within(0.1));
-                Assert.That(new SomeClass(1, 1.1, "1.1", null), Is.Not.EqualTo(instance));
-                Assert.That(new SomeClass(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance));
-                Assert.That(new SomeClass(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance));
-                Assert.That(new SomeClass(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", zero), Is.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.EqualTo(instance).Within(0.1));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", null), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance));
             });
         }
 
-        private sealed class SomeClass
+        private sealed class ClassWithSomeToleranceAwareMembers
         {
-            public SomeClass(int valueA, double valueB, string valueC, SomeClass? chained)
+            public ClassWithSomeToleranceAwareMembers(int valueA, double valueB, string valueC, ClassWithSomeToleranceAwareMembers? chained)
             {
                 ValueA = valueA;
                 ValueB = valueB;
@@ -374,7 +385,126 @@ namespace NUnit.Framework.Tests.Assertions
             public int ValueA { get; }
             public double ValueB { get; }
             public string ValueC { get; }
-            public SomeClass? Chained { get; }
+            public ClassWithSomeToleranceAwareMembers? Chained { get; }
+
+            public override string ToString()
+            {
+                return $"{ValueA} {ValueB} '{ValueC}' [{Chained}]";
+            }
+        }
+
+        [Test]
+        public void AssertThatEqualsWithStructWithSomeToleranceAwareMembers()
+        {
+            var instance = new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.One);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.One), Is.EqualTo(instance));
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.EqualTo(instance).Within(0.1));
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.Two), Is.Not.EqualTo(instance).Within(0.1));
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 2.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
+                Assert.That(new StructWithSomeToleranceAwareMembers(2, 1.1, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
+            });
+        }
+
+        private enum SomeEnum
+        {
+            One = 1,
+            Two = 2,
+        }
+
+        private readonly struct StructWithSomeToleranceAwareMembers
+        {
+            public StructWithSomeToleranceAwareMembers(int valueA, double valueB, string valueC, SomeEnum valueD)
+            {
+                ValueA = valueA;
+                ValueB = valueB;
+                ValueC = valueC;
+                ValueD = valueD;
+            }
+
+            public int ValueA { get; }
+            public double ValueB { get; }
+            public string ValueC { get; }
+            public SomeEnum ValueD { get; }
+
+            public override string ToString()
+            {
+                return $"{ValueA} {ValueB} '{ValueC}' {ValueD}";
+            }
+        }
+
+        [Test]
+        public void AssertThatEqualsWithStructWithNoToleranceAwareMembers()
+        {
+            var instance = new StructWithNoToleranceAwareMembers("1.1", SomeEnum.One);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new StructWithNoToleranceAwareMembers("1.1", SomeEnum.One), Is.EqualTo(instance));
+                Assert.That(new StructWithNoToleranceAwareMembers("1.2", SomeEnum.One), Is.Not.EqualTo(instance));
+                Assert.That(new StructWithNoToleranceAwareMembers("1.1", SomeEnum.Two), Is.Not.EqualTo(instance));
+                Assert.That(() =>
+                    Assert.That(new StructWithNoToleranceAwareMembers("1.2", SomeEnum.One),
+                                Is.EqualTo(instance).Within(0.1)),
+                    Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+            });
+        }
+
+        private readonly struct StructWithNoToleranceAwareMembers
+        {
+            public StructWithNoToleranceAwareMembers(string valueA, SomeEnum valueB)
+            {
+                ValueA = valueA;
+                ValueB = valueB;
+            }
+
+            public string ValueA { get; }
+            public SomeEnum ValueB { get; }
+
+            public override string ToString()
+            {
+                return $"'{ValueA}' {ValueB}";
+            }
+        }
+
+        [Test]
+        public void AssertThatEqualsWithRecord()
+        {
+            var zero = new SomeRecord(0, 0.0, string.Empty, null);
+            var instance = new SomeRecord(1, 1.1, "1.1", zero);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new SomeRecord(1, 1.1, "1.1", zero), Is.EqualTo(instance));
+                Assert.That(new SomeRecord(1, 1.2, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new SomeRecord(1, 1.1, "1.1", null), Is.Not.EqualTo(instance));
+                Assert.That(new SomeRecord(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance));
+                Assert.That(new SomeRecord(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new SomeRecord(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(() =>
+                    Assert.That(new SomeRecord(1, 1.2, "1.1", zero),
+                                Is.EqualTo(instance).Within(0.1)),
+                    Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+            });
+        }
+
+        private sealed record SomeRecord
+        {
+            public SomeRecord(int valueA, double valueB, string valueC, SomeRecord? chained)
+            {
+                ValueA = valueA;
+                ValueB = valueB;
+                ValueC = valueC;
+                Chained = chained;
+            }
+
+            public int ValueA { get; }
+            public double ValueB { get; }
+            public string ValueC { get; }
+            public SomeRecord? Chained { get; }
 
             public override string ToString()
             {

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -682,7 +682,7 @@ namespace NUnit.Framework.Tests.Constraints
             [Test]
             public void CompareObjectsWithToleranceAsserts()
             {
-                Assert.Throws<AssertionException>(() => Assert.That("abc", new EqualConstraint("abcd").Within(1)));
+                Assert.Throws<NotSupportedException>(() => Assert.That("abc", new EqualConstraint("abcd").Within(1)));
             }
         }
 

--- a/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
@@ -77,5 +77,22 @@ namespace NUnit.Framework.Tests.Constraints
             var b = Tuple.Create(new Dictionary<string, string>());
             Assert.That(a, Is.EqualTo(b));
         }
+
+        [Test]
+        public void CanUseToleranceIfSomeMemberSupportsTolerance()
+        {
+            var tuple1 = Tuple.Create(true, 1);
+            var tuple2 = Tuple.Create(true, 2);
+            Assert.That(tuple1, Is.EqualTo(tuple2).Within(1));
+        }
+
+        [Test]
+        public void WillComplainAboutToleranceIfNoMemberSupportsTolerance()
+        {
+            var tuple1 = Tuple.Create(true, "1");
+            var tuple2 = Tuple.Create(true, "2");
+            Assert.That(() => Assert.That(tuple1, Is.EqualTo(tuple2).Within(1)),
+                        Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4514 

It previously fell back to property comparer if tolerance was used not even calling the type's defined comparison method.
