### PR TITLE
Fix .nuspec dependency for .NET build

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -31,7 +31,9 @@
     <tags>nunit test testing tdd framework fluent assert theory plugin addin</tags>
     <copyright>Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License.</copyright>
     <dependencies>
-      <group targetFramework="net462" />
+      <group targetFramework="net462">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
       <group targetFramework="net6.0" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fixes #4581 

We cannot really test this in the repository as it depends on the nuget package being created.

The below shows the problem.
Recompiling with an .nupkg resulting from this branch causes it to work.

[nunit-issue4581-tests.zip](https://github.com/nunit/nunit/files/13593990/nunit-issue4581-tests.zip)
