### PR TITLE
Add test coverage for Value(Source) attributes for generic methods

### DIFF
--- a/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
@@ -279,6 +279,21 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(suite.Tests[4].Name, Is.EqualTo(@"MethodWithArrayArguments([System.Byte[,]])"));
             });
         }
+
+        [Test]
+        public void GenericNullableTest<TValue>(
+            [ValueSource(nameof(GenericNullableSource))] TValue? value)
+            where TValue : struct, IConvertible
+        {
+            Assert.That(value, Is.Not.Null);
+            int index = value.Value.ToInt32(null);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.EqualTo(index));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.InstanceOf(GenericNullableSource[index].GetType()));
+        }
+
+        private static readonly object[] GenericNullableSource = [0, 1L, 2UL, 3F, 4D];
     }
 
     public class ValueSourceMayBeInherited

--- a/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ValuesAttributeTests.cs
@@ -191,5 +191,39 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(suite.Tests[3].Name, Is.EqualTo(@"MethodWithArrayArguments([1, 2, 3, 4, 5, ...])"));
             });
         }
+
+        [Test]
+        public void GenericNullable<TValue>([Values(0, 1L, 2UL, 3F, 4D)] TValue? value)
+            where TValue : struct, IConvertible
+        {
+            Assert.That(value, Is.Not.Null);
+            int index = value.Value.ToInt32(null);
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.EqualTo(index));
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value.Value, Is.InstanceOf(ExpectedType[index]));
+        }
+
+        private static readonly Type[] ExpectedType = [typeof(int), typeof(long), typeof(ulong), typeof(float), typeof(double)];
+
+        [Test, Sequential]
+        public void GenericNullableClass<TValue>(
+            [Values("Hello", null, "Hello")] TValue? greeting,
+            [Values(null, "World", "World")] TValue? to)
+            where TValue : class
+        {
+            Assert.That(greeting, Is.Null.Or.Not.Null);
+            Assert.That(to, Is.Not.Null.Or.Null);
+        }
+
+        [Test, Sequential]
+        public void GenericNullableStruct<TValue>(
+            [Values(3, null, 3)] TValue? greeting,
+            [Values(null, 4.0, 4)] TValue? to)
+            where TValue : struct
+        {
+            Assert.That(greeting, Is.Null.Or.Not.Null);
+            Assert.That(to, Is.Not.Null.Or.Null);
+        }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ValueTupleEqualityTests.cs
@@ -97,5 +97,14 @@ namespace NUnit.Framework.Tests.Constraints
             var b = ValueTuple.Create(new Dictionary<string, string>());
             Assert.That(a, Is.EqualTo(b));
         }
+
+        [Test]
+        public void SucceedsWithStringModifiers()
+        {
+            var a = (2, 5, "HELLO ");
+            var b = (2, 5, "hello");
+
+            Assert.That(a, Is.EqualTo(b).IgnoreCase.IgnoreWhiteSpace);
+        }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/nunit/nunit/issues/150 and https://github.com/nunit/nunit/issues/4868

@manfred-brands PR which fixed #4868 also fixed #150. This PR just adds some test coverage as #150 also expresses a desire for consistency between these attributes which provide values to generic methods. For this reason I'm only saying this PR "relates" and will update @manfred-brands 's PR to include a "fixes" annotation there.

This PR also adds a test for existing ValueTuple equality that I haven't merged in through other means yet.