### PR TITLE
Updated cake to version 3.1.0 and corrected breaking changes cake code

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.1.0",
+      "version": "3.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - release
-      - 'v3.13-dev'
+      - 'v3'
   pull_request:
 
 jobs:

--- a/build.cake
+++ b/build.cake
@@ -228,7 +228,7 @@ Task("CreateImage")
 
         var imageBinDir = Directory(CurrentImageDir) + Directory("bin");
 
-        CreateDirectory(imageBinDir.ToString());
+        CreateDirectory(imageBinDir);
         Information("Created imagedirectory at:" + imageBinDir.ToString());
         var directories = new String[]
         {

--- a/build.cake
+++ b/build.cake
@@ -116,8 +116,8 @@ DotNetBuildSettings CreateDotNetBuildSettings() =>
         Configuration = configuration,
         NoRestore = true,
         Verbosity = DotNetVerbosity.Minimal,
-        Version = packageVersion
-    };
+        MSBuildSettings = new DotNetMSBuildSettings { Version = packageVersion }
+     };
 
 //////////////////////////////////////////////////////////////////////
 // TEST

--- a/nunit.sln
+++ b/nunit.sln
@@ -71,6 +71,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\continuous_integration.yml = .github\workflows\continuous_integration.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".config", ".config", "{08744334-2350-4885-B57E-347010A27ABB}"
+	ProjectSection(SolutionItems) = preProject
+		.config\dotnet-tools.json = .config\dotnet-tools.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -287,8 +287,10 @@ namespace NUnit.Framework.Tests.Constraints
 
         // The following tests are each running in 14ms to 46ms on my machine. Based on that,
         // warn at 100ms and fail at 500ms
-        private const int LARGE_COLLECTION_WARN_TIME = 100;
-        private const int LARGE_COLLECTION_FAIL_TIME = 500;
+        // Seems to be slower on MacOs on build on github actions, so increasing this with 50%
+
+        private const int LARGE_COLLECTION_WARN_TIME = 100 * 3 / 2;
+        private const int LARGE_COLLECTION_FAIL_TIME = 500 * 3 / 2;
 
         [Test(Description = "Issue #2799 - CollectionAssert.AreEquivalent is extremely slow")]
         public void LargeIntCollectionsInSameOrder()


### PR DESCRIPTION
While correcting the script after the update, I noticed that we do have some tasks that seems to not be used,  Publish Test results is one - that one seems to be oriented to Azure Pipelines.  And then SignPackages.  This one I believed we should have there, but I guess we might need to update it, and also ensure we have a valid certificate.
On the other hand, nuget does an automatic repository signing for the packages. So, do we need more?

Fixes #4465 