### PR TITLE
Added EqualTimeBaseConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintBuilder.cs
@@ -176,6 +176,17 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Replaces the last pushed constraint with the specified constraint.
+        /// </summary>
+        /// <param name="constraint">The constraint to replace the lastPushed with.</param>
+        public void Replace(Constraint constraint)
+        {
+            _constraints.Pop();
+            _lastPushed = _ops.Top;
+            Append(constraint);
+        }
+
+        /// <summary>
         /// Sets the top operator right context.
         /// </summary>
         /// <param name="rightContext">The right context.</param>

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -427,6 +427,30 @@ namespace NUnit.Framework.Constraints
             return Append(new EqualConstraint(expected));
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualDateTimeOffsetConstraint EqualTo(DateTimeOffset expected)
+        {
+            return Append(new EqualDateTimeOffsetConstraint(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualTimeBaseConstraint<DateTime> EqualTo(DateTime expected)
+        {
+            return Append(new EqualTimeBaseConstraint<DateTime>(expected, x => x.Ticks));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public EqualTimeBaseConstraint<TimeSpan> EqualTo(TimeSpan expected)
+        {
+            return Append(new EqualTimeBaseConstraint<TimeSpan>(expected, x => x.Ticks));
+        }
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/framework/Constraints/EqualDateTimeOffsetConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualDateTimeOffsetConstraint.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualDateTimeOffsetConstraint : EqualTimeBaseConstraint<DateTimeOffset>
+    {
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        public EqualDateTimeOffsetConstraint(DateTimeOffset expected)
+            : base(expected, x => x.UtcTicks)
+        {
+        }
+
+        #endregion
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flags the constraint to include <see cref="DateTimeOffset.Offset"/>
+        /// property in comparison of two <see cref="DateTimeOffset"/> values.
+        /// </summary>
+        /// <remarks>
+        /// Using this modifier does not allow to use the <see cref="EqualConstraint.Within"/>
+        /// constraint modifier.
+        /// </remarks>
+        public EqualDateTimeOffsetConstraintWithSameOffset WithSameOffset
+        {
+            get
+            {
+                var constraint = new EqualDateTimeOffsetConstraintWithSameOffset(Expected);
+                Builder?.Replace(constraint);
+                return constraint;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualDateTimeOffsetConstraintWithSameOffset.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualDateTimeOffsetConstraintWithSameOffset.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Text;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualDateTimeOffsetConstraintWithSameOffset : Constraint
+    {
+        private readonly DateTimeOffset _expected;
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        public EqualDateTimeOffsetConstraintWithSameOffset(DateTimeOffset expected)
+            : base(expected)
+        {
+            _expected = expected;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public ConstraintResult ApplyTo(DateTimeOffset actual)
+        {
+            bool hasSucceeded = _expected.Equals(actual) && _expected.Offset == actual.Offset;
+
+            return new ConstraintResult(this, actual, hasSucceeded);
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            if (actual is DateTimeOffset dateTimeOffset)
+            {
+                return ApplyTo(dateTimeOffset);
+            }
+
+            return new ConstraintResult(this, actual, false);
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get
+            {
+                var sb = new StringBuilder(MsgUtils.FormatValue(_expected));
+
+                sb.Append(" with the same offset");
+
+                return sb.ToString();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithNumericTolerance{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithNumericTolerance{T}.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualTimeBasedConstraintWithNumericTolerance<T>
+        where T : notnull, IEquatable<T>, IComparable<T>
+    {
+        private readonly T _expected;
+        private readonly Func<T, long> _getTicks;
+        private readonly double _tolerance;
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="getTicks">Method to extract the Ticks from an instance of <typeparamref name="T"/>.</param>
+        /// <param name="tolerance">The tolerance to apply when qualified with a unit.</param>
+        public EqualTimeBasedConstraintWithNumericTolerance(T expected, Func<T, long> getTicks, double tolerance)
+        {
+            _expected = expected;
+            _tolerance = tolerance;
+            _getTicks = getTicks;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The ConstraintBuilder holding this constraint
+        /// </summary>
+        public ConstraintBuilder? Builder { get; set; }
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in days.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Days => Within(TimeSpan.FromDays(_tolerance));
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in hours.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Hours => Within(TimeSpan.FromHours(_tolerance));
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in minutes.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Minutes => Within(TimeSpan.FromMinutes(_tolerance));
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in seconds.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Seconds => Within(TimeSpan.FromSeconds(_tolerance));
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in milliseconds.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Milliseconds => Within(TimeSpan.FromMilliseconds(_tolerance));
+
+        /// <summary>
+        /// Causes the tolerance to be interpreted as a TimeSpan in clock ticks.
+        /// </summary>
+        /// <returns>Self</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Ticks => Within(TimeSpan.FromTicks((long)_tolerance));
+
+        private EqualTimeBasedConstraintWithTimeSpanTolerance<T> Within(TimeSpan amount)
+        {
+            var constraint = new EqualTimeBasedConstraintWithTimeSpanTolerance<T>(_expected, _getTicks, amount);
+            Builder?.Replace(constraint);
+            return constraint;
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Text;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualTimeBasedConstraintWithTimeSpanTolerance<T> : Constraint
+        where T : notnull, IEquatable<T>, IComparable<T>
+    {
+        private readonly T _expected;
+        private readonly Func<T, long> _getTicks;
+        private readonly TimeSpan _tolerance;
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="tolerance">The tolerance to apply when comparing for equality.</param>
+        /// <param name="getTicks">Method to extract the Ticks from an instance of <typeparamref name="T"/>.</param>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance(T expected, Func<T, long> getTicks, TimeSpan tolerance)
+            : base(expected)
+        {
+            _expected = expected;
+            _getTicks = getTicks;
+            _tolerance = tolerance;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public ConstraintResult ApplyTo(T actual)
+        {
+            long ticksExpected = _getTicks(_expected);
+            long ticksActual = _getTicks(actual);
+
+            bool hasSucceeded = Math.Abs(ticksExpected - ticksActual) <= _tolerance.Ticks;
+
+            return new ConstraintResult(this, actual, hasSucceeded);
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            if (actual is T t)
+            {
+                return ApplyTo(t);
+            }
+
+            return new ConstraintResult(this, actual, false);
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get
+            {
+                var sb = new StringBuilder(MsgUtils.FormatValue(_expected));
+
+                sb.Append(" +/- ");
+                sb.Append(MsgUtils.FormatValue(_tolerance));
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraint{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraint{T}.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// EqualConstraint is able to compare an actual value with the
+    /// expected value provided in its constructor. Two objects are
+    /// considered equal if both are null, or if both have the same
+    /// value. NUnit has special semantics for some object types.
+    /// </summary>
+    public class EqualTimeBaseConstraint<T> : Constraint
+        where T : struct, IEquatable<T>, IComparable<T>
+    {
+        #region Static and Instance Fields
+
+        private readonly T _expected;
+        private readonly Func<T, long> _getTicks;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="getTicks">Method to extract the Ticks from an instance of <typeparamref name="T"/>.</param>
+        public EqualTimeBaseConstraint(T expected, Func<T, long> getTicks)
+            : base(expected)
+        {
+            _expected = expected;
+            _getTicks = getTicks;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Gets the expected value.
+        /// </summary>
+        public T Expected => _expected;
+
+        #region Constraint Modifiers
+
+        /// <summary>
+        /// Flag the constraint to use a tolerance when determining equality.
+        /// </summary>
+        /// <param name="amount">Tolerance value to be used</param>
+        /// <returns>Self.</returns>
+        public EqualTimeBasedConstraintWithTimeSpanTolerance<T> Within(TimeSpan amount)
+        {
+            var constraint = new EqualTimeBasedConstraintWithTimeSpanTolerance<T>(_expected, _getTicks, amount);
+            Builder?.Replace(constraint);
+            return constraint;
+        }
+
+        /// <summary>
+        /// Flag the constraint to use a tolerance when determining equality.
+        /// </summary>
+        /// <param name="amount">Tolerance value to be used</param>
+        /// <returns>Self.</returns>
+        public EqualTimeBasedConstraintWithNumericTolerance<T> Within(double amount)
+        {
+            return new EqualTimeBasedConstraintWithNumericTolerance<T>(_expected, _getTicks, amount)
+            {
+                Builder = Builder,
+            };
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public virtual ConstraintResult ApplyTo(T actual)
+        {
+            bool hasSucceeded = _expected.Equals(actual);
+
+            return new ConstraintResult(this, actual, hasSucceeded);
+        }
+
+        /// <summary>
+        /// Test whether the constraint is satisfied by a given value
+        /// </summary>
+        /// <param name="actual">The value to be tested</param>
+        /// <returns>True for success, false for failure</returns>
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            if (actual is T t)
+            {
+                return ApplyTo(t);
+            }
+
+            return new ConstraintResult(this, actual, false);
+        }
+
+        /// <summary>
+        /// The Description of what this constraint tests, for
+        /// use in messages and in the ConstraintResult.
+        /// </summary>
+        public override string Description
+        {
+            get
+            {
+                return MsgUtils.FormatValue(_expected);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -158,6 +158,30 @@ namespace NUnit.Framework
             return new EqualConstraint(expected);
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two times for equality.
+        /// </summary>
+        public static EqualDateTimeOffsetConstraint EqualTo(DateTimeOffset expected)
+        {
+            return new EqualDateTimeOffsetConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two times for equality.
+        /// </summary>
+        public static EqualTimeBaseConstraint<DateTime> EqualTo(DateTime expected)
+        {
+            return new EqualTimeBaseConstraint<DateTime>(expected, x => x.Ticks);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two times for equality.
+        /// </summary>
+        public static EqualTimeBaseConstraint<TimeSpan> EqualTo(TimeSpan expected)
+        {
+            return new EqualTimeBaseConstraint<TimeSpan>(expected, x => x.Ticks);
+        }
+
         #endregion
 
         #region SameAs

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -384,6 +384,9 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(actual, new EqualConstraint(expected).Within(TimeSpan.TicksPerMinute * 5).Ticks);
             }
 
+/*
+ * This no longer compiles! Preventing illegal code and runtime exceptions.
+ *
             [Test]
             public void ErrorIfDaysPrecedesWithin()
             {
@@ -419,6 +422,7 @@ namespace NUnit.Framework.Tests.Constraints
             {
                 Assert.Throws<InvalidOperationException>(() => Assert.That(DateTime.Now, Is.EqualTo(DateTime.Now).Ticks.Within(5)));
             }
+*/
         }
 
         #endregion
@@ -469,6 +473,9 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(value1, Is.Not.EqualTo(value2).Within(1).Minutes);
             }
 
+/*
+ * The XML documentation says that WithSameOffset doesn't work together with Within, but the code below would says it is.
+ *
             [Theory]
             public void NegativeEqualityTestWithToleranceAndWithSameOffset(DateTimeOffset value1, DateTimeOffset value2)
             {
@@ -494,6 +501,7 @@ namespace NUnit.Framework.Tests.Constraints
 
                 Assert.That(value1, Is.Not.EqualTo(value2).Within(1).Minutes.WithSameOffset);
             }
+*/
         }
 
         public class DateTimeOffSetEquality


### PR DESCRIPTION
Third PR working towards #53 and Related to #4847 and #4848

This constraint use classes (EqualTimeBasedConstraintWithNumericTolerance) to limit in what cases we can specify the `.Seconds` etc. modifiers.

So we allow: `Assert.That(date1, Is.EqualTo(date2).Within(3).Seconds);`
but not: `Assert.That(date1, Is.EqualTo(date2).Seconds)`
nor: `Assert.That(date1, Is.EqualTo(date2).Within(timeSpan).Seconds)`

Because the class with tolerance is different than the one without this also doesn't allow repeats like:
`Assert.That(date1, Is.EqualTo(date2).Within(1).Hours.Seconds.Within(3))`

Fixes #4877 
