### PR TITLE
Add clearer documentation to custom comparers, fill testing holes.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -82,8 +82,10 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
+        /// <typeparam name="TActualElement">The type of the elements in the actual value.</typeparam>
+        /// <typeparam name="TExpectedElement">The type of the elements in the expected value.</typeparam>
         /// <returns>Self.</returns>
-        public CollectionEquivalentConstraint Using<TActual, TExpected>(Func<TActual, TExpected, bool> comparison)
+        public CollectionEquivalentConstraint Using<TActualElement, TExpectedElement>(Func<TActualElement, TExpectedElement, bool> comparison)
         {
             base.Using(EqualityAdapter.For(comparison));
             return this;

--- a/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSubsetConstraint.cs
@@ -69,8 +69,10 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
+        /// <typeparam name="TSubsetElement">The type of the elements in the actual subset.</typeparam>
+        /// <typeparam name="TSupersetElement">The type of the elements in the expected superset.</typeparam>
         /// <returns>Self.</returns>
-        public CollectionSubsetConstraint Using<TSubsetType, TSupersetType>(Func<TSubsetType, TSupersetType, bool> comparison)
+        public CollectionSubsetConstraint Using<TSubsetElement, TSupersetElement>(Func<TSubsetElement, TSupersetElement, bool> comparison)
         {
             base.Using(EqualityAdapter.For(comparison));
             return this;

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -72,7 +73,7 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
-        /// <typeparam name="TSupersetElement">THe type of the elements in the actual superset.</typeparam>
+        /// <typeparam name="TSupersetElement">The type of the elements in the actual superset.</typeparam>
         /// <typeparam name="TSubsetElement">The type of the elements in the expected subset.</typeparam>
         /// <returns>Self.</returns>
         public CollectionSupersetConstraint Using<TSupersetElement, TSubsetElement>(Func<TSupersetElement, TSubsetElement, bool> comparison)

--- a/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionSupersetConstraint.cs
@@ -72,11 +72,13 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
+        /// <typeparam name="TSupersetElement">THe type of the elements in the actual superset.</typeparam>
+        /// <typeparam name="TSubsetElement">The type of the elements in the expected subset.</typeparam>
         /// <returns>Self.</returns>
-        public CollectionSupersetConstraint Using<TSupersetType, TSubsetType>(Func<TSupersetType, TSubsetType, bool> comparison)
+        public CollectionSupersetConstraint Using<TSupersetElement, TSubsetElement>(Func<TSupersetElement, TSubsetElement, bool> comparison)
         {
             // internal code reverses the expected order of the arguments.
-            Func<TSubsetType, TSupersetType, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
+            Func<TSubsetElement, TSupersetElement, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
             base.Using(EqualityAdapter.For(invertedComparison));
             return this;
         }

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -61,13 +61,13 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
-        /// <typeparam name="TActualValue">The type of the dictionary's <c>TValue</c>.</typeparam>
+        /// <typeparam name="TActualValueElement">The type of the dictionary's <c>TValue</c>.</typeparam>
         /// <typeparam name="TExpected">The type of the expected value.</typeparam>
         /// <returns>Self.</returns>
-        public DictionaryContainsValueConstraint Using<TActualValue, TExpected>(Func<TActualValue, TExpected, bool> comparison)
+        public DictionaryContainsValueConstraint Using<TActualValueElement, TExpected>(Func<TActualValueElement, TExpected, bool> comparison)
         {
             // reverse the order of the arguments to match expectations of PredicateEqualityComparer
-            Func<TExpected, TActualValue, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
+            Func<TExpected, TActualValueElement, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
 
             base.Using(EqualityAdapter.For(invertedComparison));
             return this;

--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsValueConstraint.cs
@@ -61,11 +61,13 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
+        /// <typeparam name="TActualValue">The type of the dictionary's <c>TValue</c>.</typeparam>
+        /// <typeparam name="TExpected">The type of the expected value.</typeparam>
         /// <returns>Self.</returns>
-        public DictionaryContainsValueConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
+        public DictionaryContainsValueConstraint Using<TActualValue, TExpected>(Func<TActualValue, TExpected, bool> comparison)
         {
             // reverse the order of the arguments to match expectations of PredicateEqualityComparer
-            Func<TMemberType, TCollectionType, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
+            Func<TExpected, TActualValue, bool> invertedComparison = (actual, expected) => comparison.Invoke(expected, actual);
 
             base.Using(EqualityAdapter.For(invertedComparison));
             return this;

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -371,8 +371,10 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied predicate function
         /// </summary>
         /// <param name="comparison">The comparison function to use.</param>
+        /// <typeparam name="TActual">The type of the actual value. Note for collection comparisons this is the element type.</typeparam>
+        /// <typeparam name="TExpected">The type of the expected value. Note for collection comparisons this is the element type.</typeparam>
         /// <returns>Self.</returns>
-        public EqualConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
+        public EqualConstraint Using<TActual, TExpected>(Func<TActual, TExpected, bool> comparison)
         {
             _comparer.ExternalComparers.Add(EqualityAdapter.For(comparison));
             return this;

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -56,11 +56,11 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag the constraint to use the supplied <see cref="Func{TCollectionType, TMemberType, Boolean}"/> object.
         /// </summary>
-        /// <typeparam name="TCollectionType">The type of the elements in the collection.</typeparam>
-        /// <typeparam name="TMemberType">The type of the member.</typeparam>
+        /// <typeparam name="TActualCollectionElement">The type of the elements in the collection.</typeparam>
+        /// <typeparam name="TExpectedElement">The type of the expected element.</typeparam>
         /// <param name="comparison">The comparison function to use.</param>
         /// <returns>Self.</returns>
-        public SomeItemsConstraint Using<TCollectionType, TMemberType>(Func<TCollectionType, TMemberType, bool> comparison)
+        public SomeItemsConstraint Using<TActualCollectionElement, TExpectedElement>(Func<TActualCollectionElement, TExpectedElement, bool> comparison)
         {
             CheckPrecondition(nameof(comparison));
             _equalConstraint.Using(comparison);

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
@@ -57,10 +58,10 @@ namespace NUnit.Framework.Constraints
         /// Flag the constraint to use the supplied <see cref="Func{TCollectionType, TMemberType, Boolean}"/> object.
         /// </summary>
         /// <typeparam name="TActualCollectionElement">The type of the elements in the collection.</typeparam>
-        /// <typeparam name="TExpectedElement">The type of the expected element.</typeparam>
+        /// <typeparam name="TExpected">The type of the expected value.</typeparam>
         /// <param name="comparison">The comparison function to use.</param>
         /// <returns>Self.</returns>
-        public SomeItemsConstraint Using<TActualCollectionElement, TExpectedElement>(Func<TActualCollectionElement, TExpectedElement, bool> comparison)
+        public SomeItemsConstraint Using<TActualCollectionElement, TExpected>(Func<TActualCollectionElement, TExpected, bool> comparison)
         {
             CheckPrecondition(nameof(comparison));
             _equalConstraint.Using(comparison);

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -96,6 +96,14 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(dictionary, Does.ContainValue(value).UsingPropertiesComparer());
         }
 
+        [Test]
+        public void UsingCustomComparerIsHonored()
+        {
+            var dictionary = new Dictionary<string, int> { { "a", 1 }, { "b", 2 }, { "c", 3 } };
+
+            Assert.That(dictionary, new DictionaryContainsValueConstraint("1").Using<int, string>((left, right) => left.ToString() == right));
+        }
+
         private sealed class XY
         {
             public XY(double x, double y)

--- a/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DictionaryContainsValueConstraintTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var dictionary = new Dictionary<string, int> { { "a", 1 }, { "b", 2 }, { "c", 3 } };
 
-            Assert.That(dictionary, new DictionaryContainsValueConstraint("1").Using<int, string>((left, right) => left.ToString() == right));
+            Assert.That(dictionary, new DictionaryContainsValueConstraint("1").Using<int, string>((actual, expected) => actual.ToString() == expected));
         }
 
         private sealed class XY

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1038,6 +1038,12 @@ namespace NUnit.Framework.Tests.Constraints
 
                 Assert.That(actual, Is.EqualTo(expected).Using<string, int>((s, i) => i.ToString() == s));
             }
+
+            [Test]
+            public void UsesProvidedPredicateForDirectComparisonDifferentTypes()
+            {
+                Assert.That("1", Is.EqualTo(1).Using<string, int>((s, i) => i.ToString() == s));
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes #4726

Following the advice of @manfred-brands:

> I think that renaming the type parameters to `TCollectionElementType` and `TExpectedType` would clear things up.

I took the opportunity to find every instance of the in-line comparers to clear things up.

I dropped the `Type` at the end of the the generic parameter names because it began to feel too verbose, I'll add it back in if that's the preferred convention.

Some of the more pathological cases had testing holes so I filled those in as well.