### PR TITLE
Fix numeric comparison when actual is declared as object.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -156,6 +156,17 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
+        /// Flag the constraint to use a tolerance defined elsewhere when determining equality.
+        /// </summary>
+        /// <param name="tolerance">Tolerance to be used</param>
+        /// <returns>Self.</returns>
+        internal EqualConstraint WithinConfiguredTolerance(Tolerance tolerance)
+        {
+            _tolerance = tolerance;
+            return this;
+        }
+
+        /// <summary>
         /// Flag the constraint to use a tolerance when determining equality.
         /// </summary>
         /// <param name="amount">Tolerance value to be used</param>

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -155,7 +155,7 @@ namespace NUnit.Framework.Constraints
 
                 hasSucceeded = equatable.Equals(_expected);
             }
-            else if (Numerics.IsNumericType(typeof(TActual)))
+            else if (Numerics.IsNumericType(actual))
             {
                 hasSucceeded = Numerics.AreEqual(actual, _expected, ref _tolerance);
             }
@@ -163,7 +163,7 @@ namespace NUnit.Framework.Constraints
             {
                 // We fall back to pre 4.3 EqualConstraint behavior
                 // Maybe TActual is not a numeric type, but supports indirect comparions with T
-                return new EqualConstraint(_expected).ApplyTo(actual);
+                return new EqualConstraint(_expected).WithinConfiguredTolerance(_tolerance).ApplyTo(actual);
             }
 
             return ConstraintResult(actual, hasSucceeded);

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -85,6 +85,13 @@ namespace NUnit.Framework.Tests.Constraints
         }
 
         [Test]
+        public void TestFloatsAndDoubles()
+        {
+            object x = 0.0500000007f;
+            Assert.That(x, Is.EqualTo(0.05).Within(0.0000001));
+        }
+
+        [Test]
         public void CanCompareDecimalsWithHighPrecision()
         {
             var expected = 95217168582.206969750145956m;


### PR DESCRIPTION
Fixes #4917

And value types must be mismatched: double vs float.