### PR TITLE
Add Prefix in TestContext.AddTestAttachment for long file paths

### DIFF
--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -371,7 +371,7 @@ namespace NUnit.Framework
 
             string prefix = string.Empty;
 #if NETFRAMEWORK
-            if (filePath.Length > 260)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT & filePath.Length > 260)
                 prefix = @"\\?\";
 #endif
 

--- a/src/NUnitFramework/framework/TestContext.cs
+++ b/src/NUnitFramework/framework/TestContext.cs
@@ -369,7 +369,13 @@ namespace NUnit.Framework
             if (!Path.IsPathRooted(filePath))
                 filePath = Path.Combine(TestContext.CurrentContext.WorkDirectory, filePath);
 
-            if (!File.Exists(filePath))
+            string prefix = string.Empty;
+#if NETFRAMEWORK
+            if (filePath.Length > 260)
+                prefix = @"\\?\";
+#endif
+
+            if (!File.Exists($"{prefix}{filePath}"))
                 throw new FileNotFoundException("Test attachment file path could not be found.", filePath);
 
             var result = TestExecutionContext.CurrentContext.CurrentResult;

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -25,13 +25,17 @@ namespace NUnit.Framework.Tests
         private string _tempFilePath;
         private string _tempLongFilePath;
 
-        private readonly string _longPathPrefix = @"\\?\";
+        private string _longPathPrefix;
 
         private const string TempFileName = "TestContextTests.tmp";
 
         [OneTimeSetUp]
         public void CreateTempFiles()
         {
+            _longPathPrefix = string.Empty;
+#if NETFRAMEWORK
+            _longPathPrefix = $@"\\?\";
+#endif
             _tempFilePath = Path.Combine(_workDirectory, TempFileName);
             File.Create(_tempFilePath).Dispose();
 


### PR DESCRIPTION
Fixes #4353.

For .NetFramework, with file path greater than 260, TestContext.AddTestAttachment was throwing attachment not found exception. As [suggested](https://learn.microsoft.com/en-gb/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces) prefixing "\\\\?\\" with absolute path works fine. The issue is with .NET Framework variants but not on .NET Core3.1, .NET6, or .NET7. Therefore adding prefix only in case of .NetFramework 

                  string prefix = string.Empty;
      #if NETFRAMEWORK
                  if (filePath.Length > 260)
                      prefix = @"\\?\";
      #endif
                  if (!File.Exists($"{prefix}{filePath}"))
                      throw new FileNotFoundException("Test attachment file path could not be found.", filePath);