### PR TITLE
Add support for Generic Nullable parameters

### DIFF
--- a/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
+++ b/src/NUnitFramework/framework/Internal/GenericMethodHelper.cs
@@ -108,6 +108,10 @@ namespace NUnit.Framework.Internal
                             TryApplyArgType(genericArgTypes[i], argTypes[i]);
                     }
                 }
+                else if (Reflect.IsNullable(parmType) && !argType.IsClass)
+                {
+                    ApplyArgType(genericArgTypes[0], argType);
+                }
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/Reflect.cs
+++ b/src/NUnitFramework/framework/Internal/Reflect.cs
@@ -336,7 +336,7 @@ namespace NUnit.Framework.Internal
             return !type.IsValueType || IsNullable(type);
         }
 
-        private static bool IsNullable(Type type)
+        internal static bool IsNullable(Type type)
         {
             // Compare with https://github.com/dotnet/coreclr/blob/bb01fb0d954c957a36f3f8c7aad19657afc2ceda/src/mscorlib/src/System/Nullable.cs#L152-L157
             return type.IsGenericType

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -897,5 +897,25 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         private static readonly Type[] ExpectedType = [typeof(int), typeof(long), typeof(ulong), typeof(float), typeof(double)];
+
+        [TestCase("Hello", null)]
+        [TestCase(null, "World")]
+        [TestCase("Hello", "World")]
+        public void GenericNullableClass<TValue>(TValue? greeting, TValue? to)
+            where TValue : class
+        {
+            Assert.That(greeting, Is.Null.Or.Not.Null);
+            Assert.That(to, Is.Not.Null.Or.Null);
+        }
+
+        [TestCase(3, null)]
+        [TestCase(null, 4.0)]
+        [TestCase(3, 4)]
+        public void GenericNullableStruct<TValue>(TValue? greeting, TValue? to)
+            where TValue : struct
+        {
+            Assert.That(greeting, Is.Null.Or.Not.Null);
+            Assert.That(to, Is.Not.Null.Or.Null);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseAttributeTests.cs
@@ -875,5 +875,27 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(convertedValue, Is.TypeOf<T>());
             Assert.That(convertedValue, Is.Not.TypeOf(input.GetType()));
         }
+
+        [TestCase(0, TypeArgs = [typeof(int)])]
+#if NET6_0_OR_GREATER
+        [TestCase<int>(0)]
+#endif
+        [TestCase(0)]
+        [TestCase(1L)]
+        [TestCase(2UL)]
+        [TestCase(3F)]
+        [TestCase(4D)]
+        public void GenericNullable<TValue>(TValue? value)
+            where TValue : struct, IConvertible
+        {
+            Assert.That(value, Is.Not.Null);
+            int index = value.Value.ToInt32(null);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.EqualTo(index));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.InstanceOf(ExpectedType[index]));
+        }
+
+        private static readonly Type[] ExpectedType = [typeof(int), typeof(long), typeof(ulong), typeof(float), typeof(double)];
     }
 }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -756,6 +756,24 @@ namespace NUnit.Framework.Tests.Attributes
             await Task.Delay(100); // Simulate another asynchronous operation
             yield return new TestCaseData(51, 51);
         }
+
+        #region Generic Nullable
+
+        [TestCaseSource(nameof(GenericNullableSource))]
+        public void GenericNullableTest<TValue>(TValue? value)
+            where TValue : struct, IConvertible
+        {
+            Assert.That(value, Is.Not.Null);
+            int index = value.Value.ToInt32(null);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.EqualTo(index));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.InstanceOf(GenericNullableSource[index].GetType()));
+        }
+
+        private static readonly object[] GenericNullableSource = [0, 1L, 2UL, 3F, 4D];
+
+        #endregion
     }
 
     public class TestSourceMayBeInherited


### PR DESCRIPTION
Fixes #4868 

The PR fixes this:
```csharp
[TestCase(0)]
[TestCase(1L)]
[TestCase(2UL)]
[TestCase(3F)]
[TestCase(4D)]
public void GenericNullable<TValue>(TValue? value)
    where TValue : struct, IConvertible
```

With the generic type determined correctly:

![{0AFD890A-51E3-4C21-AE05-53C80F2A4F14}](https://github.com/user-attachments/assets/09553e1d-81fc-4d70-9683-cbd30b38f664)
