### PR TITLE
Generic test case attribute

### DIFF
--- a/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs
@@ -476,4 +476,91 @@ namespace NUnit.Framework
 
         #endregion
     }
+
+#if NET6_0_OR_GREATER // Although this compiles for .NET Framework, it fails at runtime with a NotSupportedException : Generic types are not valid.
+
+#pragma warning disable CS3015 // Type has no accessible constructors which use only CLS-compliant types
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TestCaseAttribute<T> : TestCaseAttribute
+    {
+        /// <summary>
+        /// Construct a TestCaseAttribute with a list of arguments.
+        /// </summary>
+        public TestCaseAttribute(T argument)
+            : base(new object?[] { argument })
+        {
+            TypeArgs = new[] { typeof(T) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TestCaseAttribute<T1, T2> : TestCaseAttribute
+    {
+        /// <summary>
+        /// Construct a TestCaseAttribute with a list of arguments.
+        /// </summary>
+        public TestCaseAttribute(T1 argument1, T2 argument2)
+            : base(new object?[] { argument1, argument2 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TestCaseAttribute<T1, T2, T3> : TestCaseAttribute
+    {
+        /// <summary>
+        /// Construct a TestCaseAttribute with a list of arguments.
+        /// </summary>
+        public TestCaseAttribute(T1 argument1, T2 argument2, T3 argument3)
+            : base(new object?[] { argument1, argument2, argument3 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TestCaseAttribute<T1, T2, T3, T4> : TestCaseAttribute
+    {
+        /// <summary>
+        /// Construct a TestCaseAttribute with a list of arguments.
+        /// </summary>
+        public TestCaseAttribute(T1 argument1, T2 argument2, T3 argument3, T4 argument4)
+            : base(new object?[] { argument1, argument2, argument3, argument4 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TestCaseAttribute<T1, T2, T3, T4, T5> : TestCaseAttribute
+    {
+        /// <summary>
+        /// Construct a TestCaseAttribute with a list of arguments.
+        /// </summary>
+        public TestCaseAttribute(T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
+            : base(new object?[] { argument1, argument2, argument3, argument4, argument5 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) };
+        }
+    }
+
+#pragma warning restore CS3015 // Type has no accessible constructors which use only CLS-compliant types
+#endif
 }

--- a/src/NUnitFramework/framework/TestCaseData.cs
+++ b/src/NUnitFramework/framework/TestCaseData.cs
@@ -194,4 +194,82 @@ namespace NUnit.Framework
 
         #endregion
     }
+
+#if NET6_0_OR_GREATER // Although this compiles for .NET Framework, it fails at runtime with a NotSupportedException : Generic types are not valid.
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    public class TestCaseData<T> : TestCaseData
+    {
+        /// <summary>
+        /// Construct a TestCaseData with a list of arguments.
+        /// </summary>
+        public TestCaseData(T argument)
+            : base(new object?[] { argument })
+        {
+            TypeArgs = new[] { typeof(T) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    public class TestCaseData<T1, T2> : TestCaseData
+    {
+        /// <summary>
+        /// Construct a TestCaseData with a list of arguments.
+        /// </summary>
+        public TestCaseData(T1 argument1, T2 argument2)
+            : base(new object?[] { argument1, argument2 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    public class TestCaseData<T1, T2, T3> : TestCaseData
+    {
+        /// <summary>
+        /// Construct a TestCaseData with a list of arguments.
+        /// </summary>
+        public TestCaseData(T1 argument1, T2 argument2, T3 argument3)
+            : base(new object?[] { argument1, argument2, argument3 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    public class TestCaseData<T1, T2, T3, T4> : TestCaseData
+    {
+        /// <summary>
+        /// Construct a TestCaseData with a list of arguments.
+        /// </summary>
+        public TestCaseData(T1 argument1, T2 argument2, T3 argument3, T4 argument4)
+            : base(new object?[] { argument1, argument2, argument3, argument4 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
+        }
+    }
+
+    /// <summary>
+    /// Marks a method as a parameterized test suite and provides arguments for each test case.
+    /// </summary>
+    public class TestCaseData<T1, T2, T3, T4, T5> : TestCaseData
+    {
+        /// <summary>
+        /// Construct a TestCaseData with a list of arguments.
+        /// </summary>
+        public TestCaseData(T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
+            : base(new object?[] { argument1, argument2, argument3, argument4, argument5 })
+        {
+            TypeArgs = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) };
+        }
+    }
+#endif
 }

--- a/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseAttributeFixture.cs
@@ -116,7 +116,16 @@ namespace NUnit.TestData.TestCaseAttributeFixture
         }
 
         [TestCase("doesn't work", TypeArgs = new[] { typeof(int) })]
-        public static void MethodWithIncompatibleTypeArgs<T>(T input)
+        public static void MethodWithIncompatibleTypeArgs<T>(T _)
+        {
+        }
+
+        [TestCase(2.0)]
+#if NET6_0_OR_GREATER
+        [TestCase<double>(2)]
+        [TestCase<double>(2.0)]
+#endif
+        public static void MethodWithoutTypeArgsWithIncompatibleParameters(string _)
         {
         }
     }

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -766,8 +766,65 @@ namespace NUnit.Framework.Tests.Attributes
         [TestCase(2L, TypeArgs = new[] { typeof(long) }, ExpectedResult = typeof(long))]
         [TestCase(2, ExpectedResult = typeof(int))]
         [TestCase(2L, ExpectedResult = typeof(long))]
-        public Type GenericMethodAndParameterWithExplicitOrImplicitTyping<T>(T input)
+        [TestCase(2, TypeArgs = new[] { typeof(double) }, ExpectedResult = typeof(double))]
+        public Type GenericMethodAndParameterWithExplicitOrImplicitTyping<T>(T _)
             => typeof(T);
+
+#if NET6_0_OR_GREATER
+        [TestCase<double>(2)]
+        [TestCase<double>(2.0)]
+        public void ExplicitGenericTypeArgsWithCompatibleParameters<T>(T input)
+        {
+            Assert.That(input, Is.InstanceOf<T>());
+        }
+
+        [TestCase<int, double>(2, 2.0)]
+        public void ExplicitGenericTypeArgsWithCompatibleParameters<T1, T2>(T1 input1, T2 input2)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+            });
+        }
+
+        [TestCase<string, int, double>("2", 2, 2.0)]
+        public void ExplicitGenericTypeArgsWithCompatibleParameters<T1, T2, T3>(T1 input1, T2 input2, T3 input3)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+            });
+        }
+
+        [TestCase<bool, string, int, double>(true, "2", 2, 2.0)]
+        public void ExplicitGenericTypeArgsWithCompatibleParameters<T1, T2, T3, T4>(T1 input1, T2 input2, T3 input3, T4 input4)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+                Assert.That(input4, Is.InstanceOf<T4>());
+            });
+        }
+
+        [TestCase<bool, char, string, int, double>(true, 'N', "2", 2, 2.0)]
+        public void ExplicitGenericTypeArgsWithCompatibleParameters<T1, T2, T3, T4, T5>(T1 input1, T2 input2, T3 input3, T4 input4, T5 input5)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+                Assert.That(input4, Is.InstanceOf<T4>());
+                Assert.That(input5, Is.InstanceOf<T5>());
+            });
+        }
+
+#endif
 
         [Test]
         public void ExplicitTypeArgsWithUnassignableParametersFailsAtRuntime()
@@ -784,6 +841,29 @@ namespace NUnit.Framework.Tests.Attributes
 
             Assert.That(result.FailCount, Is.EqualTo(1));
             Assert.That(result.Message, Does.Contain("Object of type 'System.String' cannot be converted to type 'System.Int32'."));
+        }
+
+        [Test]
+        public void MethodWithoutTypeArgsWithIncompatibleParametersFailsAtRuntime()
+        {
+            var suite = TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseAttributeFixture),
+                nameof(TestCaseAttributeFixture.MethodWithoutTypeArgsWithIncompatibleParameters));
+
+            Assert.Multiple(() =>
+            {
+                for (int i = 0; i < suite.TestCaseCount; i++)
+                {
+                    var test = (Test)suite.Tests[i];
+
+                    Assert.That(test.RunState, Is.EqualTo(RunState.Runnable));
+
+                    var result = TestBuilder.RunTest(test);
+
+                    Assert.That(result.FailCount, Is.EqualTo(1));
+                    Assert.That(result.Message, Does.Contain("Object of type 'System.Double' cannot be converted to type 'System.String'."));
+                }
+            });
         }
 
         [TestCase(2, TypeArgs = new[] { typeof(long) })]

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -514,6 +514,20 @@ namespace NUnit.Framework.Tests.Attributes
             {
                 ExpectedResult = typeof(long)
             };
+#if NET6_0_OR_GREATER
+            yield return new TestCaseData<long>(2)
+            {
+                ExpectedResult = typeof(long)
+            };
+            yield return new TestCaseData<long>(2L)
+            {
+                ExpectedResult = typeof(long)
+            };
+            yield return new TestCaseData<int>(2)
+            {
+                ExpectedResult = typeof(int)
+            };
+#endif
         }
 
         [Test]
@@ -556,7 +570,95 @@ namespace NUnit.Framework.Tests.Attributes
             {
                 TypeArgs = new[] { typeof(IntConverter), typeof(int) }
             };
+#if NET6_0_OR_GREATER
+            yield return new TestCaseData<IntConverter, int>(new DerivedIntConverter(), 2);
+#endif
         }
+
+#if NET6_0_OR_GREATER
+        [TestCaseSource(nameof(GenericDataWithGenericConstraint1))]
+        public void ExplicitGenericDataWithCompatibleParameters<T>(T input)
+        {
+            Assert.That(input, Is.InstanceOf<T>());
+        }
+
+        private static IEnumerable<TestCaseData> GenericDataWithGenericConstraint1()
+        {
+            yield return new TestCaseData<int>(2);
+            yield return new TestCaseData<double>(2);
+        }
+
+        [TestCaseSource(nameof(GenericDataWithGenericConstraint2))]
+        public void ExplicitGenericDataWithCompatibleParameters<T1, T2>(T1 input1, T2 input2)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+            });
+        }
+
+        private static IEnumerable<TestCaseData> GenericDataWithGenericConstraint2()
+        {
+            yield return new TestCaseData<int, double>(2, 2.0);
+            yield return new TestCaseData<double, int>(2.0, 2);
+        }
+
+        [TestCaseSource(nameof(GenericDataWithGenericConstraint3))]
+        public void ExplicitGenericDataWithCompatibleParameters<T1, T2, T3>(T1 input1, T2 input2, T3 input3)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+            });
+        }
+
+        private static IEnumerable<TestCaseData> GenericDataWithGenericConstraint3()
+        {
+            yield return new TestCaseData<string, int, double>("2", 2, 2.0);
+            yield return new TestCaseData<double, int, string>(2.0, 2, "2");
+        }
+
+        [TestCaseSource(nameof(GenericDataWithGenericConstraint4))]
+        public void ExplicitGenericDataWithCompatibleParameters<T1, T2, T3, T4>(T1 input1, T2 input2, T3 input3, T4 input4)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+                Assert.That(input4, Is.InstanceOf<T4>());
+            });
+        }
+
+        private static IEnumerable<TestCaseData> GenericDataWithGenericConstraint4()
+        {
+            yield return new TestCaseData<bool, string, int, double>(true, "2", 2, 2.0);
+            yield return new TestCaseData<double, int, string, bool>(2.0, 2, "2", true);
+        }
+
+        [TestCaseSource(nameof(GenericDataWithGenericConstraint5))]
+        public void ExplicitGenericDataWithCompatibleParameters<T1, T2, T3, T4, T5>(T1 input1, T2 input2, T3 input3, T4 input4, T5 input5)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(input1, Is.InstanceOf<T1>());
+                Assert.That(input2, Is.InstanceOf<T2>());
+                Assert.That(input3, Is.InstanceOf<T3>());
+                Assert.That(input4, Is.InstanceOf<T4>());
+                Assert.That(input5, Is.InstanceOf<T5>());
+            });
+        }
+
+        private static IEnumerable<TestCaseData> GenericDataWithGenericConstraint5()
+        {
+            yield return new TestCaseData<bool, char, string, int, double>(true, 'N', "2", 2, 2.0);
+            yield return new TestCaseData<double, int, string, char, bool>(2.0, 2, "2", 'N', true);
+        }
+
+#endif
 
         #region Sources used by the tests
         private static readonly object[] MyData = new object[]


### PR DESCRIPTION
Add support for:

* `[TestCase<double>(2)]`
* `new TestCaseData<double>(2)`

Both support up to 5 generic arguments.
