### PR TITLE
chore: Bump `Cake.MinVer` to avoid warning

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=Cake.MinVer&version=3.0.0"
+#addin "nuget:?package=Cake.MinVer&version=4.0.0"
 #load "CakeScripts/VersionParsers.cs"
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
To avoid the warning 
```
The assembly 'Cake.MinVer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (3.0.0). 
For best compatibility it should target Cake.Core version 4.0.0.
```
in `dotnet tool run dotnet-cake --target=Test --test-run-name=Windows --configuration=Release`