### PR TITLE
Ony Unwrap TargetInvocationException if raised from inside NUnit.Framework

### DIFF
--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -225,7 +225,8 @@ namespace NUnit.Framework.Internal
             }
 
             while (exception is TargetInvocationException targetInvocationException &&
-                targetInvocationException.InnerException is not null)
+                targetInvocationException.InnerException is not null &&
+                targetInvocationException.StackTrace?.Contains("NUnit.Framework") is true)
             {
                 exception = targetInvocationException.InnerException;
             }

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -9,6 +9,12 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
     public class UnexpectedExceptionFixture
     {
         [Test]
+        public void ThrowsException()
+        {
+            throw new Exception("Thrown Exception");
+        }
+
+        [Test]
         public void ThrowsWithInnerException()
         {
             throw new Exception("Outer Exception", new Exception("Inner Exception"));
@@ -48,6 +54,12 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
         public void ThrowsCustomException()
         {
             throw new CustomException("message", new CustomType());
+        }
+
+        [Test]
+        public void ThrowsTargetInvocationException()
+        {
+            GetType().GetMethod(nameof(ThrowsException))!.Invoke(this, null);
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -17,6 +17,22 @@ namespace NUnit.Framework.Tests.Internal
         }
 
         [Test]
+        public void FailRecordsException()
+        {
+            string expectedMessage =
+                "System.Exception : Thrown Exception";
+
+            ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsException));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo(expectedMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsException)));
+            });
+        }
+
+        [Test]
         public void FailRecordsInnerException()
         {
             string expectedMessage =
@@ -28,6 +44,7 @@ namespace NUnit.Framework.Tests.Internal
             {
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
                 Assert.That(result.Message, Is.EqualTo(expectedMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsWithInnerException)));
             });
         }
 
@@ -45,6 +62,7 @@ namespace NUnit.Framework.Tests.Internal
             {
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
                 Assert.That(result.Message, Is.EqualTo(expectedMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsWithNestedInnerException)));
             });
         }
 
@@ -63,6 +81,7 @@ namespace NUnit.Framework.Tests.Internal
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
                 Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
                 Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsWithAggregateException)));
             });
         }
 
@@ -81,6 +100,7 @@ namespace NUnit.Framework.Tests.Internal
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
                 Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
                 Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsWithAggregateExceptionContainingNestedInnerException)));
             });
         }
 
@@ -106,6 +126,25 @@ namespace NUnit.Framework.Tests.Internal
             {
                 Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
                 Assert.That(result.Message, Is.EqualTo("NUnit.TestData.UnexpectedExceptionFixture.CustomException : message"));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsCustomException)));
+            });
+        }
+
+        [Test]
+        public void TargetInvocationExceptionInUserCodeIsPassedThrough()
+        {
+            string expectedStartOfMessage = "System.Reflection.TargetInvocationException";
+            string expectedEndOfMessage = "  ----> System.Exception : Thrown Exception";
+
+            ITestResult result = RunDataTestCase(nameof(UnexpectedExceptionFixture.ThrowsTargetInvocationException));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Does.StartWith(expectedStartOfMessage));
+                Assert.That(result.Message, Does.EndWith(expectedEndOfMessage));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsTargetInvocationException)));
+                Assert.That(result.StackTrace, Does.Contain(nameof(UnexpectedExceptionFixture.ThrowsException)));
             });
         }
 


### PR DESCRIPTION
Fixes #4718 