### PR TITLE
Don't generate output content twice in TestResult.AddToXml

### DIFF
--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -357,10 +357,12 @@ namespace NUnit.Framework.Internal
                     break;
             }
 
-            if (Output.Length > 0)
-                AddOutputElement(thisNode);
+            // allocate output result only once
+            var output = Output;
+            if (output.Length > 0)
+                AddOutputElement(thisNode, output);
 
-            if (AssertionResults.Count > 0)
+            if (_assertionResults.Count > 0)
                 AddAssertionsElement(thisNode);
 
             if (_testAttachments.Count > 0)
@@ -382,12 +384,12 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Gets a count of pending failures (from Multiple Assert)
         /// </summary>
-        public int PendingFailures => AssertionResults.Count(ar => ar.Status == AssertionStatus.Failed);
+        public int PendingFailures => _assertionResults.Count(static ar => ar.Status == AssertionStatus.Failed);
 
         /// <summary>
         /// Gets the worst assertion status (highest enum) in all the assertion results
         /// </summary>
-        public AssertionStatus WorstAssertionStatus => AssertionResults.Aggregate((ar1, ar2) => ar1.Status > ar2.Status ? ar1 : ar2).Status;
+        public AssertionStatus WorstAssertionStatus => _assertionResults.Aggregate(static (ar1, ar2) => ar1.Status > ar2.Status ? ar1 : ar2).Status;
 
         #endregion
 
@@ -443,13 +445,13 @@ namespace NUnit.Framework.Internal
 
             SetResult(result.ResultState, result.Message, result.StackTrace);
 
-            if (AssertionResults.Count > 0 && result.ResultState == ResultState.Error)
+            if (_assertionResults.Count > 0 && result.ResultState == ResultState.Error)
             {
                 // Add pending failures to the legacy result message
                 Message += Environment.NewLine + Environment.NewLine + CreateLegacyFailureMessage();
 
                 // Add to the list of assertion errors, so that newer runners will see it
-                AssertionResults.Add(new AssertionResult(AssertionStatus.Error, result.Message, result.StackTrace));
+                _assertionResults.Add(new AssertionResult(AssertionStatus.Error, result.Message, result.StackTrace));
             }
         }
 
@@ -549,16 +551,16 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public void RecordTestCompletion()
         {
-            switch (AssertionResults.Count)
+            switch (_assertionResults.Count)
             {
                 case 0:
                     SetResult(ResultState.Success);
                     break;
                 case 1:
                     SetResult(
-                        AssertionStatusToResultState(AssertionResults[0].Status),
-                        AssertionResults[0].Message,
-                        AssertionResults[0].StackTrace);
+                        AssertionStatusToResultState(_assertionResults[0].Status),
+                        _assertionResults[0].Message,
+                        _assertionResults[0].StackTrace);
                     break;
                 default:
                     SetResult(
@@ -602,11 +604,11 @@ namespace NUnit.Framework.Internal
         {
             var writer = new StringWriter();
 
-            if (AssertionResults.Count > 1)
+            if (_assertionResults.Count > 1)
                 writer.WriteLine("Multiple failures or warnings in test:");
 
             int counter = 0;
-            foreach (var assertion in AssertionResults)
+            foreach (var assertion in _assertionResults)
                 writer.WriteLine($"  {++counter}) {assertion.Message}");
 
             return writer.ToString();
@@ -634,16 +636,16 @@ namespace NUnit.Framework.Internal
             return failureNode;
         }
 
-        private TNode AddOutputElement(TNode targetNode)
+        private TNode AddOutputElement(TNode targetNode, string output)
         {
-            return targetNode.AddElementWithCDATA("output", Output);
+            return targetNode.AddElementWithCDATA("output", output);
         }
 
         private TNode AddAssertionsElement(TNode targetNode)
         {
             var assertionsNode = targetNode.AddElement("assertions");
 
-            foreach (var assertion in AssertionResults)
+            foreach (var assertion in _assertionResults)
             {
                 TNode assertionNode = assertionsNode.AddElement("assertion");
                 assertionNode.AddAttribute("result", assertion.Status.ToString());


### PR DESCRIPTION
Extract the essential part from #4460 and skipping generating the output twice. Also checking against backing field `_assertionResults` instead of of interface-returning get-property to remove interface dispatch and enumerator boxing.