### PR TITLE
v4 - Revert "Indicate that SetupFixtureAttribute should not be used on base-classes"

### DIFF
--- a/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SetUpFixtureAttribute.cs
@@ -14,7 +14,7 @@ namespace NUnit.Framework
     /// <see cref="OneTimeTearDownAttribute" /> methods for all the test fixtures
     /// under a given namespace.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class SetUpFixtureAttribute : NUnitAttribute, IFixtureBuilder
     {
         #region ISuiteBuilder Members

--- a/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/SetUpFixtureAttributeTests.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Tests.Attributes
             var usageAttrib = Attribute.GetCustomAttribute(typeof(SetUpFixtureAttribute), typeof(AttributeUsageAttribute)) as AttributeUsageAttribute;
 
             Assert.That(usageAttrib, Is.Not.Null);
-            Assert.That(usageAttrib.Inherited, Is.False);
+            Assert.That(usageAttrib.Inherited, Is.True);
         }
 
         private static class StaticSetupClass


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/4554
Relates to https://github.com/nunit/nunit/pull/4555