### PR TITLE
Fix accidentally dropped version numbers.

### DIFF
--- a/CakeScripts.Tests/CakeScripts.Tests.csproj
+++ b/CakeScripts.Tests/CakeScripts.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -12,7 +12,7 @@
   <!-- General Packages -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="FSharp.Core" Version="8.0.400" />
   </ItemGroup>


### PR DESCRIPTION
@OsirisTerje  You accidentally dropped the version number of two of the package references causing NU1604 and NU1701 compile warnings!

```
D:\a\nunit\nunit\CakeScripts.Tests\CakeScripts.Tests.csproj : warning NU1604: Project dependency Microsoft.NET.Test.Sdk does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results. [D:\a\nunit\nunit\nunit.sln]
D:\a\nunit\nunit\CakeScripts.Tests\CakeScripts.Tests.csproj : warning NU1604: Project dependency NUnit3TestAdapter does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results. [D:\a\nunit\nunit\nunit.sln]
D:\a\nunit\nunit\CakeScripts.Tests\CakeScripts.Tests.csproj : warning NU1701: Package 'NUnit3TestAdapter 3.0.10' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net6.0'. This package may not be fully compatible with your project. [D:\a\nunit\nunit\nunit.sln]
```

Because our Directory.Packages.props is in the `src/NUnitFramework` subdirectory, it is not picked up for the Cake projects.
