### PR TITLE
Support And/Or linking with DictionaryContainsKeyValuePairConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -262,6 +262,27 @@ namespace NUnit.Framework.Constraints
             }
         }
 
+        /// <summary>
+        /// Returns a ConstraintExpression by appending Instead
+        /// to the current constraint.
+        /// </summary>
+        internal ConstraintExpression Instead
+        {
+            get
+            {
+                ConstraintBuilder? builder = Builder;
+                if (builder is null)
+                {
+                    builder = new ConstraintBuilder();
+                    builder.Append(this);
+                }
+
+                builder.Append(new InsteadOperator());
+
+                return new ConstraintExpression(builder);
+            }
+        }
+
         #endregion
 
         #region After Modifier

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -53,16 +53,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public DictionaryContainsKeyValuePairConstraint WithValue(object expectedValue)
         {
-            var builder = Builder;
-            if (builder is null)
-            {
-                builder = new ConstraintBuilder();
-                builder.Append(this);
-            }
-
-            var constraint = new DictionaryContainsKeyValuePairConstraint(Expected, expectedValue);
-            builder.Append(constraint);
-            return constraint;
+            return (DictionaryContainsKeyValuePairConstraint)Instead.Append(new DictionaryContainsKeyValuePairConstraint(Expected, expectedValue));
         }
 
         private bool Matches(object? actual)

--- a/src/NUnitFramework/framework/Constraints/Operators/InsteadOperator.cs
+++ b/src/NUnitFramework/framework/Constraints/Operators/InsteadOperator.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Operator that replaces the left constraint with the right constraint
+    /// </summary>
+    public class InsteadOperator : BinaryOperator
+    {
+        /// <summary>
+        /// Construct an InsteadOperator
+        /// </summary>
+        public InsteadOperator()
+        {
+            left_precedence = 1;
+            right_precedence = 99;
+        }
+
+        /// <summary>
+        /// Apply the operator to replace the left constraint
+        /// </summary>
+        public override IConstraint ApplyOperator(IConstraint left, IConstraint right)
+        {
+            return right;
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -53,6 +53,48 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByAnd()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo").And.ContainKey("Hello").WithValue("World"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByOrBothTrue()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo").Or.ContainKey("Hello").WithValue("World"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByOrLeftKeyWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("NotKey").WithValue("Mundo").Or.ContainKey("Hello").WithValue("World"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByOrLeftValueWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("NotValue").Or.ContainKey("Hello").WithValue("World"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByOrRightKeyWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo").Or.ContainKey("NotKey").WithValue("World"));
+        }
+
+        [Test]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValueJoinedByOrRightValueWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo").Or.ContainKey("Hello").WithValue("NotValue"));
+        }
+
+        [Test]
         public void FailsWhenNotUsedAgainstADictionary()
         {
             List<KeyValuePair<string, string>> keyValuePairs = new List<KeyValuePair<string, string>>(
@@ -61,6 +103,66 @@ namespace NUnit.Framework.Tests.Constraints
             TestDelegate act = () => Assert.That(keyValuePairs, new DictionaryContainsKeyValuePairConstraint("Hi", "Universe"));
 
             Assert.That(act, Throws.ArgumentException.With.Message.Contains("IDictionary"));
+        }
+
+        [Test]
+        public void FailsWhenPairIsPresentUsingContainKeyWithValueJoinedByAndBothFalse()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            var expression = (IResolveConstraint)Does.ContainKey("NotKeyLeft").WithValue("NotValueLeft").And.ContainKey("NotKeyRight").WithValue("NotValueRight");
+            var constraint = expression.Resolve();
+            var result = constraint.ApplyTo(dictionary);
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void FailsWhenPairIsPresentUsingContainKeyWithValueJoinedByAndLeftKeyWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            var expression = (IResolveConstraint)Does.ContainKey("NotKey").WithValue("Mundo").And.ContainKey("Hello").WithValue("World");
+            var constraint = expression.Resolve();
+            var result = constraint.ApplyTo(dictionary);
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void FailsWhenPairIsPresentUsingContainKeyWithValueJoinedByAndLeftValueWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            var expression = (IResolveConstraint)Does.ContainKey("Hola").WithValue("NotValue").And.ContainKey("Hello").WithValue("World");
+            var constraint = expression.Resolve();
+            var result = constraint.ApplyTo(dictionary);
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void FailsWhenPairIsPresentUsingContainKeyWithValueJoinedByAndRightKeyWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            var expression = (IResolveConstraint)Does.ContainKey("Hola").WithValue("Mundo").And.ContainKey("NotKey").WithValue("World");
+            var constraint = expression.Resolve();
+            var result = constraint.ApplyTo(dictionary);
+
+            Assert.That(result.IsSuccess, Is.False);
+        }
+
+        [Test]
+        public void FailsWhenPairIsPresentUsingContainKeyWithValueJoinedByAndRightValueWrong()
+        {
+            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
+
+            var expression = (IResolveConstraint)Does.ContainKey("Hola").WithValue("Mundo").And.ContainKey("Hello").WithValue("NotValue");
+            var constraint = expression.Resolve();
+            var result = constraint.ApplyTo(dictionary);
+
+            Assert.That(result.IsSuccess, Is.False);
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4670

The implementation of #3486 did not combine the the key and value checks, which lead to issues when combining with `And` or `Or`. This PR adds the `InsteadOperator` with high precedence which allows to replace the `DictionaryContainsKeyConstraint` with the `DictionaryContainsKeyValuePairConstraint` since there is no other nice way to replace an entry on the `ConstraintStack` that would also work with correct precedence.

I initially tried to use the `AndOperator`, but this would fail in `Does.Not` cases as the `NotOperator` would apply to the key-check before the AND would be applied.

I also tried using `Contraint.With` (which is currently an alias for `And` and NOT using `WithOperator`). But that would also only bind the key on the right side and adds the value afterwards.