### PR TITLE
Issue3918 white space

### DIFF
--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -33,6 +33,7 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+        <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net6.0" />
     </dependencies>

--- a/src/NUnitFramework/framework/Constraints/AnyOfConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AnyOfConstraint.cs
@@ -71,6 +71,18 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Flag the constraint to ignore white space and return self.
+        /// </summary>
+        public AnyOfConstraint IgnoreWhiteSpace
+        {
+            get
+            {
+                _comparer.IgnoreWhiteSpace = true;
+                return this;
+            }
+        }
+
+        /// <summary>
         /// Flag the constraint to use the supplied IComparer object.
         /// </summary>
         /// <param name="comparer">The IComparer object to use.</param>

--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -41,6 +41,11 @@ namespace NUnit.Framework.Constraints
         protected bool IgnoringCase => _comparer.IgnoreCase;
 
         /// <summary>
+        /// Get a flag indicating whether the user requested us to ignore white space.
+        /// </summary>
+        protected bool IgnoringWhiteSpace => _comparer.IgnoreWhiteSpace;
+
+        /// <summary>
         /// Get a flag indicating whether any external comparers are in use.
         /// </summary>
         protected bool UsingExternalComparer => _comparer.ExternalComparers.Count > 0;
@@ -57,6 +62,18 @@ namespace NUnit.Framework.Constraints
             get
             {
                 _comparer.IgnoreCase = true;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to ignore white space and return self.
+        /// </summary>
+        public CollectionItemsEqualConstraint IgnoreWhiteSpace
+        {
+            get
+            {
+                _comparer.IgnoreWhiteSpace = true;
                 return this;
             }
         }

--- a/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StringsComparer.cs
@@ -17,9 +17,22 @@ namespace NUnit.Framework.Constraints.Comparers
             if (tolerance.HasVariance)
                 return EqualMethodResult.ToleranceNotSupported;
 
-            var stringComparison = equalityComparer.IgnoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
-            return xString.Equals(yString, stringComparison) ?
-                EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
+            return Equals(xString, yString, equalityComparer.IgnoreCase, equalityComparer.IgnoreWhiteSpace) ?
+                EqualMethodResult.ComparedEqual :
+                EqualMethodResult.ComparedNotEqual;
+        }
+
+        public static bool Equals(string x, string y, bool ignoreCase, bool ignoreWhiteSpace)
+        {
+            if (ignoreWhiteSpace)
+            {
+                (int mismatchExpected, int mismatchActual) = MsgUtils.FindMismatchPosition(x, y, ignoreCase, true);
+                return mismatchExpected == -1 && mismatchActual == -1;
+            }
+            else
+            {
+                return x.Equals(y, ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal);
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -104,6 +104,23 @@ namespace NUnit.Framework.Constraints
             return constraint;
         }
 
+        /// <summary>
+        /// Appends a constraint to the expression and returns that
+        /// constraint, which is associated with the current state
+        /// of the expression being built. Note that the constraint
+        /// is not reduced at this time. For example, if there
+        /// is a NotOperator on the stack we don't reduce and
+        /// return a NotConstraint. The original constraint must
+        /// be returned because it may support modifiers that
+        /// are yet to be applied.
+        /// </summary>
+        public T Append<T>(T constraint)
+            where T : Constraint
+        {
+            builder.Append(constraint);
+            return constraint;
+        }
+
         #endregion
 
         #region Not
@@ -300,7 +317,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for null
         /// </summary>
-        public NullConstraint Null => (NullConstraint)Append(new NullConstraint());
+        public NullConstraint Null => Append(new NullConstraint());
 
         #endregion
 
@@ -309,7 +326,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for default value
         /// </summary>
-        public DefaultConstraint Default => (DefaultConstraint)Append(new DefaultConstraint());
+        public DefaultConstraint Default => Append(new DefaultConstraint());
 
         #endregion
 
@@ -318,7 +335,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for True
         /// </summary>
-        public TrueConstraint True => (TrueConstraint)Append(new TrueConstraint());
+        public TrueConstraint True => Append(new TrueConstraint());
 
         #endregion
 
@@ -327,7 +344,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for False
         /// </summary>
-        public FalseConstraint False => (FalseConstraint)Append(new FalseConstraint());
+        public FalseConstraint False => Append(new FalseConstraint());
 
         #endregion
 
@@ -336,7 +353,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for a positive value
         /// </summary>
-        public GreaterThanConstraint Positive => (GreaterThanConstraint)Append(new GreaterThanConstraint(0));
+        public GreaterThanConstraint Positive => Append(new GreaterThanConstraint(0));
 
         #endregion
 
@@ -345,7 +362,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for a negative value
         /// </summary>
-        public LessThanConstraint Negative => (LessThanConstraint)Append(new LessThanConstraint(0));
+        public LessThanConstraint Negative => Append(new LessThanConstraint(0));
 
         #endregion
 
@@ -354,7 +371,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests if item is equal to zero
         /// </summary>
-        public EqualConstraint Zero => (EqualConstraint)Append(new EqualConstraint(0));
+        public EqualConstraint Zero => Append(new EqualConstraint(0));
 
         #endregion
 
@@ -363,7 +380,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for NaN
         /// </summary>
-        public NaNConstraint NaN => (NaNConstraint)Append(new NaNConstraint());
+        public NaNConstraint NaN => Append(new NaNConstraint());
 
         #endregion
 
@@ -372,7 +389,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests for empty
         /// </summary>
-        public EmptyConstraint Empty => (EmptyConstraint)Append(new EmptyConstraint());
+        public EmptyConstraint Empty => Append(new EmptyConstraint());
 
         #endregion
 
@@ -382,14 +399,14 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether a collection
         /// contains all unique items.
         /// </summary>
-        public UniqueItemsConstraint Unique => (UniqueItemsConstraint)Append(new UniqueItemsConstraint());
+        public UniqueItemsConstraint Unique => Append(new UniqueItemsConstraint());
 
         #endregion
 
         /// <summary>
         /// Returns a constraint that tests whether an object graph is serializable in XML format.
         /// </summary>
-        public XmlSerializableConstraint XmlSerializable => (XmlSerializableConstraint)Append(new XmlSerializableConstraint());
+        public XmlSerializableConstraint XmlSerializable => Append(new XmlSerializableConstraint());
 
         #region EqualTo
 
@@ -398,7 +415,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EqualConstraint EqualTo(object? expected)
         {
-            return (EqualConstraint)Append(new EqualConstraint(expected));
+            return Append(new EqualConstraint(expected));
         }
 
         #endregion
@@ -410,7 +427,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SameAsConstraint SameAs(object? expected)
         {
-            return (SameAsConstraint)Append(new SameAsConstraint(expected));
+            return Append(new SameAsConstraint(expected));
         }
 
         #endregion
@@ -423,7 +440,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanConstraint GreaterThan(object expected)
         {
-            return (GreaterThanConstraint)Append(new GreaterThanConstraint(expected));
+            return Append(new GreaterThanConstraint(expected));
         }
 
         #endregion
@@ -436,7 +453,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanOrEqualConstraint GreaterThanOrEqualTo(object expected)
         {
-            return (GreaterThanOrEqualConstraint)Append(new GreaterThanOrEqualConstraint(expected));
+            return Append(new GreaterThanOrEqualConstraint(expected));
         }
 
         /// <summary>
@@ -445,7 +462,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public GreaterThanOrEqualConstraint AtLeast(object expected)
         {
-            return (GreaterThanOrEqualConstraint)Append(new GreaterThanOrEqualConstraint(expected));
+            return Append(new GreaterThanOrEqualConstraint(expected));
         }
 
         #endregion
@@ -458,7 +475,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanConstraint LessThan(object expected)
         {
-            return (LessThanConstraint)Append(new LessThanConstraint(expected));
+            return Append(new LessThanConstraint(expected));
         }
 
         #endregion
@@ -471,7 +488,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanOrEqualConstraint LessThanOrEqualTo(object expected)
         {
-            return (LessThanOrEqualConstraint)Append(new LessThanOrEqualConstraint(expected));
+            return Append(new LessThanOrEqualConstraint(expected));
         }
 
         /// <summary>
@@ -480,7 +497,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public LessThanOrEqualConstraint AtMost(object expected)
         {
-            return (LessThanOrEqualConstraint)Append(new LessThanOrEqualConstraint(expected));
+            return Append(new LessThanOrEqualConstraint(expected));
         }
 
         #endregion
@@ -493,7 +510,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ExactTypeConstraint TypeOf(Type expectedType)
         {
-            return (ExactTypeConstraint)Append(new ExactTypeConstraint(expectedType));
+            return Append(new ExactTypeConstraint(expectedType));
         }
 
         /// <summary>
@@ -502,7 +519,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ExactTypeConstraint TypeOf<TExpected>()
         {
-            return (ExactTypeConstraint)Append(new ExactTypeConstraint(typeof(TExpected)));
+            return Append(new ExactTypeConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -515,7 +532,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public InstanceOfTypeConstraint InstanceOf(Type expectedType)
         {
-            return (InstanceOfTypeConstraint)Append(new InstanceOfTypeConstraint(expectedType));
+            return Append(new InstanceOfTypeConstraint(expectedType));
         }
 
         /// <summary>
@@ -524,7 +541,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public InstanceOfTypeConstraint InstanceOf<TExpected>()
         {
-            return (InstanceOfTypeConstraint)Append(new InstanceOfTypeConstraint(typeof(TExpected)));
+            return Append(new InstanceOfTypeConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -537,7 +554,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableFromConstraint AssignableFrom(Type expectedType)
         {
-            return (AssignableFromConstraint)Append(new AssignableFromConstraint(expectedType));
+            return Append(new AssignableFromConstraint(expectedType));
         }
 
         /// <summary>
@@ -546,7 +563,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableFromConstraint AssignableFrom<TExpected>()
         {
-            return (AssignableFromConstraint)Append(new AssignableFromConstraint(typeof(TExpected)));
+            return Append(new AssignableFromConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -559,7 +576,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableToConstraint AssignableTo(Type expectedType)
         {
-            return (AssignableToConstraint)Append(new AssignableToConstraint(expectedType));
+            return Append(new AssignableToConstraint(expectedType));
         }
 
         /// <summary>
@@ -568,7 +585,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public AssignableToConstraint AssignableTo<TExpected>()
         {
-            return (AssignableToConstraint)Append(new AssignableToConstraint(typeof(TExpected)));
+            return Append(new AssignableToConstraint(typeof(TExpected)));
         }
 
         #endregion
@@ -582,7 +599,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionEquivalentConstraint EquivalentTo(IEnumerable expected)
         {
-            return (CollectionEquivalentConstraint)Append(new CollectionEquivalentConstraint(expected));
+            return Append(new CollectionEquivalentConstraint(expected));
         }
 
         #endregion
@@ -595,7 +612,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionSubsetConstraint SubsetOf(IEnumerable expected)
         {
-            return (CollectionSubsetConstraint)Append(new CollectionSubsetConstraint(expected));
+            return Append(new CollectionSubsetConstraint(expected));
         }
 
         #endregion
@@ -608,7 +625,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public CollectionSupersetConstraint SupersetOf(IEnumerable expected)
         {
-            return (CollectionSupersetConstraint)Append(new CollectionSupersetConstraint(expected));
+            return Append(new CollectionSupersetConstraint(expected));
         }
 
         #endregion
@@ -618,7 +635,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests whether a collection is ordered
         /// </summary>
-        public CollectionOrderedConstraint Ordered => (CollectionOrderedConstraint)Append(new CollectionOrderedConstraint());
+        public CollectionOrderedConstraint Ordered => Append(new CollectionOrderedConstraint());
 
         #endregion
 
@@ -630,7 +647,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SomeItemsConstraint Member(object? expected)
         {
-            return (SomeItemsConstraint)Append(new SomeItemsConstraint(new EqualConstraint(expected)));
+            return Append(new SomeItemsConstraint(new EqualConstraint(expected)));
         }
 
         #endregion
@@ -649,7 +666,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SomeItemsConstraint Contains(object? expected)
         {
-            return (SomeItemsConstraint)Append(new SomeItemsConstraint(new EqualConstraint(expected)));
+            return Append(new SomeItemsConstraint(new EqualConstraint(expected)));
         }
 
         /// <summary>
@@ -665,7 +682,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public ContainsConstraint Contains(string? expected)
         {
-            return (ContainsConstraint)Append(new ContainsConstraint(expected));
+            return Append(new ContainsConstraint(expected));
         }
 
         /// <summary>
@@ -700,7 +717,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The key to be matched in the Dictionary key collection</param>
         public DictionaryContainsKeyConstraint ContainKey(object expected)
         {
-            return (DictionaryContainsKeyConstraint)Append(new DictionaryContainsKeyConstraint(expected));
+            return Append(new DictionaryContainsKeyConstraint(expected));
         }
 
         /// <summary>
@@ -710,7 +727,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">The value to be matched in the Dictionary value collection</param>
         public DictionaryContainsValueConstraint ContainValue(object expected)
         {
-            return (DictionaryContainsValueConstraint)Append(new DictionaryContainsValueConstraint(expected));
+            return Append(new DictionaryContainsValueConstraint(expected));
         }
         #endregion
 
@@ -722,7 +739,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public StartsWithConstraint StartWith(string expected)
         {
-            return (StartsWithConstraint)Append(new StartsWithConstraint(expected));
+            return Append(new StartsWithConstraint(expected));
         }
 
         /// <summary>
@@ -731,7 +748,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public StartsWithConstraint StartsWith(string expected)
         {
-            return (StartsWithConstraint)Append(new StartsWithConstraint(expected));
+            return Append(new StartsWithConstraint(expected));
         }
 
         #endregion
@@ -744,7 +761,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EndsWithConstraint EndWith(string expected)
         {
-            return (EndsWithConstraint)Append(new EndsWithConstraint(expected));
+            return Append(new EndsWithConstraint(expected));
         }
 
         /// <summary>
@@ -753,7 +770,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public EndsWithConstraint EndsWith(string expected)
         {
-            return (EndsWithConstraint)Append(new EndsWithConstraint(expected));
+            return Append(new EndsWithConstraint(expected));
         }
 
         #endregion
@@ -766,7 +783,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Match([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
         {
-            return (RegexConstraint)Append(new RegexConstraint(pattern));
+            return Append(new RegexConstraint(pattern));
         }
 
         /// <summary>
@@ -775,7 +792,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Match(Regex regex)
         {
-            return (RegexConstraint)Append(new RegexConstraint(regex));
+            return Append(new RegexConstraint(regex));
         }
 
         /// <summary>
@@ -784,7 +801,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Matches([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
         {
-            return (RegexConstraint)Append(new RegexConstraint(pattern));
+            return Append(new RegexConstraint(pattern));
         }
 
         /// <summary>
@@ -793,7 +810,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public RegexConstraint Matches(Regex regex)
         {
-            return (RegexConstraint)Append(new RegexConstraint(regex));
+            return Append(new RegexConstraint(regex));
         }
 
         #endregion
@@ -806,7 +823,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SamePathConstraint SamePath(string expected)
         {
-            return (SamePathConstraint)Append(new SamePathConstraint(expected));
+            return Append(new SamePathConstraint(expected));
         }
 
         #endregion
@@ -819,7 +836,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SubPathConstraint SubPathOf(string expected)
         {
-            return (SubPathConstraint)Append(new SubPathConstraint(expected));
+            return Append(new SubPathConstraint(expected));
         }
 
         #endregion
@@ -832,7 +849,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public SamePathOrUnderConstraint SamePathOrUnder(string expected)
         {
-            return (SamePathOrUnderConstraint)Append(new SamePathOrUnderConstraint(expected));
+            return Append(new SamePathOrUnderConstraint(expected));
         }
 
         #endregion
@@ -846,7 +863,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="to">Inclusive end of the range.</param>
         public RangeConstraint InRange(object from, object to)
         {
-            return (RangeConstraint)Append(new RangeConstraint(from, to));
+            return Append(new RangeConstraint(from, to));
         }
 
         #endregion
@@ -874,7 +891,7 @@ namespace NUnit.Framework.Constraints
                 expected = new object?[] { null };
             }
 
-            return (AnyOfConstraint)Append(new AnyOfConstraint(expected));
+            return Append(new AnyOfConstraint(expected));
         }
 
         /// <summary>
@@ -883,7 +900,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="expected">Expected values</param>
         public AnyOfConstraint AnyOf(ICollection expected)
         {
-            return (AnyOfConstraint)Append(new AnyOfConstraint(expected));
+            return Append(new AnyOfConstraint(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -393,6 +393,15 @@ namespace NUnit.Framework.Constraints
 
         #endregion
 
+        #region WhiteSpace
+
+        /// <summary>
+        /// Returns a constraint that tests for white-space
+        /// </summary>
+        public WhiteSpaceConstraint WhiteSpace => Append(new WhiteSpaceConstraint());
+
+        #endregion
+
         #region Unique
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ContainsConstraint.cs
@@ -17,6 +17,7 @@ namespace NUnit.Framework.Constraints
         private readonly object? _expected;
         private Constraint? _realConstraint;
         private bool _ignoreCase;
+        private bool _ignoreWhiteSpace;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContainsConstraint"/> class.
@@ -62,6 +63,18 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Flag the constraint to ignore white-space and return self.
+        /// </summary>
+        public ContainsConstraint IgnoreWhiteSpace
+        {
+            get
+            {
+                _ignoreWhiteSpace = true;
+                return this;
+            }
+        }
+
+        /// <summary>
         /// Test whether the constraint is satisfied by a given value
         /// </summary>
         /// <param name="actual">The value to be tested</param>
@@ -78,6 +91,8 @@ namespace NUnit.Framework.Constraints
                 StringConstraint constraint = new SubstringConstraint(substring);
                 if (_ignoreCase)
                     constraint = constraint.IgnoreCase;
+                if (_ignoreWhiteSpace)
+                    throw new InvalidOperationException("IgnoreWhiteSpace not supported on SubStringConstraint");
                 _realConstraint = constraint;
             }
             else
@@ -85,6 +100,8 @@ namespace NUnit.Framework.Constraints
                 var itemConstraint = new EqualConstraint(_expected);
                 if (_ignoreCase)
                     itemConstraint = itemConstraint.IgnoreCase;
+                if (_ignoreWhiteSpace)
+                    itemConstraint = itemConstraint.IgnoreWhiteSpace;
                 _realConstraint = new SomeItemsConstraint(itemConstraint);
             }
 

--- a/src/NUnitFramework/framework/Constraints/EmptyStringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EmptyStringConstraint.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The value to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             return actual == string.Empty;
         }

--- a/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EndsWithConstraint.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual"></param>
         /// <returns></returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             var stringComparison = caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual is not null && actual.EndsWith(expected, stringComparison);

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -66,6 +66,14 @@ namespace NUnit.Framework.Constraints
         public bool CaseInsensitive => _comparer.IgnoreCase;
 
         /// <summary>
+        /// Gets a value indicating whether to compare ignoring white space.
+        /// </summary>
+        /// <value>
+        ///   <see langword="true"/> if comparing ignoreing white space; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool IgnoringWhiteSpace => _comparer.IgnoreWhiteSpace;
+
+        /// <summary>
         /// Gets a value indicating whether or not to clip strings.
         /// </summary>
         /// <value>
@@ -92,6 +100,18 @@ namespace NUnit.Framework.Constraints
             get
             {
                 _comparer.IgnoreCase = true;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to ignore white space and return self.
+        /// </summary>
+        public EqualConstraint IgnoreWhiteSpace
+        {
+            get
+            {
+                _comparer.IgnoreWhiteSpace = true;
                 return this;
             }
         }
@@ -396,6 +416,9 @@ namespace NUnit.Framework.Constraints
 
                 if (_comparer.IgnoreCase)
                     sb.Append(", ignoring case");
+
+                if (_comparer.IgnoreWhiteSpace)
+                    sb.Append(", ignoring white-space");
 
                 return sb.ToString();
             }

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -16,6 +16,7 @@ namespace NUnit.Framework.Constraints
         private readonly object? _expectedValue;
         private readonly Tolerance _tolerance;
         private readonly bool _caseInsensitive;
+        private readonly bool _ignoringWhiteSpace;
         private readonly bool _clipStrings;
         private readonly IList<NUnitEqualityComparer.FailurePoint> _failurePoints;
 
@@ -49,6 +50,7 @@ namespace NUnit.Framework.Constraints
             _expectedValue = constraint.Arguments[0];
             _tolerance = constraint.Tolerance;
             _caseInsensitive = constraint.CaseInsensitive;
+            _ignoringWhiteSpace = constraint.IgnoringWhiteSpace;
             _clipStrings = constraint.ClipStrings;
             _failurePoints = constraint.FailurePoints;
         }
@@ -82,14 +84,14 @@ namespace NUnit.Framework.Constraints
         #region DisplayStringDifferences
         private void DisplayStringDifferences(MessageWriter writer, string expected, string actual)
         {
-            int mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, _caseInsensitive);
+            (int mismatchExpected, int mismatchActual) = MsgUtils.FindMismatchPosition(expected, actual, _caseInsensitive, _ignoringWhiteSpace);
 
             if (expected.Length == actual.Length)
-                writer.WriteMessageLine(StringsDiffer_1, expected.Length, mismatch);
+                writer.WriteMessageLine(StringsDiffer_1, expected.Length, mismatchExpected);
             else
-                writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatch);
+                writer.WriteMessageLine(StringsDiffer_2, expected.Length, actual.Length, mismatchExpected);
 
-            writer.DisplayStringDifferences(expected, actual, mismatch, _caseInsensitive, _clipStrings);
+            writer.DisplayStringDifferences(expected, actual, mismatchExpected, mismatchActual, _caseInsensitive, _ignoringWhiteSpace, _clipStrings);
         }
         #endregion
 
@@ -162,12 +164,12 @@ namespace NUnit.Framework.Constraints
         {
             if (failurePoint.ExpectedValue is string expectedString && failurePoint.ActualValue is string actualString)
             {
-                int mismatch = MsgUtils.FindMismatchPosition(expectedString, actualString, 0, _caseInsensitive);
+                (int mismatchExpected, int _) = MsgUtils.FindMismatchPosition(expectedString, actualString, _caseInsensitive, _ignoringWhiteSpace);
 
                 if (expectedString.Length == actualString.Length)
-                    writer.WriteMessageLine(StringsDiffer_1, expectedString.Length, mismatch);
+                    writer.WriteMessageLine(StringsDiffer_1, expectedString.Length, mismatchExpected);
                 else
-                    writer.WriteMessageLine(StringsDiffer_2, expectedString.Length, actualString.Length, mismatch);
+                    writer.WriteMessageLine(StringsDiffer_2, expectedString.Length, actualString.Length, mismatchExpected);
                 writer.WriteLine($"  Expected: {MsgUtils.FormatCollection(expected)}");
                 writer.WriteLine($"  But was:  {MsgUtils.FormatCollection(actual)}");
                 writer.WriteLine($"  First non-matching item at index [{failurePoint.Position}]: \"{failurePoint.ExpectedValue}\"");

--- a/src/NUnitFramework/framework/Constraints/MessageWriter.cs
+++ b/src/NUnitFramework/framework/Constraints/MessageWriter.cs
@@ -81,10 +81,12 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="expected">The expected string value</param>
         /// <param name="actual">The actual string value</param>
-        /// <param name="mismatch">The point at which the strings don't match or -1</param>
+        /// <param name="mismatchExpected">The point in <paramref name="expected"/> at which the strings don't match or -1</param>
+        /// <param name="mismatchActual">The point in <paramref name="actual"/> at which the strings don't match or -1</param>
         /// <param name="ignoreCase">If true, case is ignored in locating the point where the strings differ</param>
+        /// <param name="ignoreWhiteSpace">If true, white space is ignored in locating the point where the strings differ</param>
         /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
-        public abstract void DisplayStringDifferences(string expected, string actual, int mismatch, bool ignoreCase, bool clipping);
+        public abstract void DisplayStringDifferences(string expected, string actual, int mismatchExpected, int mismatchActual, bool ignoreCase, bool ignoreWhiteSpace, bool clipping);
 
         /// <summary>
         /// Writes the text for an actual value.

--- a/src/NUnitFramework/framework/Constraints/MessageWriter.cs
+++ b/src/NUnitFramework/framework/Constraints/MessageWriter.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using System.Collections;
+using System;
 
 namespace NUnit.Framework.Constraints
 {
@@ -81,12 +82,32 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="expected">The expected string value</param>
         /// <param name="actual">The actual string value</param>
+        /// <param name="mismatch">The point in <paramref name="expected"/> at which the strings don't match or -1</param>
+        /// <param name="ignoreCase">If true, case is ignored in locating the point where the strings differ</param>
+        /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
+        public abstract void DisplayStringDifferences(string expected, string actual, int mismatch, bool ignoreCase, bool clipping);
+
+        /// <summary>
+        /// Display the expected and actual string values on separate lines.
+        /// If the mismatch parameter is >=0, an additional line is displayed
+        /// line containing a caret that points to the mismatch point.
+        /// </summary>
+        /// <param name="expected">The expected string value</param>
+        /// <param name="actual">The actual string value</param>
         /// <param name="mismatchExpected">The point in <paramref name="expected"/> at which the strings don't match or -1</param>
         /// <param name="mismatchActual">The point in <paramref name="actual"/> at which the strings don't match or -1</param>
         /// <param name="ignoreCase">If true, case is ignored in locating the point where the strings differ</param>
         /// <param name="ignoreWhiteSpace">If true, white space is ignored in locating the point where the strings differ</param>
         /// <param name="clipping">If true, the strings should be clipped to fit the line</param>
-        public abstract void DisplayStringDifferences(string expected, string actual, int mismatchExpected, int mismatchActual, bool ignoreCase, bool ignoreWhiteSpace, bool clipping);
+        public virtual void DisplayStringDifferences(string expected, string actual, int mismatchExpected, int mismatchActual, bool ignoreCase, bool ignoreWhiteSpace, bool clipping)
+        {
+            if (ignoreWhiteSpace && mismatchExpected != mismatchActual)
+            {
+                throw new NotImplementedException("Please override to show difference with 'ignoreWhiteSpace'");
+            }
+
+            DisplayStringDifferences(expected, actual, mismatchExpected, ignoreCase, clipping);
+        }
 
         /// <summary>
         /// Writes the text for an actual value.

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -395,64 +395,83 @@ namespace NUnit.Framework.Constraints
         [return: NotNullIfNotNull("s")]
         public static string? EscapeControlChars(string? s)
         {
-            if (s is not null)
+            int index = 0;
+            return EscapeControlChars(s, ref index);
+        }
+
+        /// <summary>
+        /// Converts any control characters in a string
+        /// to their escaped representation.
+        /// </summary>
+        /// <param name="s">The string to be converted</param>
+        /// <param name="index">The index in the array of a specific spot, which needs to be updated when expanding.</param>
+        /// <returns>The converted string</returns>
+        [return: NotNullIfNotNull("s")]
+        public static string? EscapeControlChars(string? s, ref int index)
+        {
+            if (s is null)
+                return null;
+
+            int originalIndex = index;
+            StringBuilder sb = new(s.Length + 32);
+
+            for (int i = 0; i < s.Length; i++)
             {
-                StringBuilder sb = new StringBuilder();
-
-                foreach (char c in s)
+                char c = s[i];
+                string? escaped = EscapeControlChars(c);
+                if (escaped is null)
                 {
-                    switch (c)
+                    sb.Append(c);
+                }
+                else
+                {
+                    sb.Append(escaped);
+                    if (originalIndex > i)
                     {
-                        //case '\'':
-                        //    sb.Append("\\\'");
-                        //    break;
-                        //case '\"':
-                        //    sb.Append("\\\"");
-                        //    break;
-                        case '\\':
-                            sb.Append("\\\\");
-                            break;
-                        case '\0':
-                            sb.Append("\\0");
-                            break;
-                        case '\a':
-                            sb.Append("\\a");
-                            break;
-                        case '\b':
-                            sb.Append("\\b");
-                            break;
-                        case '\f':
-                            sb.Append("\\f");
-                            break;
-                        case '\n':
-                            sb.Append("\\n");
-                            break;
-                        case '\r':
-                            sb.Append("\\r");
-                            break;
-                        case '\t':
-                            sb.Append("\\t");
-                            break;
-                        case '\v':
-                            sb.Append("\\v");
-                            break;
-
-                        case '\x0085':
-                        case '\x2028':
-                        case '\x2029':
-                            sb.Append($"\\x{(int)c:X4}");
-                            break;
-
-                        default:
-                            sb.Append(c);
-                            break;
+                        index += escaped.Length - 1;
                     }
                 }
-
-                s = sb.ToString();
             }
 
-            return s;
+            return sb.ToString();
+        }
+
+        private static string? EscapeControlChars(char c)
+        {
+            switch (c)
+            {
+                //case '\'':
+                //    return "\\\'";
+                //case '\"':
+                //    return ("\\\"");
+                //    break;
+                case '\\':
+                    return "\\\\";
+                case '\0':
+                    return "\\0";
+                case '\a':
+                    return "\\a";
+                case '\b':
+                    return "\\b";
+                case '\f':
+                    return "\\f";
+                case '\n':
+                    return "\\n";
+                case '\r':
+                    return "\\r";
+                case '\t':
+                    return "\\t";
+                case '\v':
+                    return "\\v";
+
+                case '\x0085':
+                case '\x2028':
+                case '\x2029':
+                    return $"\\x{(int)c:X4}";
+
+                default:
+                    return null;
+            }
         }
 
         /// <summary>
@@ -536,85 +555,147 @@ namespace NUnit.Framework.Constraints
         /// string with ellipses representing the removed parts
         /// </summary>
         /// <param name="s">The string to be clipped</param>
-        /// <param name="maxStringLength">The maximum permitted length of the result string</param>
+        /// <param name="clipLength">The length of the clipped string</param>
         /// <param name="clipStart">The point at which to start clipping</param>
         /// <returns>The clipped string</returns>
-        public static string ClipString(string s, int maxStringLength, int clipStart)
+        public static string ClipString(string s, int clipLength, int clipStart)
         {
-            int clipLength = maxStringLength;
             StringBuilder sb = new StringBuilder();
 
             if (clipStart > 0)
-            {
-                clipLength -= ELLIPSIS.Length;
                 sb.Append(ELLIPSIS);
+
+            int remainingLength = s.Length - clipStart;
+            int count = Math.Min(remainingLength, clipLength);
+            sb.Append(s, clipStart, count);
+
+            if (remainingLength > clipLength)
+                sb.Append(ELLIPSIS);
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Clips the <paramref name="s"/> string if it exceeds <paramref name="maxDisplayLength"/>.
+        /// </summary>
+        /// <remarks>
+        /// The string ensures that the content around <paramref name="mismatchLocation"/> stays visible
+        /// by either clipping from the front or the back or both. The clipped part is replaced with "...".
+        /// </remarks>
+        /// <param name="s">The string to clip</param>
+        /// <param name="length">The assumed length of the string (needed if called for a pair)</param>
+        /// <param name="maxDisplayLength">The maximum length of the display message.</param>
+        /// <param name="mismatchLocation">The location in <paramref name="s"/> that needs to stay visible.</param>
+        /// <returns>Clip string with a maximum length of <paramref name="maxDisplayLength"/>.</returns>
+        public static string ClipWhenNeeded(string s, int length, int maxDisplayLength, ref int mismatchLocation)
+        {
+            if (length <= maxDisplayLength)
+            {
+                // No need to clip
+                return s;
             }
 
-            if (s.Length - clipStart > clipLength)
+            // We need to clip at least one side.
+            maxDisplayLength -= ELLIPSIS.Length;
+
+            const int minimumJoiningMatchingCharacters = 5;
+
+            int clipStart;
+
+            if (mismatchLocation + minimumJoiningMatchingCharacters < maxDisplayLength)
             {
-                clipLength -= ELLIPSIS.Length;
-                sb.Append(s.Substring(clipStart, clipLength));
-                sb.Append(ELLIPSIS);
+                // Clip the tail
+                clipStart = 0;
             }
-            else if (clipStart > 0)
+            else if (length - mismatchLocation + minimumJoiningMatchingCharacters < maxDisplayLength)
             {
-                sb.Append(s.Substring(clipStart));
+                // Show the tail
+                clipStart = length - maxDisplayLength;
             }
             else
             {
-                sb.Append(s);
+                // We need to clip both sides.
+                maxDisplayLength -= ELLIPSIS.Length;
+
+                // Centre the clip around the mismatchLocation
+                clipStart = mismatchLocation - maxDisplayLength / 2;
             }
 
-            return sb.ToString();
+            if (clipStart > 0)
+            {
+                // If clipping off the front, adjust the location
+                // and correct for the ... added to the front.
+                mismatchLocation -= clipStart - ELLIPSIS.Length;
+            }
+
+            return ClipString(s, maxDisplayLength, clipStart);
         }
 
         /// <summary>
         /// Clip the expected and actual strings in a coordinated fashion,
         /// so that they may be displayed together.
         /// </summary>
-        /// <param name="expected"></param>
-        /// <param name="actual"></param>
-        /// <param name="maxDisplayLength"></param>
-        /// <param name="mismatch"></param>
-        public static void ClipExpectedAndActual(ref string expected, ref string actual, int maxDisplayLength, int mismatch)
+        /// <remarks>
+        /// The values of <paramref name="mismatchExpected"/> and <paramref name="mismatchActual"/>
+        /// are assumed to be the same. If <paramref name="expected"/> and <paramref name="actual"/>
+        /// are not linked, then call <see cref="ClipWhenNeeded"/> individually.
+        /// </remarks>
+        /// <param name="expected">The expected string to clip</param>
+        /// <param name="actual">The actual string to clip</param>
+        /// <param name="maxDisplayLength">The maximum length of the display message.</param>
+        /// <param name="mismatchExpected">The location in <paramref name="expected"/> that needs to stay visible.</param>
+        /// <param name="mismatchActual">The location in <paramref name="actual"/> that needs to stay visible.</param>
+        public static void ClipExpectedAndActual(ref string expected, ref string actual, int maxDisplayLength, ref int mismatchExpected, ref int mismatchActual)
         {
-            // Case 1: Both strings fit on line
-            int maxStringLength = Math.Max(expected.Length, actual.Length);
-            if (maxStringLength <= maxDisplayLength)
+            if (mismatchExpected != mismatchActual)
+            {
+                throw new ArgumentException($"The values for {nameof(mismatchExpected)} and {nameof(mismatchActual)} should be the same.");
+            }
+
+            // Clip based upon longest length
+            int longestLength = Math.Max(expected.Length, actual.Length);
+            if (longestLength <= maxDisplayLength)
                 return;
 
-            // Case 2: Assume that the tail of each string fits on line
-            int clipLength = maxDisplayLength - ELLIPSIS.Length;
-            int clipStart = maxStringLength - clipLength;
-
-            // Case 3: If it doesn't, center the mismatch position
-            if (clipStart > mismatch)
-                clipStart = Math.Max(0, mismatch - clipLength / 2);
-
-            expected = ClipString(expected, maxDisplayLength, clipStart);
-            actual = ClipString(actual, maxDisplayLength, clipStart);
+            expected = ClipWhenNeeded(expected, longestLength, maxDisplayLength, ref mismatchExpected);
+            actual = ClipWhenNeeded(actual, longestLength, maxDisplayLength, ref mismatchActual);
         }
 
         /// <summary>
-        /// Shows the position two strings start to differ.  Comparison
-        /// starts at the start index.
+        /// Finds the position two strings start to differ.
         /// </summary>
         /// <param name="expected">The expected string</param>
         /// <param name="actual">The actual string</param>
-        /// <param name="istart">The index in the strings at which comparison should start</param>
         /// <param name="ignoreCase">Boolean indicating whether case should be ignored</param>
-        /// <returns>-1 if no mismatch found, or the index where mismatch found</returns>
-        public static int FindMismatchPosition(string expected, string actual, int istart, bool ignoreCase)
+        /// <param name="ignoreWhiteSpace">Boolean indicating whether white space should be ignored</param>
+        /// <returns>(-1,-1) if no mismatch found, or the indices (expected, actual) where mismatches found.</returns>
+        public static (int, int) FindMismatchPosition(string expected, string actual, bool ignoreCase, bool ignoreWhiteSpace)
         {
-            int length = Math.Min(expected.Length, actual.Length);
-
             string s1 = ignoreCase ? expected.ToLower() : expected;
             string s2 = ignoreCase ? actual.ToLower() : actual;
+            int i1 = 0;
+            int i2 = 0;
 
-            for (int i = istart; i < length; i++)
+            while (true)
             {
-                if (s1[i] != s2[i])
-                    return i;
+                if (ignoreWhiteSpace)
+                {
+                    // Find next non-white space character in both s1 and s2.
+                    i1 = FindNonWhiteSpace(s1, i1);
+                    i2 = FindNonWhiteSpace(s2, i2);
+                }
+
+                if (i1 < s1.Length && i2 < s2.Length)
+                {
+                    if (s1[i1] != s2[i2])
+                        return (i1, i2);
+                    i1++;
+                    i2++;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             //
@@ -622,13 +703,21 @@ namespace NUnit.Framework.Constraints
             // Mismatch occurs because string lengths are different, so show
             // that they start differing where the shortest string ends
             //
-            if (expected.Length != actual.Length)
-                return length;
+            if (i1 < s1.Length || i2 < s2.Length)
+                return (i1, i2);
 
             //
             // Same strings : We shouldn't get here
             //
-            return -1;
+            return (-1, -1);
+        }
+
+        private static int FindNonWhiteSpace(string s, int i)
+        {
+            while (i < s.Length && char.IsWhiteSpace(s[i]))
+                i++;
+
+            return i;
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -413,7 +413,8 @@ namespace NUnit.Framework.Constraints
                 return null;
 
             int originalIndex = index;
-            StringBuilder sb = new(s.Length + 32);
+            const int headRoom = 42;
+            StringBuilder sb = new(s.Length + headRoom);
 
             for (int i = 0; i < s.Length; i++)
             {
@@ -485,7 +486,8 @@ namespace NUnit.Framework.Constraints
         {
             if (s is not null)
             {
-                StringBuilder sb = new StringBuilder(s.Length + 32);
+                const int headRoom = 42;
+                StringBuilder sb = new(s.Length + headRoom);
 
                 foreach (char c in s)
                 {

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -485,7 +485,7 @@ namespace NUnit.Framework.Constraints
         {
             if (s is not null)
             {
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(s.Length + 32);
 
                 foreach (char c in s)
                 {
@@ -560,7 +560,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>The clipped string</returns>
         public static string ClipString(string s, int clipLength, int clipStart)
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(s.Length + 2 * ELLIPSIS.Length);
 
             if (clipStart > 0)
                 sb.Append(ELLIPSIS);

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -59,6 +59,11 @@ namespace NUnit.Framework.Constraints
         private bool _caseInsensitive;
 
         /// <summary>
+        /// If true, all string comparisons will ignore white space differences
+        /// </summary>
+        private bool _ignoreWhiteSpace;
+
+        /// <summary>
         /// If true, arrays will be treated as collections, allowing
         /// those of different dimensions to be compared
         /// </summary>
@@ -99,6 +104,16 @@ namespace NUnit.Framework.Constraints
         {
             get => _caseInsensitive;
             set => _caseInsensitive = value;
+        }
+
+        /// <summary>
+        /// Gets and sets a flag indicating whether white space should
+        /// be ignored in determining equality.
+        /// </summary>
+        public bool IgnoreWhiteSpace
+        {
+            get => _ignoreWhiteSpace;
+            set => _ignoreWhiteSpace = value;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathConstraint.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The value to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             return actual is not null && StringUtil.StringsEqual(Canonicalize(expected), Canonicalize(actual), caseInsensitive);
         }

--- a/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SamePathOrUnderConstraint.cs
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The value to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             if (actual is null)
                 return false;

--- a/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StartsWithConstraint.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual"></param>
         /// <returns></returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             var stringComparison = caseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
             return actual is not null && actual.StartsWith(expected, stringComparison);

--- a/src/NUnitFramework/framework/Constraints/StringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/StringConstraint.cs
@@ -100,6 +100,6 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The string to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected abstract bool Matches(string actual);
+        protected abstract bool Matches(string? actual);
     }
 }

--- a/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubPathConstraint.cs
@@ -26,7 +26,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The value to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             return actual is not null && IsSubPath(Canonicalize(expected), Canonicalize(actual));
         }

--- a/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SubstringConstraint.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="actual">The value to be tested</param>
         /// <returns>True for success, false for failure</returns>
-        protected override bool Matches(string actual)
+        protected override bool Matches(string? actual)
         {
             if (actual is null)
                 return false;

--- a/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/UniqueItemsConstraint.cs
@@ -5,6 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework.Constraints.Comparers;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -100,10 +102,10 @@ namespace NUnit.Framework.Constraints
                 {
                     var itemsOfT = ItemsCastMethod.MakeGenericMethod(itemsType).Invoke(null, new[] { actual })!;
 
-                    if (IgnoringCase)
+                    if (IgnoringCase || IgnoringWhiteSpace)
                     {
                         if (itemsType == typeof(string))
-                            return (ICollection)StringsUniqueIgnoringCase((IEnumerable<string>)itemsOfT);
+                            return (ICollection)StringsUniqueIgnoringCaseOrWhiteSpace((IEnumerable<string>)itemsOfT);
                         else if (itemsType == typeof(char))
                             return (ICollection)CharsUniqueIgnoringCase((IEnumerable<char>)itemsOfT);
                     }
@@ -156,11 +158,11 @@ namespace NUnit.Framework.Constraints
             else if (!IsTypeSafeForFastPath(memberType))
                 return OriginalAlgorithm(actual);
 
-            // Special handling for ignore case with strings and chars
-            if (IgnoringCase)
+            // Special handling for ignore case/white-space with strings and chars
+            if (IgnoringCase || IgnoringWhiteSpace)
             {
                 if (memberType == typeof(string))
-                    return (ICollection)StringsUniqueIgnoringCase((IEnumerable<string>)actual);
+                    return (ICollection)StringsUniqueIgnoringCaseOrWhiteSpace((IEnumerable<string>)actual);
                 else if (memberType == typeof(char))
                     return (ICollection)CharsUniqueIgnoringCase((IEnumerable<char>)actual);
             }
@@ -182,14 +184,14 @@ namespace NUnit.Framework.Constraints
         private static ICollection<T> ItemsUnique<T>(IEnumerable<T> actual)
             => NonUniqueItemsInternal(actual, EqualityComparer<T>.Default);
 
-        private ICollection<string> StringsUniqueIgnoringCase(IEnumerable<string> actual)
-            => NonUniqueItemsInternal(actual, new NUnitStringEqualityComparer(IgnoringCase));
+        private ICollection<string> StringsUniqueIgnoringCaseOrWhiteSpace(IEnumerable<string> actual)
+            => NonUniqueItemsInternal(actual, new NUnitStringEqualityComparer(IgnoringCase, IgnoringWhiteSpace));
 
         private ICollection<char> CharsUniqueIgnoringCase(IEnumerable<char> actual)
         {
             var result = NonUniqueItemsInternal(
                 actual.Select(x => x.ToString()),
-                new NUnitStringEqualityComparer(IgnoringCase));
+                new NUnitStringEqualityComparer(IgnoringCase, false));
             return result.Select(x => x[0]).ToList();
         }
 
@@ -247,27 +249,40 @@ namespace NUnit.Framework.Constraints
 
         private sealed class NUnitStringEqualityComparer : IEqualityComparer<string>
         {
-            private readonly bool _ignoreCase;
+            private static readonly Regex WhiteSpace = new(@"\s+", RegexOptions.Compiled);
 
-            public NUnitStringEqualityComparer(bool ignoreCase)
+            private readonly bool _ignoreCase;
+            private readonly bool _ignoreWhiteSpace;
+
+            public NUnitStringEqualityComparer(bool ignoreCase, bool ignoreWhiteSpace)
             {
                 _ignoreCase = ignoreCase;
+                _ignoreWhiteSpace = ignoreWhiteSpace;
             }
 
             public bool Equals(string? x, string? y)
             {
-                var stringComparison = _ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.Ordinal;
-                return string.Equals(x, y, stringComparison);
+                return x is not null && y is not null ?
+                    StringsComparer.Equals(x, y, _ignoreCase, _ignoreWhiteSpace) :
+                    ReferenceEquals(x, y);
             }
 
             public int GetHashCode(string obj)
             {
-                if (obj is null)
+                if (obj is not string s)
+                {
                     return 0;
-                else if (_ignoreCase)
-                    return StringComparer.CurrentCultureIgnoreCase.GetHashCode(obj);
+                }
+
+                if (_ignoreWhiteSpace)
+                {
+                    s = WhiteSpace.Replace(s, string.Empty);
+                }
+
+                if (_ignoreCase)
+                    return StringComparer.CurrentCultureIgnoreCase.GetHashCode(s);
                 else
-                    return obj.GetHashCode();
+                    return s.GetHashCode();
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/WhiteSpaceConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/WhiteSpaceConstraint.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// WhiteSpaceConstraint tests whether a string contains white space.
+    /// </summary>
+    public class WhiteSpaceConstraint : StringConstraint
+    {
+        private const string WhiteSpace = "white-space";
+
+        /// <inheritdoc/>
+        public override string Description => WhiteSpace;
+
+        /// <inheritdoc/>
+        public override string DisplayName => WhiteSpace;
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        protected override bool Matches(string? actual)
+        {
+            return string.IsNullOrWhiteSpace(actual);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -165,6 +165,12 @@ namespace NUnit.Framework.Internal
         }
 
         /// <inheritdoc/>
+        public override void DisplayStringDifferences(string expected, string actual, int mismatch, bool ignoreCase, bool clipping)
+        {
+            DisplayStringDifferences(expected, actual, mismatch, mismatch, ignoreCase, false, clipping);
+        }
+
+        /// <inheritdoc/>
         public override void DisplayStringDifferences(string expected, string actual, int mismatchExpected, int mismatchActual, bool ignoreCase, bool ignoreWhiteSpace, bool clipping)
         {
             // Maximum string we can display without truncating
@@ -198,7 +204,6 @@ namespace NUnit.Framework.Internal
             if (mismatchExpected >= 0 && mismatchExpected != mismatchActual)
                 WriteCaretLine(mismatchExpected);
             WriteActualLine(actual);
-            //DisplayDifferences(expected, actual);
             if (mismatchActual >= 0)
                 WriteCaretLine(mismatchActual);
         }

--- a/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TextMessageWriter.cs
@@ -164,17 +164,8 @@ namespace NUnit.Framework.Internal
             }
         }
 
-        /// <summary>
-        /// Display the expected and actual string values on separate lines.
-        /// If the mismatch parameter is >=0, an additional line is displayed
-        /// line containing a caret that points to the mismatch point.
-        /// </summary>
-        /// <param name="expected">The expected string value</param>
-        /// <param name="actual">The actual string value</param>
-        /// <param name="mismatch">The point at which the strings don't match or -1</param>
-        /// <param name="ignoreCase">If true, case is ignored in string comparisons</param>
-        /// <param name="clipping">If true, clip the strings to fit the max line length</param>
-        public override void DisplayStringDifferences(string expected, string actual, int mismatch, bool ignoreCase, bool clipping)
+        /// <inheritdoc/>
+        public override void DisplayStringDifferences(string expected, string actual, int mismatchExpected, int mismatchActual, bool ignoreCase, bool ignoreWhiteSpace, bool clipping)
         {
             // Maximum string we can display without truncating
             int maxDisplayLength = MaxLineLength
@@ -182,23 +173,34 @@ namespace NUnit.Framework.Internal
                 - 2;           // 2 quotation marks
 
             if (clipping)
-                MsgUtils.ClipExpectedAndActual(ref expected, ref actual, maxDisplayLength, mismatch);
+            {
+                if (ignoreWhiteSpace)
+                {
+                    expected = MsgUtils.ClipWhenNeeded(expected, expected.Length, maxDisplayLength, ref mismatchExpected);
+                    actual = MsgUtils.ClipWhenNeeded(actual, actual.Length, maxDisplayLength, ref mismatchActual);
+                }
+                else
+                {
+                    MsgUtils.ClipExpectedAndActual(ref expected, ref actual, maxDisplayLength, ref mismatchExpected, ref mismatchActual);
+                }
+            }
 
-            expected = MsgUtils.EscapeControlChars(expected);
-            actual = MsgUtils.EscapeControlChars(actual);
-
-            // The mismatch position may have changed due to clipping or white space conversion
-            mismatch = MsgUtils.FindMismatchPosition(expected, actual, 0, ignoreCase);
+            expected = MsgUtils.EscapeControlChars(expected, ref mismatchExpected);
+            actual = MsgUtils.EscapeControlChars(actual, ref mismatchActual);
 
             Write(Pfx_Expected);
             Write(MsgUtils.FormatValue(expected));
             if (ignoreCase)
                 Write(", ignoring case");
+            if (ignoreWhiteSpace)
+                Write(", ignoring white-space");
             WriteLine();
+            if (mismatchExpected >= 0 && mismatchExpected != mismatchActual)
+                WriteCaretLine(mismatchExpected);
             WriteActualLine(actual);
             //DisplayDifferences(expected, actual);
-            if (mismatch >= 0)
-                WriteCaretLine(mismatch);
+            if (mismatchActual >= 0)
+                WriteCaretLine(mismatchActual);
         }
         #endregion
 

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -115,6 +115,15 @@ namespace NUnit.Framework
 
         #endregion
 
+        #region WhiteSpace
+
+        /// <summary>
+        /// Returns a constraint that tests for white-space
+        /// </summary>
+        public static WhiteSpaceConstraint WhiteSpace => new();
+
+        #endregion
+
         #region Unique
 
         /// <summary>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
@@ -31,6 +31,20 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void ItemIsPresent_IgnoreWhiteSpace()
+        {
+            var anyOf = new AnyOfConstraint(new[] { "a", "B", "a b" }).IgnoreWhiteSpace;
+            Assert.That(anyOf.ApplyTo("ab").Status, Is.EqualTo(ConstraintStatus.Success));
+        }
+
+        [Test]
+        public void ItemIsPresent_IgnoreCaseWhiteSpace()
+        {
+            var anyOf = new AnyOfConstraint(new[] { "a", "B", "ab" }).IgnoreCase.IgnoreWhiteSpace;
+            Assert.That(anyOf.ApplyTo("A B").Status, Is.EqualTo(ConstraintStatus.Success));
+        }
+
+        [Test]
         public void ItemIsPresent_WithEqualityComparer()
         {
             Func<string, string, bool> comparer = (expected, actual) => actual.Contains(expected);

--- a/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEqualsTests.cs
@@ -95,6 +95,17 @@ namespace NUnit.Framework.Tests.Constraints
             new object[] { new List<string> { "a", "b", "c" }, new List<string> { "A", "B", "C" } },
         };
 
+        [TestCaseSource(nameof(IgnoreWhiteSpaceData))]
+        public void HonorsIgnoreWhiteSpace(IEnumerable expected, IEnumerable actual)
+        {
+            Assert.That(expected, Is.EqualTo(actual).IgnoreWhiteSpace);
+        }
+
+        private static readonly object[] IgnoreWhiteSpaceData =
+        {
+            new object[] { new SimpleObjectCollection(" x", "y ", " z "), new SimpleObjectCollection("x ", " y", "z") },
+        };
+
         [Test]
         [DefaultFloatingPointTolerance(0.5)]
         public void StructuralComparerOnSameCollection_RespectsAndSetsToleranceByRef()

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -102,6 +102,15 @@ public class CollectionEquivalentConstraintTests
     }
 
     [Test]
+    public void EquivalentHonorsIgnoreWhiteSpace()
+    {
+        ICollection set1 = new SimpleObjectCollection("abc", "def", "ghi");
+        ICollection set2 = new SimpleObjectCollection("g h i", "d e f", "a b c");
+
+        Assert.That(new CollectionEquivalentConstraint(set1).IgnoreWhiteSpace.ApplyTo(set2).IsSuccess);
+    }
+
+    [Test]
     [TestCaseSource(typeof(IgnoreCaseDataProvider), nameof(IgnoreCaseDataProvider.TestCases))]
     public void HonorsIgnoreCase(IEnumerable expected, IEnumerable actual)
     {

--- a/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintExpressionTests.cs
@@ -89,6 +89,14 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void ConstraintExpressionAnyOfTypeIgnoreWhiteSpace()
+        {
+            var constraintExpression = new ConstraintExpression();
+            var constraint = constraintExpression.AnyOf(new string[] { "RED", "GREEN" }).IgnoreWhiteSpace;
+            Assert.That(" R E D ", constraint);
+        }
+
+        [Test]
         public void ConstraintExpressionAnyOfList()
         {
             var constraintExpression = new ConstraintExpression();

--- a/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ContainsConstraintTests.cs
@@ -21,6 +21,26 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(result.IsSuccess);
         }
 
+        [Test]
+        public void HonorsIgnoreWhiteSpaceForStringCollection()
+        {
+            var actualItems = new[] { "ABC", "d e f" };
+            var constraint = new ContainsConstraint("def").IgnoreWhiteSpace;
+
+            var result = constraint.ApplyTo(actualItems);
+            Assert.That(result.IsSuccess);
+        }
+
+        [Test]
+        public void HonorsIgnoreWhiteSpaceForStringCollectionSearchItem()
+        {
+            var actualItems = new[] { "ABC", "d e f" };
+            var constraint = new ContainsConstraint("A B C").IgnoreWhiteSpace;
+
+            var result = constraint.ApplyTo(actualItems);
+            Assert.That(result.IsSuccess);
+        }
+
         [Test, SetCulture("en-US")]
         public void HonorsIgnoreCaseForString()
         {

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -79,6 +79,14 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("HI", "UNIVERSE").IgnoreCase);
         }
 
+        [Test]
+        public void IgnoreWhiteSpaceIsHonored()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi ", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", " U n i v e r s e").IgnoreWhiteSpace);
+        }
+
         [Test, SetCulture("en-US")]
         public void UsingIsHonored()
         {

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -69,6 +69,14 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(dictionary, new DictionaryContainsValueConstraint("UNIVERSE").IgnoreCase);
         }
 
+        [Test]
+        public void IgnoreWhiteSpaceIsHonored()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+
+            Assert.That(dictionary, new DictionaryContainsValueConstraint("U n i v e r s e").IgnoreWhiteSpace);
+        }
+
         [Test, SetCulture("en-US")]
         public void UsingIsHonored()
         {

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -66,6 +66,59 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void IgnoreWhiteSpace()
+        {
+            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace;
+
+            var result = constraint.ApplyTo("Hello\tWorld");
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public void ExtendedIgnoreWhiteSpaceExample()
+        {
+            const string prettyJson = """
+                "persons":[
+                  {
+                    "name": "John",
+                    "surname": "Smith"
+                  },
+                  {
+                    "name": "Jane",
+                    "surname": Doe"
+                  }
+                ]
+                """;
+            const string condensedJson = """
+                "persons":[{"name":"John","surname":"Smith"},{"name": "Jane","surname": Doe"}]
+                """;
+
+            Assert.That(condensedJson, Is.Not.EqualTo(prettyJson));
+            Assert.That(condensedJson, Is.EqualTo(prettyJson).IgnoreWhiteSpace);
+        }
+
+        [Test]
+        public void IgnoreWhiteSpaceFail()
+        {
+            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace;
+
+            var result = constraint.ApplyTo("Hello Universe");
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void IgnoreWhiteSpaceAndIgnoreCase()
+        {
+            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace.IgnoreCase;
+
+            var result = constraint.ApplyTo("hello\r\nworld\r\n");
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [Test]
         public void Bug524CharIntWithoutOverload()
         {
             char c = '\u0000';

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -86,12 +86,12 @@ namespace NUnit.Framework.Tests.Constraints
                   },
                   {
                     "name": "Jane",
-                    "surname": Doe"
+                    "surname": "Doe"
                   }
                 ]
                 """;
             const string condensedJson = """
-                "persons":[{"name":"John","surname":"Smith"},{"name": "Jane","surname": Doe"}]
+                "persons":[{"name":"John","surname":"Smith"},{"name": "Jane","surname": "Doe"}]
                 """;
 
             Assert.That(condensedJson, Is.Not.EqualTo(prettyJson));

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -45,11 +45,26 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(result.IsSuccess, Is.False, $"{actual} should not be unique ignoring case");
         }
 
+        [TestCaseSource(nameof(IgnoreWhiteSpaceData))]
+        public void HonorsIgnoreWhiteSpace(IEnumerable actual)
+        {
+            var constraint = new UniqueItemsConstraint().IgnoreWhiteSpace;
+            var result = constraint.ApplyTo(actual);
+
+            Assert.That(result.IsSuccess, Is.False, $"{actual} should not be unique ignoring white-space");
+        }
+
         private static readonly object[] IgnoreCaseData =
         {
             new object[] { new SimpleObjectCollection("x", "y", "z", "Z") },
             new object[] { new[] { 'A', 'B', 'C', 'c' } },
             new object[] { new[] { "a", "b", "c", "C" } }
+        };
+
+        private static readonly object[] IgnoreWhiteSpaceData =
+        {
+            new object[] { new SimpleObjectCollection("x", "y", "z", " z ") },
+            new object[] { new[] { "a", "b", "c", " c " } }
         };
 
         private static readonly object[] DuplicateItemsData =

--- a/src/NUnitFramework/tests/Constraints/WhiteSpaceContraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/WhiteSpaceContraintTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Tests.Constraints
+{
+    [TestFixture]
+    public class WhiteSpaceContraintTests : StringConstraintTests
+    {
+        protected override Constraint TheConstraint { get; } = new WhiteSpaceConstraint();
+
+        [SetUp]
+        public void SetUp()
+        {
+            ExpectedDescription = "white-space";
+            StringRepresentation = "<white-space>";
+        }
+
+        private static readonly object[] SuccessData = new object[]
+        {
+            string.Empty,
+            " ",
+            "\f",
+            "\n",
+            "\r",
+            "\t",
+            "\v",
+        };
+        private static readonly object[] FailureData = new object[]
+        {
+            new TestCaseData("Hello", "\"Hello\""),
+            new TestCaseData("Hello World", "\"Hello World\""),
+        };
+
+        [TestCaseSource(nameof(SuccessData))]
+        public void TestIsWhiteSpace(string text)
+        {
+            Assert.That(text, Is.WhiteSpace);
+        }
+
+        [TestCaseSource(nameof(FailureData))]
+        public void TestIsNotWhiteSpace(string text, string message)
+        {
+            Assert.That(text, Is.Not.WhiteSpace, message);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
+++ b/src/NUnitFramework/tests/Internal/TextMessageWriterTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Tests.Internal
             string s72 = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             string exp = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXY...";
 
-            _writer.DisplayStringDifferences(s72, "abcde", 5, false, true);
+            _writer.DisplayStringDifferences(s72, "abcde", 5, 5, false, false, true);
             string message = _writer.ToString();
             Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(exp) + NL +
@@ -44,12 +44,28 @@ namespace NUnit.Framework.Tests.Internal
         {
             string s72 = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
-            _writer.DisplayStringDifferences(s72, "abcde", 5, false, false);
+            _writer.DisplayStringDifferences(s72, "abcde", 5, 5, false, false, false);
             string message = _writer.ToString();
             Assert.That(message, Is.EqualTo(
                 TextMessageWriter.Pfx_Expected + Q(s72) + NL +
                 TextMessageWriter.Pfx_Actual + Q("abcde") + NL +
                 "  ----------------^" + NL));
+        }
+
+        [Test]
+        public void DisplayStringDifferences_IgnoreWhiteSpace()
+        {
+            string expected = "abc def";
+            string actual = "a b c d e g";
+
+            _writer.DisplayStringDifferences(expected, actual, 6, 10, false, true, false);
+            string message = _writer.ToString();
+            string expectedMessage =
+                TextMessageWriter.Pfx_Expected + Q(expected) + ", ignoring white-space" + NL +
+                "  -----------------^" + NL +
+                TextMessageWriter.Pfx_Actual + Q(actual) + NL +
+                "  ---------------------^" + NL;
+            Assert.That(message, Is.EqualTo(expectedMessage));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #3918 

Adds preparation work for #4662 

There are two new constraints:

One to match String.IsNullOrWhiteSpace . This I modeled on 'Empty':

```csharp
Assert.That(<s>, Is.WhiteSpace)
Assert.That(<s>, Is.Not.WhiteSpace)
```

The other is a modifier on existing constrains, which I modeled on `IgnoreCase`:

```csharp
Assert.That("Hello World"), Is.EqualTo("HelloWorld").IgnoreWhiteSpace)
```

Adding the constraint was easy, to get sensible error messages in case of failure where strings have different white space was harder. In case of mis-matched white-space, the message now contains two carrots, one for `expected` and one for `actual`:

```
Expected: "abc def", ignoring white-space
-----------------^
But was:  "a b c d e g"
---------------------^
```
