### PR TITLE
Improve Assert.That error text message

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraintResult.cs
@@ -42,11 +42,11 @@ namespace NUnit.Framework.Constraints
         {
             if (_itemList is null || _itemList.Count == 0)
             {
-                writer.Write("no items");
+                writer.Write("no matching items");
                 return;
             }
 
-            writer.Write(_matchCount != 1 ? "{0} items " : "{0} item ", _matchCount);
+            writer.Write(_matchCount != 1 ? "{0} matching items " : "{0} matching item ", _matchCount);
             writer.Write(MsgUtils.FormatCollection(_itemList));
         }
     }

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -18,6 +18,16 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void ZeroItemsMatchWithEmptyCollectionFails()
+        {
+            var expectedMessage =
+                TextMessageWriter.Pfx_Expected + "exactly one item equal to \"Charlie\"" + Environment.NewLine +
+                TextMessageWriter.Pfx_Actual + "no matching items" + Environment.NewLine;
+            var ex = Assert.Throws<AssertionException>(() => Assert.That(Array.Empty<string>(), Has.Exactly(1).EqualTo("Charlie")));
+            Assert.That(ex?.Message, Does.Contain(expectedMessage));
+        }
+
+        [Test]
         public void ZeroItemsMatchFails()
         {
             var expectedMessage =

--- a/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactCountConstraintTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "no item equal to \"Charlie\"" + Environment.NewLine +
-                TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
+                TextMessageWriter.Pfx_Actual + "2 matching items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(0, Is.EqualTo("Charlie"))));
             Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly one item equal to \"Charlie\"" + Environment.NewLine +
-                TextMessageWriter.Pfx_Actual + "2 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
+                TextMessageWriter.Pfx_Actual + "2 matching items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1, Is.EqualTo("Charlie"))));
             Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
@@ -76,7 +76,7 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly 2 items equal to \"Fred\"" + Environment.NewLine +
-                TextMessageWriter.Pfx_Actual + "1 item < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
+                TextMessageWriter.Pfx_Actual + "1 matching item < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(2, Is.EqualTo("Fred"))));
             Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var expectedMessage =
                 TextMessageWriter.Pfx_Expected + "exactly one item" + Environment.NewLine +
-                TextMessageWriter.Pfx_Actual + "4 items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
+                TextMessageWriter.Pfx_Actual + "4 matching items < \"Charlie\", \"Fred\", \"Joe\", \"Charlie\" >" + Environment.NewLine;
             var ex = Assert.Throws<AssertionException>(() => Assert.That(Names, new ExactCountConstraint(1)));
             Assert.That(ex?.Message, Does.Contain(expectedMessage));
         }
@@ -132,7 +132,7 @@ namespace NUnit.Framework.Tests.Constraints
                 + "exactly 5 items"
                 + Environment.NewLine
                 + TextMessageWriter.Pfx_Actual
-                + "10 items < \"Alfa\", \"Bravo\", \"Charlie\", \"Delta\", \"Echo\", \"Foxtrot\", \"Golf\", \"Hotel\", \"India\", \"Juliett\" >"
+                + "10 matching items < \"Alfa\", \"Bravo\", \"Charlie\", \"Delta\", \"Echo\", \"Foxtrot\", \"Golf\", \"Hotel\", \"India\", \"Juliett\" >"
                 + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(longElementList, Has.Exactly(5).Items));
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Tests.Constraints
                 + "exactly 10 items"
                 + Environment.NewLine
                 + TextMessageWriter.Pfx_Actual
-                + "15 items < \"Alfa\", \"Bravo\", \"Charlie\", \"Delta\", \"Echo\", \"Foxtrot\", \"Golf\", \"Hotel\", \"India\", \"Juliett\"... >"
+                + "15 matching items < \"Alfa\", \"Bravo\", \"Charlie\", \"Delta\", \"Echo\", \"Foxtrot\", \"Golf\", \"Hotel\", \"India\", \"Juliett\"... >"
                 + Environment.NewLine;
 
             var ex = Assert.Throws<AssertionException>(() => Assert.That(longElementList, Has.Exactly(10).Items));


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/3767.

`Assert.That` for collections, error text changes to:

```
  Message: 
      Expected: exactly one item equal to "boop"
      But was:  **0 matching items** < "no-store, no-cache" >
```

by adding `x matching item/s` to the message text.

- [x] Add `matching` keyword to error message
- [x] Unit tests
- [x] Unit test for `no matching items` missing use-case