### PR TITLE
Apply test output from timedout tests on non-threadabort platforms

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Internal.Commands
                 var testExecution = Task.Run(() => innerCommand.Execute(separateContext));
                 var timedOut = Task.WaitAny(new Task[] { testExecution }, _timeout) == -1;
 
-                separateContext.CurrentResult.ApplyOutput(context.CurrentResult);
+                context.CurrentResult.CopyOutputTo(separateContext.CurrentResult);
 
                 if (timedOut && !_debugger.IsAttached)
                 {

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -119,9 +119,12 @@ namespace NUnit.Framework.Internal.Commands
 
         private Task<TestResult> RunTestOnSeparateThread(TestExecutionContext context)
         {
-            var separateContext = new TestExecutionContext(context);
+            var separateContext = new TestExecutionContext(context)
+            {
+                CurrentResult = context.CurrentTest.MakeTestResult()
+            };
 
-            return Task.Run(() => innerCommand.Execute(context));
+            return Task.Run(() => innerCommand.Execute(separateContext));
         }
 #endif
     }

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -102,11 +102,10 @@ namespace NUnit.Framework.Internal.Commands
                 }
                 else
                 {
-                    string message = $"Test exceeded Timeout value of {_timeout}ms";
-
+                    context.CurrentResult.ApplyTimeoutResult(testExecution.Result);
                     context.CurrentResult.SetResult(
                         ResultState.Failure,
-                        message);
+                        $"Test exceeded Timeout value of {_timeout}ms");
                 }
             }
             catch (Exception exception)

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -101,8 +101,6 @@ namespace NUnit.Framework.Internal.Commands
                 var testExecution = Task.Run(() => innerCommand.Execute(separateContext));
                 var timedOut = Task.WaitAny(new Task[] { testExecution }, _timeout) == -1;
 
-                context.CurrentResult.CopyOutputTo(separateContext.CurrentResult);
-
                 if (timedOut && !_debugger.IsAttached)
                 {
                     context.CurrentResult.SetResult(
@@ -111,6 +109,7 @@ namespace NUnit.Framework.Internal.Commands
                 }
                 else
                 {
+                    context.CurrentResult.CopyOutputTo(separateContext.CurrentResult);
                     context.CurrentResult = testExecution.GetAwaiter().GetResult();
                 }
             }

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -119,11 +119,9 @@ namespace NUnit.Framework.Internal.Commands
 
         private Task<TestResult> RunTestOnSeparateThread(TestExecutionContext context)
         {
-            var separateContext = new TestExecutionContext(context)
-            {
-                CurrentResult = context.CurrentTest.MakeTestResult()
-            };
-            return Task.Run(() => innerCommand.Execute(separateContext));
+            var separateContext = new TestExecutionContext(context);
+
+            return Task.Run(() => innerCommand.Execute(context));
         }
 #endif
     }

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -156,10 +156,10 @@ namespace NUnit.Framework.Internal
         /// Apply the output from the provided TestResult to this one
         /// </summary>
         /// <param name="result">The TestResult to apply output from</param>
-        internal void ApplyOutput(TestResult result)
+        internal void CopyOutputTo(TestResult result)
         {
-            result.OutWriter.Flush();
-            OutWriter.Write(result.Output);
+            OutWriter.Flush();
+            result.OutWriter.Write(Output);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -153,6 +153,18 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
+        /// Apply a test result from a timed out test
+        /// </summary>
+        /// <param name="result">The TestResult from the test which timed out</param>
+        internal void ApplyTimeoutResult(TestResult result)
+        {
+            OutWriter.Write(result.Output);
+            //result.OutWriter.Close();
+            //result.Output = ""
+            // Apply things but in a way further writes to the output writer are not applied
+        }
+
+        /// <summary>
         /// Gets the collection of files attached to the test
         /// </summary>
         public ICollection<TestAttachment> TestAttachments => new ReadOnlyCollection<TestAttachment>(_testAttachments);

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -153,15 +153,13 @@ namespace NUnit.Framework.Internal
         }
 
         /// <summary>
-        /// Apply a test result from a timed out test
+        /// Apply the output from the provided TestResult to this one
         /// </summary>
-        /// <param name="result">The TestResult from the test which timed out</param>
-        internal void ApplyTimeoutResult(TestResult result)
+        /// <param name="result">The TestResult to apply output from</param>
+        internal void ApplyOutput(TestResult result)
         {
+            result.OutWriter.Flush();
             OutWriter.Write(result.Output);
-            //result.OutWriter.Close();
-            //result.Output = ""
-            // Apply things but in a way further writes to the output writer are not applied
         }
 
         /// <summary>

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -154,4 +154,27 @@ namespace NUnit.TestData
         {
         }
     }
+
+    [TestFixture]
+    public class TimeoutWithSetupTestAndTeardownOutputFixture
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestContext.WriteLine("setup");
+        }
+
+        [Test, Timeout(2_000)]
+        public void Test2()
+        {
+            TestContext.WriteLine("method output");
+            Assert.That(1, Is.EqualTo(0));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TestContext.WriteLine("teardown");
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -108,4 +108,20 @@ namespace NUnit.TestData
             Thread.Sleep(delay);
         }
     }
+
+    [TestFixture]
+    public class TimeoutWithTeardownAndOutputFixture
+    {
+        [Test, Timeout(60_000)]
+        public void Test2()
+        {
+            TestContext.WriteLine("line1");
+            Assert.That(1, Is.EqualTo(0));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -110,12 +110,42 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
-    public class TimeoutWithTeardownAndOutputFixture
+    public class TimeoutWithSetupAndOutputAfterTimeoutFixture
     {
-        [Test, Timeout(60_000)]
+        [SetUp]
+        public void Setup()
+        {
+            TestContext.WriteLine("setup");
+        }
+
+        [Test, Timeout(600)]
         public void Test2()
         {
-            TestContext.WriteLine("line1");
+            TestContext.WriteLine("method output before pause");
+            Thread.Sleep(1_000);
+            TestContext.WriteLine("method output after pause");
+            Assert.That(1, Is.EqualTo(0));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class TimeoutWithSetupAndOutputFixture
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestContext.WriteLine("setup");
+        }
+
+        [Test, Timeout(2_000)]
+        public void Test2()
+        {
+            TestContext.WriteLine("method output");
             Assert.That(1, Is.EqualTo(0));
         }
 

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -305,5 +305,27 @@ namespace NUnit.Framework.Tests.Attributes
         {
             public bool IsAttached { get; set; }
         }
+
+        [TestFixture]
+        public class Context
+        {
+            [Test, Timeout(60_000)]
+            public void Test2()
+            {
+                TestContext.WriteLine("line1");
+                Assert.That(1, Is.EqualTo(0));
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTeardown()
+            {
+                var v = TestExecutionContext.CurrentContext.CurrentTest;
+            }
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -186,6 +186,17 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void OutputIsCapturedOnNonTimedoutTest()
+        {
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupTestAndTeardownOutputFixture));
+            var testMethod = suiteResult.Children.First();
+
+            Assert.That(testMethod.Output, Does.Contain("setup"));
+            Assert.That(testMethod.Output, Does.Contain("method output"));
+            Assert.That(testMethod.Output, Does.Contain("teardown"));
+        }
+
+        [Test]
         public void OutputIsCapturedOnTimedoutTestAfterTimeout()
         {
             var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupAndOutputAfterTimeoutFixture));

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -178,10 +178,22 @@ namespace NUnit.Framework.Tests.Attributes
         [Test]
         public void OutputIsCapturedOnTimedoutTest()
         {
-            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithTeardownAndOutputFixture));
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupAndOutputFixture));
             var testMethod = suiteResult.Children.First();
 
-            Assert.That(testMethod.Output, Is.EqualTo($"line1{Environment.NewLine}"));
+            Assert.That(testMethod.Output, Does.Contain("setup"));
+            Assert.That(testMethod.Output, Does.Contain("method output"));
+        }
+
+        [Test]
+        public void OutputIsCapturedOnTimedoutTestAfterTimeout()
+        {
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupAndOutputAfterTimeoutFixture));
+            var testMethod = suiteResult.Children.First();
+
+            Assert.That(testMethod.Output, Does.Contain("setup"));
+            Assert.That(testMethod.Output, Does.Contain("method output before pause"));
+            Assert.That(testMethod.Output, Does.Not.Contain("method output after pause"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -2,14 +2,13 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Abstractions;
 using NUnit.Framework.Tests.TestUtilities;
-using System.Linq;
 using NUnit.TestData;
-using System.Diagnostics;
 
 namespace NUnit.Framework.Tests.Attributes
 {

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework.Internal.Abstractions;
 using NUnit.Framework.Tests.TestUtilities;
 using System.Linq;
 using NUnit.TestData;
+using System.Diagnostics;
 
 namespace NUnit.Framework.Tests.Attributes
 {
@@ -157,6 +158,7 @@ namespace NUnit.Framework.Tests.Attributes
             TestMethod? testMethod = (TestMethod?)TestFinder.Find(nameof(TimeoutFixture.VeryLongTestWith50msTimeout), suite, false);
             Assert.That(testMethod, Is.Not.Null);
             ITestResult result = TestBuilder.RunTest(testMethod, fixture);
+
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
             Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));
             Assert.That(result.Message, Does.Contain("50ms"));
@@ -172,6 +174,15 @@ namespace NUnit.Framework.Tests.Attributes
 #if THREAD_ABORT
             Assert.That(fixture.TearDownWasRun, "TearDown was not run");
 #endif
+        }
+
+        [Test]
+        public void OutputIsCapturedOnTimedoutTest()
+        {
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithTeardownAndOutputFixture));
+            var testMethod = suiteResult.Children.First();
+
+            Assert.That(testMethod.Output, Is.EqualTo($"line1{Environment.NewLine}"));
         }
 
         [Test]
@@ -304,28 +315,6 @@ namespace NUnit.Framework.Tests.Attributes
         private class StubDebugger : IDebugger
         {
             public bool IsAttached { get; set; }
-        }
-
-        [TestFixture]
-        public class Context
-        {
-            [Test, Timeout(60_000)]
-            public void Test2()
-            {
-                TestContext.WriteLine("line1");
-                Assert.That(1, Is.EqualTo(0));
-            }
-
-            [TearDown]
-            public void TearDown()
-            {
-            }
-
-            [OneTimeTearDown]
-            public void OneTimeTeardown()
-            {
-                var v = TestExecutionContext.CurrentContext.CurrentTest;
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/4598

@manfred-brands You mentioned [in the source issue](https://github.com/nunit/nunit/issues/4598#issuecomment-2026408377) that you may also be looking into this on your own branch.

I've put up this PR as I was able to get this working in a relatively self-contained way for the existing code which may be able to merge either independent of your larger rework or could perhaps be PR'd into it as well. This PR could also be discarded if you've already gotten it working on your end too