### PR TITLE
Switch to using macos-14 instead of macos-latest for CI

### DIFF
--- a/.github/workflows/NUnit.CI.yml
+++ b/.github/workflows/NUnit.CI.yml
@@ -8,6 +8,10 @@ on:
       - release
       - 'v3'
   pull_request:
+  
+env:
+  DOTNET_NOLOGO: true                     # Disable the .NET logo
+  DOTNET_CLI_TELEMETRY_OPTOUT: true       # Disable sending .NET CLI telemetry  
 
 jobs:
   build-windows:
@@ -81,7 +85,7 @@ jobs:
 
   build-macos:
     name: MacOS Build
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: ⤵️ Checkout Source
@@ -91,6 +95,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
+        dotnet-version: 6.x
 
     - name: 🛠️ Install dotnet tools
       run: dotnet tool restore


### PR DESCRIPTION
[github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)

[And it's fast ](https://github.com/sebastienros/jint/pull/1769#issuecomment-1918470696)

Needed to install NET 6 SDK specifically as only NET 7 and NET 8 come OOTB. Setting CI friendly values for [DOTNET_NOLOGO](DOTNET_NOLOGO) and [DOTNET_CLI_TELEMETRY_OPTOUT](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_cli_telemetry_optout) (true).

Fixes https://github.com/nunit/nunit/issues/4649
fixes #4381 (hopefully) as MacOS build is now pretty much as fast as Ubuntu build:

![image](https://github.com/nunit/nunit/assets/171892/556bc9f0-d679-4002-9248-739d65f6bb06)
