### PR TITLE
Fix IsEquivalent on default ImmutableArray throws exception

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -43,6 +43,14 @@ namespace NUnit.Framework.Constraints
             IEnumerable actual,
             out CollectionTally.CollectionTallyResult tallyResult)
         {
+            // Early return if both collections are reference-equal or
+            // both collections are in their default or uninitialized state.
+            if (actual.Equals(_expected))
+            {
+                tallyResult = new CollectionTally.CollectionTallyResult([], []);
+                return true;
+            }
+
             CollectionTally ct = Tally(_expected);
             ct.TryRemove(actual);
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -48,6 +48,15 @@ public class CollectionEquivalentConstraintTests
     }
 
     [Test]
+    public void WorksWithDefaultImmutableArrays()
+    {
+        ImmutableArray<int> array1 = default;
+        ImmutableArray<int> array2 = default;
+
+        Assert.That(new CollectionEquivalentConstraint(array1).ApplyTo(array2).IsSuccess);
+    }
+
+    [Test]
     public void EquivalentIgnoresOrder()
     {
         ICollection set1 = new SimpleObjectCollection("x", "y", "z");


### PR DESCRIPTION
Fixes the issue (#3772) when trying to compare equivalency of two `default(ImmutableArray)`s.

Added an early return at the `Matches` method so that any test which passes `EqualityComparer<T>.Default.Equals` also passes `Is.EquivalentTo()`.