### PR TITLE
Added an EqualNumericConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -427,6 +427,25 @@ namespace NUnit.Framework.Constraints
             return Append(new EqualConstraint(expected));
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualConstraint EqualTo(DateTime expected)
+        {
+            return Append(new EqualConstraint(expected));
+        }
+
+#pragma warning disable CS3024 // Constraint type is not CLS-compliant
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualNumericConstraint<T> EqualTo<T>(T expected)
+            where T : unmanaged, IConvertible, IEquatable<T>
+        {
+            return Append(new EqualNumericConstraint<T>(expected));
+        }
+#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -58,6 +58,21 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Construct an EqualConstraintResult
+        /// </summary>
+        public EqualConstraintResult(Constraint constraint, object? actual, Tolerance tolerance, bool hasSucceeded)
+            : base(constraint, actual, hasSucceeded)
+        {
+            _expectedValue = constraint.Arguments[0];
+            _tolerance = tolerance;
+            _comparingProperties = false;
+            _caseInsensitive = false;
+            _ignoringWhiteSpace = false;
+            _clipStrings = false;
+            _failurePoints = Array.Empty<NUnitEqualityComparer.FailurePoint>();
+        }
+
+        /// <summary>
         /// Write a failure message. Overridden to provide custom
         /// failure messages for EqualConstraint.
         /// </summary>

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -50,6 +50,11 @@ namespace NUnit.Framework.Constraints
         public override string DisplayName => "Equal";
 
         /// <summary>
+        /// The expected value.
+        /// </summary>
+        public T Expected => _expected;
+
+        /// <summary>
         /// Gets the tolerance for this comparison.
         /// </summary>
         /// <value>

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+#pragma warning disable CS3024 // Constraint type is not CLS-compliant
+    public class EqualNumericConstraint<T> : Constraint
+#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+        where T : unmanaged, IConvertible, IEquatable<T>
+    {
+        #region Static and Instance Fields
+
+        private readonly T _expected;
+
+        private Func<T, T, bool> _comparer;
+        private Func<object, object, bool>? _nonTypedComparer;
+
+        private Tolerance _tolerance = Tolerance.Default;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        public EqualNumericConstraint(T expected)
+            : base(expected)
+        {
+            _expected = expected;
+            _comparer = (x, y) => Numerics.AreEqual(x, y, ref _tolerance);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override string DisplayName => "Equal";
+
+        /// <summary>
+        /// Gets the tolerance for this comparison.
+        /// </summary>
+        /// <value>
+        /// The tolerance.
+        /// </value>
+        public Tolerance Tolerance => _tolerance;
+
+        #endregion
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flag the constraint to use a tolerance when determining equality.
+        /// </summary>
+        /// <param name="amount">Tolerance value to be used</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Within(T amount)
+        {
+            if (!_tolerance.IsUnsetOrDefault)
+                throw new InvalidOperationException("Within modifier may appear only once in a constraint expression");
+
+            _tolerance = new Tolerance(amount);
+            return this;
+        }
+
+        /// <summary>
+        /// Switches the .Within() modifier to interpret its tolerance as
+        /// a distance in representable values (see remarks).
+        /// </summary>
+        /// <returns>Self.</returns>
+        /// <remarks>
+        /// Ulp stands for "unit in the last place" and describes the minimum
+        /// amount a given value can change. For any integers, an ulp is 1 whole
+        /// digit. For floating point values, the accuracy of which is better
+        /// for smaller numbers and worse for larger numbers, an ulp depends
+        /// on the size of the number. Using ulps for comparison of floating
+        /// point results instead of fixed tolerances is safer because it will
+        /// automatically compensate for the added inaccuracy of larger numbers.
+        /// </remarks>
+        public EqualNumericConstraint<T> Ulps
+        {
+            get
+            {
+                _tolerance = _tolerance.Ulps;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Switches the .Within() modifier to interpret its tolerance as
+        /// a percentage that the actual values is allowed to deviate from
+        /// the expected value.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualNumericConstraint<T> Percent
+        {
+            get
+            {
+                _tolerance = _tolerance.Percent;
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(IEqualityComparer<T> comparer)
+        {
+            _comparer = (x, y) => comparer.Equals(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied boolean-returning delegate.
+        /// </summary>
+        /// <param name="comparer">The boolean-returning delegate to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(Func<T, T, bool> comparer)
+        {
+            _comparer = comparer;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied predicate function
+        /// </summary>
+        /// <param name="comparer">The comparison function to use.</param>
+        /// <typeparam name="TActual">The type of the actual value. Note for collection comparisons this is the element type.</typeparam>
+        /// <typeparam name="TExpected">The type of the expected value. Note for collection comparisons this is the element type.</typeparam>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using<TActual, TExpected>(Func<TActual, TExpected, bool> comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Invoke((TActual)x, (TExpected)y);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(IComparer<T> comparer)
+        {
+            _comparer = (x, y) => comparer.Compare(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied Comparison object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(Comparison<T> comparer)
+        {
+            _comparer = (x, y) => comparer.Invoke(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IEqualityComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(IEqualityComparer comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Equals(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using(IComparer comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Compare(x, y) == 0;
+            return this;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use the supplied IComparer object.
+        /// </summary>
+        /// <param name="comparer">The IComparer object to use.</param>
+        /// <returns>Self.</returns>
+        public EqualNumericConstraint<T> Using<TOther>(IComparer<TOther> comparer)
+        {
+            _nonTypedComparer = (x, y) => comparer.Compare((TOther)x, (TOther)y) == 0;
+            return this;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public ConstraintResult ApplyTo(T actual)
+        {
+            bool hasSucceeded;
+
+            if (_nonTypedComparer is not null)
+            {
+                hasSucceeded = _nonTypedComparer.Invoke(_expected, actual);
+            }
+            else
+            {
+                hasSucceeded = _comparer.Invoke(_expected, actual);
+            }
+
+            return ConstraintResult(actual, hasSucceeded);
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            bool hasSucceeded;
+
+            if (actual is null)
+            {
+                hasSucceeded = false;
+            }
+            else if (_nonTypedComparer is not null)
+            {
+                hasSucceeded = _nonTypedComparer.Invoke(actual, _expected);
+            }
+            else if (actual is T t)
+            {
+                hasSucceeded = _comparer.Invoke(t, _expected);
+            }
+            else if (actual is IEquatable<T> equatable)
+            {
+                hasSucceeded = equatable.Equals(_expected);
+            }
+            else if (actual is not string and IConvertible)
+            {
+                hasSucceeded = Numerics.AreEqual(actual, _expected, ref _tolerance);
+            }
+            else
+            {
+                hasSucceeded = false;
+            }
+
+            return ConstraintResult(actual, hasSucceeded);
+        }
+
+        private ConstraintResult ConstraintResult<TActual>(TActual actual, bool hasSucceeded)
+        {
+            return new EqualConstraintResult(this, actual, _tolerance, hasSucceeded);
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get
+            {
+                var sb = new StringBuilder(MsgUtils.FormatValue(_expected));
+
+                if (_tolerance is not null && _tolerance.HasVariance)
+                {
+                    sb.Append(" +/- ");
+                    sb.Append(MsgUtils.FormatValue(_tolerance.Amount));
+                    if (_tolerance.Mode != ToleranceMode.Linear)
+                    {
+                        sb.Append(" ");
+                        sb.Append(_tolerance.Mode.ToString());
+                    }
+                }
+
+                return sb.ToString();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraintExtensions.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraintExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Extension methods for <see cref="EqualNumericConstraint{T}"/>.
+    /// </summary>
+    public static class EqualNumericConstraintExtensions
+    {
+        /// <summary>
+        /// Flag the constraint to use a tolerance when determining equality.
+        /// </summary>
+        /// <param name="constraint">The original constraint.</param>
+        /// <param name="amount">Tolerance value to be used</param>
+        /// <returns>Original constraint promoted to <see cref="double"/>.</returns>
+        public static EqualNumericConstraint<double> Within(this EqualNumericConstraint<int> constraint, double amount)
+        {
+            return new EqualNumericConstraint<double>(constraint.Expected).Within(amount);
+        }
+
+        /// <summary>
+        /// Flag the constraint to use a tolerance when determining equality.
+        /// </summary>
+        /// <param name="constraint">The original constraint.</param>
+        /// <param name="amount">Tolerance value to be used</param>
+        /// <returns>Original constraint promoted to <see cref="double"/>.</returns>
+        public static EqualNumericConstraint<double> Within(this EqualNumericConstraint<float> constraint, double amount)
+        {
+            return new EqualNumericConstraint<double>(constraint.Expected).Within(amount);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -161,6 +161,43 @@ namespace NUnit.Framework.Constraints
             return AreEqual(Convert.ToInt32(expected), Convert.ToInt32(actual), tolerance);
         }
 
+        /// <summary>
+        /// Test two numeric values for equality, performing the usual numeric
+        /// conversions and using a provided or default tolerance. If the tolerance
+        /// provided is Empty, this method may set it to a default tolerance.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="tolerance">A reference to the tolerance in effect</param>
+        /// <returns>True if the values are equal</returns>
+        public static bool AreEqual<T1, T2>(T1 expected, T2 actual, ref Tolerance tolerance)
+            where T1 : unmanaged, IConvertible
+            where T2 : unmanaged, IConvertible
+        {
+            if (expected is double || actual is double)
+                return AreEqual(expected.ToDouble(null), actual.ToDouble(null), ref tolerance);
+
+            if (expected is float || actual is float)
+                return AreEqual(expected.ToSingle(null), actual.ToSingle(null), ref tolerance);
+
+            if (tolerance.Mode == ToleranceMode.Ulps)
+                throw new InvalidOperationException("Ulps may only be specified for floating point arguments");
+
+            if (expected is decimal || actual is decimal)
+                return AreEqual(expected.ToDecimal(null), actual.ToDecimal(null), tolerance);
+
+            if (expected is ulong || actual is ulong)
+                return AreEqual(expected.ToUInt64(null), actual.ToUInt64(null), tolerance);
+
+            if (expected is long || actual is long)
+                return AreEqual(expected.ToInt64(null), actual.ToInt64(null), tolerance);
+
+            if (expected is uint || actual is uint)
+                return AreEqual(expected.ToUInt32(null), actual.ToUInt32(null), tolerance);
+
+            return AreEqual(expected.ToInt32(null), actual.ToInt32(null), tolerance);
+        }
+
         private static bool AreEqual(double expected, double actual, ref Tolerance tolerance)
         {
             if (double.IsNaN(expected) && double.IsNaN(actual))

--- a/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PrefixConstraint.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -42,8 +44,16 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         internal static string FormatDescription(string descriptionPrefix, IConstraint baseConstraint)
         {
+            bool isEqualConstraint = baseConstraint is EqualConstraint;
+
+            if (!isEqualConstraint)
+            {
+                Type constraintType = baseConstraint.GetType();
+                isEqualConstraint = constraintType.IsGenericType && constraintType.GetGenericTypeDefinition() == typeof(EqualNumericConstraint<>);
+            }
+
             return string.Format(
-                baseConstraint is EqualConstraint ? "{0} equal to {1}" : "{0} {1}",
+                isEqualConstraint ? "{0} equal to {1}" : "{0} {1}",
                 descriptionPrefix,
                 baseConstraint.Description);
         }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -158,6 +158,25 @@ namespace NUnit.Framework
             return new EqualConstraint(expected);
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two collections for equality.
+        /// </summary>
+        public static EqualConstraint EqualTo(DateTime expected)
+        {
+            return new EqualConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+#pragma warning disable CS3024 // Constraint type is not CLS-compliant
+        public static EqualNumericConstraint<T> EqualTo<T>(T expected)
+            where T : unmanaged, IConvertible, IEquatable<T>
+        {
+            return new EqualNumericConstraint<T>(expected);
+        }
+#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -929,7 +929,7 @@ namespace NUnit.Framework.Tests.Constraints
                 var comparer = new GenericEqualityComparison<int>();
                 Assert.Multiple(() =>
                 {
-                    Assert.That(2 + 2, Is.EqualTo(4).Using<int>(comparer.Delegate));
+                    Assert.That(2 + 2, Is.EqualTo(4).Using(comparer.Delegate));
                     Assert.That(comparer.WasCalled, "Comparer was not called");
                 });
             }
@@ -937,13 +937,13 @@ namespace NUnit.Framework.Tests.Constraints
             [Test]
             public void UsesBooleanReturningDelegate()
             {
-                Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.Equals(y)));
+                Assert.That(2 + 2, Is.EqualTo(4).Using((x, y) => x.Equals(y)));
             }
 
             [Test]
             public void UsesProvidedLambda_IntArgs()
             {
-                Assert.That(2 + 2, Is.EqualTo(4).Using<int>((x, y) => x.CompareTo(y)));
+                Assert.That(2 + 2, Is.EqualTo(4).Using((x, y) => x.CompareTo(y)));
             }
 
             [Test, SetCulture("en-US")]

--- a/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ToleranceTests.cs
@@ -125,8 +125,6 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(Is.EqualTo(5).Within(2).Tolerance.ToString(), Is.EqualTo("2"));
                 Assert.That(Is.EqualTo(5).Within(2).Ulps.Tolerance.ToString(), Is.EqualTo("2 Ulps"));
                 Assert.That(Is.EqualTo(5).Within(2).Percent.Tolerance.ToString(), Is.EqualTo("2 Percent"));
-                Assert.That(Is.EqualTo(5).Within(2).Seconds.Tolerance.ToString(), Is.EqualTo("00:00:02"));
-                Assert.That(Is.EqualTo(5).Within(2).Minutes.Tolerance.ToString(), Is.EqualTo("00:02:00"));
             });
         }
     }

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -83,12 +83,8 @@ namespace NUnit.Framework.Tests.Syntax
                 // Bug Fix 1743844
                 Assert.That(2.20492d, Is.EqualTo(2.2d).Within(0.01f),
                     "Double actual, Double expected, Single tolerance");
-                Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01d),
-                    "Double actual, Single expected, Double tolerance");
                 Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01f),
                     "Double actual, Single expected, Single tolerance");
-                Assert.That(2.20492f, Is.EqualTo(2.2f).Within(0.01d),
-                    "Single actual, Single expected, Double tolerance");
                 Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01d),
                     "Single actual, Double expected, Double tolerance");
                 Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01f),
@@ -104,8 +100,6 @@ namespace NUnit.Framework.Tests.Syntax
                 // Extending tolerance to all numeric types
                 Assert.That(202d, Is.EqualTo(200d).Within(2),
                     "Double actual, Double expected, int tolerance");
-                Assert.That(4.87m, Is.EqualTo(5).Within(.25),
-                    "Decimal actual, int expected, Double tolerance");
                 Assert.That(4.87m, Is.EqualTo(5ul).Within(1),
                     "Decimal actual, ulong expected, int tolerance");
                 Assert.That(487, Is.EqualTo(500).Within(25),

--- a/src/NUnitFramework/tests/Syntax/EqualityTests.cs
+++ b/src/NUnitFramework/tests/Syntax/EqualityTests.cs
@@ -83,8 +83,12 @@ namespace NUnit.Framework.Tests.Syntax
                 // Bug Fix 1743844
                 Assert.That(2.20492d, Is.EqualTo(2.2d).Within(0.01f),
                     "Double actual, Double expected, Single tolerance");
+                Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01d),
+                    "Double actual, Single expected, Double tolerance");
                 Assert.That(2.20492d, Is.EqualTo(2.2f).Within(0.01f),
                     "Double actual, Single expected, Single tolerance");
+                Assert.That(2.20492f, Is.EqualTo(2.2f).Within(0.01d),
+                    "Single actual, Single expected, Double tolerance");
                 Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01d),
                     "Single actual, Double expected, Double tolerance");
                 Assert.That(2.20492f, Is.EqualTo(2.2d).Within(0.01f),
@@ -100,6 +104,8 @@ namespace NUnit.Framework.Tests.Syntax
                 // Extending tolerance to all numeric types
                 Assert.That(202d, Is.EqualTo(200d).Within(2),
                     "Double actual, Double expected, int tolerance");
+                Assert.That(4.87m, Is.EqualTo(5).Within(.25),
+                    "Decimal actual, int expected, Double tolerance");
                 Assert.That(4.87m, Is.EqualTo(5ul).Within(1),
                     "Decimal actual, ulong expected, int tolerance");
                 Assert.That(487, Is.EqualTo(500).Within(25),


### PR DESCRIPTION
@stevenaw This is for discussion, to show issues we face.

Contributes to https://github.com/nunit/nunit/issues/53

I added a specific constraint for comparing numbers (`EqualNumericConstraint`)

Like with the `EqualStringConstraint` it restricts modifiers.
This doesn't allow passing in `.IgnoreCase` on numeric values.
Nor does it allow passing in _Time_ based tolerance modifiers, like `Seconds` and `Minutes`.

This constraint does try to prevent boxing when comparing.

I had to add a specific overload for `DateTime` as that type matched my generic constraint on numerics:

```csharp
public static EqualNumericConstraint<T> EqualTo<T>(T expected)
    where T : unmanaged, IConvertible, IEquatable<T>
{
    return new EqualNumericConstraint<T>(expected);
}
```

There is one downside with generics is that we don't get the auto-promotions to the next type like in:
`Assert.That(1.1, Is.EqualTo(1))`
This creates an `int` constraint with a `double` actual.
My code correctly converts the `1` into `1.0` at runtime.
However because the constraint is `int` it is restricting the `.Within` amount to `int`.
`Assert.That(1.0, Is.EqualTo(1).Within(0.1)` will not compile.

I find it not really an issue, but I added a 2nd commit with extension methods.
Where if you have an `int/float` constraint and use `Within(double)` the constraint gets converted to a `double` one.

Fixes #4874 