### PR TITLE
Tuple and Properties compare now obey DefaultFloatingPointTolerance

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -42,33 +42,26 @@ namespace NUnit.Framework.Constraints.Comparers
             string declaringTypeName = xType.Name;
 
             uint redoWithoutTolerance = 0x0;
-            if (tolerance.HasVariance)
+            for (int i = 0; i < properties.Length; i++)
             {
-                for (int i = 0; i < properties.Length; i++)
+                PropertyInfo property = properties[i];
+                object? xPropertyValue = property.GetValue(x, null);
+                object? yPropertyValue = property.GetValue(y, null);
+
+                EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, comparisonState);
+                if (result == EqualMethodResult.ComparedNotEqual)
                 {
-                    PropertyInfo property = properties[i];
-                    object? xPropertyValue = property.GetValue(x, null);
-                    object? yPropertyValue = property.GetValue(y, null);
-
-                    EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, comparisonState);
-                    if (result == EqualMethodResult.ComparedNotEqual)
-                    {
-                        return PropertyNotEqualResult(equalityComparer, i, declaringTypeName, property.Name, xPropertyValue, yPropertyValue);
-                    }
-
-                    if (result == EqualMethodResult.ToleranceNotSupported)
-                    {
-                        redoWithoutTolerance |= 1U << i;
-                    }
+                    return PropertyNotEqualResult(equalityComparer, i, declaringTypeName, property.Name, xPropertyValue, yPropertyValue);
                 }
 
-                if (redoWithoutTolerance == (1U << properties.Length) - 1)
-                    return EqualMethodResult.ToleranceNotSupported;
+                if (result == EqualMethodResult.ToleranceNotSupported)
+                {
+                    redoWithoutTolerance |= 1U << i;
+                }
             }
-            else
-            {
-                redoWithoutTolerance = (1U << properties.Length) - 1;
-            }
+
+            if (redoWithoutTolerance == (1U << properties.Length) - 1)
+                return EqualMethodResult.ToleranceNotSupported;
 
             if (redoWithoutTolerance != 0)
             {

--- a/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
@@ -26,28 +26,21 @@ namespace NUnit.Framework.Constraints.Comparers
             ComparisonState comparisonState = state.PushComparison(x, y);
 
             uint redoWithoutTolerance = 0x0;
-            if (tolerance.HasVariance)
+            for (int i = 0; i < numberOfGenericArgs; i++)
             {
-                for (int i = 0; i < numberOfGenericArgs; i++)
-                {
-                    string propertyName = i < 7 ? "Item" + (i + 1) : "Rest";
-                    object? xItem = getValue(xType, propertyName, x);
-                    object? yItem = getValue(yType, propertyName, y);
+                string propertyName = i < 7 ? "Item" + (i + 1) : "Rest";
+                object? xItem = getValue(xType, propertyName, x);
+                object? yItem = getValue(yType, propertyName, y);
 
-                    EqualMethodResult result = equalityComparer.AreEqual(xItem, yItem, ref tolerance, comparisonState);
-                    if (result == EqualMethodResult.ComparedNotEqual)
-                        return result;
-                    if (result == EqualMethodResult.ToleranceNotSupported)
-                        redoWithoutTolerance |= 1U << i;
-                }
+                EqualMethodResult result = equalityComparer.AreEqual(xItem, yItem, ref tolerance, comparisonState);
+                if (result == EqualMethodResult.ComparedNotEqual)
+                    return result;
+                if (result == EqualMethodResult.ToleranceNotSupported)
+                    redoWithoutTolerance |= 1U << i;
+            }
 
-                if (redoWithoutTolerance == (1U << numberOfGenericArgs) - 1)
-                    return EqualMethodResult.ToleranceNotSupported;
-            }
-            else
-            {
-                redoWithoutTolerance = (1U << numberOfGenericArgs) - 1;
-            }
+            if (redoWithoutTolerance == (1U << numberOfGenericArgs) - 1)
+                return EqualMethodResult.ToleranceNotSupported;
 
             if (redoWithoutTolerance != 0)
             {

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -388,6 +388,16 @@ namespace NUnit.Framework.Tests.Assertions
             });
         }
 
+        [Test]
+        [DefaultFloatingPointTolerance(0.1)]
+        public void AssertThatEqualsWithClassWithSomeToleranceAwareMembersUsesDefaultFloatingPointTolerance()
+        {
+            var zero = new ClassWithSomeToleranceAwareMembers(0, 0.0, string.Empty, null);
+            var instance = new ClassWithSomeToleranceAwareMembers(1, 1.1, "1.1", zero);
+
+            Assert.That(new ClassWithSomeToleranceAwareMembers(1, 1.2, "1.1", zero), Is.EqualTo(instance).UsingPropertiesComparer());
+        }
+
         private sealed class ClassWithSomeToleranceAwareMembers
         {
             public ClassWithSomeToleranceAwareMembers(int valueA, double valueB, string valueC, ClassWithSomeToleranceAwareMembers? chained)

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -14,10 +14,28 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(2.05d, Is.EqualTo(2.0d));
         }
 
+        [Test, DefaultFloatingPointTolerance(0.1)]
+        public void DefaultToleranceOnTuple_Success()
+        {
+            Assert.That((2.05d, 0.95d), Is.EqualTo((2.0d, 1.0d)));
+        }
+
+        [Test, DefaultFloatingPointTolerance(0.1)]
+        public void DefaultToleranceOnMixedTuple_Success()
+        {
+            Assert.That((1, 2.05d, true), Is.EqualTo((1, 2.0d, true)));
+        }
+
         [Test, DefaultFloatingPointTolerance(0.01)]
         public void DefaultTolerance_Failure()
         {
             Assert.That(2.05d, Is.Not.EqualTo(2.0d));
+        }
+
+        [Test, DefaultFloatingPointTolerance(0.01)]
+        public void DefaultToleranceOnTuple_Failure()
+        {
+            Assert.That((2.05d, 0.95d), Is.Not.EqualTo((2.0d, 1.0d)));
         }
 
         [Test, DefaultFloatingPointTolerance(0.5)]


### PR DESCRIPTION
Fixes #4750 

The Tuple and Properties comparer were passing in supplied variance only if explicitly set with `.Within`.
Now this test is removed which allows the NumericsComparer to fall back to the `DefaultFloatingPointTolerance`.

review compare with ignore white space changes.
