### PR TITLE
Specify units in `After(int delayInMilliseconds, int pollingInterval)`

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -304,7 +304,7 @@ namespace NUnit.Framework.Constraints
         /// and polling interval.
         /// </summary>
         /// <param name="delayInMilliseconds">The delay in milliseconds.</param>
-        /// <param name="pollingInterval">The interval at which to test the constraint.</param>
+        /// <param name="pollingInterval">The interval at which to test the constraint, in milliseconds.</param>
         /// <returns></returns>
         public DelayedConstraint After(int delayInMilliseconds, int pollingInterval)
         {


### PR DESCRIPTION
Although milliseconds is the natural unit for an `int` delay, specifying can still be helpful just to be sure.