### PR TITLE
Switch to using license expression

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Charlie Poole, Rob Prouse</authors>
     <owners>Charlie Poole, Rob Prouse</owners>
-    <license type="file">LICENSE.txt</license>
+    <license type="expression">MIT</license>
     <projectUrl>https://nunit.org</projectUrl>
     <repository type="git" url="https://github.com/nunit/nunit"/>
     <icon>icon.png</icon>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Charlie Poole, Rob Prouse</authors>
     <owners>Charlie Poole, Rob Prouse</owners>
-    <license type="file">LICENSE.txt</license>
+    <license type="expression">MIT</license>
     <projectUrl>https://nunit.org</projectUrl>
     <repository type="git" url="https://github.com/nunit/nunit"/>
     <icon>icon.png</icon>


### PR DESCRIPTION
By using license expression it will show up correctly on nuget.org and helps license validators/checkers to know what is the exact license type. Usually you have this in csproj file producing the nuspec, but I checked what kind of file is generated with `<PackageLicenseExpression>MIT</PackageLicenseExpression>`. The package will also still contain the license file.

Currently on [nuget.org](https://www.nuget.org/packages/NUnit):

![image](https://github.com/nunit/nunit/assets/171892/46c668e8-4ba5-4aa8-ada0-9aa0e27f1b9a)

Ideally like for [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json):

![image](https://github.com/nunit/nunit/assets/171892/108de37d-1d1c-471b-9217-c038691884e0)

