### PR TITLE
Async disposal of test fixtures

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/DisposeFixtureCommand.cs
@@ -27,8 +27,7 @@ namespace NUnit.Framework.Internal.Commands
             {
                 try
                 {
-                    if (context.TestObject is IDisposable disposable)
-                        disposable.Dispose();
+                    DisposeHelper.EnsureDisposed(context.TestObject);
                 }
                 catch (Exception ex)
                 {

--- a/src/NUnitFramework/framework/Internal/DisposeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/DisposeHelper.cs
@@ -20,10 +20,10 @@ namespace NUnit.Framework.Internal
         {
             if (value is not null)
             {
-                if (value is IDisposable disposable)
-                    disposable.Dispose();
-                else if (TryGetAsyncDispose(value.GetType(), out var method))
+                if (TryGetAsyncDispose(value.GetType(), out var method))
                     AsyncToSyncAdapter.Await(() => method.Invoke(value, null));
+                else if (value is IDisposable disposable)
+                    disposable.Dispose();
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/DisposeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/DisposeHelper.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+#if NETFRAMEWORK
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+#endif
 
 namespace NUnit.Framework.Internal
 {
@@ -43,6 +45,7 @@ namespace NUnit.Framework.Internal
             }
         }
 
+#if NETFRAMEWORK
         private static bool TryGetAsyncDispose(Type type, [NotNullWhen(true)] out MethodInfo? method)
         {
             method = null;
@@ -54,5 +57,6 @@ namespace NUnit.Framework.Internal
             method = asyncDisposable.GetMethod("DisposeAsync", Type.EmptyTypes);
             return method is not null;
         }
+#endif
     }
 }

--- a/src/NUnitFramework/framework/Internal/DisposeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/DisposeHelper.cs
@@ -24,7 +24,6 @@ namespace NUnit.Framework.Internal
                     disposable.Dispose();
                 else if (TryGetAsyncDispose(value.GetType(), out var method))
                     AsyncToSyncAdapter.Await(() => method.Invoke(value, null));
-
             }
         }
 
@@ -36,19 +35,8 @@ namespace NUnit.Framework.Internal
             if (asyncDisposable is null)
                 return false;
 
-            var interfaceMethod = asyncDisposable.GetMethod("DisposeAsync");
-            if (interfaceMethod is null)
-                return false;
-
-            if (interfaceMethod.ReturnType.FullName == "System.Threading.Tasks.ValueType")
-                return false;
-
-            var map = type.GetInterfaceMap(asyncDisposable);
-            if (map.TargetMethods.Length == 0)
-                return false;
-
-            method = map.TargetMethods[0];
-            return true;
+            method = asyncDisposable.GetMethod("DisposeAsync", Type.EmptyTypes);
+            return method is not null;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/DisposeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/DisposeHelper.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace NUnit.Framework.Internal
+{
+    internal static class DisposeHelper
+    {
+        public static bool IsDisposable(Type type)
+        {
+            if (typeof(IDisposable).IsAssignableFrom(type))
+                return true;
+
+            return TryGetAsyncDispose(type, out _);
+        }
+
+        public static void EnsureDisposed(object? value)
+        {
+            if (value is not null)
+            {
+                if (value is IDisposable disposable)
+                    disposable.Dispose();
+                else if (TryGetAsyncDispose(value.GetType(), out var method))
+                    AsyncToSyncAdapter.Await(() => method.Invoke(value, null));
+
+            }
+        }
+
+        private static bool TryGetAsyncDispose(Type type, [NotNullWhen(true)] out MethodInfo? method)
+        {
+            method = null;
+
+            var asyncDisposable = type.GetInterface("System.IAsyncDisposable");
+            if (asyncDisposable is null)
+                return false;
+
+            var interfaceMethod = asyncDisposable.GetMethod("DisposeAsync");
+            if (interfaceMethod is null)
+                return false;
+
+            if (interfaceMethod.ReturnType.FullName == "System.Threading.Tasks.ValueType")
+                return false;
+
+            var map = type.GetInterfaceMap(asyncDisposable);
+            if (map.TargetMethods.Length == 0)
+                return false;
+
+            method = map.TargetMethods[0];
+            return true;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Extensions;
+using System.Linq;
 
 namespace NUnit.Framework.Internal.Execution
 {
@@ -232,7 +233,7 @@ namespace NUnit.Framework.Internal.Execution
                 command = new OneTimeTearDownCommand(command, item);
 
             // Dispose of fixture if necessary
-            if (Test is IDisposableFixture && Test.TypeInfo is not null && typeof(IDisposable).IsAssignableFrom(Test.TypeInfo.Type) && !Test.HasLifeCycle(LifeCycle.InstancePerTestCase))
+            if (Test is IDisposableFixture && Test.TypeInfo is not null && DisposeHelper.IsDisposable(Test.TypeInfo.Type) && !Test.HasLifeCycle(LifeCycle.InstancePerTestCase))
                 command = new DisposeFixtureCommand(command);
 
             return command;

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Extensions;
-using System.Linq;
 
 namespace NUnit.Framework.Internal.Execution
 {

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -114,7 +114,7 @@ namespace NUnit.Framework.Internal.Execution
 
                 // Dispose of fixture if necessary
                 var isInstancePerTestCase = Test.HasLifeCycle(LifeCycle.InstancePerTestCase);
-                if (isInstancePerTestCase && parentFixture is IDisposableFixture && typeof(IDisposable).IsAssignableFrom(parentFixture.TypeInfo.Type))
+                if (isInstancePerTestCase && parentFixture is IDisposableFixture && DisposeHelper.IsDisposable(parentFixture.TypeInfo.Type))
                     command = new DisposeFixtureCommand(command);
 
                 // In the current implementation, upstream actions only apply to tests. If that should change in the future,

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace NUnit.TestData.LifeCycleTests

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -433,5 +433,27 @@ namespace NUnit.TestData.LifeCycleTests
         public void VerifyDisposed() => Assert.That(DisposeCount, Is.EqualTo(1));
     }
 
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class InstancePerTestCaseWithAsyncDisposeTestCase : IAsyncDisposable
+    {
+        public static int DisposeCount;
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref DisposeCount);
+            return new ValueTask(Task.CompletedTask);
+        }
+
+        [Test]
+        [Order(1)]
+        public void Test() => Assert.Pass();
+
+        [Test]
+        [Order(2)]
+        public void VerifyDisposed() => Assert.That(DisposeCount, Is.EqualTo(1));
+    }
+
     #endregion
 }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -433,7 +433,6 @@ namespace NUnit.TestData.LifeCycleTests
         public void VerifyDisposed() => Assert.That(DisposeCount, Is.EqualTo(1));
     }
 
-
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class InstancePerTestCaseWithAsyncDisposeTestCase : IAsyncDisposable

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -520,6 +520,43 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
     }
 
     [TestFixture]
+    public class AsyncAndSyncDisposableFixture : IAsyncDisposable, IDisposable
+    {
+        public int DisposeCalled = 0;
+        public List<string> Actions = new();
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Actions.Add(nameof(OneTimeSetUp));
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Actions.Add(nameof(OneTimeTearDown));
+        }
+
+        [Test]
+        public void OneTest()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Actions.Add(nameof(DisposeAsync));
+            DisposeCalled++;
+            return new ValueTask(Task.CompletedTask);
+        }
+
+        public void Dispose()
+        {
+            Actions.Add(nameof(Dispose));
+            DisposeCalled++;
+        }
+    }
+
+    [TestFixture]
     public class DisposableFixtureWithTestCases : IDisposable
     {
         public int DisposeCalled = 0;

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace NUnit.TestData.OneTimeSetUpTearDownData
@@ -480,6 +481,42 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
             Actions.Add("Dispose");
             DisposeCalled++;
         }
+    }
+
+
+    [TestFixture]
+    public class AsyncDisposableFixture : IAsyncDisposable
+    {
+        public int DisposeCalled = 0;
+        public List<string> Actions = new();
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Actions.Add(nameof(OneTimeSetUp));
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Actions.Add(nameof(OneTimeTearDown));
+        }
+
+        [Test]
+        public void OneTest()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Actions.Add(nameof(DisposeAsync));
+            DisposeCalled++;
+            return new ValueTask(Task.CompletedTask);
+        }
+    }
+
+    public class InheritedAsyncDisposableFixture : AsyncDisposableFixture
+    {
     }
 
     [TestFixture]

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -483,7 +483,6 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         }
     }
 
-
     [TestFixture]
     public class AsyncDisposableFixture : IAsyncDisposable
     {

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
     <ProjectReference Include="..\nunit.framework.legacy\nunit.framework.legacy.csproj" />
   </ItemGroup>

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -212,6 +212,17 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(InstancePerTestCaseWithDisposeTestCase.DisposeCount, Is.EqualTo(2));
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
+
+        [Test]
+        public void InstancePerTestCaseWithAsyncDispose()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(InstancePerTestCaseWithAsyncDisposeTestCase));
+
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(InstancePerTestCaseWithAsyncDisposeTestCase.DisposeCount, Is.EqualTo(2));
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+        }
+
         #endregion
 
         #region Assembly level InstancePerTestCase

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -209,7 +209,7 @@ namespace NUnit.Framework.Tests.Attributes
             var fixture = TestBuilder.MakeFixture(typeof(InstancePerTestCaseWithDisposeTestCase));
 
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(InstancePerTestCaseWithDisposeTestCase.DisposeCount, Is.EqualTo(2));
+            Assert.That(InstancePerTestCaseWithDisposeTestCase.DisposeCount, Is.EqualTo(fixture.TestCaseCount));
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
 
@@ -219,7 +219,7 @@ namespace NUnit.Framework.Tests.Attributes
             var fixture = TestBuilder.MakeFixture(typeof(InstancePerTestCaseWithAsyncDisposeTestCase));
 
             ITestResult result = TestBuilder.RunTest(fixture);
-            Assert.That(InstancePerTestCaseWithAsyncDisposeTestCase.DisposeCount, Is.EqualTo(2));
+            Assert.That(InstancePerTestCaseWithAsyncDisposeTestCase.DisposeCount, Is.EqualTo(fixture.TestCaseCount));
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
 

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -378,8 +378,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var fixture = new AsyncDisposableFixture();
             TestBuilder.RunTestFixture(fixture);
+
+            var expected = new[] { nameof(AsyncDisposableFixture.OneTimeSetUp), nameof(AsyncDisposableFixture.OneTimeTearDown), nameof(AsyncDisposableFixture.DisposeAsync) };
+
             Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
-            Assert.That(fixture.Actions, Is.EqualTo(new object[] { "OneTimeSetUp", "OneTimeTearDown", "DisposeAsync" }));
+            Assert.That(fixture.Actions, Is.EqualTo(expected));
         }
 
         [Test]
@@ -387,8 +390,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var fixture = new InheritedAsyncDisposableFixture();
             TestBuilder.RunTestFixture(fixture);
+
+            var expected = new[] { nameof(AsyncDisposableFixture.OneTimeSetUp), nameof(AsyncDisposableFixture.OneTimeTearDown), nameof(AsyncDisposableFixture.DisposeAsync) };
+
             Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
-            Assert.That(fixture.Actions, Is.EqualTo(new object[] { "OneTimeSetUp", "OneTimeTearDown", "DisposeAsync" }));
+            Assert.That(fixture.Actions, Is.EqualTo(expected));
         }
 
         [Test]
@@ -397,8 +403,8 @@ namespace NUnit.Framework.Tests.Attributes
             var fixture = new AsyncAndSyncDisposableFixture();
             TestBuilder.RunTestFixture(fixture);
             Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
-            Assert.That(fixture.Actions, Does.Contain("DisposeAsync"));
-            Assert.That(fixture.Actions, Does.Not.Contain("Dispose"));
+            Assert.That(fixture.Actions, Does.Contain(nameof(IAsyncDisposable.DisposeAsync)));
+            Assert.That(fixture.Actions, Does.Not.Contain(nameof(IDisposable.Dispose)));
         }
     }
 

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -390,6 +390,16 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
             Assert.That(fixture.Actions, Is.EqualTo(new object[] { "OneTimeSetUp", "OneTimeTearDown", "DisposeAsync" }));
         }
+
+        [Test]
+        public void AsyncDisposePrioritizedWhenSyncAndAsyncDispose()
+        {
+            var fixture = new AsyncAndSyncDisposableFixture();
+            TestBuilder.RunTestFixture(fixture);
+            Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
+            Assert.That(fixture.Actions, Does.Contain("DisposeAsync"));
+            Assert.That(fixture.Actions, Does.Not.Contain("Dispose"));
+        }
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -372,6 +372,24 @@ namespace NUnit.Framework.Tests.Attributes
             TestBuilder.RunTestFixture(fixture);
             Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
         }
+
+        [Test]
+        public void AsyncDisposeCalledOnceWhenFixtureImplementsIAsyncDisposable()
+        {
+            var fixture = new AsyncDisposableFixture();
+            TestBuilder.RunTestFixture(fixture);
+            Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
+            Assert.That(fixture.Actions, Is.EqualTo(new object[] { "OneTimeSetUp", "OneTimeTearDown", "DisposeAsync" }));
+        }
+
+        [Test]
+        public void AsyncDisposeCalledOnceWhenFixtureImplementsIAsyncDisposableThroughInheritance()
+        {
+            var fixture = new InheritedAsyncDisposableFixture();
+            TestBuilder.RunTestFixture(fixture);
+            Assert.That(fixture.DisposeCalled, Is.EqualTo(1));
+            Assert.That(fixture.Actions, Is.EqualTo(new object[] { "OneTimeSetUp", "OneTimeTearDown", "DisposeAsync" }));
+        }
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -12,9 +12,12 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />


### PR DESCRIPTION
Contributes to #3043 

Adds support for async disposal of test fixtures

@nunit/framework-team This has been a "20 minutes at a time" sort of change over the last several weeks. I welcome a closer scrutiny from the team over any design or implementation decisions here 