### PR TITLE
Allow more string comparisons

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -422,7 +422,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public EqualConstraint EqualTo(object? expected)
+        public EqualConstraint EqualTo<T>(T? expected)
         {
             return Append(new EqualConstraint(expected));
         }
@@ -462,13 +462,96 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests two numbers for equality
         /// </summary>
-#pragma warning disable CS3024 // Constraint type is not CLS-compliant
-        public EqualNumericConstraint<T> EqualTo<T>(T expected)
-            where T : unmanaged, IConvertible, IEquatable<T>
+        public EqualNumericConstraint<double> EqualTo(double expected)
         {
-            return Append(new EqualNumericConstraint<T>(expected));
+            return Append(new EqualNumericConstraint<double>(expected));
         }
-#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<float> EqualTo(float expected)
+        {
+            return Append(new EqualNumericConstraint<float>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<decimal> EqualTo(decimal expected)
+        {
+            return Append(new EqualNumericConstraint<decimal>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<long> EqualTo(long expected)
+        {
+            return Append(new EqualNumericConstraint<long>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<int> EqualTo(int expected)
+        {
+            return Append(new EqualNumericConstraint<int>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<short> EqualTo(short expected)
+        {
+            return Append(new EqualNumericConstraint<short>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<byte> EqualTo(byte expected)
+        {
+            return Append(new EqualNumericConstraint<byte>(expected));
+        }
+
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<ulong> EqualTo(ulong expected)
+        {
+            return Append(new EqualNumericConstraint<ulong>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<uint> EqualTo(uint expected)
+        {
+            return Append(new EqualNumericConstraint<uint>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<ushort> EqualTo(ushort expected)
+        {
+            return Append(new EqualNumericConstraint<ushort>(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public EqualNumericConstraint<sbyte> EqualTo(sbyte expected)
+        {
+            return Append(new EqualNumericConstraint<sbyte>(expected));
+        }
+
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
+#pragma warning restore CS3002 // Return type is not CLS-compliant
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -422,6 +422,14 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
+        public EqualConstraint EqualTo(object? expected)
+        {
+            return Append(new EqualConstraint(expected));
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
         public EqualConstraint EqualTo<T>(T? expected)
         {
             return Append(new EqualConstraint(expected));

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -10,10 +8,8 @@ namespace NUnit.Framework.Constraints
     /// considered equal if both are null, or if both have the same
     /// value. NUnit has special semantics for some object types.
     /// </summary>
-#pragma warning disable CS3024 // Constraint type is not CLS-compliant
     public class EqualNumericConstraint<T> : EqualNumericWithoutUsingConstraint<T>, IEqualWithUsingConstraint<T>
-        where T : unmanaged, IConvertible, IEquatable<T>
-#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+        where T : struct
     {
         #region Constructor
 

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Constraints
         /// Marked internal to prevent external instantiation with non-supported types.
         /// </remarks>
         /// <param name="expected">The expected value.</param>
-        internal EqualNumericConstraint(T expected)
+        public EqualNumericConstraint(T expected)
             : base(expected)
         {
         }

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -20,8 +20,11 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
         /// </summary>
+        /// <remarks>
+        /// Marked internal to prevent external instantiation with non-supported types.
+        /// </remarks>
         /// <param name="expected">The expected value.</param>
-        public EqualNumericConstraint(T expected)
+        internal EqualNumericConstraint(T expected)
             : base(expected)
         {
         }

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -141,12 +141,17 @@ namespace NUnit.Framework.Constraints
             {
                 hasSucceeded = false;
             }
-            else if (actual is T t)
+            else if (actual is T t && typeof(T).IsPrimitive)
             {
                 hasSucceeded = Numerics.AreEqual(_expected, t, ref _tolerance);
             }
             else if (actual is IEquatable<T> equatable)
             {
+                if (!_tolerance.IsUnsetOrDefault)
+                {
+                    throw new InvalidOperationException("Cannot use Tolerance with IEquatable<>.");
+                }
+
                 hasSucceeded = equatable.Equals(_expected);
             }
             else if (actual is not string and IConvertible)

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Constraints
         /// Marked internal to prevent external instantiation with non-supported types.
         /// </remarks>
         /// <param name="expected">The expected value.</param>
-        internal EqualNumericWithoutUsingConstraint(T expected)
+        public EqualNumericWithoutUsingConstraint(T expected)
             : base(expected)
         {
             Guard.ArgumentValid(Numerics.IsNumericType(typeof(T)), "EqualNumericWithoutUsingConstraint<T> may only be used with numeric types.", nameof(T));

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -127,7 +127,7 @@ namespace NUnit.Framework.Constraints
             // In that case fall back to the default equality comparison.
             bool hasSucceeded;
 
-            if (Numerics.IsNumericType(actual))
+            if (Numerics.IsNumericType(typeof(T)))
             {
                 hasSucceeded = Numerics.AreEqual(_expected, actual, ref _tolerance);
             }
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
             {
                 hasSucceeded = false;
             }
-            else if (actual is T t && Numerics.IsNumericType(t))
+            else if (actual is T t && Numerics.IsNumericType(typeof(T)))
             {
                 hasSucceeded = Numerics.AreEqual(_expected, t, ref _tolerance);
             }

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -29,8 +29,11 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Initializes a new instance of the <see cref="EqualConstraint"/> class.
         /// </summary>
+        /// <remarks>
+        /// Marked internal to prevent external instantiation with non-supported types.
+        /// </remarks>
         /// <param name="expected">The expected value.</param>
-        public EqualNumericWithoutUsingConstraint(T expected)
+        internal EqualNumericWithoutUsingConstraint(T expected)
             : base(expected)
         {
             _expected = expected;
@@ -123,21 +126,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True for success, false for failure</returns>
         public ConstraintResult ApplyTo(T actual)
         {
-            // As we cannot use exact generic constraints, T could be a type not supported by Numerics.
-            // In that case fall back to the default equality comparison.
-            bool hasSucceeded;
-
-            if (Numerics.IsNumericType(typeof(T)))
-            {
-                hasSucceeded = Numerics.AreEqual(_expected, actual, ref _tolerance);
-            }
-            else
-            {
-                if (!_tolerance.IsUnsetOrDefault)
-                    throw new InvalidOperationException("Cannot use Tolerance with IEquatable<>.");
-
-                hasSucceeded = _expected.Equals(actual);
-            }
+            bool hasSucceeded = Numerics.AreEqual(_expected, actual, ref _tolerance);
 
             return ConstraintResult(actual, hasSucceeded);
         }
@@ -155,7 +144,7 @@ namespace NUnit.Framework.Constraints
             {
                 hasSucceeded = false;
             }
-            else if (actual is T t && Numerics.IsNumericType(typeof(T)))
+            else if (actual is T t)
             {
                 hasSucceeded = Numerics.AreEqual(_expected, t, ref _tolerance);
             }

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -141,7 +141,7 @@ namespace NUnit.Framework.Constraints
             {
                 hasSucceeded = false;
             }
-            else if (actual is T t && typeof(T).IsPrimitive)
+            else if (actual is T t && (typeof(T).IsPrimitive || typeof(T) == typeof(decimal)))
             {
                 hasSucceeded = Numerics.AreEqual(_expected, t, ref _tolerance);
             }

--- a/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Linq;
 using System.Text;
 using NUnit.Framework.Constraints.Comparers;
 
@@ -129,10 +128,6 @@ namespace NUnit.Framework.Constraints
             {
                 return ApplyTo(actualString);
             }
-            else if (CanCastToString(actual, out string? actualCastToString))
-            {
-                return ApplyTo(actualCastToString);
-            }
             else if (actual is IEquatable<string> equatableString)
             {
                 if (_caseInsensitive || _ignoringWhiteSpace)
@@ -155,26 +150,6 @@ namespace NUnit.Framework.Constraints
             }
 
             return ConstraintResult(actual, hasSucceeded);
-        }
-
-        private static bool CanCastToString<TActual>(TActual actual, out string? s)
-        {
-            // Check if the type implements an implicit cast to string
-            // Note that we don't have to check the parameter types
-            // as the compiler only allows cast from/to TActual and we check the return type.
-            var implicitCastToString = typeof(TActual).GetMethods()
-                                                      .FirstOrDefault(x => x.IsStatic &&
-                                                                      x.Name == "op_Implicit" &&
-                                                                      x.ReturnType == typeof(string));
-
-            if (implicitCastToString is null)
-            {
-                s = null;
-                return false;
-            }
-
-            s = (string?)implicitCastToString.Invoke(null, [actual]);
-            return true;
         }
 
         private ConstraintResult ConstraintResult<T>(T actual, bool hasSucceeded)

--- a/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
@@ -167,10 +167,9 @@ namespace NUnit.Framework.Constraints
             // Note that we don't have to check the parameter types
             // as the compiler only allows cast from/to TActual and we check the return type.
             var implicitCastToString = typeof(TActual).GetMethods()
-                                                      .Where(x => x.IsStatic &&
-                                                                  x.Name == "op_Implicit" &&
-                                                                  x.ReturnType == typeof(string))
-                                                      .SingleOrDefault();
+                                                      .FirstOrDefault(x => x.IsStatic &&
+                                                                      x.Name == "op_Implicit" &&
+                                                                      x.ReturnType == typeof(string));
 
             if (implicitCastToString is null)
             {

--- a/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
@@ -125,10 +125,6 @@ namespace NUnit.Framework.Constraints
             {
                 hasSucceeded = _expected is null;
             }
-            else if (_expected is null)
-            {
-                hasSucceeded = false;
-            }
             else if (actual is string actualString)
             {
                 return ApplyTo(actualString);
@@ -145,6 +141,10 @@ namespace NUnit.Framework.Constraints
                 }
 
                 hasSucceeded = equatableString.Equals(_expected);
+            }
+            else if (_expected is null)
+            {
+                hasSucceeded = false;
             }
             else
             {

--- a/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualStringWithoutUsingConstraint.cs
@@ -148,14 +148,10 @@ namespace NUnit.Framework.Constraints
             }
             else
             {
-#if TRUE
-                hasSucceeded = false;
-#else
-                // Alternatively we could fall back to pre 4.3 EqualConstraint behavior
+                // We fall back to pre 4.3 EqualConstraint behavior
                 // But if the actual value cannot be convert to a string nor can be compared to one
-                // we should fail the test.
+                // not sure if that makes any difference.
                 return new EqualConstraint(_expected).ApplyTo(actual);
-#endif
             }
 
             return ConstraintResult(actual, hasSucceeded);

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -145,7 +145,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public static EqualConstraint EqualTo(object? expected)
+        public static EqualConstraint EqualTo<T>(T? expected)
         {
             return new EqualConstraint(expected);
         }
@@ -193,13 +193,96 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two numbers for equality
         /// </summary>
-#pragma warning disable CS3024 // Constraint type is not CLS-compliant
-        public static EqualNumericConstraint<T> EqualTo<T>(T expected)
-            where T : unmanaged, IConvertible, IEquatable<T>
+        public static EqualNumericConstraint<double> EqualTo(double expected)
         {
-            return new EqualNumericConstraint<T>(expected);
+            return new EqualNumericConstraint<double>(expected);
         }
-#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<float> EqualTo(float expected)
+        {
+            return new EqualNumericConstraint<float>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<decimal> EqualTo(decimal expected)
+        {
+            return new EqualNumericConstraint<decimal>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<long> EqualTo(long expected)
+        {
+            return new EqualNumericConstraint<long>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<int> EqualTo(int expected)
+        {
+            return new EqualNumericConstraint<int>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<short> EqualTo(short expected)
+        {
+            return new EqualNumericConstraint<short>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<byte> EqualTo(byte expected)
+        {
+            return new EqualNumericConstraint<byte>(expected);
+        }
+
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<ulong> EqualTo(ulong expected)
+        {
+            return new EqualNumericConstraint<ulong>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<uint> EqualTo(uint expected)
+        {
+            return new EqualNumericConstraint<uint>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<ushort> EqualTo(ushort expected)
+        {
+            return new EqualNumericConstraint<ushort>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<sbyte> EqualTo(sbyte expected)
+        {
+            return new EqualNumericConstraint<sbyte>(expected);
+        }
+
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
+#pragma warning restore CS3002 // Return type is not CLS-compliant
 
         #endregion
 

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -145,6 +145,14 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
+        public static EqualConstraint EqualTo(object? expected)
+        {
+            return new EqualConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
         public static EqualConstraint EqualTo<T>(T? expected)
         {
             return new EqualConstraint(expected);

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -360,6 +360,70 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(ex?.Message, Does.Contain("Assert.That(() => false, Is.True)"));
         }
 
+        [TestCase(default(string), default(string))]
+        [TestCase("", "")]
+        public void AssertWithStrings(string? actual, string? expected)
+        {
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void AssertWithTypeImplicitConvertibleToString()
+        {
+            const string value = "Implicit Cast";
+            var instance = new TypeWithImplicitCastToString(value);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.Value, Is.EqualTo(value), "Value");
+                Assert.That(instance, Is.EqualTo(value), "EqualStringConstaint");
+                Assert.That(instance, Is.EqualTo(value.ToLowerInvariant()).IgnoreCase, "EqualStringConstaint.IgnoreCase");
+                Assert.That(instance, Is.EqualTo(value.Replace(" ", string.Empty)).IgnoreWhiteSpace, "EqualStringConstaint.IgnoreWhiteSpace");
+            });
+        }
+
+        private sealed class TypeWithImplicitCastToString
+        {
+            public string Value { get; }
+
+            public TypeWithImplicitCastToString(string value)
+            {
+                Value = value;
+            }
+
+            public static implicit operator string(TypeWithImplicitCastToString instance) => instance.Value;
+        }
+
+        [Test]
+        public void AssertWithTypeWhichImplementsIEquatableString()
+        {
+            const string value = "Equatable<string>";
+            var intance = new TypeWhichImplementsIEquatableString(value);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(intance.Value, Is.EqualTo(value), "Value");
+                Assert.That(intance, Is.EqualTo(value), "EqualStringConstaint");
+                Assert.That(() => Assert.That(intance, Is.EqualTo(value.ToLowerInvariant()).IgnoreCase),
+                            Throws.InvalidOperationException);
+            });
+        }
+
+        private sealed class TypeWhichImplementsIEquatableString : IEquatable<string>
+        {
+            public string Value { get; }
+
+            public TypeWhichImplementsIEquatableString(string value)
+            {
+                Value = value;
+            }
+
+            public bool Equals(string? other)
+            {
+                return Value.Equals(other);
+            }
+        }
+
         [TestCase("Hello", "World")]
         [TestCase('A', 'B')]
         [TestCase(false, true)]

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -103,6 +103,46 @@ namespace NUnit.Framework.Tests.Assertions
 
         private int ReturnsFour() => 4;
 
+        [Test]
+        public void TestEquatableWithConvertible()
+        {
+            var actual = new Number(42);
+            var expected = new Number(42.0);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private readonly struct Number : IEquatable<Number>, IConvertible
+        {
+            private readonly double _value;
+
+            public Number(int value) => _value = value;
+            public Number(double value) => _value = value;
+
+            public bool Equals(Number other)
+            {
+                return _value == other._value;
+            }
+
+            TypeCode IConvertible.GetTypeCode() => TypeCode.Object;
+            byte IConvertible.ToByte(IFormatProvider? provider) => throw new NotImplementedException();
+            sbyte IConvertible.ToSByte(IFormatProvider? provider) => throw new NotImplementedException();
+            ushort IConvertible.ToUInt16(IFormatProvider? provider) => throw new NotImplementedException();
+            short IConvertible.ToInt16(IFormatProvider? provider) => throw new NotImplementedException();
+            uint IConvertible.ToUInt32(IFormatProvider? provider) => throw new NotImplementedException();
+            int IConvertible.ToInt32(IFormatProvider? provider) => throw new NotImplementedException();
+            ulong IConvertible.ToUInt64(IFormatProvider? provider) => throw new NotImplementedException();
+            long IConvertible.ToInt64(IFormatProvider? provider) => throw new NotImplementedException();
+            string IConvertible.ToString(IFormatProvider? provider) => throw new NotImplementedException();
+            bool IConvertible.ToBoolean(IFormatProvider? provider) => throw new NotImplementedException();
+            char IConvertible.ToChar(IFormatProvider? provider) => throw new NotImplementedException();
+            DateTime IConvertible.ToDateTime(IFormatProvider? provider) => throw new NotImplementedException();
+            decimal IConvertible.ToDecimal(IFormatProvider? provider) => throw new NotImplementedException();
+            double IConvertible.ToDouble(IFormatProvider? provider) => throw new NotImplementedException();
+            float IConvertible.ToSingle(IFormatProvider? provider) => throw new NotImplementedException();
+            object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => throw new NotImplementedException();
+        }
+
 #pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
 
         [Test]
@@ -368,10 +408,28 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
+        public void AssertWithExpectedClassImplicitConvertibleToString()
+        {
+            const string value = "Implicit Cast";
+            var instance = new ClassWithImplicitCastToString(value);
+
+            Assert.That(value, Is.EqualTo(instance), "EqualStringConstaint");
+        }
+
+        [Test]
+        public void AssertWithExpectedStructImplicitConvertibleToString()
+        {
+            const string value = "Implicit Cast";
+            var instance = new StructWithImplicitCastToString(value);
+
+            Assert.That(value, Is.EqualTo(instance), "EqualStringConstaint");
+        }
+
+        [Test]
         public void AssertWithTypeImplicitConvertibleToString()
         {
             const string value = "Implicit Cast";
-            var instance = new TypeWithImplicitCastToString(value);
+            var instance = new ClassWithImplicitCastToString(value);
 
             Assert.Multiple(() =>
             {
@@ -382,16 +440,28 @@ namespace NUnit.Framework.Tests.Assertions
             });
         }
 
-        private sealed class TypeWithImplicitCastToString
+        private sealed class StructWithImplicitCastToString
         {
             public string Value { get; }
 
-            public TypeWithImplicitCastToString(string value)
+            public StructWithImplicitCastToString(string value)
             {
                 Value = value;
             }
 
-            public static implicit operator string(TypeWithImplicitCastToString instance) => instance.Value;
+            public static implicit operator string(StructWithImplicitCastToString instance) => instance.Value;
+        }
+
+        private sealed class ClassWithImplicitCastToString
+        {
+            public string Value { get; }
+
+            public ClassWithImplicitCastToString(string value)
+            {
+                Value = value;
+            }
+
+            public static implicit operator string(ClassWithImplicitCastToString instance) => instance.Value;
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -408,73 +408,52 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
-        public void AssertWithExpectedClassImplicitConvertibleToString()
+        public void AssertWithExpectedTypeImplicitConvertibleToString()
         {
             const string value = "Implicit Cast";
-            var instance = new ClassWithImplicitCastToString(value);
+            var instance = new TypeWithImplicitCastToString(value);
 
-            Assert.That(value, Is.EqualTo(instance), "EqualStringConstaint");
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+            Assert.That(value, Is.Not.EqualTo(instance), "EqualConstaint");
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
         }
 
         [Test]
-        public void AssertWithExpectedStructImplicitConvertibleToString()
+        public void AssertWithActualTypeImplicitConvertibleToString()
         {
             const string value = "Implicit Cast";
-            var instance = new StructWithImplicitCastToString(value);
-
-            Assert.That(value, Is.EqualTo(instance), "EqualStringConstaint");
-        }
-
-        [Test]
-        public void AssertWithTypeImplicitConvertibleToString()
-        {
-            const string value = "Implicit Cast";
-            var instance = new ClassWithImplicitCastToString(value);
+            var instance = new TypeWithImplicitCastToString(value);
 
             Assert.Multiple(() =>
             {
                 Assert.That(instance.Value, Is.EqualTo(value), "Value");
-                Assert.That(instance, Is.EqualTo(value), "EqualStringConstaint");
-                Assert.That(instance, Is.EqualTo(value.ToLowerInvariant()).IgnoreCase, "EqualStringConstaint.IgnoreCase");
-                Assert.That(instance, Is.EqualTo(value.Replace(" ", string.Empty)).IgnoreWhiteSpace, "EqualStringConstaint.IgnoreWhiteSpace");
+                Assert.That(instance, Is.Not.EqualTo(value), "ImplicitOperatorNotConsidered");
             });
         }
 
-        private sealed class StructWithImplicitCastToString
+        private sealed class TypeWithImplicitCastToString
         {
             public string Value { get; }
 
-            public StructWithImplicitCastToString(string value)
+            public TypeWithImplicitCastToString(string value)
             {
                 Value = value;
             }
 
-            public static implicit operator string(StructWithImplicitCastToString instance) => instance.Value;
-        }
-
-        private sealed class ClassWithImplicitCastToString
-        {
-            public string Value { get; }
-
-            public ClassWithImplicitCastToString(string value)
-            {
-                Value = value;
-            }
-
-            public static implicit operator string(ClassWithImplicitCastToString instance) => instance.Value;
+            public static implicit operator string(TypeWithImplicitCastToString instance) => instance.Value;
         }
 
         [Test]
         public void AssertWithTypeWhichImplementsIEquatableString()
         {
             const string value = "Equatable<string>";
-            var intance = new TypeWhichImplementsIEquatableString(value);
+            var instance = new TypeWhichImplementsIEquatableString(value);
 
             Assert.Multiple(() =>
             {
-                Assert.That(intance.Value, Is.EqualTo(value), "Value");
-                Assert.That(intance, Is.EqualTo(value), "EqualStringConstaint");
-                Assert.That(() => Assert.That(intance, Is.EqualTo(value.ToLowerInvariant()).IgnoreCase),
+                Assert.That(instance.Value, Is.EqualTo(value), "Value");
+                Assert.That(instance, Is.EqualTo(value), "EqualStringConstaint");
+                Assert.That(() => Assert.That(instance, Is.EqualTo(value.ToLowerInvariant()).IgnoreCase),
                             Throws.InvalidOperationException);
             });
         }


### PR DESCRIPTION
Fixes #4898 for strings:

1. Types that can be implicit cast to string
2. Types that implement IEquatable<string>

Fixes #4898 for types implementing both `IEquatable` and `IConvertible`. The latter path is only chosen if the actual type is neither a primitive nor decimal. Otherwise `IEquatable.Equals` is called.