### PR TITLE
WIP: Added an EqualStringConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -427,6 +427,14 @@ namespace NUnit.Framework.Constraints
             return Append(new EqualConstraint(expected));
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualStringConstraint EqualTo(string? expected)
+        {
+            return Append(new EqualStringConstraint(expected));
+        }
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -58,6 +58,21 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Construct an EqualConstraintResult
+        /// </summary>
+        public EqualConstraintResult(Constraint constraint, object? actual, bool caseInsensitive, bool ignoringWhiteSpace, bool clipStrings, bool hasSucceeded)
+            : base(constraint, actual, hasSucceeded)
+        {
+            _expectedValue = constraint.Arguments[0];
+            _tolerance = Tolerance.Exact;
+            _comparingProperties = false;
+            _caseInsensitive = caseInsensitive;
+            _ignoringWhiteSpace = ignoringWhiteSpace;
+            _clipStrings = clipStrings;
+            _failurePoints = Array.Empty<NUnitEqualityComparer.FailurePoint>();
+        }
+
+        /// <summary>
         /// Write a failure message. Overridden to provide custom
         /// failure messages for EqualConstraint.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/EqualStringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualStringConstraint.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework.Constraints.Comparers;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualStringConstraint : Constraint
+    {
+        #region Static and Instance Fields
+
+        private readonly string? _expected;
+
+        private Func<string, string, bool> _comparer;
+        private Func<object, object, bool>? _nonTypedComparer;
+
+        private bool _caseInsensitive;
+        private bool _ignoringWhiteSpace;
+        private bool _clipStrings;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        public EqualStringConstraint(string? expected)
+            : base(expected)
+        {
+            _expected = expected;
+            _clipStrings = true;
+
+            _comparer = (x, y) => StringsComparer.Equals(x, y, _caseInsensitive, _ignoringWhiteSpace);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Gets the expected value.
+        /// </summary>
+        public string? Expected => _expected;
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flag the constraint to ignore case and return self.
+        /// </summary>
+        public EqualStringConstraint IgnoreCase
+        {
+            get
+            {
+                _caseInsensitive = true;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to ignore white space and return self.
+        /// </summary>
+        public EqualStringConstraint IgnoreWhiteSpace
+        {
+            get
+            {
+                _ignoringWhiteSpace = true;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to suppress string clipping
+        /// and return self.
+        /// </summary>
+        public EqualStringConstraint NoClip
+        {
+            get
+            {
+                _clipStrings = false;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(IEqualityComparer<string> comparer)
+        {
+            _comparer = (x, y) => comparer.Equals(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(Func<string, string, bool> comparer)
+        {
+            _comparer = comparer;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(IComparer<string> comparer)
+        {
+            _comparer = (x, y) => comparer.Compare(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied Comparison object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(Comparison<string> comparer)
+        {
+            _comparer = (x, y) => comparer.Invoke(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(IEqualityComparer comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Equals(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using(IComparer comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Compare(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualStringConstraint Using<TOther>(IComparer<TOther> comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Compare((TOther)x, (TOther)y) == 0;
+            return this;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public ConstraintResult ApplyTo(string? actual)
+        {
+            bool hasSucceeded;
+
+            if (actual is null)
+            {
+                hasSucceeded = _expected is null;
+            }
+            else if (_expected is null)
+            {
+                hasSucceeded = false;
+            }
+            else if (_nonTypedComparer is not null)
+            {
+                hasSucceeded = _nonTypedComparer.Invoke(_expected, actual);
+            }
+            else
+            {
+                hasSucceeded = _comparer.Invoke(_expected, actual);
+            }
+
+            return ConstraintResult(actual, hasSucceeded);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// I wish we could hide this method, but it is public in the base class.
+        /// </remarks>
+        public sealed override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            bool hasSucceeded;
+
+            if (actual is null)
+            {
+                hasSucceeded = _expected is null;
+            }
+            else if (_expected is null)
+            {
+                hasSucceeded = false;
+            }
+            else if (_nonTypedComparer is not null)
+            {
+                hasSucceeded = _nonTypedComparer.Invoke(_expected, actual);
+            }
+            else
+            {
+                return ApplyTo(actual as string);
+            }
+
+            return ConstraintResult(actual, hasSucceeded);
+        }
+
+        private ConstraintResult ConstraintResult<T>(T actual, bool hasSucceeded)
+        {
+            return new EqualConstraintResult(this, actual, _caseInsensitive, _ignoringWhiteSpace, _clipStrings, hasSucceeded);
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get
+            {
+                var sb = new StringBuilder(MsgUtils.FormatValue(_expected));
+
+                if (_caseInsensitive)
+                    sb.Append(", ignoring case");
+
+                if (_ignoringWhiteSpace)
+                    sb.Append(", ignoring white-space");
+
+                return sb.ToString();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Constraints
         internal static string FormatDescription(string descriptionPrefix, IConstraint baseConstraint)
         {
             return string.Format(
-                baseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}",
+                baseConstraint is EqualConstraint or EqualStringConstraint ? "{0} equal to {1}" : "{0} {1}",
                 descriptionPrefix,
                 baseConstraint.Description);
         }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -149,6 +149,14 @@ namespace NUnit.Framework
             return new EqualConstraint(expected);
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public static EqualStringConstraint EqualTo(string? expected)
+        {
+            return new EqualStringConstraint(expected);
+        }
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void RespectsCultureWhenCaseIgnored()
         {
-            var constraint = new EqualConstraint("r\u00E9sum\u00E9").IgnoreCase;
+            var constraint = new EqualStringConstraint("r\u00E9sum\u00E9").IgnoreCase;
 
             var result = constraint.ApplyTo("re\u0301sume\u0301");
 
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void DoesntRespectCultureWhenCasingMatters()
         {
-            var constraint = new EqualConstraint("r\u00E9sum\u00E9");
+            var constraint = new EqualStringConstraint("r\u00E9sum\u00E9");
 
             var result = constraint.ApplyTo("re\u0301sume\u0301");
 
@@ -69,7 +69,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void IgnoreWhiteSpace()
         {
-            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace;
+            var constraint = new EqualStringConstraint("Hello World").IgnoreWhiteSpace;
 
             var result = constraint.ApplyTo("Hello\tWorld");
 
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void IgnoreWhiteSpaceFail()
         {
-            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace;
+            var constraint = new EqualStringConstraint("Hello World").IgnoreWhiteSpace;
 
             var result = constraint.ApplyTo("Hello Universe");
 
@@ -112,7 +112,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void IgnoreWhiteSpaceAndIgnoreCase()
         {
-            var constraint = new EqualConstraint("Hello World").IgnoreWhiteSpace.IgnoreCase;
+            var constraint = new EqualStringConstraint("Hello World").IgnoreWhiteSpace.IgnoreCase;
 
             var result = constraint.ApplyTo("hello\r\nworld\r\n");
 
@@ -804,7 +804,9 @@ namespace NUnit.Framework.Tests.Constraints
             [Test]
             public void CompareObjectsWithToleranceAsserts()
             {
-                Assert.Throws<NotSupportedException>(() => Assert.That("abc", new EqualConstraint("abcd").Within(1)));
+                // This now no longer compiled as EqualStringConstraint doesn't support Tolerance.
+                // Assert.Throws<NotSupportedException>(() => Assert.That("abc", new EqualStringConstraint("abcd").Within(1)));
+                Assert.Pass("EqualStringConstraint does not support Tolerance, so this test is not applicable.");
             }
         }
 
@@ -949,7 +951,7 @@ namespace NUnit.Framework.Tests.Constraints
             [Test, SetCulture("en-US")]
             public void UsesProvidedLambda_StringArgs()
             {
-                Assert.That("hello", Is.EqualTo("HELLO").Using<string>((x, y) => StringUtil.Compare(x, y, true)));
+                Assert.That("hello", Is.EqualTo("HELLO").Using((x, y) => StringUtil.Compare(x, y, true)));
             }
 
             [Test]

--- a/src/NUnitFramework/tests/Constraints/EqualTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualTest.cs
@@ -15,7 +15,7 @@ namespace NUnit.Framework.Tests.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That("abcdgfe", new EqualConstraint("abcdefg"));
+                    Assert.That("abcdgfe", new EqualStringConstraint("abcdefg"));
                 }));
         }
 
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Tests.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, Is.EqualTo(expected));
                 }));
         }
 
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Tests.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, Is.EqualTo(expected));
                 }));
         }
 
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Tests.Constraints
             CheckExceptionMessage(
                 Assert.Throws<AssertionException>(() =>
                 {
-                    Assert.That(actual, new EqualConstraint(expected));
+                    Assert.That(actual, Is.EqualTo(expected));
                 }));
         }
 

--- a/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Tests.Constraints
         [Test]
         public void NotHonorsIgnoreCaseUsingConstructors()
         {
-            var ex = Assert.Throws<AssertionException>(() => Assert.That("abc", new NotConstraint(new EqualConstraint("ABC").IgnoreCase)));
+            var ex = Assert.Throws<AssertionException>(() => Assert.That("abc", new NotConstraint(new EqualStringConstraint("ABC").IgnoreCase)));
             Assert.That(ex?.Message, Does.Contain("ignoring case"));
         }
 

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -67,13 +67,13 @@ namespace NUnit.Framework.Tests.Constraints
         protected override Constraint TheConstraint { get; } = new ThrowsConstraint(
                 new AndConstraint(
                     new ExceptionTypeConstraint(typeof(ArgumentException)),
-                    new PropertyConstraint("ParamName", new EqualConstraint("myParam"))));
+                    new PropertyConstraint("ParamName", new EqualStringConstraint("myParam"))));
 
         [SetUp]
         public void SetUp()
         {
             ExpectedDescription = @"<System.ArgumentException> and property ParamName equal to ""myParam""";
-            StringRepresentation = @"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>";
+            StringRepresentation = @"<throws <and <typeof System.ArgumentException> <property ParamName <equalstring ""myParam"">>>>";
         }
 
 #pragma warning disable IDE0052 // Remove unread private members

--- a/src/NUnitFramework/tests/Constraints/ToStringTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToStringTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(constraint.Resolve().ToString(), Is.EqualTo("<propertyexists X>"));
             constraint = Has.Attribute(typeof(TestAttribute)).With.Property("Description").EqualTo("smoke");
             Assert.That(constraint.Resolve().ToString(),
-                Is.EqualTo("<attribute NUnit.Framework.TestAttribute <property Description <equal \"smoke\">>>"));
+                Is.EqualTo("<attribute NUnit.Framework.TestAttribute <property Description <equalstring \"smoke\">>>"));
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace NUnit.Framework.Tests.Constraints
             Assert.That(Is.Not.All.EqualTo(5).ToString(), Is.EqualTo("<unresolved <equal 5>>"));
             Assert.That(Has.Property("X").EqualTo(5).ToString(), Is.EqualTo("<unresolved <equal 5>>"));
             Assert.That(Has.Attribute(typeof(TestAttribute)).With.Property("Description").EqualTo("smoke").ToString(),
-                Is.EqualTo("<unresolved <equal \"smoke\">>"));
+                Is.EqualTo("<unresolved <equalstring \"smoke\">>"));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Tests.Syntax
         [SetUp]
         public void SetUp()
         {
-            ParseTree = @"<equal ""X"">";
+            ParseTree = @"<equalstring ""X"">";
             StaticSyntax = Is.EqualTo("X").IgnoreCase;
             BuilderSyntax = Builder().EqualTo("X").IgnoreCase;
         }

--- a/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework.Tests.Syntax
         {
             IResolveConstraint expr = Throws.Exception.With.Property("ParamName").EqualTo("myParam");
             Assert.That(
-                expr.Resolve().ToString(), Is.EqualTo(@"<throws <property ParamName <equal ""myParam"">>>"));
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <property ParamName <equalstring ""myParam"">>>"));
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace NUnit.Framework.Tests.Syntax
         {
             IResolveConstraint expr = Throws.TypeOf(typeof(ArgumentException)).And.Property("ParamName").EqualTo("myParam");
             Assert.That(
-                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equalstring ""myParam"">>>>"));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Tests.Syntax
         {
             IResolveConstraint expr = Throws.Exception.TypeOf(typeof(ArgumentException)).And.Property("ParamName").EqualTo("myParam");
             Assert.That(
-                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equalstring ""myParam"">>>>"));
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Framework.Tests.Syntax
         {
             IResolveConstraint expr = Throws.TypeOf(typeof(ArgumentException)).With.Property("ParamName").EqualTo("myParam");
             Assert.That(
-                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equal ""myParam"">>>>"));
+                expr.Resolve().ToString(), Is.EqualTo(@"<throws <and <typeof System.ArgumentException> <property ParamName <equalstring ""myParam"">>>>"));
         }
 
         [Test]


### PR DESCRIPTION
Contributes to #53, but instead of generic have more specific constraints for certain types.

See comment in #4456 

The idea is that with this we slowly can remove non-relevant properties (like IgnoreCase) from the `EqualConstraint` where they don't make sense as in `Assert.That(3.14, Is.EqualTo(2.72).IgnoreCase);`

The problem is with some  old constraint expected _untyped_ `IEnumerable` instead of `IEnumerable<string>`
