### PR TITLE
Add support for Exceptions for Display Name

### DIFF
--- a/src/NUnitFramework/framework/Internal/DisplayName.cs
+++ b/src/NUnitFramework/framework/Internal/DisplayName.cs
@@ -215,8 +215,31 @@ namespace NUnit.Framework.Internal
                 else if (sb.Equals(sbyte.MinValue))
                     display = "sbyte.MinValue";
             }
+            else if (arg is Exception e)
+            {
+                display = FormatException(e);
+            }
 
             return display;
+        }
+
+        private static string FormatException(Exception ex)
+        {
+            var builder = new StringBuilder();
+
+            for (Exception? e = ex; e is not null; e = e.InnerException)
+            {
+                builder.Append(e.GetType().Name);
+                builder.Append(": ");
+                builder.Append(e.Message);
+
+                if (e.InnerException is not null)
+                {
+                    builder.Append(", ");
+                }
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Issue4659.cs
+++ b/src/NUnitFramework/tests/Issue4659.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Tests
+{
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    internal sealed class Issue4659
+    {
+        [TestCaseSource(nameof(GetSomeExceptionCases))]
+        public void NoMethod_GivenException_ShouldPassTest(Exception testCase) => Assert.That(testCase, Is.Not.InstanceOf<string>());
+
+        private static TestCaseData[] GetSomeExceptionCases() => new[]
+        {
+            new TestCaseData(new ArgumentNullException()),
+            new TestCaseData(new ArgumentNullException("message", new Exception("Some Exception Message"))),
+        };
+    }
+}


### PR DESCRIPTION
Fixes #4659 

There should probably be a more Generic filter in removing characters that VS Test Explorer cannot handle.
