### PR TITLE
Increment by 'Actual bytes read' rather than the buffer size in StreamsComparer.cs

### DIFF
--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/StreamsComparerBenchmark.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/StreamsComparerBenchmark.cs
@@ -153,7 +153,7 @@ namespace NUnit.Framework
 
                     if (MemoryExtensions.SequenceEqual<byte>(bufferExpected, bufferActual))
                     {
-                        readByte += BUFFER_SIZE;
+                        readByte += readActual;
                         continue;
                     }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints.Comparers
 
                     if (MemoryExtensions.SequenceEqual<byte>(bufferExpected, bufferActual))
                     {
-                        readByte += BUFFER_SIZE;
+                        readByte += readActual;
                         continue;
                     }
 
@@ -82,7 +82,6 @@ namespace NUnit.Framework.Constraints.Comparers
                             return EqualMethodResult.ComparedNotEqual;
                         }
                     }
-                    readByte += BUFFER_SIZE;
                 }
             }
             finally

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -190,6 +190,20 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(entryStream, Is.Not.EqualTo(expectedStream));
             }
 
+            [Test]
+            public void ShortReadingMemoryStream_AssertErrorMessageFailurePointIsCorrect()
+            {
+                var unequalStream = HelloString.Remove(HelloString.Length - 1, 1) + ".";
+
+                using var expectedStream = new ShortReadingMemoryStream(Encoding.UTF8.GetBytes(HelloString));
+
+                using var entryStream = new ShortReadingMemoryStream(Encoding.UTF8.GetBytes(unequalStream));
+
+                var ex = Assert.Throws<AssertionException>(() => Assert.That(entryStream, Is.EqualTo(expectedStream)));
+
+                Assert.That(ex?.Message, Does.Contain("Stream lengths are both 9. Streams differ at offset 8."));
+            }
+
             private static ZipArchive CreateZipArchive(string content)
             {
                 var archiveContents = new MemoryStream();
@@ -205,6 +219,18 @@ namespace NUnit.Framework.Tests.Constraints
                 }
 
                 return new ZipArchive(archiveContents, ZipArchiveMode.Read, leaveOpen: false);
+            }
+
+            private class ShortReadingMemoryStream : MemoryStream
+            {
+                public ShortReadingMemoryStream(byte[] bytes) : base(bytes)
+                {
+                }
+
+                public override int Read(byte[] buffer, int offset, int count)
+                {
+                    return base.Read(buffer, offset, 2);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4684 

This PR makes further changes as discussed in the [comments](https://github.com/nunit/nunit/pull/4668/files#r1536460163) for PR #4668. 

While thinking through the change discussed, I realised that we don't need to have line 85 anymore as the byte arrays have a difference and therefore the for loop will return and not continue this loop.

I'm not 100% sure how to create a test to cover this scenario but all the existing tests pass. 