### PR TITLE
Get the benchmarks running again

### DIFF
--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -30,6 +30,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Somehow needed for rule IDE0005 to detect unused using directives -->
+    <!-- https://github.com/dotnet/roslyn/issues/41640 -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <DefineConstants Condition="$(TargetFramework.StartsWith('net4'))">$(DefineConstants);THREAD_ABORT</DefineConstants>
   </PropertyGroup>
 

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -4,7 +4,7 @@
     <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">12</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\nunit.snk</AssemblyOriginatorKeyFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NUnitLibraryFrameworks>net462;net6.0;net8.0</NUnitLibraryFrameworks>

--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -34,7 +34,7 @@
   </ItemGroup>
   <!-- Specific dependencies -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/FrameworkControllerBenchmark.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/FrameworkControllerBenchmark.cs
@@ -1,25 +1,4 @@
-// ***********************************************************************
-// Copyright (c) 2022 Charlie Poole
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// ***********************************************************************
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Collections;
 using BenchmarkDotNet.Attributes;

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/NUnitJobAttribute.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/NUnitJobAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace NUnit.Framework;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+internal class NUnitJobAttribute : Attribute, IConfigSource
+{
+    public NUnitJobAttribute()
+    {
+        var arg = new MsBuildArgument("/p:AssemblyConfiguration=Release");
+        var job = new Job(Job.Default).WithArguments([arg]);
+
+        Config = DefaultConfig.Instance.AddJob(job);
+    }
+
+    public IConfig Config { get; }
+}

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/Program.cs
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/Program.cs
@@ -3,4 +3,6 @@
 using BenchmarkDotNet.Running;
 using NUnit.Framework;
 
+[assembly: NUnitJob]
+
 BenchmarkSwitcher.FromAssembly(typeof(FrameworkControllerBenchmark).Assembly).Run(args);

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
@@ -6,9 +6,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
         <Optimize>true</Optimize>
-        <AssemblyOriginatorKeyFile>..\..\..\nunit.snk</AssemblyOriginatorKeyFile>
         <RootNamespace>NUnit.Framework</RootNamespace>
     </PropertyGroup>
+
+    <ItemGroup>
+      <Compile Remove="BenchmarkDotNet.Artifacts\**" />
+      <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
+      <None Remove="BenchmarkDotNet.Artifacts\**" />
+    </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" />

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
@@ -7,8 +7,6 @@
         <LangVersion>latest</LangVersion>
         <Optimize>true</Optimize>
         <RootNamespace>NUnit.Framework</RootNamespace>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
+++ b/src/NUnitFramework/benchmarks/nunit.framework.benchmarks/nunit.framework.benchmarks.csproj
@@ -2,11 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
         <Optimize>true</Optimize>
         <RootNamespace>NUnit.Framework</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsTestProject>false</IsTestProject>
+    <NoWarn/>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitFramework/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitFramework/mock-assembly/mock-assembly.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
     <IsTestProject>false</IsTestProject>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
     <Title>mock-assembly</Title>
   </PropertyGroup>
 

--- a/src/NUnitFramework/nunit.framework.legacy.tests/nunit.framework.legacy.tests.csproj
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/nunit.framework.legacy.tests.csproj
@@ -9,8 +9,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunit.framework.legacy/nunit.framework.legacy.csproj
+++ b/src/NUnitFramework/nunit.framework.legacy/nunit.framework.legacy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework.Legacy</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn/>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
+++ b/src/NUnitFramework/nunitlite-runner/nunitlite-runner.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnitLite</RootNamespace>
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Title>NUnit Test Runner</Title>
   </PropertyGroup>
 

--- a/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
+++ b/src/NUnitFramework/nunitlite.tests/nunitlite.tests.csproj
@@ -5,8 +5,6 @@
     <RootNamespace>NUnitLite.Tests</RootNamespace>
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
     <Title>NUnitLite Runner Tests</Title>
   </PropertyGroup>
 

--- a/src/NUnitFramework/nunitlite/nunitlite.csproj
+++ b/src/NUnitFramework/nunitlite/nunitlite.csproj
@@ -7,11 +7,6 @@
     <Title>NUnitLite Runner $(AssemblyConfiguration)</Title>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS1591</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\framework\nunit.framework.csproj" />
   </ItemGroup>

--- a/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
+++ b/src/NUnitFramework/slow-tests/slow-nunit-tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
     <Title>slow-nunit-tests</Title>
   </PropertyGroup>
 

--- a/src/NUnitFramework/testdata/nunit.testdata.csproj
+++ b/src/NUnitFramework/testdata/nunit.testdata.csproj
@@ -5,8 +5,6 @@
     <TargetFrameworks>$(NUnitRuntimeFrameworks)</TargetFrameworks>
     <Optimize>false</Optimize>
     <IsTestProject>false</IsTestProject>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -8,8 +8,7 @@
     nunit.framework.tests.deps.json file. Maybe fixed by https://github.com/nunit/nunit/issues/3353? -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <IsTestProject>true</IsTestProject>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>1591,NU1029</NoWarn>
+        <NoWarn>$(NoWarn),NU1029</NoWarn>
         <Title>NUnit Framework Tests</Title>
     </PropertyGroup>
 

--- a/src/NUnitFramework/windows-tests/windows-tests.csproj
+++ b/src/NUnitFramework/windows-tests/windows-tests.csproj
@@ -7,8 +7,6 @@
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/4806

This PR gets the benchmarks running again by following the steps outlined in the issue. I was able to inject the assemblyconfiguration at runtime by defining a BenchmarkDotNet Job based on the default one