### PR TITLE
Issue-3359 : Add XML documentation on SetName letting folks know abou…

### DIFF
--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -73,6 +73,11 @@ namespace NUnit.Framework
         /// Sets the name of the test case
         /// </summary>
         /// <returns>The modified TestCaseData instance</returns>
+        /// <remarks>
+        /// Consider using <see cref="SetArgDisplayNames"/>for setting argument values in the test name.
+        /// <see cref="SetArgDisplayNames"/> allows you to specify the display names for parameters directly without
+        /// needing to use tokens like {m}.
+        /// </remarks>
         public TestCaseData SetName(string? name)
         {
             TestName = name;
@@ -82,6 +87,13 @@ namespace NUnit.Framework
         /// <summary>
         /// Sets the list of display names to use as the parameters in the test name.
         /// </summary>
+        /// <returns>The modified TestCaseData instance</returns>
+        /// <example>
+        /// <code>
+        /// TestCaseData testCase = new TestCaseData(args)
+        ///     .SetArgDisplayNames("arg1DisplayName", "arg2DisplayName");
+        /// </code>
+        /// </example>
         public TestCaseData SetArgDisplayNames(params string[]? displayNames)
         {
             ArgDisplayNames = displayNames;


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/3359
For setting argument values in the test name, poeple should consider using SetArgDisplayNames instead of SetNames. 
It allows to specify the display names for parameters directly without  needing to use tokens like {m} or {0}. This method preserves namespace information and avoids issues related to prefiltering that can occur with SetNames