### PR TITLE
Make DelayedConstraint work with ThrowsContraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -258,7 +258,6 @@ namespace NUnit.Framework.Constraints
             long now = Stopwatch.GetTimestamp();
             long delayEnd = TimestampOffset(now, DelayInterval.AsTimeSpan);
 
-            object? actual;
             if (PollingInterval.IsNotZero)
             {
                 long nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
@@ -268,11 +267,9 @@ namespace NUnit.Framework.Constraints
                         ThreadUtility.BlockingDelay((int)TimestampDiff(delayEnd < nextPoll ? delayEnd : nextPoll, now).TotalMilliseconds);
                     nextPoll = TimestampOffset(now, PollingInterval.AsTimeSpan);
 
-                    actual = InvokeDelegate(del);
-
                     try
                     {
-                        ConstraintResult result = BaseConstraint.ApplyTo(actual);
+                        ConstraintResult result = BaseConstraint.ApplyTo(del);
                         if (result.IsSuccess)
                             return new DelegatingConstraintResult(this, result);
                     }
@@ -285,8 +282,7 @@ namespace NUnit.Framework.Constraints
             if ((now = Stopwatch.GetTimestamp()) < delayEnd)
                 ThreadUtility.BlockingDelay((int)TimestampDiff(delayEnd, now).TotalMilliseconds);
 
-            actual = InvokeDelegate(del);
-            return new DelegatingConstraintResult(this, BaseConstraint.ApplyTo(actual));
+            return new DelegatingConstraintResult(this, BaseConstraint.ApplyTo(del));
         }
 
         /// <summary>

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -241,6 +241,53 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(PollCount, Is.EqualTo(4).After(110, 25));
         }
 
+        [Test]
+        public void AssertionExpectingAnExceptionWithRetrySucceeds()
+        {
+            int i = 0;
+            void ThrowsAfterRetry()
+            {
+                if (i++ > 3)
+                {
+                    throw new InvalidOperationException("Always throws after third attempt.");
+                }
+            }
+
+            Assert.That(ThrowsAfterRetry, Throws.InvalidOperationException.After(AFTER, POLLING));
+        }
+
+        [Test]
+        public void AssertionExpectingNoExceptionWithRetrySucceeds()
+        {
+            int i = 0;
+            void DoesNotThrowAfterRetry()
+            {
+                if (i++ < 3)
+                {
+                    throw new InvalidOperationException("Only throws before third attempt.");
+                }
+            }
+
+            Assert.That(DoesNotThrowAfterRetry, Throws.Nothing.After(AFTER, POLLING));
+        }
+
+        [Test]
+        public void AssertionForDelegateWhichThrowsExceptionUntilRetriedSucceeds()
+        {
+            int i = 0;
+            string DoesNotThrowAfterRetry()
+            {
+                if (i++ < 3)
+                {
+                    throw new InvalidOperationException("Only throws before third attempt.");
+                }
+
+                return "Success!";
+            }
+
+            Assert.That(DoesNotThrowAfterRetry, Is.EqualTo("Success!").After(AFTER, POLLING));
+        }
+
         private int PollCount()
         {
             return _pollCount++;
@@ -280,7 +327,8 @@ namespace NUnit.Framework.Tests.Constraints
 
         private static readonly AutoResetEvent WaitEvent = new AutoResetEvent(false);
 
-        [OneTimeTearDown] public void OneTimeTearDown()
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
         {
             WaitEvent.Dispose();
         }


### PR DESCRIPTION
Fixes #4281.

Previously, DelayedConstraint would execute the delegate by itself. However, underlying contraints might have additional logic for delegate handling - like ThrowsConstraint, which catches the exception.

Therefore, the fix is to pass the delegate to the constraint instead of executing it.


This fix has a change in the behavior. Currently, the test would fail if the delegate throws an exception. Now, since the delegate is invoked inside of try-catch block, it would be retried (for all constraints, not only Throws ones).
In my opinion, that's an expected behavior.
Still, let me know if you have any concerns.