### PR TITLE
Compare records by properties when requested

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">11</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">12</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
   <!-- Specific dependencies -->
   <ItemGroup>

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints.Comparers
 {
@@ -16,6 +17,12 @@ namespace NUnit.Framework.Constraints.Comparers
                 return EqualMethodResult.TypesNotSupported;
 
             Type xType = x.GetType();
+
+            if (equalityComparer.CompareProperties && TypeHelper.IsRecord(xType))
+            {
+                // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
+                return EqualMethodResult.TypesNotSupported;
+            }
 
             if (OverridesEqualsObject(xType))
             {

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework.Constraints.Comparers
 
             Type xType = x.GetType();
 
-            if (equalityComparer.CompareProperties && TypeHelper.IsRecord(xType))
+            if (equalityComparer.CompareProperties && TypeHelper.HasCompilerGeneratedEquals(xType))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
                 return EqualMethodResult.TypesNotSupported;

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (equalityComparer.CompareProperties && TypeHelper.IsRecord(xType))
+            if (equalityComparer.CompareProperties && TypeHelper.HasCompilerGeneratedEquals(xType))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
                 return EqualMethodResult.TypesNotSupported;

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints.Comparers
 {
@@ -17,6 +18,12 @@ namespace NUnit.Framework.Constraints.Comparers
 
             Type xType = x.GetType();
             Type yType = y.GetType();
+
+            if (equalityComparer.CompareProperties && TypeHelper.IsRecord(xType))
+            {
+                // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
+                return EqualMethodResult.TypesNotSupported;
+            }
 
             MethodInfo? equals = FirstImplementsIEquatableOfSecond(xType, yType);
             if (equals is not null)

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -389,13 +389,10 @@ namespace NUnit.Framework.Internal
             return type.FullName ?? throw new InvalidOperationException("No name for type: " + type);
         }
 
-        private static readonly Type[] EqualsObjectParameterTypes = { typeof(object) };
-
-        internal static bool IsRecord(this Type type)
+        internal static bool HasCompilerGeneratedEquals(this Type type)
         {
-            // Check if Equals method has CompilerGenerated attribute
             var equalsMethod = type.GetMethod(nameof(type.Equals), BindingFlags.Instance | BindingFlags.Public,
-                                  null, EqualsObjectParameterTypes, null);
+                null, [type], null);
 
             return equalsMethod?.GetCustomAttribute<CompilerGeneratedAttribute>() is not null;
         }

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using NUnit.Framework.Interfaces;
 
@@ -386,6 +387,17 @@ namespace NUnit.Framework.Internal
         internal static string FullName(this Type type)
         {
             return type.FullName ?? throw new InvalidOperationException("No name for type: " + type);
+        }
+
+        private static readonly Type[] EqualsObjectParameterTypes = { typeof(object) };
+
+        internal static bool IsRecord(this Type type)
+        {
+            // Check if Equals method has CompilerGenerated attribute
+            var equalsMethod = type.GetMethod(nameof(type.Equals), BindingFlags.Instance | BindingFlags.Public,
+                                  null, EqualsObjectParameterTypes, null);
+
+            return equalsMethod?.GetCustomAttribute<CompilerGeneratedAttribute>() is not null;
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -3,8 +3,8 @@
 using System;
 using System.Threading.Tasks;
 using NUnit.Framework.Interfaces;
-using NUnit.TestData;
 using NUnit.Framework.Tests.TestUtilities;
+using NUnit.TestData;
 
 namespace NUnit.Framework.Tests.Assertions
 {
@@ -599,6 +599,15 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(list1, Is.EqualTo(list2).UsingPropertiesComparer());
         }
 
+        [Test]
+        public void AssertRecordsComparingProperties()
+        {
+            var record1 = new Record("Name", new[] { 1, 2, 3 });
+            var record2 = new Record("Name", new[] { 1, 2, 3 });
+
+            Assert.That(record1, Is.EqualTo(record2).UsingPropertiesComparer());
+        }
+
         private sealed class LinkedList
         {
             public LinkedList(int value, LinkedList? next = null)
@@ -654,6 +663,8 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(two, Is.EqualTo(one).UsingPropertiesComparer());
              */
         }
+
+        private record Record(string Name, int[] Collection);
 
         private sealed class ParentClass
         {

--- a/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
@@ -84,5 +84,53 @@ namespace NUnit.Framework.Tests.Internal
         }
 
         #endregion
+
+        #region IsRecord
+
+        [TestCase(typeof(RecordClass), ExpectedResult = true)]
+        [TestCase(typeof(RecordStruct), ExpectedResult = true)]
+        [TestCase(typeof(RecordWithProperties), ExpectedResult = true)]
+        [TestCase(typeof(int), ExpectedResult = false)]
+        [TestCase(typeof(int[]), ExpectedResult = false)]
+        [TestCase(typeof(DtoClass), ExpectedResult = false)]
+        [TestCase(typeof(ClassWithPrimaryConstructor), ExpectedResult = false)]
+        [TestCase(typeof(ClassWithOverriddenEquals), ExpectedResult = false)]
+        public bool IsRecordTests(Type type) => TypeHelper.IsRecord(type);
+
+        private class DtoClass
+        {
+            public string? Name { get; set; }
+        }
+
+        private class ClassWithPrimaryConstructor(string name)
+        {
+            public string Name => name;
+        }
+
+        private class ClassWithOverriddenEquals
+        {
+            public string? Name { get; set; }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is ClassWithOverriddenEquals other && other.Name == Name;
+            }
+
+            public override int GetHashCode()
+            {
+                return 539060726 + EqualityComparer<string?>.Default.GetHashCode(Name ?? string.Empty);
+            }
+        }
+
+        private record class RecordClass(string Name);
+
+        private record struct RecordStruct(string Name);
+
+        private record RecordWithProperties
+        {
+            public string? Name { get; set; }
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/TypeHelperTests.cs
@@ -85,17 +85,18 @@ namespace NUnit.Framework.Tests.Internal
 
         #endregion
 
-        #region IsRecord
+        #region HasCompilerGeneratedEquals
 
         [TestCase(typeof(RecordClass), ExpectedResult = true)]
         [TestCase(typeof(RecordStruct), ExpectedResult = true)]
         [TestCase(typeof(RecordWithProperties), ExpectedResult = true)]
+        [TestCase(typeof(RecordWithOverriddenEquals), ExpectedResult = false)]
         [TestCase(typeof(int), ExpectedResult = false)]
         [TestCase(typeof(int[]), ExpectedResult = false)]
         [TestCase(typeof(DtoClass), ExpectedResult = false)]
         [TestCase(typeof(ClassWithPrimaryConstructor), ExpectedResult = false)]
         [TestCase(typeof(ClassWithOverriddenEquals), ExpectedResult = false)]
-        public bool IsRecordTests(Type type) => TypeHelper.IsRecord(type);
+        public bool HasCompilerGeneratedEqualsTests(Type type) => TypeHelper.HasCompilerGeneratedEquals(type);
 
         private class DtoClass
         {
@@ -129,6 +130,19 @@ namespace NUnit.Framework.Tests.Internal
         private record RecordWithProperties
         {
             public string? Name { get; set; }
+        }
+
+        private record RecordWithOverriddenEquals(string Name)
+        {
+            public virtual bool Equals(RecordWithOverriddenEquals? other)
+            {
+                return string.Equals(Name, other?.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override int GetHashCode()
+            {
+                return Name.ToUpperInvariant().GetHashCode();
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes #4836 .

If CompareProperties is true, and actual value is record type, I ignore compiler-generated Equals methods, and force it to compare by properties instead.

In order to check that provided type is record, I verify that Equals method has CompilerGeneratedAttribute. Not sure if there's a better way.

I wanted to add a test for class with primary constructor, therefore I increased LangVersion to 12. Let me know if that causes any issues.