### PR TITLE
Incorporate Generic Numerical EqualConstraint into the constraint hierarchy

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -445,7 +445,7 @@ namespace NUnit.Framework.Constraints
 
         // Currently, we only adjust for ArraySegments that have a
         // null array reference. Others could be added in the future.
-        private void AdjustArgumentIfNeeded<T>(ref T arg)
+        private protected static void AdjustArgumentIfNeeded<T>(ref T arg)
         {
             if (arg is not null)
             {

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -19,12 +19,12 @@ namespace NUnit.Framework.Constraints
 
         private readonly object? _expected;
 
-        private Tolerance _tolerance = Tolerance.Default;
+        private protected Tolerance _tolerance = Tolerance.Default;
 
         /// <summary>
         /// NUnitEqualityComparer used to test equality.
         /// </summary>
-        private readonly NUnitEqualityComparer _comparer = new();
+        private protected readonly NUnitEqualityComparer _comparer = new();
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
@@ -13,12 +13,11 @@ namespace NUnit.Framework.Constraints
     /// value. NUnit has special semantics for some object types.
     /// </summary>
     public class EqualConstraint<T> : EqualConstraint
-        where T : struct, IEquatable<T>
+        where T : struct//, IEquatable<T>
     {
         #region Static and Instance Fields
 
         private readonly T _expected;
-        private Func<T, T, bool> _customComparer = null!;
 
         #endregion
 
@@ -30,6 +29,7 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint(T expected)
             : base(expected)
         {
+            AdjustArgumentIfNeeded(ref expected);
             _expected = expected;
         }
         #endregion
@@ -67,7 +67,7 @@ namespace NUnit.Framework.Constraints
             if (!_tolerance.IsUnsetOrDefault)
                 throw new InvalidOperationException("Within modifier may appear only once in a constraint expression");
 
-            _tolerance = new Tolerance(amount);
+            _tolerance = new Tolerance(amount!);
             return this;
         }
 
@@ -148,7 +148,6 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public EqualConstraint<T> Using(IComparer<T> comparer)
         {
-            _customComparer = (l, r) => comparer.Compare(l, r) == 0;
             return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
@@ -159,7 +158,6 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public EqualConstraint<T> Using(Func<T, T, bool> comparer)
         {
-            _customComparer = comparer;
             return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
@@ -170,7 +168,6 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public EqualConstraint<T> Using(Comparison<T> comparer)
         {
-            _customComparer = (l, r) => comparer(l, r) == 0;
             return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
@@ -181,7 +178,6 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public new EqualConstraint<T> Using(IEqualityComparer comparer)
         {
-            _customComparer = (l, r) => comparer.Equals(l, r);
             return (EqualConstraint<T>)base.Using(comparer);
         }
 
@@ -192,8 +188,19 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public EqualConstraint<T> Using(IEqualityComparer<T> comparer)
         {
-            _customComparer = (l, r) => comparer.Equals(l, r);
             return (EqualConstraint<T>)base.Using<T>(comparer);
+        }
+
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public new EqualConstraint<T> UsingPropertiesComparer()
+        {
+            return (EqualConstraint<T>)base.UsingPropertiesComparer();
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints
 {
@@ -36,6 +35,27 @@ namespace NUnit.Framework.Constraints
         #endregion
 
         #region Constraint Modifiers
+        /// <summary>
+        /// Flag the constraint to ignore case and return self.
+        /// </summary>
+        public new EqualConstraint<T> IgnoreCase => (EqualConstraint<T>)base.IgnoreCase;
+
+        /// <summary>
+        /// Flag the constraint to ignore white space and return self.
+        /// </summary>
+        public new EqualConstraint<T> IgnoreWhiteSpace => (EqualConstraint<T>)base.IgnoreWhiteSpace;
+
+        /// <summary>
+        /// Flag the constraint to suppress string clipping
+        /// and return self.
+        /// </summary>
+        public new EqualConstraint<T> NoClip => (EqualConstraint<T>)base.NoClip;
+
+        /// <summary>
+        /// Flag the constraint to compare arrays as collections
+        /// and return self.
+        /// </summary>
+        public new EqualConstraint<T> AsCollection => (EqualConstraint<T>)base.AsCollection;
 
         /// <summary>
         /// Flag the constraint to use a tolerance when determining equality.
@@ -52,6 +72,16 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Flags the constraint to include <see cref="DateTimeOffset.Offset"/>
+        /// property in comparison of two <see cref="DateTimeOffset"/> values.
+        /// </summary>
+        /// <remarks>
+        /// Using this modifier does not allow to use the <see cref="Within"/>
+        /// constraint modifier.
+        /// </remarks>
+        public new EqualConstraint<T> WithSameOffset => (EqualConstraint<T>)base.WithSameOffset;
+
+        /// <summary>
         /// Switches the .Within() modifier to interpret its tolerance as
         /// a distance in representable values (see remarks).
         /// </summary>
@@ -65,14 +95,7 @@ namespace NUnit.Framework.Constraints
         /// point results instead of fixed tolerances is safer because it will
         /// automatically compensate for the added inaccuracy of larger numbers.
         /// </remarks>
-        public new EqualConstraint<T> Ulps
-        {
-            get
-            {
-                _tolerance = _tolerance.Ulps;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Ulps => (EqualConstraint<T>)base.Ulps;
 
         /// <summary>
         /// Switches the .Within() modifier to interpret its tolerance as
@@ -80,92 +103,43 @@ namespace NUnit.Framework.Constraints
         /// the expected value.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Percent
-        {
-            get
-            {
-                _tolerance = _tolerance.Percent;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Percent => (EqualConstraint<T>)base.Percent;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in days.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Days
-        {
-            get
-            {
-                _tolerance = _tolerance.Days;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Days => (EqualConstraint<T>)base.Days;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in hours.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Hours
-        {
-            get
-            {
-                _tolerance = _tolerance.Hours;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Hours => (EqualConstraint<T>)base.Hours;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in minutes.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Minutes
-        {
-            get
-            {
-                _tolerance = _tolerance.Minutes;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Minutes => (EqualConstraint<T>)base.Minutes;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in seconds.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Seconds
-        {
-            get
-            {
-                _tolerance = _tolerance.Seconds;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Seconds => (EqualConstraint<T>)base.Seconds;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in milliseconds.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Milliseconds
-        {
-            get
-            {
-                _tolerance = _tolerance.Milliseconds;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Milliseconds => (EqualConstraint<T>)base.Milliseconds;
 
         /// <summary>
         /// Causes the tolerance to be interpreted as a TimeSpan in clock ticks.
         /// </summary>
         /// <returns>Self</returns>
-        public new EqualConstraint<T> Ticks
-        {
-            get
-            {
-                _tolerance = _tolerance.Ticks;
-                return this;
-            }
-        }
+        public new EqualConstraint<T> Ticks => (EqualConstraint<T>)base.Ticks;
 
         /// <summary>
         /// Flag the constraint to use the supplied IComparer object.
@@ -175,8 +149,7 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint<T> Using(IComparer<T> comparer)
         {
             _customComparer = (l, r) => comparer.Compare(l, r) == 0;
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
-            return this;
+            return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
         /// <summary>
@@ -187,8 +160,7 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint<T> Using(Func<T, T, bool> comparer)
         {
             _customComparer = comparer;
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
-            return this;
+            return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
         /// <summary>
@@ -199,8 +171,7 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint<T> Using(Comparison<T> comparer)
         {
             _customComparer = (l, r) => comparer(l, r) == 0;
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
-            return this;
+            return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
         /// <summary>
@@ -211,8 +182,7 @@ namespace NUnit.Framework.Constraints
         public new EqualConstraint<T> Using(IEqualityComparer comparer)
         {
             _customComparer = (l, r) => comparer.Equals(l, r);
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
-            return this;
+            return (EqualConstraint<T>)base.Using(comparer);
         }
 
         /// <summary>
@@ -223,8 +193,7 @@ namespace NUnit.Framework.Constraints
         public EqualConstraint<T> Using(IEqualityComparer<T> comparer)
         {
             _customComparer = (l, r) => comparer.Equals(l, r);
-            _comparer.ExternalComparers.Add(EqualityAdapter.For(comparer));
-            return this;
+            return (EqualConstraint<T>)base.Using<T>(comparer);
         }
 
         #endregion
@@ -240,17 +209,8 @@ namespace NUnit.Framework.Constraints
         {
             if (actual is T a)
             {
-                bool isSuccess = false;
-
-                if (_customComparer is null)
-                {
-                    GetTolerance(ref _tolerance);
-                    isSuccess = _comparer.AreEqual(_expected, a, ref _tolerance);
-                }
-                else
-                {
-                    isSuccess = _customComparer(_expected, a);
-                }
+                AdjustArgumentIfNeeded(ref a);
+                bool isSuccess = _comparer.AreEqual(_expected, a, ref _tolerance);
 
                 return new EqualConstraintResult(this, GetConstraintResultData(), actual, isSuccess);
             }
@@ -269,18 +229,6 @@ namespace NUnit.Framework.Constraints
                 ClipStrings = ClipStrings,
                 FailurePoints = HasFailurePoints ? FailurePoints : Array.Empty<NUnitEqualityComparer.FailurePoint>()
             };
-        }
-
-        private static void GetTolerance(ref Tolerance tolerance)
-        {
-            if (tolerance.IsUnsetOrDefault && (typeof(T) == typeof(double) || typeof(T) == typeof(float)))
-            {
-                var defaultFloatingPointTolerance = TestExecutionContext.CurrentContext?.DefaultFloatingPointTolerance;
-                if (defaultFloatingPointTolerance is not null && !defaultFloatingPointTolerance.IsUnsetOrDefault)
-                {
-                    tolerance = defaultFloatingPointTolerance;
-                }
-            }
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -145,7 +145,7 @@ namespace NUnit.Framework
         /// Returns a constraint that tests two items for equality
         /// </summary>
         public static EqualConstraint<T> EqualTo<T>(T expected)
-            where T : struct, IEquatable<T>
+            where T : struct//, IEquatable<T>
         {
             return new EqualConstraint<T>(expected);
         }

--- a/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
@@ -97,5 +97,14 @@ namespace NUnit.Framework.Tests.Constraints
             var b = ValueTuple.Create(new Dictionary<string, string>());
             Assert.That(a, Is.EqualTo(b));
         }
+
+        [Test]
+        public void SucceedsWithStringModifiers()
+        {
+            var a = (2, 5, "HELLO ");
+            var b = (2, 5, "hello");
+
+            Assert.That(a, Is.EqualTo(b).IgnoreCase.IgnoreWhiteSpace);
+        }
     }
 }


### PR DESCRIPTION
I'm putting this in as a separate PR so that the changes can be more visible.
Contributes to https://github.com/nunit/nunit/pull/4456

This contributes to https://github.com/nunit/nunit/pull/4456 and will move the EqualConstraint<T> class as a subclass under EqualConstraint. It implements `new` copies of all the modifiers in order to change the return type to continue to return `EqualConstraint<T>` when modifying the constraint. Internally it always defers to base for implementation.

This also drops `EqualConstraint<T>`'s separate copy of custom comparers passed into `Using()` as our deferral to a generic method on the comparer itself can handle those in a way consistent with other constraints.

This also gets us a little closer to being able to remove the generic constraints altogether and to have the generic constraint handle everything. It's still currently constrained to `struct` as there's some edge cases around comparing different types (ex: `4` and `"4"`) which aren't quite working yet