### PR TITLE
WIP: Keep output writer when Timeout on modern .NET

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -119,11 +119,9 @@ namespace NUnit.Framework.Internal.Commands
 
         private Task<TestResult> RunTestOnSeparateThread(TestExecutionContext context)
         {
-            var separateContext = new TestExecutionContext(context)
-            {
-                CurrentResult = context.CurrentTest.MakeTestResult()
-            };
-            return Task.Run(() => innerCommand.Execute(separateContext));
+            var separateContext = new TestExecutionContext(context);
+
+            return Task.Run(() => innerCommand.Execute(context));
         }
 #endif
     }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -305,5 +305,27 @@ namespace NUnit.Framework.Tests.Attributes
         {
             public bool IsAttached { get; set; }
         }
+
+        [TestFixture]
+        public class Context
+        {
+            [Test, Timeout(60_000)]
+            public void Test2()
+            {
+                TestContext.WriteLine("line1");
+                Assert.That(1, Is.EqualTo(0));
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTeardown()
+            {
+                var v = TestExecutionContext.CurrentContext.CurrentTest;
+            }
+        }
     }
 }


### PR DESCRIPTION
Relates to #4598 
Initial POC to try to get output printing when combining `Timeout` with `Teardown`