### PR TITLE
Optimize message formatting

### DIFF
--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -65,7 +65,13 @@ namespace NUnit.Framework.Constraints
             // Initialize formatter to default for values of indeterminate type.
             DefaultValueFormatter = FormatValueWithoutThrowing;
 
+            AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsTuple, GetValueFromTuple) ?? next(val));
+
             AddFormatter(next => val => val is ValueType ? string.Format(Fmt_ValueType, val) : next(val));
+
+            AddFormatter(next => val => TryFormatKeyValuePair(val) ?? next(val));
+
+            AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsValueTuple, GetValueFromValueTuple) ?? next(val));
 
             AddFormatter(next => val => val is DateTime value ? FormatDateTime(value) : next(val));
 
@@ -86,12 +92,6 @@ namespace NUnit.Framework.Constraints
             AddFormatter(next => val => val is DictionaryEntry de ? FormatKeyValuePair(de.Key, de.Value) : next(val));
 
             AddFormatter(next => val => val is Array valArray ? FormatArray(valArray) : next(val));
-
-            AddFormatter(next => val => TryFormatKeyValuePair(val) ?? next(val));
-
-            AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsTuple, GetValueFromTuple) ?? next(val));
-
-            AddFormatter(next => val => TryFormatTuple(val, TypeHelper.IsValueTuple, GetValueFromValueTuple) ?? next(val));
         }
 
 #if NETFRAMEWORK


### PR DESCRIPTION
Move expensive formatting checks to the end.

I don't have any real data on which types are most commonly formatted, but I'm willing to bet `Tuple`/`ValueTuple`/`KeyValuePair` aren't on that list. Luckily, this speeds up even those scenarios, because they all recurse the formatting logic onto their respective elements.

The ordering is a little unusual, in order to ensure the checks against structs come before the `ValueType` check.

On an related note, once net462 is dropped, all the tuple checks can be drastically simplified by using the [ITuple](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.ituple) interface.

On my machine:
```
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.4780/22H2/2022Update)
Intel Core i9-9880H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.108
  [Host]     : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
```

Before:

| Method      | Value                | Mean       | Error    | StdDev   | Allocated |
|------------ |--------------------- |-----------:|---------:|---------:|----------:|
| FormatValue |                      |   136.3 ns |  1.80 ns |  1.50 ns |     256 B |
| FormatValue | (1, 2, 3)            | 1,494.4 ns | 28.42 ns | 30.41 ns |    1553 B |
| FormatValue | (1, 2, 3)            | 1,199.3 ns | 13.33 ns | 12.46 ns |    1384 B |
| FormatValue | abc                  |   190.1 ns |  3.82 ns |  5.48 ns |     288 B |
| FormatValue | The q(...)y dog [43] |   196.2 ns |  3.95 ns |  4.71 ns |     368 B |
| FormatValue | [abc, 123]           |   903.7 ns | 17.66 ns | 18.90 ns |    1112 B |

After:

| Method      | Value                | Mean        | Error     | StdDev    | Median      | Allocated |
|------------ |--------------------- |------------:|----------:|----------:|------------:|----------:|
| FormatValue |                      |    21.48 ns |  0.480 ns |  0.656 ns |    21.31 ns |         - |
| FormatValue | (1, 2, 3)            | 1,328.54 ns | 26.306 ns | 55.487 ns | 1,314.82 ns |    1168 B |
| FormatValue | (1, 2, 3)            | 1,039.59 ns | 20.804 ns | 41.547 ns | 1,018.04 ns |    1000 B |
| FormatValue | abc                  |    66.02 ns |  1.379 ns |  1.933 ns |    65.57 ns |      32 B |
| FormatValue | The q(...)y dog [43] |    72.42 ns |  1.478 ns |  1.702 ns |    72.24 ns |     112 B |
| FormatValue | [abc, 123]           |   655.29 ns | 13.101 ns | 18.366 ns |   651.20 ns |     496 B |

<details>
<summary>Benchmark code</summary>

```csharp
using BenchmarkDotNet.Attributes;

namespace NUnit.Framework;

[MemoryDiagnoser(false)]
public class StringFormatBenchmarks
{
    public static IEnumerable<object> Values
    {
        get
        {
            yield return "";
            yield return "abc";
            yield return "The quick brown fox jumps over the lazy dog";

            yield return Tuple.Create(1, 2, 3);
            yield return ValueTuple.Create(1, 2, 3);

            yield return KeyValuePair.Create("abc", 123);
        }
    }

    [ParamsSource(nameof(Values))]
    public object Value { get; set; }

    [Benchmark]
    public string FormatValue()
    {
        return Constraints.MsgUtils.FormatValue(Value);
    }
}

```

</details>