### PR TITLE
Expand SupportOSPlatform to mean minimum supported version

### DIFF
--- a/nunit.sln
+++ b/nunit.sln
@@ -77,6 +77,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".config", ".config", "{0874
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "windows-tests", "src\NUnitFramework\windows-tests\windows-tests.csproj", "{7C19F745-B5F0-4A3A-B545-1E1DF4FA1F78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -131,6 +133,10 @@ Global
 		{59DC5039-5FCD-4C0C-AC92-7F06610136D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59DC5039-5FCD-4C0C-AC92-7F06610136D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59DC5039-5FCD-4C0C-AC92-7F06610136D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C19F745-B5F0-4A3A-B545-1E1DF4FA1F78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C19F745-B5F0-4A3A-B545-1E1DF4FA1F78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C19F745-B5F0-4A3A-B545-1E1DF4FA1F78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C19F745-B5F0-4A3A-B545-1E1DF4FA1F78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
@@ -52,10 +52,16 @@ namespace NUnit.Framework.Tests.Attributes
 
         private void OutputReferenceId(string location)
         {
-            if (!ObjectIds.TryGetValue(this, out long id))
+            long id;
+
+            lock (ObjectIds)
             {
-                ObjectIds[this] = id = ObjectIds.Count + 1;
+                if (!ObjectIds.TryGetValue(this, out id))
+                {
+                    ObjectIds[this] = id = ObjectIds.Count + 1;
+                }
             }
+
             TestContext.WriteLine($"{location}: {id}>");
         }
     }

--- a/src/NUnitFramework/tests/Attributes/OSPlatformAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OSPlatformAttributeTests.cs
@@ -17,9 +17,7 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(Path.DirectorySeparatorChar, Is.EqualTo('/'));
         }
 
-        [SupportedOSPlatform("Windows")]
-        [SupportedOSPlatform("Windows10.0")]
-        [SupportedOSPlatform("Windows11.0")]
+        [SupportedOSPlatform("Windows7.0")]
         [Test]
         public void SupportedBackwardSlashDirectorySeparator()
         {

--- a/src/NUnitFramework/tests/Attributes/OSPlatformTranslatorTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OSPlatformTranslatorTests.cs
@@ -15,8 +15,8 @@ namespace NUnit.Framework.Tests.Attributes
     public class OSPlatformTranslatorTests
     {
         [TestCase("Windows", ExpectedResult = "Win")]
-        [TestCase("Windows7.0", ExpectedResult = "Windows7")]
-        [TestCase("Windows10.0", ExpectedResult = "Windows10")]
+        [TestCase("Windows7.0", ExpectedResult = "Windows7,Windows8,Windows10,Windows11")]
+        [TestCase("Windows10.0", ExpectedResult = "Windows10,Windows11")]
         [TestCase("Windows11.0", ExpectedResult = "Windows11")]
         [TestCase("Linux", ExpectedResult = "Linux")]
         [TestCase("OSX", ExpectedResult = "MacOsX")]
@@ -24,17 +24,33 @@ namespace NUnit.Framework.Tests.Attributes
         [TestCase("Android", ExpectedResult = "Android")]
         public string TranslatePlatform(string platformName)
         {
-            return OSPlatformTranslator.Translate(platformName);
+            return string.Join(",", OSPlatformTranslator.Translate(platformName));
         }
 
 #if NET5_0_OR_GREATER
         [Test]
-        public void TranslateSupportedOSPlatformAttribute()
+        public void TranslateSupportedOSPlatformAttributeWindows7()
         {
             var supported = new SupportedOSPlatformAttribute("Windows7.0");
 
             PlatformAttribute platform = TranslateIntoSinglePlatform(supported);
-            Assert.That(platform.Include, Is.EqualTo("Windows7"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows7"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows8"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows10"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows11"), nameof(platform.Include));
+            Assert.That(platform.Exclude, Is.Null, nameof(platform.Exclude));
+        }
+
+        [Test]
+        public void TranslateSupportedOSPlatformAttributeWindows10()
+        {
+            var supported = new SupportedOSPlatformAttribute("Windows10.0");
+
+            PlatformAttribute platform = TranslateIntoSinglePlatform(supported);
+            Assert.That(platform.Include, Does.Not.Contain("Windows7"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Not.Contain("Windows8"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows10"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows11"), nameof(platform.Include));
             Assert.That(platform.Exclude, Is.Null, nameof(platform.Exclude));
         }
 
@@ -56,7 +72,9 @@ namespace NUnit.Framework.Tests.Attributes
             var osPlatforms = new OSPlatformAttribute[] { supported1, supported2 };
 
             PlatformAttribute platform = TranslateIntoSinglePlatform(osPlatforms);
-            Assert.That(platform.Include, Is.EqualTo("Windows7,Linux"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows7"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows10"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Linux"), nameof(platform.Include));
             Assert.That(platform.Exclude, Is.Null, nameof(platform.Exclude));
         }
 
@@ -68,7 +86,9 @@ namespace NUnit.Framework.Tests.Attributes
             var unsupported = new UnsupportedOSPlatformAttribute("Android");
 
             PlatformAttribute platform = TranslateIntoSinglePlatform(supported1, unsupported, supported2);
-            Assert.That(platform.Include, Is.EqualTo("Windows7,Linux"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows7"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows10"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Linux"), nameof(platform.Include));
             Assert.That(platform.Exclude, Is.EqualTo("Android"), nameof(platform.Exclude));
         }
 
@@ -80,7 +100,8 @@ namespace NUnit.Framework.Tests.Attributes
             var sourcePlatform = new PlatformAttribute("Win");
 
             PlatformAttribute platform = TranslateIntoSinglePlatform(sourcePlatform, supported1, supported2);
-            Assert.That(platform.Include, Is.EqualTo("Win,Windows10"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Win"), nameof(platform.Include));
+            Assert.That(platform.Include, Does.Contain("Windows10"), nameof(platform.Include));
             Assert.That(platform.Exclude, Is.Null, nameof(platform.Exclude));
         }
 

--- a/src/NUnitFramework/windows-tests/WindowsOnlyTest.cs
+++ b/src/NUnitFramework/windows-tests/WindowsOnlyTest.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Windows.Tests
+{
+    [TestFixture]
+    public sealed class PathTest
+    {
+        [Test]
+        public void DirectorySeparator()
+        {
+            Assert.That(Path.DirectorySeparatorChar, Is.EqualTo('\\'));
+        }
+
+        [Test]
+        public void VolumeSeparator()
+        {
+            Assert.That(Path.VolumeSeparatorChar, Is.EqualTo(':'));
+        }
+
+        [Test]
+        public void PathSeparator()
+        {
+            Assert.That(Path.PathSeparator, Is.EqualTo(';'));
+        }
+    }
+}

--- a/src/NUnitFramework/windows-tests/windows-tests.csproj
+++ b/src/NUnitFramework/windows-tests/windows-tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0-windows7;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <RootNamespace>NUnit.Windows.Tests</RootNamespace>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\framework\nunit.framework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #4564 

Windows7 => WIndows7, Windows8, Windows10, Windows11
Windows10 => Windows10, Windows11

Added windows only test assembly with MS generated SupportOSPlatform attribute