### PR TITLE
Add test and fix code for (Value)Tuples with less than 2 elements.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/TupleComparerBase.cs
@@ -25,6 +25,9 @@ namespace NUnit.Framework.Constraints.Comparers
 
             ComparisonState comparisonState = state.PushComparison(x, y);
 
+            if (numberOfGenericArgs == 0) // Nothing to compare
+                return EqualMethodResult.ComparedEqual;
+
             uint redoWithoutTolerance = 0x0;
             for (int i = 0; i < numberOfGenericArgs; i++)
             {

--- a/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/TupleEqualityTests.cs
@@ -17,6 +17,22 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void SucceedsWhenTuplesAreTheSameWithinTolerance()
+        {
+            var tuple1 = Tuple.Create("Hello", 3);
+            var tuple2 = Tuple.Create("Hello", 4);
+            Assert.That(tuple1, Is.EqualTo(tuple2).Within(1));
+        }
+
+        [Test]
+        public void SucceedsWhenSingleTuplesAreTheSame()
+        {
+            var tuple1 = Tuple.Create(3);
+            var tuple2 = Tuple.Create(3);
+            Assert.That(tuple1, Is.EqualTo(tuple2));
+        }
+
+        [Test]
         public void SucceedsWhenContentOfTuplesAreEquivalent()
         {
             var actual = Tuple.Create(1, 2);

--- a/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
@@ -9,11 +9,35 @@ namespace NUnit.Framework.Tests.Constraints
     public class ValueTupleEqualityTests
     {
         [Test]
+        public void SucceedsWhenTuplesAreEmpty()
+        {
+            ValueTuple tuple1 = ValueTuple.Create();
+            ValueTuple tuple2 = ValueTuple.Create();
+            Assert.That(tuple1, Is.EqualTo(tuple2));
+        }
+
+        [Test]
+        public void SucceedsWhenSingleTuplesAreTheSame()
+        {
+            ValueTuple<int> tuple1 = ValueTuple.Create(3);
+            ValueTuple<int> tuple2 = ValueTuple.Create(3);
+            Assert.That(tuple1, Is.EqualTo(tuple2));
+        }
+
+        [Test]
         public void SucceedsWhenTuplesAreTheSame()
         {
             ValueTuple<string, int> tuple1 = ("Hello", 3);
             ValueTuple<string, int> tuple2 = ("Hello", 3);
             Assert.That(tuple1, Is.EqualTo(tuple2));
+        }
+
+        [Test]
+        public void SucceedsWhenTuplesAreTheSameWithinTolerance()
+        {
+            ValueTuple<string, int> tuple1 = ("Hello", 3);
+            ValueTuple<string, int> tuple2 = ("Hello", 4);
+            Assert.That(tuple1, Is.EqualTo(tuple2).Within(1));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4807 

Added test for ValueTuples with 0, 1 argument and for Tuple with 1 argument.
Added early exit if there are no arguments.
