### PR TITLE
Add 'main' to CI yaml

### DIFF
--- a/.github/workflows/NUnit.CI.yml
+++ b/.github/workflows/NUnit.CI.yml
@@ -3,6 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
+      - main
       - master
       - release
       - 'v3'


### PR DESCRIPTION
Contributes to https://github.com/nunit/nunit/issues/3981

All the other references for this in the repo are in READMEs or other docs which would make sense to update after renaming: https://github.com/search?q=repo%3Anunit%2Fnunit%20master&type=code

The renaming itself should happen after 4.1 goes out the door