### PR TITLE
Fixes #4798

### DIFF
--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.ValueTuple" version="4.5.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <!-- General Packages -->
   <ItemGroup>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -20,7 +20,6 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
-
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -14,14 +14,13 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.ValueTuple" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Memory" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Framework.Tests.SolutionTests
         }
 
         [Test]
-        public void NUnitFrameworkNuspecContainsCorrectDependencies()
+        public void AllPackagesInCsprojIsInNuspec()
         {
             VerifyDependencies.ComparePackages(_csprojPackages, _nuspecPackages);
         }

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -15,7 +15,9 @@ namespace NUnit.Framework.Tests.SolutionTests
     {
         private Dictionary<string, List<string>> _nuspecPackages;
         private Dictionary<string, List<string>> _csprojPackages;
+
         private const string Root = "../../../../../../";
+        private const string NotSpecified = nameof(NotSpecified);
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -41,8 +43,6 @@ namespace NUnit.Framework.Tests.SolutionTests
         internal sealed class CsprojReader
         {
             private const string PathToFrameworkFolder = $"{Root}/src/NUnitFramework/";
-
-            public const string NotSpecified = nameof(NotSpecified);
 
             private string Xml { get; }
 
@@ -118,7 +118,7 @@ namespace NUnit.Framework.Tests.SolutionTests
                     foreach (var group in dependenciesSection.Elements(ns + "group"))
                     {
                         // Get the targetFramework attribute
-                        var framework = group.Attribute("targetFramework")?.Value ?? CsprojReader.NotSpecified;
+                        var framework = group.Attribute("targetFramework")?.Value ?? NotSpecified;
 
                         // Find all dependency elements in the current group
                         var dependencies = group.Elements(ns + "dependency")
@@ -149,7 +149,7 @@ namespace NUnit.Framework.Tests.SolutionTests
                 // Iterate through the frameworks in the csprojPackages dictionary
                 foreach (var csprojFramework in csprojPackages.Keys)
                 {
-                    if (csprojFramework == CsprojReader.NotSpecified)
+                    if (csprojFramework == NotSpecified)
                     {
                         TestContext.Out.WriteLine("Checking for packages that should be in all frameworks in the .nuspec file");
                         // Check if the packages from the csproj are present in all nuspec framework

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -11,15 +11,17 @@ namespace NUnit.Framework.Tests.SolutionTests
     /// <summary>
     /// Checks that the csproj of the framework projects are reflected correctly in the nuspec files.
     /// </summary>
-    [TestFixture("framework/nunit.nuspec", "NUnitFramework/framework/nunit.framework.csproj")]
-    [TestFixture("nunitlite/nunitlite.nuspec", "NUnitFramework/nunitlite/nunitlite.csproj")]
+    [TestFixture("framework/nunit.nuspec", "framework/nunit.framework.csproj")]
+    [TestFixture("nunitlite/nunitlite.nuspec", "nunitlite/nunitlite.csproj")]
     internal sealed class NuspecDependenciesTests
     {
         private readonly string _nuspecPath;
         private readonly string _csprojPath;
+        private readonly string _propsPath;
 
-        private Dictionary<string, List<string>> _nuspecPackages;
-        private Dictionary<string, List<string>> _csprojPackages;
+        private Dictionary<string, List<PackageWithVersion>> _nuspecPackages;
+        private Dictionary<string, List<PackageWithVersion>> _csprojPackages;
+        private Dictionary<string, string> _csprojPackageVersions;
 
         private const string Root = "../../../../../../";
         private const string NotSpecified = nameof(NotSpecified);
@@ -27,14 +29,16 @@ namespace NUnit.Framework.Tests.SolutionTests
         public NuspecDependenciesTests(string nuspecPath, string csProjPath)
         {
             _nuspecPath = Path.GetFullPath($"{Root}/nuget/{nuspecPath}");
-            _csprojPath = Path.GetFullPath($"{Root}/src/{csProjPath}");
+            _csprojPath = Path.GetFullPath($"{Root}/src/NUnitFramework/{csProjPath}");
+            _propsPath = Path.GetFullPath($"{Root}/src/NUnitFramework/Directory.Packages.props");
         }
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
             _nuspecPackages = NuspecReader.ExtractNuspecPackages(_nuspecPath);
-            _csprojPackages = CsprojReader.ExtractCsprojPackages(_csprojPath);
+            _csprojPackageVersions = PackageVersionReader.ExtractPackageVersions(_propsPath);
+            _csprojPackages = CsprojReader.ExtractCsprojPackages(_csprojPath, _csprojPackageVersions);
         }
 
         [Test]
@@ -49,16 +53,56 @@ namespace NUnit.Framework.Tests.SolutionTests
             VerifyDependencies.CheckNuspecPackages(_nuspecPackages, _csprojPackages);
         }
 
+        private sealed record class PackageWithVersion(string Package, string Version);
+
+        private static class PackageVersionReader
+        {
+            // Function to extract packages from the .csproj file
+            public static Dictionary<string, string> ExtractPackageVersions(string path)
+            {
+                Assert.That(path, Does.Exist, $"props file at {path} not found.");
+                string xml = File.ReadAllText(path);
+
+                var doc = XDocument.Parse(xml);
+                var packageVersions = new Dictionary<string, string>();
+
+                foreach (var itemGroup in doc.Descendants("ItemGroup"))
+                {
+                    var packageReferences = itemGroup.Descendants("PackageVersion");
+
+                    foreach (var packageReference in packageReferences)
+                    {
+                        var package = packageReference.Attribute("Include")?.Value;
+                        var version = packageReference.Attribute("Version")?.Value;
+
+                        if (package is not null && version is not null)
+                        {
+                            if (packageVersions.TryGetValue(package, out string? previousVersion))
+                            {
+                                Assert.That(previousVersion, Is.EqualTo(version), $"Package {package} has multiple versions in the same file");
+                            }
+
+                            packageVersions[package] = version;
+                        }
+                    }
+                }
+
+                return packageVersions;
+            }
+        }
+
         private static class CsprojReader
         {
             // Function to extract packages from the .csproj file
-            public static Dictionary<string, List<string>> ExtractCsprojPackages(string path)
+            public static Dictionary<string, List<PackageWithVersion>> ExtractCsprojPackages(
+                string path,
+                Dictionary<string, string> packageVersions)
             {
                 Assert.That(path, Does.Exist, $"Csproj file at {path} not found.");
                 string xml = File.ReadAllText(path);
 
                 var doc = XDocument.Parse(xml);
-                var groupedPackages = new Dictionary<string, List<string>>();
+                var groupedPackages = new Dictionary<string, List<PackageWithVersion>>();
 
                 foreach (var itemGroup in doc.Descendants("ItemGroup"))
                 {
@@ -77,22 +121,35 @@ namespace NUnit.Framework.Tests.SolutionTests
                                                      .Select(include => include!) // Use non-null assertion to ensure the result is a List<string>
                                                      .ToList();
 
+                    var packageReferencesWithVersion = new List<PackageWithVersion>(packageReferences.Count);
+                    foreach (var packageReference in packageReferences)
+                    {
+                        if (!packageVersions.TryGetValue(packageReference, out string? packageVersion))
+                        {
+                            Assert.Fail($"Package {packageReference} in .csproj does not have a version in Directory.Packages.props");
+                        }
+                        else
+                        {
+                            packageReferencesWithVersion.Add(new PackageWithVersion(packageReference, packageVersion));
+                        }
+                    }
+
                     if (itemGroup.Descendants("ProjectReference")
                                  .Select(pr => pr.Attribute("Include")?.Value)
                                  .Where(include => !string.IsNullOrEmpty(include)) // Ensure it's non-null and non-empty
                                  .Select(include => include!) // Use non-null assertion to ensure the result is a List<string>
                                  .Any(include => include.EndsWith("nunit.framework.csproj")))
                     {
-                        packageReferences.Add("NUnit");
+                        packageReferencesWithVersion.Add(new PackageWithVersion("NUnit", "[$version$]"));
                     }
 
-                    if (!groupedPackages.TryGetValue(framework, out List<string>? referencesForFramework))
+                    if (!groupedPackages.TryGetValue(framework, out List<PackageWithVersion>? versionedReferencesForFramework))
                     {
-                        referencesForFramework = new List<string>();
-                        groupedPackages[framework] = referencesForFramework;
+                        versionedReferencesForFramework = new List<PackageWithVersion>();
+                        groupedPackages[framework] = versionedReferencesForFramework;
                     }
 
-                    referencesForFramework.AddRange(packageReferences);
+                    versionedReferencesForFramework.AddRange(packageReferencesWithVersion);
                 }
 
                 return groupedPackages;
@@ -101,7 +158,7 @@ namespace NUnit.Framework.Tests.SolutionTests
 
         private static class NuspecReader
         {
-            public static Dictionary<string, List<string>> ExtractNuspecPackages(string path)
+            public static Dictionary<string, List<PackageWithVersion>> ExtractNuspecPackages(string path)
             {
                 Assert.That(path, Does.Exist, $"Nuspec file at {path} not found.");
                 string xml = File.ReadAllText(path);
@@ -110,7 +167,7 @@ namespace NUnit.Framework.Tests.SolutionTests
                 XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
 
                 // Dictionary to hold dependencies grouped by targetFramework
-                var groupedDependencies = new Dictionary<string, List<string>>();
+                var groupedDependencies = new Dictionary<string, List<PackageWithVersion>>();
 
                 // Find the dependencies section
                 var dependenciesSection = doc.Descendants(ns + "dependencies").FirstOrDefault();
@@ -123,20 +180,28 @@ namespace NUnit.Framework.Tests.SolutionTests
                         var framework = group.Attribute("targetFramework")?.Value ?? NotSpecified;
 
                         // Find all dependency elements in the current group
-                        var dependencies = group.Elements(ns + "dependency")
-                                                .Select(dep => dep.Attribute("id")?.Value)
-                                                .Where(dep => !string.IsNullOrEmpty(dep))
-                                                .Select(dep => dep!) // Ensure non-null values
-                                                .ToList();
+                        var dependencies = group.Elements(ns + "dependency");
 
-                        // Add dependencies to the respective framework group
-                        if (!groupedDependencies.TryGetValue(framework, out List<string>? dependenciesForFramework))
+                        var versionedDependencies = new List<PackageWithVersion>();
+                        foreach (var dependency in dependencies)
                         {
-                            dependenciesForFramework = new List<string>();
-                            groupedDependencies[framework] = dependenciesForFramework;
+                            var id = dependency.Attribute("id")?.Value;
+                            var version = dependency.Attribute("version")?.Value;
+
+                            if (id is not null && version is not null)
+                            {
+                                versionedDependencies.Add(new PackageWithVersion(id, version));
+                            }
                         }
 
-                        dependenciesForFramework.AddRange(dependencies);
+                        // Add dependencies to the respective framework group
+                        if (!groupedDependencies.TryGetValue(framework, out List<PackageWithVersion>? versionedDependenciesForFramework))
+                        {
+                            versionedDependenciesForFramework = new List<PackageWithVersion>();
+                            groupedDependencies[framework] = versionedDependenciesForFramework;
+                        }
+
+                        versionedDependenciesForFramework.AddRange(versionedDependencies);
                     }
                 }
 
@@ -146,7 +211,7 @@ namespace NUnit.Framework.Tests.SolutionTests
 
         private sealed class VerifyDependencies
         {
-            public static void ComparePackages(Dictionary<string, List<string>> csprojPackages, Dictionary<string, List<string>> nuspecPackages)
+            public static void ComparePackages(Dictionary<string, List<PackageWithVersion>> csprojPackages, Dictionary<string, List<PackageWithVersion>> nuspecPackages)
             {
                 // Iterate through the frameworks in the csprojPackages dictionary
                 foreach (var csprojFramework in csprojPackages.Keys)
@@ -159,11 +224,7 @@ namespace NUnit.Framework.Tests.SolutionTests
                         {
                             foreach (var framework in nuspecPackages.Keys)
                             {
-                                var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[framework]).ToList();
-
-                                // Assert that there are no missing packages in any nuspec framework
-                                Assert.That(missingPackages, Is.Empty,
-                                    $"Missing packages in framework '{framework}' in .nuspec: {string.Join(", ", missingPackages)}");
+                                MatchForSingleFramework(framework, csprojPackages[csprojFramework], nuspecPackages[framework]);
                             }
                         });
                     }
@@ -180,21 +241,38 @@ namespace NUnit.Framework.Tests.SolutionTests
                         Assert.That(matchingNuspecFramework, Is.Not.Null, $"Framework '{csprojFramework}' is in .csproj but not in .nuspec.");
 
                         // Find packages in csproj that are missing in nuspec
-                        var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[matchingNuspecFramework]).ToList();
-
-                        // Assert that no packages are missing
-                        Assert.That(missingPackages, Is.Empty, $"Missing packages for framework '{csprojFramework}' in .nuspec: {string.Join(", ", missingPackages)}");
+                        MatchForSingleFramework(matchingNuspecFramework, csprojPackages[csprojFramework], nuspecPackages[matchingNuspecFramework]);
                     }
                 }
             }
 
-            public static void CheckNuspecPackages(Dictionary<string, List<string>> nuspecPackages, Dictionary<string, List<string>> csprojPackages)
+            private static void MatchForSingleFramework(string framework, List<PackageWithVersion> csprojPackages, List<PackageWithVersion> nuspecPackages)
+            {
+                List<string> csProjPackagesForFramework = csprojPackages.Select(x => x.Package).ToList();
+                List<string> nuspecPackagesForFramework = nuspecPackages.Select(x => x.Package).ToList();
+                var missingPackages = csProjPackagesForFramework.Except(nuspecPackagesForFramework).ToList();
+
+                Assert.Multiple(() =>
+                {
+                    // Assert that there are no missing packages in any nuspec framework
+                    Assert.That(missingPackages, Is.Empty,
+                        $"Missing packages in framework '{framework}' in .nuspec: {string.Join(", ", missingPackages)}");
+
+                    foreach (var pair in csprojPackages)
+                    {
+                        var nuspecVersion = nuspecPackages.First(x => x.Package == pair.Package).Version;
+                        Assert.That(nuspecVersion, Is.EqualTo(pair.Version), $"Package {pair.Package} in .csproj should have version '{pair.Version}' in .nuspec");
+                    }
+                });
+            }
+
+            public static void CheckNuspecPackages(Dictionary<string, List<PackageWithVersion>> nuspecPackages, Dictionary<string, List<PackageWithVersion>> csprojPackages)
             {
                 // Extract all packages from csproj
-                var allCsprojPackages = csprojPackages.Values.SelectMany(x => x);
+                var allCsprojPackages = csprojPackages.Values.SelectMany(x => x).Select(x => x.Package).ToList();
 
                 // Extract all packages from nuspec
-                var allNuspecPackages = nuspecPackages.Values.SelectMany(x => x).ToList();
+                var allNuspecPackages = nuspecPackages.Values.SelectMany(x => x).Select(x => x.Package).ToList();
 
                 // Find packages in nuspec that are missing in csproj
                 var missingPackages = allNuspecPackages.Except(allCsprojPackages).ToList();

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -38,7 +38,6 @@ namespace NUnit.Framework.Tests.SolutionTests
             VerifyDependencies.CheckNuspecPackages(_nuspecPackages, _csprojPackages);
         }
 
-
         internal sealed class CsprojReader
         {
             private const string PathToFrameworkFolder = $"{Root}/src/NUnitFramework/";

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -13,157 +13,160 @@ namespace NUnit.Framework.Tests.SolutionTests
     /// </summary>
     internal class NuspecDependenciesTests
     {
+        private const string Root = "../../../../../../";
+
         [Test]
         public void NUnitFrameworkNuspecContainsCorrectDependencies()
         {
-            var nuspec = new NuspecReader(@"framework\NUnit.nuspec");
-            var csproj = new CsprojReader(@"framework\NUnit.Framework.csproj");
+            var nuspec = new NuspecReader("framework/nunit.nuspec");
+            var csproj = new CsprojReader("framework/nunit.framework.csproj");
             var nuspecPackages = nuspec.ExtractNuspecPackages();
             var csprojPackages = csproj.ExtractCsprojPackages();
             VerifyDependencies.ComparePackages(csprojPackages, nuspecPackages);
         }
-    }
 
-    internal class CsprojReader
-    {
-        public const string NotSpecified = nameof(NotSpecified);
-        public string CsProjPath { get; }
-        private const string Root = "../../../../../../";
-        private string Xml { get; }
-
-        private const string PathToFrameworkFolder = $"{Root}/src/nunitframework/";
-        public CsprojReader(string nunitFrameworkCsproj)
+        internal sealed class CsprojReader
         {
-            CsProjPath = Path.GetFullPath(Path.Combine(PathToFrameworkFolder, nunitFrameworkCsproj));
-            Assert.That(File.Exists(CsProjPath), $"Csproj file at {CsProjPath} not found.");
-            Xml = File.ReadAllText(CsProjPath);
-        }
+            private const string PathToFrameworkFolder = $"{Root}/src/NUnitFramework/";
 
-        // Function to extract packages from the .csproj file
-        public Dictionary<string, List<string>> ExtractCsprojPackages()
-        {
-            var doc = XDocument.Parse(Xml);
-            var groupedPackages = new Dictionary<string, List<string>>();
+            public const string NotSpecified = nameof(NotSpecified);
 
-            foreach (var itemGroup in doc.Descendants("ItemGroup"))
+            private string Xml { get; }
+
+            public CsprojReader(string nunitFrameworkCsproj)
             {
-                var condition = itemGroup.Attribute("Condition")?.Value;
-                string framework = NotSpecified;
-
-                if (!string.IsNullOrEmpty(condition) && condition.Contains("TargetFrameworkIdentifier"))
-                {
-                    var split = condition.Split(new[] { "==" }, StringSplitOptions.RemoveEmptyEntries);
-                    framework = split[1].Trim().Replace("'", string.Empty);
-                }
-
-                var packageReferences = itemGroup.Descendants("PackageReference")
-                                                 .Select(pr => pr.Attribute("Include")?.Value)
-                                                 .Where(include => !string.IsNullOrEmpty(include)) // Ensure it's non-null and non-empty
-                                                 .Select(include => include!) // Use non-null assertion to ensure the result is a List<string>
-                                                 .ToList();
-
-                if (!groupedPackages.ContainsKey(framework))
-                {
-                    groupedPackages[framework] = new List<string>();
-                }
-
-                groupedPackages[framework].AddRange(packageReferences);
+                var path = Path.GetFullPath(Path.Combine(PathToFrameworkFolder, nunitFrameworkCsproj));
+                Assert.That(File.Exists(path), $"Csproj file at {path} not found.");
+                Xml = File.ReadAllText(path);
             }
 
-            return groupedPackages;
-        }
-    }
-
-    public class NuspecReader
-    {
-        private const string Root = "../../../../../../";
-
-        private const string PathToNuspecFolder = $"{Root}/nuget/";
-        private string Xml { get; }
-        public NuspecReader(string nuspecPath)
-        {
-            var path = Path.GetFullPath(Path.Combine(PathToNuspecFolder, nuspecPath));
-            Assert.That(File.Exists(path), $"Nuspec file at {path} not found.");
-            Xml = File.ReadAllText(path);
-        }
-
-        public Dictionary<string, List<string>> ExtractNuspecPackages()
-        {
-            var doc = XDocument.Parse(Xml);
-            XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
-
-            // Dictionary to hold dependencies grouped by targetFramework
-            var groupedDependencies = new Dictionary<string, List<string>>();
-
-            // Find the dependencies section
-            var dependenciesSection = doc.Descendants(ns + "dependencies").FirstOrDefault();
-            if (dependenciesSection != null)
+            // Function to extract packages from the .csproj file
+            public Dictionary<string, List<string>> ExtractCsprojPackages()
             {
-                // Iterate over all group elements within the dependencies block
-                foreach (var group in dependenciesSection.Elements(ns + "group"))
+                var doc = XDocument.Parse(Xml);
+                var groupedPackages = new Dictionary<string, List<string>>();
+
+                foreach (var itemGroup in doc.Descendants("ItemGroup"))
                 {
-                    // Get the targetFramework attribute
-                    var framework = group.Attribute("targetFramework")?.Value ?? "Both";
+                    var condition = itemGroup.Attribute("Condition")?.Value;
+                    string framework = NotSpecified;
 
-                    // Find all dependency elements in the current group
-                    var dependencies = group.Elements(ns + "dependency")
-                                            .Select(dep => dep.Attribute("id")?.Value)
-                                            .Where(dep => !string.IsNullOrEmpty(dep))
-                                            .Select(dep => dep!) // Ensure non-null values
-                                            .ToList();
-
-
-                    // Add dependencies to the respective framework group
-                    if (!groupedDependencies.ContainsKey(framework))
+                    if (!string.IsNullOrEmpty(condition) && condition.Contains("TargetFrameworkIdentifier"))
                     {
-                        groupedDependencies[framework] = new List<string>();
+                        var split = condition.Split(new[] { "==" }, StringSplitOptions.RemoveEmptyEntries);
+                        framework = split[1].Trim().Replace("'", string.Empty);
                     }
 
-                    groupedDependencies[framework].AddRange(dependencies);
+                    var packageReferences = itemGroup.Descendants("PackageReference")
+                                                     .Select(pr => pr.Attribute("Include")?.Value)
+                                                     .Where(include => !string.IsNullOrEmpty(include)) // Ensure it's non-null and non-empty
+                                                     .Select(include => include!) // Use non-null assertion to ensure the result is a List<string>
+                                                     .ToList();
+
+                    if (!groupedPackages.TryGetValue(framework, out List<string>? referencesForFramework))
+                    {
+                        referencesForFramework = new List<string>();
+                        groupedPackages[framework] = referencesForFramework;
+                    }
+
+                    referencesForFramework.AddRange(packageReferences);
                 }
+
+                return groupedPackages;
+            }
+        }
+
+        internal sealed class NuspecReader
+        {
+            private const string PathToNuspecFolder = $"{Root}/nuget/";
+
+            private string Xml { get; }
+
+            public NuspecReader(string nuspecPath)
+            {
+                var path = Path.GetFullPath(Path.Combine(PathToNuspecFolder, nuspecPath));
+                Assert.That(File.Exists(path), $"Nuspec file at {path} not found.");
+                Xml = File.ReadAllText(path);
             }
 
-            return groupedDependencies;
-        }
-    }
-
-    public class VerifyDependencies
-    {
-        public static void ComparePackages(Dictionary<string, List<string>> csprojPackages, Dictionary<string, List<string>> nuspecPackages)
-        {
-            // Iterate through the frameworks in the csprojPackages dictionary
-            foreach (var csprojFramework in csprojPackages.Keys)
+            public Dictionary<string, List<string>> ExtractNuspecPackages()
             {
-                if (csprojFramework == CsprojReader.NotSpecified)
-                {
-                    TestContext.Out.WriteLine("Checking for packages that should be in all frameworks in the .nuspec file");
-                    // Check if the packages from the csproj are present in all nuspec framework
-                    foreach (var framework in nuspecPackages.Keys)
-                    {
-                        var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[framework]).ToList();
+                var doc = XDocument.Parse(Xml);
+                XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
 
-                        // Assert that there are no missing packages in any nuspec framework
-                        Assert.That(missingPackages, Is.Empty,
-                            $"Missing packages for framework '{framework}' in .nuspec for 'Both' csproj framework: {string.Join(", ", missingPackages)}");
+                // Dictionary to hold dependencies grouped by targetFramework
+                var groupedDependencies = new Dictionary<string, List<string>>();
+
+                // Find the dependencies section
+                var dependenciesSection = doc.Descendants(ns + "dependencies").FirstOrDefault();
+                if (dependenciesSection is not null)
+                {
+                    // Iterate over all group elements within the dependencies block
+                    foreach (var group in dependenciesSection.Elements(ns + "group"))
+                    {
+                        // Get the targetFramework attribute
+                        var framework = group.Attribute("targetFramework")?.Value ?? "Both";
+
+                        // Find all dependency elements in the current group
+                        var dependencies = group.Elements(ns + "dependency")
+                                                .Select(dep => dep.Attribute("id")?.Value)
+                                                .Where(dep => !string.IsNullOrEmpty(dep))
+                                                .Select(dep => dep!) // Ensure non-null values
+                                                .ToList();
+
+                        // Add dependencies to the respective framework group
+                        if (!groupedDependencies.TryGetValue(framework, out List<string>? dependenciesForFramework))
+                        {
+                            dependenciesForFramework = new List<string>();
+                            groupedDependencies[framework] = dependenciesForFramework;
+                        }
+
+                        dependenciesForFramework.AddRange(dependencies);
                     }
                 }
-                else
+
+                return groupedDependencies;
+            }
+        }
+
+        public class VerifyDependencies
+        {
+            public static void ComparePackages(Dictionary<string, List<string>> csprojPackages, Dictionary<string, List<string>> nuspecPackages)
+            {
+                // Iterate through the frameworks in the csprojPackages dictionary
+                foreach (var csprojFramework in csprojPackages.Keys)
                 {
-                    TestContext.Out.WriteLine($"Checking for packages that should be in corresponding '{csprojFramework}' in the .nuspec file");
-                    // Handle specific framework case
-                    var matchingNuspecFramework = nuspecPackages.Keys.FirstOrDefault(nuspecFramework =>
-                        (csprojFramework == ".NETFramework" && nuspecFramework.StartsWith("net") &&
-                         int.TryParse(nuspecFramework.Substring(3), out var version) && version >= 462) ||
-                        (csprojFramework != ".NETFramework" && nuspecFramework == csprojFramework));
+                    if (csprojFramework == CsprojReader.NotSpecified)
+                    {
+                        TestContext.Out.WriteLine("Checking for packages that should be in all frameworks in the .nuspec file");
+                        // Check if the packages from the csproj are present in all nuspec framework
+                        foreach (var framework in nuspecPackages.Keys)
+                        {
+                            var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[framework]).ToList();
 
-                    // Assert that the matching framework was found
-                    Assert.That(matchingNuspecFramework, Is.Not.Null, $"Framework '{csprojFramework}' is in .csproj but not in .nuspec.");
+                            // Assert that there are no missing packages in any nuspec framework
+                            Assert.That(missingPackages, Is.Empty,
+                                $"Missing packages for framework '{framework}' in .nuspec for 'Both' csproj framework: {string.Join(", ", missingPackages)}");
+                        }
+                    }
+                    else
+                    {
+                        TestContext.Out.WriteLine($"Checking for packages that should be in corresponding '{csprojFramework}' in the .nuspec file");
+                        // Handle specific framework case
+                        var matchingNuspecFramework = nuspecPackages.Keys.FirstOrDefault(nuspecFramework =>
+                            (csprojFramework == ".NETFramework" && nuspecFramework.StartsWith("net") &&
+                             int.TryParse(nuspecFramework.Substring(3), out var version) && version >= 462) ||
+                            (csprojFramework != ".NETFramework" && nuspecFramework == csprojFramework));
 
-                    // Find packages in csproj that are missing in nuspec
-                    var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[matchingNuspecFramework]).ToList();
+                        // Assert that the matching framework was found
+                        Assert.That(matchingNuspecFramework, Is.Not.Null, $"Framework '{csprojFramework}' is in .csproj but not in .nuspec.");
 
-                    // Assert that no packages are missing
-                    Assert.That(missingPackages, Is.Empty, $"Missing packages for framework '{csprojFramework}' in .nuspec: {string.Join(", ", missingPackages)}");
+                        // Find packages in csproj that are missing in nuspec
+                        var missingPackages = csprojPackages[csprojFramework].Except(nuspecPackages[matchingNuspecFramework]).ToList();
+
+                        // Assert that no packages are missing
+                        Assert.That(missingPackages, Is.Empty, $"Missing packages for framework '{csprojFramework}' in .nuspec: {string.Join(", ", missingPackages)}");
+                    }
                 }
             }
         }

--- a/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecDependenciesTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Tests.SolutionTests
             VerifyDependencies.CheckNuspecPackages(_nuspecPackages, _csprojPackages);
         }
 
-        internal sealed class CsprojReader
+        private sealed class CsprojReader
         {
             private const string PathToFrameworkFolder = $"{Root}/src/NUnitFramework/";
 
@@ -89,7 +89,7 @@ namespace NUnit.Framework.Tests.SolutionTests
             }
         }
 
-        internal sealed class NuspecReader
+        private sealed class NuspecReader
         {
             private const string PathToNuspecFolder = $"{Root}/nuget/";
 
@@ -142,7 +142,7 @@ namespace NUnit.Framework.Tests.SolutionTests
             }
         }
 
-        public class VerifyDependencies
+        private sealed class VerifyDependencies
         {
             public static void ComparePackages(Dictionary<string, List<string>> csprojPackages, Dictionary<string, List<string>> nuspecPackages)
             {


### PR DESCRIPTION
Fixes #4798 

I followed the idea from @stevenaw and made this into a test.
The test is in folder for SolutionTests, indicating that it doesn't test code, but tests the setup of the projects.

Writing code like this with XML parsing and so is not something I am very fond out, so I did take some "help" from the ChatGPT "friend".   The parsing code it did pretty well, but the logic - that was more of a struggle.  I believe I have managed to clean up most of that, after NNN iterations, but there certainly some more weirdoes around there.  Appreciate some good comments!

The first commit shows the error, so the action should go red.  
The next commit will fix that error, and should go green. 

The code takes the csproj as the "truth" and checks that the nuspec have the same setup.  Right now it says the System.Memory is missing in the .net6.0 dependency group in the nuspec, but we know that is should instead be placed under the .netframework condition in the csproj.  Some thinking is still needed from the devs :-)  
