### PR TITLE
Backport tests from PR #4692 to 3.x

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,7 +107,7 @@ jobs:
 
   build-macos:
     name: MacOS Build
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - name: ⤵️ Checkout Source

--- a/src/NUnitFramework/testdata/TimeoutFixture.cs
+++ b/src/NUnitFramework/testdata/TimeoutFixture.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if THREAD_ABORT
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -29,6 +28,7 @@ using NUnit.Framework;
 
 namespace NUnit.TestData
 {
+#if THREAD_ABORT
     [TestFixture]
     public class TimeoutFixture
     {
@@ -120,5 +120,51 @@ namespace NUnit.TestData
             Thread.Sleep(delay);
         }
     }
-}
 #endif
+
+    [TestFixture]
+    public class TimeoutWithSetupAndOutputAfterTimeoutFixture
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestContext.WriteLine("setup");
+        }
+
+        [Test, Timeout(600)]
+        public void Test2()
+        {
+            TestContext.WriteLine("method output before pause");
+            Thread.Sleep(1_000);
+            TestContext.WriteLine("method output after pause");
+            Assert.That(1, Is.EqualTo(0));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class TimeoutWithSetupAndOutputFixture
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestContext.WriteLine("setup");
+        }
+
+        [Test, Timeout(2_000)]
+        public void Test2()
+        {
+            TestContext.WriteLine("method output");
+            Assert.That(1, Is.EqualTo(0));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -174,6 +174,27 @@ namespace NUnit.Framework.Attributes
             }
         }
 
+        [Test]
+        public void OutputIsCapturedOnTimedoutTest()
+        {
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupAndOutputFixture));
+            var testMethod = suiteResult.Children.First();
+
+            Assert.That(testMethod.Output, Does.Contain("setup"));
+            Assert.That(testMethod.Output, Does.Contain("method output"));
+        }
+
+        [Test]
+        public void OutputIsCapturedOnTimedoutTestAfterTimeout()
+        {
+            var suiteResult = TestBuilder.RunTestFixture(typeof(TimeoutWithSetupAndOutputAfterTimeoutFixture));
+            var testMethod = suiteResult.Children.First();
+
+            Assert.That(testMethod.Output, Does.Contain("setup"));
+            Assert.That(testMethod.Output, Does.Contain("method output before pause"));
+            Assert.That(testMethod.Output, Does.Not.Contain("method output after pause"));
+        }
+
         [Test, Timeout(500), SetCulture("fr-BE"), SetUICulture("es-BO")]
         public void TestWithTimeoutRespectsCulture()
         {


### PR DESCRIPTION
Backport tests from https://github.com/nunit/nunit/pull/4692
To verify the functionality from 3.x that we're restoring. Relates to https://github.com/nunit/nunit/issues/4598

This PR also switches the macos image on github actions to target specifically `macos-12` in order to work around this NET5-related issue: https://github.com/dotnet/runtime/issues/48068. It seems this may be the first time we're running CI on the 3.x branch since `macos-latest` was changed to `macos-14` and the newer silicon architecture.