### PR TITLE
Add early return for Streams Equal comparison when they are empty

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/StreamsComparer.cs
@@ -30,8 +30,14 @@ namespace NUnit.Framework.Constraints.Comparers
 
             bool bothSeekable = xStream.CanSeek && yStream.CanSeek;
 
-            if (bothSeekable && xStream.Length != yStream.Length)
-                return EqualMethodResult.ComparedNotEqual;
+            if (bothSeekable)
+            {
+                if (xStream.Length != yStream.Length)
+                    return EqualMethodResult.ComparedNotEqual;
+
+                if (xStream.Length == 0)
+                    return EqualMethodResult.ComparedEqual;
+            }
 
             byte[] bufferExpected = new byte[BUFFER_SIZE];
             byte[] bufferActual = new byte[BUFFER_SIZE];

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -190,6 +190,16 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(entryStream, Is.Not.EqualTo(expectedStream));
             }
 
+            [Test]
+            public void SeekableEmptyStreamEqual()
+            {
+                using var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(string.Empty));
+
+                using var actualStream = new MemoryStream(Encoding.UTF8.GetBytes(string.Empty));
+
+                Assert.That(actualStream, Is.EqualTo(expectedStream));
+            }
+
             private static ZipArchive CreateZipArchive(string content)
             {
                 var archiveContents = new MemoryStream();


### PR DESCRIPTION
When the streams are seekable and are empty, we can return they are equal and save the allocation of the byte arrays and the comparisons around them.