### PR TITLE
Fix Build by disabling WinRTAot in Directory.Build.props

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -16,6 +16,7 @@
     <AnnotatedReferenceAssemblyVersion>7.0.0</AnnotatedReferenceAssemblyVersion>
     <GenerateNullableAttributes>false</GenerateNullableAttributes>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
     <Company>NUnit Software</Company>
     <Product>NUnit 4</Product>
     <Version Condition="'$(Version)'==''">4.0.0.0</Version>


### PR DESCRIPTION
Add `<CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>` to fix the current build errors. This is necessary due to a change in the recent SDK changes. For further reference see [dotnet/sdk:#44026](https://github.com/dotnet/sdk/issues/44026)