### PR TITLE
Add explicit generic type specification to TestCase

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.100",
     "allowPrerelease": false,
-    "rollForward": "disable"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -248,6 +248,11 @@ namespace NUnit.Framework
         public string? ExcludePlatform { get; set; }
 
         /// <summary>
+        /// Comma-delimited list of platforms to run the test for
+        /// </summary>
+        public Type[]? TypeArgs { get; set; } = null;
+
+        /// <summary>
         /// Gets and sets the category for this test case.
         /// May be a comma-separated list of categories.
         /// </summary>
@@ -300,7 +305,10 @@ namespace NUnit.Framework
                 int argsNeeded = parameters.Length;
                 int argsProvided = Arguments.Length;
 
-                parms = new TestCaseParameters(this);
+                parms = new TestCaseParameters(this)
+                {
+                    TypeArgs = TypeArgs
+                };
 
                 // Special handling for ExpectedResult (see if it needs to be converted into method return type)
                 if (parms.HasExpectedResult

--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -248,7 +248,9 @@ namespace NUnit.Framework
         public string? ExcludePlatform { get; set; }
 
         /// <summary>
-        /// Comma-delimited list of platforms to run the test for
+        /// Get or set the type arguments for a generic test method.
+        /// If not set explicitly, the generic types will be inferred
+        /// based on the test case parameters.
         /// </summary>
         public Type[]? TypeArgs { get; set; } = null;
 

--- a/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/NUnitTestCaseBuilder.cs
@@ -219,8 +219,13 @@ namespace NUnit.Framework.Internal.Builders
 
             if (testMethod.Method.IsGenericMethodDefinition)
             {
-                if (arglist is null || !new GenericMethodHelper(testMethod.Method.MethodInfo).TryGetTypeArguments(arglist, out var typeArguments))
+                var typeArguments = parms?.TypeArgs;
+
+                if (typeArguments is null && (
+                    arglist is null || !new GenericMethodHelper(testMethod.Method.MethodInfo).TryGetTypeArguments(arglist, out typeArguments)))
+                {
                     return MarkAsNotRunnable(testMethod, "Unable to determine type arguments for method");
+                }
 
                 testMethod.Method = testMethod.Method.MakeGenericMethod(typeArguments);
                 parameters = testMethod.Method.GetParameters();

--- a/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
@@ -81,6 +81,11 @@ namespace NUnit.Framework.Internal
 
         #endregion
 
-        internal Type[]? TypeArgs { get; set; } = null;
+        /// <summary>
+        /// Get or set the type arguments for a generic test method.
+        /// If not set explicitly, the generic types will be inferred
+        /// based on the test case parameters.
+        /// </summary>
+        public Type[]? TypeArgs { get; set; } = null;
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestCaseParameters.cs
@@ -80,5 +80,7 @@ namespace NUnit.Framework.Internal
         public bool HasExpectedResult { get; set; }
 
         #endregion
+
+        internal Type[]? TypeArgs { get; set; } = null;
     }
 }

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -114,5 +114,10 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         public void MethodWithArrayArguments(object o)
         {
         }
+
+        [TestCase("doesn't work", TypeArgs = new[] { typeof(int) })]
+        public void MethodWithIncompatibleTypeArgs<T>(T input)
+        {
+        }
     }
 }

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -116,7 +116,7 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         }
 
         [TestCase("doesn't work", TypeArgs = new[] { typeof(int) })]
-        public void MethodWithIncompatibleTypeArgs<T>(T input)
+        public static void MethodWithIncompatibleTypeArgs<T>(T input)
         {
         }
     }

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -142,6 +142,11 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
         }
 
+        [TestCaseSource(nameof(IncompatibleGenericTypeAndArgumentTestCases))]
+        public void MethodWithIncompatibleGenericTypeAndArgument(object o)
+        {
+        }
+
         private static IEnumerable ExceptionSource
         {
             get
@@ -188,6 +193,14 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
             foreach (var argumentValue in ComplexArrayBasedTestInput)
                 yield return new TestCaseData(args: new[] { argumentValue });
+        }
+
+        public static IEnumerable<TestCaseData> IncompatibleGenericTypeAndArgumentTestCases()
+        {
+            yield return new TestCaseData("doesn't work")
+            {
+                TypeArgs = new[] { typeof(string) }
+            };
         }
 
         #region Test name tests

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -143,7 +143,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         }
 
         [TestCaseSource(nameof(IncompatibleGenericTypeAndArgumentTestCases))]
-        public void MethodWithIncompatibleGenericTypeAndArgument(object o)
+        public static void MethodWithIncompatibleGenericTypeAndArgument<T>(T o)
         {
         }
 
@@ -199,7 +199,7 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
         {
             yield return new TestCaseData("doesn't work")
             {
-                TypeArgs = new[] { typeof(string) }
+                TypeArgs = new[] { typeof(int) }
             };
         }
 

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -756,21 +756,22 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(typeof(T), Is.EqualTo(typeof(int)));
         }
 
-        [TestCase(2, TypeArgs = new[] { typeof(int) })]
-        public void ExplicitTypeArgsWithUnrelatedParameters<T>(int input)
+        [TestCase("2", TypeArgs = new[] { typeof(long) })]
+        public void ExplicitTypeArgsWithUnrelatedParameters<T>(string input)
         {
-            Assert.That(typeof(T), Is.EqualTo(typeof(int)));
-            Assert.That(input, Is.EqualTo(2));
+            Assert.That(typeof(T), Is.EqualTo(typeof(long)));
+            Assert.That(input, Is.EqualTo("2"));
         }
 
-        [TestCase(2, TypeArgs = new[] { typeof(int) })]
-        public void ExplicitTypeArgsWithCompatibleParameters<T>(T input)
-        {
-            Assert.Pass();
-        }
+        [TestCase(2, TypeArgs = new[] { typeof(long) }, ExpectedResult = typeof(long))]
+        [TestCase(2L, TypeArgs = new[] { typeof(long) }, ExpectedResult = typeof(long))]
+        [TestCase(2, ExpectedResult = typeof(int))]
+        [TestCase(2L, ExpectedResult = typeof(long))]
+        public Type GenericMethodAndParameterWithExplicitOrImplicitTyping<T>(T input)
+            => typeof(T);
 
         [Test]
-        public void ExplicitTypeArgsWithIncompatibleParametersFailsAtRuntime()
+        public void ExplicitTypeArgsWithUnassignableParametersFailsAtRuntime()
         {
             var methodName = nameof(TestCaseAttributeFixture.MethodWithIncompatibleTypeArgs);
             var test = (Test)TestBuilder.MakeParameterizedMethodSuite(
@@ -781,6 +782,16 @@ namespace NUnit.Framework.Tests.Attributes
             var exception = Assert.Throws<NUnitException>(() => test.Method!.Invoke(test.Parent, test.Arguments));
 
             Assert.That(exception.InnerException, Has.Message.EqualTo("Object does not match target type."));
+        }
+
+        [TestCase(2, TypeArgs = new[] { typeof(long) })]
+        public void ExplicitTypeArgsWithGenericConstraintSatisfied<T>(int input)
+            where T : IConvertible
+        {
+            var convertedValue = ((IConvertible)input).ToType(typeof(T), null);
+
+            Assert.That(convertedValue, Is.TypeOf<T>());
+            Assert.That(convertedValue, Is.Not.TypeOf(input.GetType()));
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -773,15 +772,18 @@ namespace NUnit.Framework.Tests.Attributes
         [Test]
         public void ExplicitTypeArgsWithUnassignableParametersFailsAtRuntime()
         {
-            var methodName = nameof(TestCaseAttributeFixture.MethodWithIncompatibleTypeArgs);
-            var test = (Test)TestBuilder.MakeParameterizedMethodSuite(
-                typeof(TestCaseAttributeFixture), methodName).Tests[0];
+            var suite = TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture),
+                nameof(TestCaseAttributeFixture.MethodWithIncompatibleTypeArgs));
+
+            var test = (Test)suite.Tests[0];
 
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
 
-            var exception = Assert.Throws<NUnitException>(() => test.Method!.Invoke(test.Parent, test.Arguments));
+            var result = TestBuilder.RunTest(test);
 
-            Assert.That(exception.InnerException, Has.Message.EqualTo("Object does not match target type."));
+            Assert.That(result.FailCount, Is.EqualTo(1));
+            Assert.That(result.Message, Does.Contain("Object of type 'System.String' cannot be converted to type 'System.Int32'."));
         }
 
         [TestCase(2, TypeArgs = new[] { typeof(long) })]

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -537,7 +537,8 @@ namespace NUnit.Framework.Tests.Attributes
         public void ExplicitTypeArgsWithGenericConstraintSatisfied<T1, T2>(T1 a, T2 b)
             where T1 : IComparer<T2>
         {
-            Assert.Pass();
+            Assert.That(typeof(T1), Is.EqualTo(typeof(IntConverter)));
+            Assert.That(a, Is.TypeOf<DerivedIntConverter>());
         }
 
         public class IntConverter : IComparer<int>

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -525,12 +524,14 @@ namespace NUnit.Framework.Tests.Attributes
                 typeof(TestCaseSourceAttributeFixture),
                 nameof(TestCaseSourceAttributeFixture.MethodWithIncompatibleGenericTypeAndArgument));
 
-            var test = suite.Tests[0];
+            var test = (Test)suite.Tests[0];
 
             Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
-            var exception = Assert.Throws<NUnitException>(() => test.Method!.Invoke(test.Parent, test.Arguments));
 
-            Assert.That(exception.InnerException, Has.Message.EqualTo("Object does not match target type."));
+            var result = TestBuilder.RunTest(test);
+
+            Assert.That(result.FailCount, Is.EqualTo(1));
+            Assert.That(result.Message, Does.Contain("Object of type 'System.String' cannot be converted to type 'System.Int32'."));
         }
 
         [TestCaseSource(nameof(ExplicitTypeArgsWithGenericConstraintSatisfiedTestCases))]


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/1215

Adds support for explicitly specifying a generic type for a test case method. I've chosen to keep it simple and let the runtime itself ensure that cases like this work or not:
```
[TestCase("2", TypeArgs = new[] { typeof(int) })]
public void ExplicitTypeArgsWithIncompatibleParameters<T>(T input)
```

I'd like to hear thoughts on if we wanted to allow the framework to eagerly detect and mark these as `NonRunnable`. My own suggestion is to propose we defer it to another PR