### PR TITLE
(For Discussion) Revert "Indicate that SetupFixtureAttribute should not be used on base-classes"

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework
     /// <see cref="OneTimeTearDownAttribute" /> methods for all the test fixtures
     /// under a given namespace.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class SetUpFixtureAttribute : NUnitAttribute, IFixtureBuilder
     {
         #region ISuiteBuilder Members

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Attributes
             var usageAttrib = Attribute.GetCustomAttribute(typeof(SetUpFixtureAttribute), typeof(AttributeUsageAttribute)) as AttributeUsageAttribute;
 
             Assert.NotNull(usageAttrib);
-            Assert.False(usageAttrib.Inherited);
+            Assert.True(usageAttrib.Inherited);
         }
 
         private static class StaticSetupClass


### PR DESCRIPTION
Relates to https://github.com/nunit/nunit/issues/4554 https://github.com/nunit/nunit/issues/3937 https://github.com/nunit/nunit/issues/4158

Based on the discussion in https://github.com/nunit/nunit/issues/4554 and https://github.com/nunit/nunit/issues/3937 it seems as though nunit has traditionally not supported `SetupFixture` to work on a base class, though it doesn't seem to appear in the docs. The last time I can find an [explicit discussion](https://github.com/nunit/nunit/issues/3937#issuecomment-1081302248) it appears that this was intended to not work. It appears to have accidentally started working at some point, likely in 3.13.3.

We explicitly turned off the `Inherited` flag on the attribute in 3.14 and 4.0, which inadvertently seem to have broken some users of 3.x who had built an inheritance structure around `SetupFixture`.

I've expressed hesitation about reverting the change in 4.0 unless we decide as a team it _should_ work but in the interest of compatibility I've opened this PR for us to consider reverting it on 3.x. There's pros and cons to merging this. Pros would be minimizing accidental breaking changes in 3.x while the cons would be explicitly reenabling a behaviour we seem to want to discourage.

@OsirisTerje @jnm2 I'd like to hear your thoughts on this. I'm also happy to have this PR close without merging if we want to actively discourage this pattern in 3.x. The workaround for users who hit this in 3.14 is simply to add the attribute at each level of their inheritance hierarchy.