### PR TITLE
Async Test continuations now also run on the same thread when SIngleThreaded is used.

### DIFF
--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -23,7 +23,7 @@ namespace NUnit.Framework
             Exception? caughtException = null;
             try
             {
-                AsyncToSyncAdapter.Await(code.Invoke);
+                AsyncToSyncAdapter.Await(TestExecutionContext.CurrentContext, code.Invoke);
             }
             catch (Exception e)
             {

--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -230,7 +230,7 @@ namespace NUnit.Framework
         {
             using (EnterMultipleScope())
             {
-                AsyncToSyncAdapter.Await(testDelegate.Invoke);
+                AsyncToSyncAdapter.Await(TestExecutionContext.CurrentContext, testDelegate.Invoke);
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Constraints
         public virtual ConstraintResult ApplyTo<TActual>(ActualValueDelegate<TActual> del)
         {
             if (AsyncToSyncAdapter.IsAsyncOperation(del))
-                return ApplyTo(AsyncToSyncAdapter.Await(() => del.Invoke()));
+                return ApplyTo(AsyncToSyncAdapter.Await(TestExecutionContext.CurrentContext, () => del.Invoke()));
 
             return ApplyTo(GetTestObject(del));
         }

--- a/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DelayedConstraint.cs
@@ -361,14 +361,6 @@ namespace NUnit.Framework.Constraints
             return new DelegatingConstraintResult(this, await BaseConstraint.ApplyToAsync(taskDel));
         }
 
-        private static object? InvokeDelegate<T>(ActualValueDelegate<T> del)
-        {
-            if (AsyncToSyncAdapter.IsAsyncOperation(del))
-                return AsyncToSyncAdapter.Await(() => del.Invoke());
-
-            return del();
-        }
-
         /// <summary>
         /// Returns the string representation of the constraint.
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/AsyncEnumerableAdapter.NetCore.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncEnumerableAdapter.NetCore.cs
@@ -50,10 +50,10 @@ namespace NUnit.Framework.Internal
             public object? Current => _asyncEnumerator.Current;
 
             public void Dispose()
-                => AsyncToSyncAdapter.Await(() => _asyncEnumerator.DisposeAsync());
+                => AsyncToSyncAdapter.Await(context: null, () => _asyncEnumerator.DisposeAsync());
 
             public bool MoveNext()
-                => AsyncToSyncAdapter.Await<bool>(() => _asyncEnumerator.MoveNextAsync());
+                => AsyncToSyncAdapter.Await<bool>(context: null, () => _asyncEnumerator.MoveNextAsync());
 
             public void Reset()
                 => throw new InvalidOperationException("Can not reset an async enumerable.");

--- a/src/NUnitFramework/framework/Internal/AsyncEnumerableAdapter.NetFramework.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncEnumerableAdapter.NetFramework.cs
@@ -95,10 +95,10 @@ namespace NUnit.Framework.Internal
             public object? Current => _getCurrentMethod.Invoke();
 
             public void Dispose()
-                => AsyncToSyncAdapter.Await(() => _disposeAsyncMethod.Invoke(_asyncEnumerator, null));
+                => AsyncToSyncAdapter.Await(context: null, () => _disposeAsyncMethod.Invoke(_asyncEnumerator, null));
 
             public bool MoveNext()
-                => AsyncToSyncAdapter.Await<bool>(() => _moveNextAsyncMethod.Invoke());
+                => AsyncToSyncAdapter.Await<bool>(context: null, () => _moveNextAsyncMethod.Invoke());
 
             public void Reset()
                 => throw new InvalidOperationException("Can not reset an async enumerable.");

--- a/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
+++ b/src/NUnitFramework/framework/Internal/AsyncToSyncAdapter.cs
@@ -21,12 +21,6 @@ namespace NUnit.Framework.Internal
             return IsAsyncOperation(@delegate.GetMethodInfo());
         }
 
-        public static object? Await(Func<object?> invoke)
-            => Await<object?>(default(TestExecutionContext), invoke);
-
-        public static TResult? Await<TResult>(Func<object?> invoke)
-            => Await<TResult>(default(TestExecutionContext), invoke);
-
         public static object? Await(TestExecutionContext? context, Func<object?> invoke)
             => Await<object?>(context, invoke);
 

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -94,7 +94,7 @@ namespace NUnit.Framework.Internal.Commands
             var methodInfo = MethodInfoCache.Get(method);
 
             if (methodInfo.IsAsyncOperation)
-                AsyncToSyncAdapter.Await(() => InvokeMethod(method, context));
+                AsyncToSyncAdapter.Await(context, () => InvokeMethod(method, context));
             else
                 InvokeMethod(method, context);
         }

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -66,7 +66,7 @@ namespace NUnit.Framework.Internal.Commands
 
             if (methodInfo.IsAsyncOperation)
             {
-                return AsyncToSyncAdapter.Await(() => InvokeTestMethod(context, lastParameterAcceptsCancellationToken));
+                return AsyncToSyncAdapter.Await(context, () => InvokeTestMethod(context, lastParameterAcceptsCancellationToken));
             }
 
             return InvokeTestMethod(context, lastParameterAcceptsCancellationToken);

--- a/src/NUnitFramework/framework/Internal/DisposeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/DisposeHelper.cs
@@ -30,12 +30,12 @@ namespace NUnit.Framework.Internal
 #if NETFRAMEWORK
                 if (TryGetAsyncDispose(value.GetType(), out var method))
                 {
-                    AsyncToSyncAdapter.Await(() => method.Invoke(value, null));
+                    AsyncToSyncAdapter.Await(context: null, () => method.Invoke(value, null));
                 }
 #else
                 if (value is IAsyncDisposable asyncDisposable)
                 {
-                    AsyncToSyncAdapter.Await(() => asyncDisposable.DisposeAsync());
+                    AsyncToSyncAdapter.Await(context: null, () => asyncDisposable.DisposeAsync());
                 }
 #endif
                 else if (value is IDisposable disposable)

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -172,7 +172,7 @@ namespace NUnit.Framework.Internal
                 {
                     try
                     {
-                        AsyncToSyncAdapter.Await(parameterlessDelegate.DynamicInvokeWithTransparentExceptions);
+                        AsyncToSyncAdapter.Await(TestExecutionContext.CurrentContext, parameterlessDelegate.DynamicInvokeWithTransparentExceptions);
                     }
                     catch (Exception ex)
                     {

--- a/src/NUnitFramework/framework/Internal/Extensions/MethodInfoExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/MethodInfoExtensions.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Internal.Extensions
         public static TReturn? InvokeMaybeAwait<TReturn>(this MethodInfo m, object?[]? methodArgs)
         {
             if (AsyncToSyncAdapter.IsAsyncOperation(m))
-                return (TReturn?)AsyncToSyncAdapter.Await(() => m.Invoke(null, methodArgs));
+                return (TReturn?)AsyncToSyncAdapter.Await(context: null, () => m.Invoke(null, methodArgs));
             return (TReturn?)m.Invoke(null, methodArgs);
         }
 

--- a/src/NUnitFramework/tests/HelperConstraints.cs
+++ b/src/NUnitFramework/tests/HelperConstraints.cs
@@ -43,7 +43,7 @@ namespace NUnit.Framework.Tests
                 if (AsyncToSyncAdapter.IsAsyncOperation(@delegate))
                 {
                     stopwatch.Start();
-                    AsyncToSyncAdapter.Await(() => @delegate.DynamicInvoke());
+                    AsyncToSyncAdapter.Await(TestExecutionContext.CurrentContext, () => @delegate.DynamicInvoke());
                     stopwatch.Stop();
                 }
                 else


### PR DESCRIPTION
Fixes #4110 

If the `TestContext.IsSingleThreaded` is set using the `[SingleThreaded]` attribute and an Async operation is executed a SingleThreadedSynchronizationContext is created.

