### PR TITLE
Add a .NET 8.0 target

### DIFF
--- a/CakeScripts.Tests/CakeScripts.Tests.csproj
+++ b/CakeScripts.Tests/CakeScripts.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/CakeScripts/CakeScripts.csproj
+++ b/CakeScripts/CakeScripts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/nuget/framework/nunit.nuspec
+++ b/nuget/framework/nunit.nuspec
@@ -25,7 +25,8 @@
 
             Supported platforms:
             - .NET Framework 4.6.2+
-            - .NET 6.0+
+            - .NET 6.0
+            - .NET 8.0+
         </description>
         <releaseNotes>See release notes at https://docs.nunit.org/articles/nunit/release-notes/framework.html#nunit-400---november-26-2023</releaseNotes>
         <language>en-US</language>
@@ -38,6 +39,7 @@
                 <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
             </group>
             <group targetFramework="net6.0" />
+            <group targetFramework="net8.0" />
         </dependencies>
     </metadata>
     <files>
@@ -58,6 +60,12 @@
         <file src="bin/net6.0/nunit.framework.legacy.dll" target="lib\net6.0" />
         <file src="bin/net6.0/nunit.framework.legacy.xml" target="lib\net6.0" />
         <file src="bin/net6.0/nunit.framework.legacy.pdb" target="lib\net6.0" />
+        <file src="bin/net8.0/nunit.framework.dll" target="lib\net8.0" />
+        <file src="bin/net8.0/nunit.framework.xml" target="lib\net8.0" />
+        <file src="bin/net8.0/nunit.framework.pdb" target="lib\net8.0" />
+        <file src="bin/net8.0/nunit.framework.legacy.dll" target="lib\net8.0" />
+        <file src="bin/net8.0/nunit.framework.legacy.pdb" target="lib\net8.0" />
+        <file src="bin/net8.0/nunit.framework.legacy.xml" target="lib\net8.0" />
         <file src="..\..\nuget\framework\NUnit.props" target="build" />
     </files>
 </package>

--- a/nuget/nunitlite/nunitlite.nuspec
+++ b/nuget/nunitlite/nunitlite.nuspec
@@ -16,7 +16,8 @@
 
 Supported platforms:
 - .NET Framework 4.6.2+
-- .NET 6.0+
+- .NET 6.0
+- .NET 8.0+
 
 How to use this package:
 
@@ -34,9 +35,6 @@ How to use this package:
         <dependency id="NUnit" version="[$version$]" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="NUnit" version="[$version$]" />      
-      </group>
-	  <group targetFramework="net9.0">
         <dependency id="NUnit" version="[$version$]" />
       </group>
     </dependencies>
@@ -52,7 +50,7 @@ How to use this package:
     <file src="bin/net462/nunitlite-runner.pdb" target="tools\net462" />
     <file src="bin/net6.0/nunitlite.dll" target="lib\net6.0" />
     <file src="bin/net6.0/nunitlite.pdb" target="lib\net6.0" />
-	<file src="bin/net8.0/nunitlite.dll" target="lib\net8.0" />
+    <file src="bin/net8.0/nunitlite.dll" target="lib\net8.0" />
     <file src="bin/net8.0/nunitlite.pdb" target="lib\net8.0" />
   </files>
 </package>

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -7,13 +7,13 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <NUnitLibraryFrameworks>net462;net6.0</NUnitLibraryFrameworks>
+    <NUnitLibraryFrameworks>net462;net6.0;net8.0</NUnitLibraryFrameworks>
     <NUnitRuntimeFrameworks>net462;net6.0;net8.0;net9.0</NUnitRuntimeFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <!--<OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>-->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
-    <AnnotatedReferenceAssemblyVersion>7.0.0</AnnotatedReferenceAssemblyVersion>
+    <AnnotatedReferenceAssemblyVersion>8.0.0</AnnotatedReferenceAssemblyVersion>
     <GenerateNullableAttributes>false</GenerateNullableAttributes>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>

--- a/src/NUnitFramework/framework/Exceptions/AssertionException.cs
+++ b/src/NUnitFramework/framework/Exceptions/AssertionException.cs
@@ -26,6 +26,7 @@ namespace NUnit.Framework
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -33,6 +34,7 @@ namespace NUnit.Framework
             System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// Gets the ResultState provided by this exception

--- a/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
+++ b/src/NUnitFramework/framework/Exceptions/IgnoreException.cs
@@ -25,6 +25,7 @@ namespace NUnit.Framework
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -32,6 +33,7 @@ namespace NUnit.Framework
             System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// Gets the ResultState provided by this exception

--- a/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
+++ b/src/NUnitFramework/framework/Exceptions/InconclusiveException.cs
@@ -28,6 +28,7 @@ namespace NUnit.Framework
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -36,6 +37,7 @@ namespace NUnit.Framework
             : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// Gets the ResultState provided by this exception

--- a/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
+++ b/src/NUnitFramework/framework/Exceptions/MultipleAssertException.cs
@@ -28,6 +28,7 @@ namespace NUnit.Framework
             TestResult = testResult;
         }
 
+#if !NET8_0_OR_GREATER
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
         /// <summary>
         /// Serialization Constructor
@@ -37,6 +38,7 @@ namespace NUnit.Framework
         {
         }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+#endif
 
         /// <summary>
         /// Gets the <see cref="ResultState"/> provided by this exception.

--- a/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
+++ b/src/NUnitFramework/framework/Exceptions/ResultStateException.cs
@@ -26,6 +26,7 @@ namespace NUnit.Framework
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -33,6 +34,7 @@ namespace NUnit.Framework
             System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// Gets the ResultState provided by this exception

--- a/src/NUnitFramework/framework/Exceptions/SuccessException.cs
+++ b/src/NUnitFramework/framework/Exceptions/SuccessException.cs
@@ -27,6 +27,7 @@ namespace NUnit.Framework
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -35,6 +36,7 @@ namespace NUnit.Framework
             : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// Gets the ResultState provided by this exception

--- a/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidDataSourceException.cs
@@ -3,7 +3,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NET8_0_OR_GREATER
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// InvalidTestFixtureException is thrown when an appropriate test
@@ -36,6 +38,7 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -43,5 +46,6 @@ namespace NUnit.Framework.Internal
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidPlatformException.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Framework.Internal
 {
@@ -36,6 +38,7 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization constructor for the <see cref="InvalidPlatformException"/> class
         /// </summary>
@@ -43,5 +46,6 @@ namespace NUnit.Framework.Internal
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
+++ b/src/NUnitFramework/framework/Internal/InvalidTestFixtureException.cs
@@ -3,7 +3,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NET8_0_OR_GREATER
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// InvalidTestFixtureException is thrown when an appropriate test
@@ -36,6 +38,7 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -43,5 +46,6 @@ namespace NUnit.Framework.Internal
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/framework/Internal/MethodWrapper.cs
+++ b/src/NUnitFramework/framework/Internal/MethodWrapper.cs
@@ -159,7 +159,7 @@ namespace NUnit.Framework.Internal
         /// <inheritdoc />
         public bool Equals(MethodWrapper? other)
         {
-            if (ReferenceEquals(null, other))
+            if (other is null)
             {
                 return false;
             }
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Internal
         /// <inheritdoc />
         public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }

--- a/src/NUnitFramework/framework/Internal/NUnitException.cs
+++ b/src/NUnitFramework/framework/Internal/NUnitException.cs
@@ -3,7 +3,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NET8_0_OR_GREATER
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// Thrown when an assertion failed. Here to preserve the inner
@@ -40,6 +42,7 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -47,5 +50,6 @@ namespace NUnit.Framework.Internal
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/framework/Internal/TestCaseTimeoutException.cs
+++ b/src/NUnitFramework/framework/Internal/TestCaseTimeoutException.cs
@@ -3,7 +3,9 @@
 namespace NUnit.Framework.Internal
 {
     using System;
+#if !NET8_0_OR_GREATER
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// TestCaseTimeoutException is thrown when a test running directly
@@ -36,6 +38,7 @@ namespace NUnit.Framework.Internal
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization Constructor
         /// </summary>
@@ -43,5 +46,6 @@ namespace NUnit.Framework.Internal
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -134,8 +134,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#if !NET6_0_OR_GREATER
 using System.Security.Permissions;
+#endif
+#endif
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -569,14 +573,17 @@ namespace NUnit.Options
             _option = optionName;
         }
 
+#if !NET8_0_OR_GREATER
         protected OptionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             _option = info.GetString("OptionName");
         }
+#endif
 
         public string OptionName => _option;
 
+#if !NET8_0_OR_GREATER
 #if !NET6_0_OR_GREATER
         [SecurityPermission(SecurityAction.LinkDemand, SerializationFormatter = true)]
 #endif
@@ -585,6 +592,7 @@ namespace NUnit.Options
             base.GetObjectData(info, context);
             info.AddValue("OptionName", _option);
         }
+#endif
     }
 
     public delegate void OptionAction<TKey, TValue>(TKey key, TValue value);

--- a/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/OutputWriter.cs
@@ -21,6 +21,7 @@ namespace NUnitLite
         /// <param name="result">The result to be written</param>
         /// <param name="outputPath">Path to the file to which the result is written</param>
         /// <param name="runSettings">A dictionary of settings used for this test run</param>
+        /// <param name="filter">The filter to apply</param>
         public void WriteResultFile(ITestResult result, string outputPath, IDictionary<string, object> runSettings, TestFilter filter)
         {
             using (var stream = new FileStream(outputPath, FileMode.Create))

--- a/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
+++ b/src/NUnitFramework/nunitlite/TestSelectionParserException.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Common
 {
@@ -28,11 +30,13 @@ namespace NUnit.Common
         {
         }
 
+#if !NET8_0_OR_GREATER
         /// <summary>
         /// Serialization constructor
         /// </summary>
         public TestSelectionParserException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -40,8 +40,10 @@ namespace NUnitLite
         public const int INVALID_ARG = -1;
         /// <summary>File not found</summary>
         public const int FILE_NOT_FOUND = -2;
+      /*
         /// <summary>Test fixture not found - No longer in use</summary>
         //public const int FIXTURE_NOT_FOUND = -3;
+       */
         /// <summary>Invalid test suite</summary>
         public const int INVALID_TEST_FIXTURE = -4;
         /// <summary>Unexpected error occurred</summary>
@@ -73,7 +75,6 @@ namespace NUnitLite
         /// specifying a test assembly whose tests are to be run.
         /// </summary>
         /// <param name="testAssembly"></param>
-        /// </summary>
         public TextRunner(Assembly testAssembly)
         {
             _testAssembly = testAssembly;

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -4,10 +4,12 @@
     <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnitLite</RootNamespace>
     <Nullable>disable</Nullable>
+    <Title>NUnitLite Runner $(AssemblyConfiguration)</Title>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Title>NUnitLite Runner $(AssemblyConfiguration)</Title>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/tests/SolutionTests/NuspecTargetInclusionsTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecTargetInclusionsTests.cs
@@ -57,8 +57,8 @@ namespace NUnit.Framework.Tests.SolutionTests
                     foreach (var extension in _extensions)
                     {
                         requiredIncludedLibFiles.Add(new FileReference(
-                            $"bin{Path.AltDirectorySeparatorChar}{targetFramework}{Path.AltDirectorySeparatorChar}{file}{extension}",
-                            $"lib{Path.AltDirectorySeparatorChar}{targetFramework}"));
+                            $"bin/{targetFramework}/{file}{extension}",
+                            $"lib/{targetFramework}"));
                     }
                 }
             }
@@ -128,9 +128,10 @@ namespace NUnit.Framework.Tests.SolutionTests
                             var src = group.Attribute("src")?.Value;
                             if (src is not null)
                             {
+                                // Microsoft with their backslashes...
                                 includedLibFiles.Add(new FileReference(
-                                    src.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-                                    target.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+                                    src.Replace('\\', '/'),
+                                    target.Replace('\\', '/')));
                             }
                         }
                     }

--- a/src/NUnitFramework/tests/SolutionTests/NuspecTargetInclusionsTests.cs
+++ b/src/NUnitFramework/tests/SolutionTests/NuspecTargetInclusionsTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NUnit.Framework.Tests.SolutionTests
+{
+    /// <summary>
+    /// Checks that the all targets of the framework projects are included in the nuspec files.
+    /// </summary>
+    [TestFixture("framework/nunit.nuspec", new string[] { "nunit.framework", "nunit.framework.legacy" }, new string[] { ".dll", ".pdb", ".xml" })]
+    [TestFixture("nunitlite/nunitlite.nuspec", new string[] { "nunitlite" }, new string[] { ".dll", ".pdb" })]
+    internal sealed class NuspecTargetInclusionsTests
+    {
+        private readonly string _nuspecPath;
+        private readonly string _propsPath;
+        private readonly string[] _files;
+        private readonly string[] _extensions;
+        private string[] _csprojTargetFrameworks;
+
+        private const string Root = "../../../../../../";
+        private const string NotSpecified = nameof(NotSpecified);
+
+        public NuspecTargetInclusionsTests(string nuspecPath, string[] files, string[] extensions)
+        {
+            _nuspecPath = Path.GetFullPath($"{Root}/nuget/{nuspecPath}");
+            _propsPath = Path.GetFullPath($"{Root}/src/NUnitFramework/Directory.Build.props");
+            _files = files;
+            _extensions = extensions;
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _csprojTargetFrameworks = PackageVersionReader.ExtractTargetFrameworks(_propsPath);
+        }
+
+        [Test]
+        public void AllRequiredFilesAreIncludedInNuspec()
+        {
+            List<FileReference> nuspecIncludedLibFiles = NuspecReader.ExtractIncludedLibFiles(_nuspecPath);
+            List<FileReference> requiredIncludedLibFiles = GetRequiredLibFiles();
+
+            Assert.That(nuspecIncludedLibFiles, Is.EquivalentTo(requiredIncludedLibFiles));
+        }
+
+        private List<FileReference> GetRequiredLibFiles()
+        {
+            var requiredIncludedLibFiles = new List<FileReference>(_csprojTargetFrameworks.Length * _files.Length * _extensions.Length);
+            foreach (var targetFramework in _csprojTargetFrameworks)
+            {
+                foreach (var file in _files)
+                {
+                    foreach (var extension in _extensions)
+                    {
+                        requiredIncludedLibFiles.Add(new FileReference(
+                            $"bin{Path.AltDirectorySeparatorChar}{targetFramework}{Path.AltDirectorySeparatorChar}{file}{extension}",
+                            $"lib{Path.AltDirectorySeparatorChar}{targetFramework}"));
+                    }
+                }
+            }
+            return requiredIncludedLibFiles;
+        }
+
+        private sealed record class FileReference(string Src, string Target)
+        {
+            public override string ToString()
+            {
+                return $"""
+                    <file src="{Src}" target="{Target}" />
+                    """;
+            }
+        }
+
+        private static class PackageVersionReader
+        {
+            // Function to extract packages from the .csproj file
+            public static string[] ExtractTargetFrameworks(string path)
+            {
+                Assert.That(path, Does.Exist, $"props file at {path} not found.");
+                string xml = File.ReadAllText(path);
+
+                var doc = XDocument.Parse(xml);
+
+                foreach (var itemGroup in doc.Descendants("PropertyGroup"))
+                {
+                    XElement? packageReferences = itemGroup.Descendants("NUnitLibraryFrameworks").LastOrDefault();
+
+                    if (packageReferences is not null)
+                    {
+                        return packageReferences.Value.Split(';');
+                    }
+                }
+
+                throw new Exception("No 'NUnitLibraryFrameworks' property found in Directory.Build.props");
+            }
+        }
+
+        private static class NuspecReader
+        {
+            public static List<FileReference> ExtractIncludedLibFiles(string path)
+            {
+                Assert.That(path, Does.Exist, $"Nuspec file at {path} not found.");
+                string xml = File.ReadAllText(path);
+
+                var doc = XDocument.Parse(xml);
+                XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
+
+                // List to include all lib files in the nuspec
+                var includedLibFiles = new List<FileReference>();
+
+                // Find the dependencies section
+                var filesSection = doc.Descendants(ns + "files").FirstOrDefault();
+                if (filesSection is not null)
+                {
+                    // Iterate over all files
+                    foreach (var group in filesSection.Descendants())
+                    {
+                        // Get the target attribute
+                        var target = group.Attribute("target")?.Value;
+
+                        if (target?.StartsWith("lib") is true)
+                        {
+                            // Get the src attribute
+                            var src = group.Attribute("src")?.Value;
+                            if (src is not null)
+                            {
+                                includedLibFiles.Add(new FileReference(
+                                    src.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                                    target.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+                            }
+                        }
+                    }
+                }
+
+                return includedLibFiles;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4890 
Works toward #4857

This adds the .NET 8.0 target. So that if users that are not allowed to use end-of-life frameworks due to lack of security updates can the .NET8.0 binaries.
