### PR TITLE
Converting to use main branch instead of master

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,7 +55,7 @@ csharp_indent_block_contents = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 
-csharp_prefer_braces = when_multiline
+csharp_prefer_braces = when_multiline:silent
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#naming
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
@@ -177,3 +177,21 @@ dotnet_diagnostic.CSIsNull001.severity = warning
 
 # CSIsNull002: Use `is object` for non-null checks
 dotnet_diagnostic.CSIsNull002.severity = warning
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+csharp_indent_labels = one_less_than_current
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent

--- a/.github/workflows/NUnit.CI.yml
+++ b/.github/workflows/NUnit.CI.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
       - release
       - 'v3'
   pull_request:

--- a/.github/workflows/NUnit.Myget.Publish.yml
+++ b/.github/workflows/NUnit.Myget.Publish.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - master
       - release
       - 'v3'
       - myget

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Documentation for all NUnit projects can be found at the [documentation site](ht
 
 ## Contributing ##
 
-For more information on contributing to the NUnit project, please see [CONTRIBUTING.md](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) and the [Developer Docs](https://docs.nunit.org/articles/developer-info/Team-Practices.html#technical-practices).
+For more information on contributing to the NUnit project, please see [CONTRIBUTING.md](https://github.com/nunit/nunit/blob/main/CONTRIBUTING.md) and the [Developer Docs](https://docs.nunit.org/articles/developer-info/Team-Practices.html#technical-practices).
 
 NUnit 3.0 was created by [Charlie Poole](https://github.com/CharliePoole), [Rob Prouse](https://github.com/rprouse), [Simone Busoli](https://github.com/simoneb), [Neil Colvin](https://github.com/oznetmaster) and numerous community contributors. A complete list of contributors since NUnit migrated to GitHub can be [found on GitHub](https://github.com/nunit/nunit/graphs/contributors).
 
@@ -43,7 +43,7 @@ Earlier versions of NUnit were developed by Charlie Poole, James W. Newkirk, Ale
 
 ## License ##
 
-NUnit is Open Source software and NUnit 4 is released under the [MIT license](https://raw.githubusercontent.com/nunit/nunit/master/LICENSE.txt). Earlier releases used the [NUnit license](https://nunit.org/nuget/license.html). Both of these licenses allow the use of NUnit in free and commercial applications and libraries without restrictions.
+NUnit is Open Source software and NUnit 4 is released under the [MIT license](https://raw.githubusercontent.com/nunit/nunit/main/LICENSE.txt). Earlier releases used the [NUnit license](https://nunit.org/nuget/license.html). Both of these licenses allow the use of NUnit in free and commercial applications and libraries without restrictions.
 
 ## NUnit Projects ##
 

--- a/THIRD_PARTY_NOTICES_DEV.md
+++ b/THIRD_PARTY_NOTICES_DEV.md
@@ -29,5 +29,5 @@
 | Reference                                   | Version         | License Type    | License                                                              |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Microsoft.NET.Test.Sdk                      | 17.7.2          | LICENSE_NET.txt | https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.6.3/License |
-| System.Collections.Immutable                | 6.0.0           | MIT             | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT             |
+| System.Collections.Immutable                | 6.0.0           | MIT             | https://github.com/dotnet/corefx/blob/main/LICENSE.TXT             |
 | TunnelVisionLabs.ReferenceAssemblyAnnotator | 1.0.0-alpha.160 | MIT             | https://licenses.nuget.org/MIT                                       |

--- a/THIRD_PARTY_NOTICES_DEV.md
+++ b/THIRD_PARTY_NOTICES_DEV.md
@@ -29,5 +29,5 @@
 | Reference                                   | Version         | License Type    | License                                                              |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Microsoft.NET.Test.Sdk                      | 17.7.2          | LICENSE_NET.txt | https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.6.3/License |
-| System.Collections.Immutable                | 6.0.0           | MIT             | https://github.com/dotnet/corefx/blob/main/LICENSE.TXT             |
+| System.Collections.Immutable                | 6.0.0           | MIT             | https://github.com/dotnet/runtime/blob/main/LICENSE.TXT             |
 | TunnelVisionLabs.ReferenceAssemblyAnnotator | 1.0.0-alpha.160 | MIT             | https://licenses.nuget.org/MIT                                       |


### PR DESCRIPTION
Fixes #3981 

The word "master" is used in different places, and have been replaced with "main".