### PR TITLE
Refactor TestAssert: Replace ToArray()[0] with First() for efficiency.

### DIFF
--- a/src/NUnitFramework/tests/TestUtilities/TestAssert.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestAssert.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework.Tests.TestUtilities
             object testObject = Reflect.Construct(type);
             ITestResult result = TestBuilder.RunTest(test, testObject);
             if (result.HasChildren) // In case it's a parameterized method
-                result = result.Children.ToArray()[0];
+                result = result.Children.First();
             Assert.That(result.ResultState, Is.EqualTo(resultState));
         }
         #endregion


### PR DESCRIPTION
This pull request refactors the TestAssert class, specifically the IsRunnable(Type type, string name, ResultState resultState) method. The change replaces the use of ToArray()[0] with the more efficient First() method from LINQ. This improves the performance by eliminating unnecessary array allocation and directly accessing the first element in the collection.

Fixes #4886 