### PR TITLE
Use obj is Array instead of obj.GetType().IsArray

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ArraysComparer.cs
@@ -11,11 +11,8 @@ namespace NUnit.Framework.Constraints.Comparers
     {
         public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
         {
-            if (!x.GetType().IsArray || !y.GetType().IsArray || equalityComparer.CompareAsCollection)
+            if (x is not Array xArray || y is not Array yArray || equalityComparer.CompareAsCollection)
                 return EqualMethodResult.TypesNotSupported;
-
-            Array xArray = (Array)x;
-            Array yArray = (Array)y;
 
             int rank = xArray.Rank;
 

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -85,7 +85,7 @@ namespace NUnit.Framework.Constraints
 
             AddFormatter(next => val => val is DictionaryEntry de ? FormatKeyValuePair(de.Key, de.Value) : next(val));
 
-            AddFormatter(next => val => val.GetType().IsArray ? FormatArray((Array)val) : next(val));
+            AddFormatter(next => val => val is Array valArray ? FormatArray(valArray) : next(val));
 
             AddFormatter(next => val => TryFormatKeyValuePair(val) ?? next(val));
 


### PR DESCRIPTION
This change has a tiny (but consistent) performance boost, and more importantly improves readability.

This should function exactly the same. [Type.IsArray](https://learn.microsoft.com/en-us/dotnet/api/system.type.isarray#remarks) differs only in edge cases which can never be hit by a `Type` returned by `GetType()` (the `Array` type, interfaces, etc).

<details>
<summary>Benchmark code</summary>

``` csharp

using BenchmarkDotNet.Attributes;

namespace NUnit.Framework;

#pragma warning disable SA1010 // Opening square brackets should be spaced correctly

[MemoryDiagnoser(false)]
public class ArrayEqualsBenchmarks
{
    [Benchmark]
    public void AssertStringsEqual()
    {
        string[] actual = ["one", "two", "three"];
        string[] expected = ["one", "two", "three"];
        Assert.That(actual, Is.EqualTo(expected));
    }

    [Benchmark]
    public void AssertStringsEqualFalse()
    {
        string[] actual = ["one", "two", "three"];
        string[] expected = ["one", "two", "four"];
        Assert.That(actual, Is.Not.EqualTo(expected));
    }

    [Benchmark]
    public void AssertIntsEqual()
    {
        int[] actual = [1, 2, 3];
        int[] expected = [1, 2, 3];
        Assert.That(actual, Is.EqualTo(expected));
    }

    [Benchmark]
    public void AssertIntsEqualFalse()
    {
        int[] actual = [1, 2, 3];
        int[] expected = [1, 2, 4];
        Assert.That(actual, Is.Not.EqualTo(expected));
    }
}

```

</details>

Before:

| Method                  | Mean       | Error    | StdDev   | Allocated |
|------------------------ |-----------:|---------:|---------:|----------:|
| AssertStringsEqual      |   300.4 ns |  4.64 ns |  4.34 ns |     728 B |
| AssertStringsEqualFalse |   604.3 ns | 11.58 ns | 10.83 ns |    1488 B |
| AssertIntsEqual         |   930.9 ns | 12.96 ns | 10.82 ns |    1024 B |
| AssertIntsEqualFalse    | 1,214.0 ns |  9.94 ns |  8.30 ns |    1776 B |

After:
| Method                  | Mean       | Error    | StdDev   | Allocated |
|------------------------ |-----------:|---------:|---------:|----------:|
| AssertStringsEqual      |   294.7 ns |  3.86 ns |  3.61 ns |     728 B |
| AssertStringsEqualFalse |   595.9 ns |  6.70 ns |  5.94 ns |    1488 B |
| AssertIntsEqual         |   915.7 ns | 13.69 ns | 12.81 ns |    1024 B |
| AssertIntsEqualFalse    | 1,193.5 ns |  8.26 ns |  6.90 ns |    1776 B |
