### PR TITLE
Issues/4572 properties comparer

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AnyOfConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AnyOfConstraint.cs
@@ -130,6 +130,19 @@ namespace NUnit.Framework.Constraints
             return this;
         }
 
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public AnyOfConstraint UsingPropertiesComparer()
+        {
+            _comparer.CompareProperties = true;
+            return this;
+        }
+
         #endregion
     }
 }

--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -127,6 +127,19 @@ namespace NUnit.Framework.Constraints
             return this;
         }
 
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public CollectionItemsEqualConstraint UsingPropertiesComparer()
+        {
+            _comparer.CompareProperties = true;
+            return this;
+        }
+
         #endregion
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualMethodResult.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualMethodResult.cs
@@ -23,8 +23,13 @@ namespace NUnit.Framework.Constraints.Comparers
         ComparedEqual,
 
         /// <summary>
-        /// Method is appropriate and the items are consisdered different.
+        /// Method is appropriate and the items are considered different.
         /// </summary>
-        ComparedNotEqual
+        ComparedNotEqual,
+
+        /// <summary>
+        /// Method is appropriate but the class has cyclic references.
+        /// </summary>
+        ComparisonPending
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace NUnit.Framework.Constraints.Comparers
@@ -29,9 +30,10 @@ namespace NUnit.Framework.Constraints.Comparers
             }
 
             PropertyInfo[] properties = xType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
-            if (properties.Length == 0 || properties.Length >= 32)
+            if (properties.Length == 0 || properties.Length >= 32 || properties.Any(p => p.GetIndexParameters().Length > 0))
             {
                 // We can't compare if there are no (or too many) properties.
+                // We also can't deal with indexer properties as we don't know the range of valid values.
                 return EqualMethodResult.TypesNotSupported;
             }
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -268,7 +268,6 @@ namespace NUnit.Framework.Constraints
                 return this;
             }
         }
-
         /// <summary>
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
@@ -343,6 +342,19 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparison));
+            return this;
+        }
+
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public EqualConstraint UsingPropertiesComparer()
+        {
+            _comparer.CompareProperties = true;
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -51,7 +51,6 @@ namespace NUnit.Framework.Constraints
             EquatablesComparer.Equal,
             EnumerablesComparer.Equal,
             EqualsComparer.Equal,
-            PropertiesComparer.Equal,
         };
 
         /// <summary>
@@ -64,6 +63,12 @@ namespace NUnit.Framework.Constraints
         /// those of different dimensions to be compared
         /// </summary>
         private bool _compareAsCollection;
+
+        /// <summary>
+        /// If true, when a class does not implement <see cref="IEquatable{T}"/>
+        /// it will be compared property by property.
+        /// </summary>
+        private bool _compareProperties;
 
         /// <summary>
         /// Comparison objects used in comparisons for some constraints.
@@ -94,6 +99,16 @@ namespace NUnit.Framework.Constraints
         {
             get => _caseInsensitive;
             set => _caseInsensitive = value;
+        }
+
+        /// <summary>
+        /// Gets and sets a flag indicating whether an instance properties
+        /// should be compared when determining equality.
+        /// </summary>
+        public bool CompareProperties
+        {
+            get => _compareProperties;
+            set => _compareProperties = value;
         }
 
         /// <summary>
@@ -133,6 +148,7 @@ namespace NUnit.Framework.Constraints
         #endregion
 
         #region Public Methods
+
         /// <summary>
         /// Compares two objects for equality within a tolerance.
         /// </summary>
@@ -193,6 +209,11 @@ namespace NUnit.Framework.Constraints
                 EqualMethodResult result = equalMethod(x, y, ref tolerance, state, this);
                 if (result != EqualMethodResult.TypesNotSupported)
                     return result;
+            }
+
+            if (_compareProperties)
+            {
+                return PropertiesComparer.Equal(x, y, ref tolerance, state, this);
             }
 
             if (tolerance.HasVariance)

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -148,6 +148,7 @@ namespace NUnit.Framework.Constraints
                     throw new NotSupportedException($"Specified Tolerance not supported for instances of type '{GetType(x)}' and '{GetType(y)}'");
                 case EqualMethodResult.ComparedEqual:
                     return true;
+                case EqualMethodResult.ComparisonPending:
                 case EqualMethodResult.ComparedNotEqual:
                 default:
                     return false;
@@ -170,7 +171,7 @@ namespace NUnit.Framework.Constraints
                 return EqualMethodResult.ComparedEqual;
 
             if (state.DidCompare(x, y))
-                return EqualMethodResult.ComparedNotEqual;
+                return EqualMethodResult.ComparisonPending;
 
             EqualityAdapter? externalComparer = GetExternalComparer(x, y);
 

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -127,6 +127,20 @@ namespace NUnit.Framework.Constraints
             return this;
         }
 
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public SomeItemsConstraint UsingPropertiesComparer()
+        {
+            CheckPrecondition(nameof(UsingPropertiesComparer));
+            _equalConstraint.UsingPropertiesComparer();
+            return this;
+        }
+
         [MemberNotNull(nameof(_equalConstraint))]
         private void CheckPrecondition(string argument)
         {

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -377,13 +377,13 @@ namespace NUnit.Framework.Tests.Assertions
 
             Assert.Multiple(() =>
             {
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", zero), Is.EqualTo(instance));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.Not.EqualTo(instance));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.EqualTo(instance).Within(0.1));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", null), Is.Not.EqualTo(instance));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance));
-                Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance));
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", zero), Is.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.EqualTo(instance).Within(0.1).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", null), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.1, "2.2", zero), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(1, 2.2, "1.1", zero), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero), Is.Not.EqualTo(instance).UsingPropertiesComparer());
             });
         }
 
@@ -415,12 +415,12 @@ namespace NUnit.Framework.Tests.Assertions
 
             Assert.Multiple(() =>
             {
-                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.One), Is.EqualTo(instance));
-                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
-                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.EqualTo(instance).Within(0.1));
-                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.Two), Is.Not.EqualTo(instance).Within(0.1));
-                Assert.That(new StructWithSomeToleranceAwareMembers(1, 2.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
-                Assert.That(new StructWithSomeToleranceAwareMembers(2, 1.1, "1.1", SomeEnum.One), Is.Not.EqualTo(instance));
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.One), Is.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.2, "1.1", SomeEnum.One), Is.EqualTo(instance).Within(0.1).UsingPropertiesComparer());
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 1.1, "1.1", SomeEnum.Two), Is.Not.EqualTo(instance).Within(0.1).UsingPropertiesComparer());
+                Assert.That(new StructWithSomeToleranceAwareMembers(1, 2.2, "1.1", SomeEnum.One), Is.Not.EqualTo(instance).UsingPropertiesComparer());
+                Assert.That(new StructWithSomeToleranceAwareMembers(2, 1.1, "1.1", SomeEnum.One), Is.Not.EqualTo(instance).UsingPropertiesComparer());
             });
         }
 
@@ -533,7 +533,8 @@ namespace NUnit.Framework.Tests.Assertions
             LinkedList list1 = new(1, new(2, new(3)));
             LinkedList list2 = new(1, new(2, new(3)));
 
-            Assert.That(list1, Is.EqualTo(list2));
+            Assert.That(list1, Is.Not.EqualTo(list2));
+            Assert.That(list1, Is.EqualTo(list2).UsingPropertiesComparer());
         }
 
         [Test]
@@ -545,7 +546,8 @@ namespace NUnit.Framework.Tests.Assertions
             list1.Next = list1;
             list2.Next = list2;
 
-            Assert.That(list1, Is.EqualTo(list2));
+            Assert.That(list1, Is.Not.EqualTo(list2));
+            Assert.That(list1, Is.EqualTo(list2).UsingPropertiesComparer());
         }
 
         private sealed class LinkedList

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -546,7 +546,7 @@ namespace NUnit.Framework.Tests.Assertions
             list1.Next = list1;
             list2.Next = list2;
 
-            Assert.That(list1, Is.Not.EqualTo(list2));
+            Assert.That(list1, Is.Not.EqualTo(list2)); // Reference comparison
             Assert.That(list1, Is.EqualTo(list2).UsingPropertiesComparer());
         }
 
@@ -561,6 +561,29 @@ namespace NUnit.Framework.Tests.Assertions
             public int Value { get; }
 
             public LinkedList? Next { get; set; }
+        }
+
+        [Test]
+        public void EqualMemberWithIndexer()
+        {
+            var members = new Members("Hello", "World", "NUnit");
+            var copy = new Members("Hello", "World", "NUnit");
+
+            Assert.That(members[1], Is.EqualTo("World"));
+            Assert.That(copy, Is.Not.EqualTo(members));
+            Assert.That(() => Assert.That(copy, Is.EqualTo(members).UsingPropertiesComparer()), Throws.InstanceOf<NotSupportedException>());
+        }
+
+        private sealed class Members
+        {
+            private readonly string[] _members;
+
+            public Members(params string[] members)
+            {
+                _members = members;
+            }
+
+            public string this[int index] => _members[index];
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -526,5 +526,39 @@ namespace NUnit.Framework.Tests.Assertions
                 return $"{ValueA} {ValueB} '{ValueC}' [{Chained}]";
             }
         }
+
+        [Test]
+        public void AssertWithRecursiveClass()
+        {
+            LinkedList list1 = new(1, new(2, new(3)));
+            LinkedList list2 = new(1, new(2, new(3)));
+
+            Assert.That(list1, Is.EqualTo(list2));
+        }
+
+        [Test]
+        public void AssertWithCyclicRecursiveClass()
+        {
+            LinkedList list1 = new(1);
+            LinkedList list2 = new(1);
+
+            list1.Next = list1;
+            list2.Next = list2;
+
+            Assert.That(list1, Is.EqualTo(list2));
+        }
+
+        private sealed class LinkedList
+        {
+            public LinkedList(int value, LinkedList? next = null)
+            {
+                Value = value;
+                Next = next;
+            }
+
+            public int Value { get; }
+
+            public LinkedList? Next { get; set; }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
@@ -63,5 +63,23 @@ namespace NUnit.Framework.Tests.Constraints
         {
             Assert.That(42, Is.Not.AnyOf(0, -1, 100));
         }
+
+        [Test]
+        public void ValidMemberUsingPropertiesComparer()
+        {
+            Assert.That(new XY(5, 12), Is.AnyOf(new XY(3, 4), new XY(5, 12)).UsingPropertiesComparer());
+        }
+
+        private sealed class XY
+        {
+            public XY(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public int X { get; }
+            public int Y { get; }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -29,14 +29,14 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
-        public void SucceedsWhenValueIsPresentUsingContainKey()
+        public void SucceedsWhenValueIsPresentUsingContainValue()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
             Assert.That(dictionary, Does.ContainValue("Mundo"));
         }
 
         [Test]
-        public void SucceedsWhenValueIsNotPresentUsingContainKey()
+        public void SucceedsWhenValueIsNotPresentUsingContainValue()
         {
             var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
             Assert.That(dictionary, Does.Not.ContainValue("NotValue"));
@@ -76,6 +76,27 @@ namespace NUnit.Framework.Tests.Constraints
 
             Assert.That(dictionary,
                 new DictionaryContainsValueConstraint("UNIVERSE").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
+        }
+
+        [Test]
+        public void UsingPropertiesComparerIsHonored()
+        {
+            var dictionary = new Dictionary<string, XY> { { "5", new(3, 4) }, { "13", new(5, 12) } };
+            var value = new XY(5, 12);
+            Assert.That(dictionary, Does.Not.ContainValue(value));
+            Assert.That(dictionary, Does.ContainValue(value).UsingPropertiesComparer());
+        }
+
+        private sealed class XY
+        {
+            public XY(double x, double y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public double X { get; }
+            public double Y { get; }
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1008,6 +1008,13 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(ex?.Message, Does.Contain(expectedMsg));
         }
 
+        [Test]
+        public void SameValueAndTypeButDifferentReferenceShowNotShowTypeDifference()
+        {
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Is.Zero, Is.EqualTo(Is.Zero)));
+            Assert.That(ex?.Message, Does.Contain("  Expected: <<equal 0>>" + NL + "  But was:  <<equal 0>>" + NL));
+        }
+
         [Test, TestCaseSource(nameof(DifferentTypeSameValueTestData))]
         public void SameValueDifferentTypeRegexMatch(object expected, object actual)
         {

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1008,13 +1008,6 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(ex?.Message, Does.Contain(expectedMsg));
         }
 
-        [Test]
-        public void SameValueAndTypeButDifferentReferenceShowNotShowTypeDifference()
-        {
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(Is.Zero, Is.EqualTo(Is.Zero)));
-            Assert.That(ex?.Message, Does.Contain("  Expected: <<equal 0>>" + NL + "  But was:  <<equal 0>>" + NL));
-        }
-
         [Test, TestCaseSource(nameof(DifferentTypeSameValueTestData))]
         public void SameValueDifferentTypeRegexMatch(object expected, object actual)
         {


### PR DESCRIPTION
Fixes #4572 
Fixes #4591

By default behaviour is as per 3.14
A new `UsingPropertiesComparer()` can be used as an opt-in.

Also fixes when using indexers with the property comparer.
Also fixes nested references.
