### PR TITLE
Make builds deterministic with ContinuousIntegrationBuild flag

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: ⤵️ Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🛠️ Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
         
@@ -35,13 +35,13 @@ jobs:
       run: dotnet tool run dotnet-cake --target=Package
 
     - name: 💾 Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Package
         path: package
 
     - name: 💾 Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test results (Windows)
         path: test-results
@@ -54,10 +54,10 @@ jobs:
 
     steps:
     - name: ⤵️ Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🛠️ Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
 
@@ -71,7 +71,7 @@ jobs:
       run: dotnet tool run dotnet-cake --target=Test --test-run-name=Linux --configuration=Release
 
     - name: 💾 Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test results (Linux)
         path: test-results
@@ -84,10 +84,10 @@ jobs:
 
     steps:
     - name: ⤵️ Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🛠️ Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
 
@@ -98,7 +98,7 @@ jobs:
       run: dotnet tool run dotnet-cake --target=Test --test-run-name=Linux --configuration=Release
 
     - name: 💾 Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test results (macOS)
         path: test-results

--- a/build.cake
+++ b/build.cake
@@ -116,7 +116,7 @@ DotNetBuildSettings CreateDotNetBuildSettings() =>
         Configuration = configuration,
         NoRestore = true,
         Verbosity = DotNetVerbosity.Minimal,
-        MSBuildSettings = new DotNetMSBuildSettings { Version = packageVersion }
+        MSBuildSettings = new DotNetMSBuildSettings { Version = packageVersion, ContinuousIntegrationBuild = true }
      };
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -116,7 +116,10 @@ DotNetBuildSettings CreateDotNetBuildSettings() =>
         Configuration = configuration,
         NoRestore = true,
         Verbosity = DotNetVerbosity.Minimal,
-        MSBuildSettings = new DotNetMSBuildSettings { Version = packageVersion, ContinuousIntegrationBuild = true }
+        MSBuildSettings = new DotNetMSBuildSettings {
+            Version = packageVersion,
+            ContinuousIntegrationBuild = BuildSystem.GitHubActions.IsRunningOnGitHubActions
+        }
      };
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently [NuGet Package Explorer gives a warning](https://nuget.info/packages/NUnit/4.0.1) about missing compilation flags. This can be fixed by setting [ContinuousIntegrationBuild](https://cakebuild.net/api/Cake.Common.Tools.DotNet.MSBuild/DotNetMSBuildSettings/29A05B4C) to true. Also updated workflow definition to use new version of tasks to get rid of warnings during CI runs.

![image](https://github.com/nunit/nunit/assets/171892/cba57604-799e-4589-90d2-51a66fbd440d)
