### PR TITLE
Use MemoryExtensions in StreamsComparer for performance

### DIFF
--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -6,6 +6,7 @@
   <!-- Packages for used features -->
   <ItemGroup>
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" version="4.5.0" />
   </ItemGroup>
   <!-- General Packages -->

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/StreamsComparerBenchmark.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/StreamsComparerBenchmark.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using BenchmarkDotNet.Attributes;
+
+namespace NUnit.Framework
+{
+    public class StreamsComparerBenchmark
+    {
+        private const int BUFFER_SIZE = 4096;
+
+        [Params(4096 * 8)]
+        public int Size { get; set; }
+        private Stream? XStream { get; set; }
+        private Stream? YStream { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var buffer = new byte[BUFFER_SIZE];
+
+            XStream = new MemoryStream(Size);
+            for (var i = 0; i < Size; i += BUFFER_SIZE)
+                XStream.Write(buffer, 0, BUFFER_SIZE);
+            XStream.Seek(0, SeekOrigin.Begin);
+
+            YStream = new MemoryStream(Size);
+            for (var i = 0; i < Size; i += BUFFER_SIZE)
+                YStream.Write(buffer, 0, BUFFER_SIZE);
+            YStream.Seek(0, SeekOrigin.Begin);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            XStream?.Dispose();
+
+            YStream?.Dispose();
+        }
+
+        [Benchmark(Baseline = true)]
+        public bool Original()
+        {
+            var equal = Equal_Original(XStream!, YStream!, out _);
+            return equal == EqualMethodResult.ComparedEqual;
+        }
+
+        [Benchmark]
+        public bool Vectorized()
+        {
+            var equal = Equal_Enhanced(XStream!, YStream!, out _);
+            return equal == EqualMethodResult.ComparedEqual;
+        }
+
+        public static EqualMethodResult Equal_Original(Stream xStream, Stream yStream, out long? failurePoint)
+        {
+            failurePoint = null;
+            bool bothSeekable = xStream.CanSeek && yStream.CanSeek;
+
+            if (bothSeekable && xStream.Length != yStream.Length)
+                return EqualMethodResult.ComparedNotEqual;
+
+            byte[] bufferExpected = new byte[BUFFER_SIZE];
+            byte[] bufferActual = new byte[BUFFER_SIZE];
+
+            BinaryReader binaryReaderExpected = new BinaryReader(xStream);
+            BinaryReader binaryReaderActual = new BinaryReader(yStream);
+
+            long expectedPosition = bothSeekable ? xStream.Position : default;
+            long actualPosition = bothSeekable ? yStream.Position : default;
+
+            try
+            {
+                if (xStream.CanSeek)
+                {
+                    binaryReaderExpected.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+                if (yStream.CanSeek)
+                {
+                    binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                int readExpected = 1;
+                int readActual = 1;
+                long readByte = 0;
+
+                while (readExpected > 0 && readActual > 0)
+                {
+                    readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
+                    readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
+
+                    for (int count = 0; count < BUFFER_SIZE; ++count)
+                    {
+                        if (bufferExpected[count] != bufferActual[count])
+                        {
+                            failurePoint = readByte + count;
+                            return EqualMethodResult.ComparedNotEqual;
+                        }
+                    }
+                    readByte += BUFFER_SIZE;
+                }
+            }
+            finally
+            {
+                if (xStream.CanSeek)
+                {
+                    xStream.Position = expectedPosition;
+                }
+                if (yStream.CanSeek)
+                {
+                    yStream.Position = actualPosition;
+                }
+            }
+
+            return EqualMethodResult.ComparedEqual;
+        }
+
+        public static EqualMethodResult Equal_Enhanced(Stream xStream, Stream yStream, out long? failurePoint)
+        {
+            failurePoint = null;
+            bool bothSeekable = xStream.CanSeek && yStream.CanSeek;
+
+            if (bothSeekable && xStream.Length != yStream.Length)
+                return EqualMethodResult.ComparedNotEqual;
+
+            byte[] bufferExpected = new byte[BUFFER_SIZE];
+            byte[] bufferActual = new byte[BUFFER_SIZE];
+
+            BinaryReader binaryReaderExpected = new BinaryReader(xStream);
+            BinaryReader binaryReaderActual = new BinaryReader(yStream);
+
+            long expectedPosition = bothSeekable ? xStream.Position : default;
+            long actualPosition = bothSeekable ? yStream.Position : default;
+
+            try
+            {
+                if (xStream.CanSeek)
+                {
+                    binaryReaderExpected.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+                if (yStream.CanSeek)
+                {
+                    binaryReaderActual.BaseStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                int readExpected = 1;
+                int readActual = 1;
+                long readByte = 0;
+
+                while (readExpected > 0 && readActual > 0)
+                {
+                    readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
+                    readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
+
+                    if (MemoryExtensions.SequenceEqual<byte>(bufferExpected, bufferActual))
+                    {
+                        readByte += BUFFER_SIZE;
+                        continue;
+                    }
+
+                    for (int count = 0; count < BUFFER_SIZE; ++count)
+                    {
+                        if (bufferExpected[count] != bufferActual[count])
+                        {
+                            failurePoint = readByte + count;
+                            return EqualMethodResult.ComparedNotEqual;
+                        }
+                    }
+                    readByte += BUFFER_SIZE;
+                }
+            }
+            finally
+            {
+                if (xStream.CanSeek)
+                {
+                    xStream.Position = expectedPosition;
+                }
+                if (yStream.CanSeek)
+                {
+                    yStream.Position = actualPosition;
+                }
+            }
+
+            return EqualMethodResult.ComparedEqual;
+        }
+
+        /// <summary>
+        /// Result of the Equal comparison method.
+        /// </summary>
+        public enum EqualMethodResult
+        {
+            /// <summary>
+            /// Method does not support the instances being compared.
+            /// </summary>
+            TypesNotSupported,
+
+            /// <summary>
+            /// Method is appropriate for the data types, but doesn't support the specified tolerance.
+            /// </summary>
+            ToleranceNotSupported,
+
+            /// <summary>
+            /// Method is appropriate and the items are considered equal.
+            /// </summary>
+            ComparedEqual,
+
+            /// <summary>
+            /// Method is appropriate and the items are considered different.
+            /// </summary>
+            ComparedNotEqual,
+
+            /// <summary>
+            /// Method is appropriate but the class has cyclic references.
+            /// </summary>
+            ComparisonPending
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -62,6 +62,12 @@ namespace NUnit.Framework.Constraints.Comparers
                     readExpected = binaryReaderExpected.Read(bufferExpected, 0, BUFFER_SIZE);
                     readActual = binaryReaderActual.Read(bufferActual, 0, BUFFER_SIZE);
 
+                    if (MemoryExtensions.SequenceEqual<byte>(bufferExpected, bufferActual))
+                    {
+                        readByte += BUFFER_SIZE;
+                        continue;
+                    }
+
                     for (int count = 0; count < BUFFER_SIZE; ++count)
                     {
                         if (bufferExpected[count] != bufferActual[count])

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="Schemas\*.xsd" CopyToOutputDirectory="Always" />
   </ItemGroup>
 

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO.Compression;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using NUnit.Framework.Constraints;
@@ -155,6 +156,21 @@ namespace NUnit.Framework.Tests.Constraints
                 using Stream actualStream = actualEntry.Open();
 
                 Assert.That(expectedStream, Is.Not.EqualTo(actualStream));
+            }
+
+            [Test]
+            public void UnSeekableLargeActualStreamEqual()
+            {
+                // This creates a string that exceeds 4096 bytes for the StreamsComparer loop.
+                string streamValue = string.Concat(Enumerable.Repeat("Greetings from a stream that is from the other side!", 100));
+
+                using var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(streamValue));
+
+                using var actualArchive = CreateZipArchive(streamValue);
+                ZipArchiveEntry entry = actualArchive.Entries[0];
+
+                using Stream entryStream = entry.Open();
+                Assert.That(entryStream, Is.EqualTo(expectedStream));
             }
 
             private static ZipArchive CreateZipArchive(string content)

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -173,6 +173,23 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(entryStream, Is.EqualTo(expectedStream));
             }
 
+            [Test]
+            public void UnSeekableLargeActualStreamUnequal()
+            {
+                // This creates a string that exceeds 4096 bytes for the StreamsComparer loop.
+                string streamValue = string.Concat(Enumerable.Repeat("Greetings from a stream that is from the other side!", 100));
+
+                string unequalStream = string.Concat(streamValue, "Some extra difference at the end.");
+
+                using var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(streamValue));
+
+                using var actualArchive = CreateZipArchive(unequalStream);
+                ZipArchiveEntry entry = actualArchive.Entries[0];
+
+                using Stream entryStream = entry.Open();
+                Assert.That(entryStream, Is.Not.EqualTo(expectedStream));
+            }
+
             private static ZipArchive CreateZipArchive(string content)
             {
                 var archiveContents = new MemoryStream();


### PR DESCRIPTION
Use MemoryExtensions to check that the expected and actual are equal.

Fixes #3829