### PR TITLE
Micro-optimizations to name generation

### DIFF
--- a/src/NUnitFramework/framework/Internal/DisplayName.cs
+++ b/src/NUnitFramework/framework/Internal/DisplayName.cs
@@ -24,7 +24,7 @@ namespace NUnit.Framework.Internal
                 else
                 {
                     var builder = new StringBuilder();
-                    builder.Append("[");
+                    builder.Append('[');
 
                     const int maxNumItemsToEnumerate = 5;
 
@@ -51,7 +51,7 @@ namespace NUnit.Framework.Internal
                     if (argArray.Length > maxNumItemsToEnumerate)
                         builder.Append($", {THREE_DOTS}");
 
-                    builder.Append("]");
+                    builder.Append(']');
                     display = builder.ToString();
                 }
             }
@@ -154,7 +154,7 @@ namespace NUnit.Framework.Internal
                 {
                     // cleanup
                     var sb = new StringBuilder();
-                    sb.Append("\"");
+                    sb.Append('\"');
                     foreach (char c in str)
                     {
                         sb.Append(EscapeCharInString(c));
@@ -165,7 +165,7 @@ namespace NUnit.Framework.Internal
                             break;
                         }
                     }
-                    sb.Append("\"");
+                    sb.Append('\"');
                     display = sb.ToString();
                 }
             }

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -186,15 +186,15 @@ namespace NUnit.Framework.Internal
 
             protected static void AppendGenericTypeNames(StringBuilder sb, MethodInfo method)
             {
-                sb.Append("<");
+                sb.Append('<');
                 int cnt = 0;
                 foreach (Type t in method.GetGenericArguments())
                 {
                     if (cnt++ > 0)
-                        sb.Append(",");
+                        sb.Append(',');
                     sb.Append(t.Name);
                 }
-                sb.Append(">");
+                sb.Append('>');
             }
 
             protected static string GetDisplayString(object? arg, int stringMax)

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -49,7 +49,7 @@ namespace NUnit.Framework.Internal
                 foreach (string nestedClass in name.Tokenize('+'))
                 {
                     if (firstClassSeen)
-                        sb.Append("+");
+                        sb.Append('+');
 
                     firstClassSeen = true;
 
@@ -58,17 +58,17 @@ namespace NUnit.Framework.Internal
                     {
                         var nestedClassName = nestedClass.Substring(0, index);
                         sb.Append(nestedClassName);
-                        sb.Append("<");
+                        sb.Append('<');
 
                         var argumentCount = Int32.Parse(nestedClass.Substring(index + 1));
                         for (int i = 0; i < argumentCount; i++)
                         {
                             if (i > 0)
-                                sb.Append(",");
+                                sb.Append(',');
 
                             sb.Append(GetDisplayName(genericArguments[currentArgument++]));
                         }
-                        sb.Append(">");
+                        sb.Append('>');
                     }
                     else
                     {
@@ -100,15 +100,16 @@ namespace NUnit.Framework.Internal
 
             StringBuilder sb = new StringBuilder(baseName);
 
-            sb.Append("(");
-            for (int i = 0; i < arglist.Length; i++)
-            {
-                if (i > 0)
-                    sb.Append(",");
+            sb.Append('(');
+            sb.Append(DisplayName.GetValueString(arglist[0], STRING_MAX));
 
+            for (int i = 1; i < arglist.Length; i++)
+            {
+                sb.Append(',');
                 sb.Append(DisplayName.GetValueString(arglist[i], STRING_MAX));
             }
-            sb.Append(")");
+
+            sb.Append(')');
 
             return sb.ToString();
         }


### PR DESCRIPTION
An ad-hoc PR.
Most of these changes are just updating to using `StringBuilder.Append(char)` where we can, but I was also able to update `TypeHelper.GetDisplayName(Type, object[])` to skip a branch in the loop since we know by that point in the method that there are at least 1 args.