### PR TITLE
Permit DictionaryContainsKeyValuePairConstraint to take in a null value (fix CS8604)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -734,7 +734,7 @@ namespace NUnit.Framework.Constraints
         /// presence of a particular value in the Dictionary value collection.
         /// </summary>
         /// <param name="expected">The value to be matched in the Dictionary value collection</param>
-        public DictionaryContainsValueConstraint ContainValue(object expected)
+        public DictionaryContainsValueConstraint ContainValue(object? expected)
         {
             return Append(new DictionaryContainsValueConstraint(expected));
         }

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -51,9 +51,9 @@ namespace NUnit.Framework.Constraints
         /// Returns a new DictionaryContainsKeyValuePairConstraint checking for the
         /// presence of a particular key-value-pair in the dictionary.
         /// </summary>
-        public DictionaryContainsKeyValuePairConstraint WithValue(object expectedValue)
+        public DictionaryContainsKeyValuePairConstraint WithValue(object? expectedValue)
         {
-            return (DictionaryContainsKeyValuePairConstraint)Instead.Append(new DictionaryContainsKeyValuePairConstraint(Expected, expectedValue));
+            return Instead.Append(new DictionaryContainsKeyValuePairConstraint(Expected, expectedValue));
         }
 
         private bool Matches(object? actual)

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyValuePairConstraint.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Construct a DictionaryContainsKeyValuePairConstraint
         /// </summary>
-        public DictionaryContainsKeyValuePairConstraint(object key, object value)
+        public DictionaryContainsKeyValuePairConstraint(object key, object? value)
         {
             _expected = new DictionaryEntry(key, value);
         }

--- a/src/NUnitFramework/framework/Contains.cs
+++ b/src/NUnitFramework/framework/Contains.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework
         /// Returns a new DictionaryContainsValueConstraint checking for the
         /// presence of a particular value in the dictionary.
         /// </summary>
-        public static DictionaryContainsValueConstraint Value(object expected)
+        public static DictionaryContainsValueConstraint Value(object? expected)
         {
             return new DictionaryContainsValueConstraint(expected);
         }

--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -71,7 +71,7 @@ namespace NUnit.Framework
         /// presence of a particular value in the Dictionary value collection.
         /// </summary>
         /// <param name="expected">The value to be matched in the Dictionary value collection</param>
-        public static DictionaryContainsValueConstraint ContainValue(object expected)
+        public static DictionaryContainsValueConstraint ContainValue(object? expected)
         {
             return Contains.Value(expected);
         }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -10,10 +10,10 @@ namespace NUnit.Framework.Tests.Constraints
     [TestFixture]
     public class DictionaryContainsKeyValuePairConstraintTests
     {
-        [Theory]
-        public void SucceedsWhenKeyValuePairIsPresent(bool valueIsNull)
+        [TestCase("Universe")]
+        [TestCase(null)]
+        public void SucceedsWhenKeyValuePairIsPresent(string? expectedValue)
         {
-            var expectedValue = valueIsNull ? null : "Universe";
             var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hi", expectedValue }, { "Hola", "Mundo" } };
 
             Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", expectedValue));
@@ -39,10 +39,10 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
         }
 
-        [Theory]
-        public void SucceedsWhenPairIsPresentUsingContainKeyWithValue(bool valueIsNull)
+        [TestCase("Mundo")]
+        [TestCase(null)]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValue(string? expectedValue)
         {
-            var expectedValue = valueIsNull ? null : "Mundo";
             var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hola", expectedValue } };
             Assert.That(dictionary, Does.ContainKey("Hola").WithValue(expectedValue));
         }

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsKeyValueConstraintTests.cs
@@ -10,12 +10,13 @@ namespace NUnit.Framework.Tests.Constraints
     [TestFixture]
     public class DictionaryContainsKeyValuePairConstraintTests
     {
-        [Test]
-        public void SucceedsWhenKeyValuePairIsPresent()
+        [Theory]
+        public void SucceedsWhenKeyValuePairIsPresent(bool valueIsNull)
         {
-            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hi", "Universe" }, { "Hola", "Mundo" } };
+            var expectedValue = valueIsNull ? null : "Universe";
+            var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hi", expectedValue }, { "Hola", "Mundo" } };
 
-            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", "Universe"));
+            Assert.That(dictionary, new DictionaryContainsKeyValuePairConstraint("Hi", expectedValue));
         }
 
         [Test]
@@ -38,11 +39,12 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
         }
 
-        [Test]
-        public void SucceedsWhenPairIsPresentUsingContainKeyWithValue()
+        [Theory]
+        public void SucceedsWhenPairIsPresentUsingContainKeyWithValue(bool valueIsNull)
         {
-            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
-            Assert.That(dictionary, Does.ContainKey("Hola").WithValue("Mundo"));
+            var expectedValue = valueIsNull ? null : "Mundo";
+            var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hola", expectedValue } };
+            Assert.That(dictionary, Does.ContainKey("Hola").WithValue(expectedValue));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -28,11 +28,12 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
         }
 
-        [Test]
-        public void SucceedsWhenValueIsPresentUsingContainValue()
+        [Theory]
+        public void SucceedsWhenValueIsPresentUsingContainValue(bool valueIsNull)
         {
-            var dictionary = new Dictionary<string, string> { { "Hello", "World" }, { "Hola", "Mundo" } };
-            Assert.That(dictionary, Does.ContainValue("Mundo"));
+            var expectedValue = valueIsNull ? null : "Mundo";
+            var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hola", expectedValue } };
+            Assert.That(dictionary, Does.ContainValue(expectedValue));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -28,10 +28,10 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(act, Throws.Exception.TypeOf<AssertionException>());
         }
 
-        [Theory]
-        public void SucceedsWhenValueIsPresentUsingContainValue(bool valueIsNull)
+        [TestCase("Mundo")]
+        [TestCase(null)]
+        public void SucceedsWhenValueIsPresentUsingContainValue(string? expectedValue)
         {
-            var expectedValue = valueIsNull ? null : "Mundo";
             var dictionary = new Dictionary<string, string?> { { "Hello", "World" }, { "Hola", expectedValue } };
             Assert.That(dictionary, Does.ContainValue(expectedValue));
         }


### PR DESCRIPTION
This matches the nullability of DictionaryEntry.

Context of the issue I hit:
```csharp
internal class Foo
{
    [Test]
    public void Bar()
    {
        var dictionary = new Dictionary<int, string?> { {0, null} };
        Assert.That(dictionary, Contains.Key(0).WithValue(null)); // This line raises CS8604.
    }
}
```