### PR TITLE
Use OverloadResolutionPriorityAttribute to prioritise generic Using overloads

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/NUnitFramework/Directory.Build.props
+++ b/src/NUnitFramework/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">12</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">13</LangVersion>
     <Features>strict</Features>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitFramework/framework/Constraints/EqualUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualUsingConstraint.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace NUnit.Framework.Constraints
@@ -52,6 +53,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="expected">The expected value.</param>
         /// <param name="comparer">The comparer to use.</param>
+        [OverloadResolutionPriority(1)]
         public EqualUsingConstraint(T? expected, IEqualityComparer<T> comparer)
             : this(expected, comparer.Equals)
         {

--- a/src/NUnitFramework/framework/Constraints/IEqualWithUsingConstraintExtensions.cs
+++ b/src/NUnitFramework/framework/Constraints/IEqualWithUsingConstraintExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework
@@ -39,6 +40,7 @@ namespace NUnit.Framework
         /// Equal constraint comparing <see cref="IEqualWithUsingConstraint{TExpected}.Expected"/>
         /// with an actual value using the user supplied comparer.
         /// </returns>
+        [OverloadResolutionPriority(2)]
         public static EqualUsingConstraint<TExpected> Using<TExpected>(this IEqualWithUsingConstraint<TExpected> constraint, IEqualityComparer<TExpected> comparer)
         {
             return WithUpdatedBuilder(new EqualUsingConstraint<TExpected>(constraint.Expected, comparer), constraint.Builder);
@@ -54,6 +56,7 @@ namespace NUnit.Framework
         /// Equal constraint comparing <see cref="IEqualWithUsingConstraint{TExpected}.Expected"/>
         /// with an actual value using the user supplied comparer.
         /// </returns>
+        [OverloadResolutionPriority(1)]
         public static EqualUsingConstraint<TExpected> Using<TExpected>(this IEqualWithUsingConstraint<TExpected> constraint, IComparer<TExpected> comparer)
         {
             return WithUpdatedBuilder(new EqualUsingConstraint<TExpected>(constraint.Expected, comparer), constraint.Builder);
@@ -106,6 +109,7 @@ namespace NUnit.Framework
         /// Equal constraint comparing <see cref="IEqualWithUsingConstraint{TExpected}.Expected"/>
         /// with an actual value using the user supplied comparer.
         /// </returns>
+        [OverloadResolutionPriority(1)]
         public static EqualUsingConstraint<TExpected> Using<TActual, TExpected>(this IEqualWithUsingConstraint<TExpected> constraint, IComparer<TActual> comparer)
         {
             return WithUpdatedBuilder(new EqualUsingConstraint<TExpected>(constraint.Expected,
@@ -126,6 +130,7 @@ namespace NUnit.Framework
         /// Equal constraint comparing <see cref="IEqualWithUsingConstraint{TExpected}.Expected"/>
         /// with an actual value using the user supplied comparer.
         /// </returns>
+        [OverloadResolutionPriority(-1)]
         public static EqualUsingConstraint<TExpected> Using<TExpected>(this IEqualWithUsingConstraint<TExpected> constraint, IEqualityComparer comparer)
         {
             return WithUpdatedBuilder(new EqualUsingConstraint<TExpected>(constraint.Expected, comparer), constraint.Builder);
@@ -141,6 +146,7 @@ namespace NUnit.Framework
         /// Equal constraint comparing <see cref="IEqualWithUsingConstraint{TExpected}.Expected"/>
         /// with an actual value using the user supplied comparer.
         /// </returns>
+        [OverloadResolutionPriority(-2)]
         public static EqualUsingConstraint<TExpected> Using<TExpected>(this IEqualWithUsingConstraint<TExpected> constraint, IComparer comparer)
         {
             return WithUpdatedBuilder(new EqualUsingConstraint<TExpected>(constraint.Expected, comparer), constraint.Builder);

--- a/src/NUnitFramework/framework/Internal/OverloadResolutionPriorityAttribute.cs
+++ b/src/NUnitFramework/framework/Internal/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,33 @@
+#if !NET9_0_OR_GREATER
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Specifies the priority of a member in overload resolution. When unspecified, the default priority is 0.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class OverloadResolutionPriorityAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OverloadResolutionPriorityAttribute"/> class.
+        /// </summary>
+        /// <param name="priority">The priority of the attributed member. Higher numbers are prioritized, lower numbers are deprioritized. 0 is the default if no attribute is present.</param>
+        public OverloadResolutionPriorityAttribute(int priority)
+        {
+            Priority = priority;
+        }
+
+        /// <summary>
+        /// The priority of the member.
+        /// </summary>
+        public int Priority { get; }
+    }
+}
+#endif

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1087,6 +1087,20 @@ namespace NUnit.Framework.Tests.Constraints
             }
 
             [Test]
+            public void PrefersGenericProvidedEqualityComparer()
+            {
+                var comparer = EqualityComparer<int>.Default;
+                Assert.That(2 + 2, Is.EqualTo(4).Using(comparer));
+            }
+
+            [Test]
+            public void WillUseObjectEqualityComparer()
+            {
+                IEqualityComparer comparer = EqualityComparer<int>.Default;
+                Assert.That(2 + 2, Is.EqualTo(4).Using(comparer));
+            }
+
+            [Test]
             public void UsesProvidedEqualityComparerForExpectedIsString()
             {
                 var comparer = new ObjectToStringEqualityComparer();


### PR DESCRIPTION
Fixes #4916 

Only if test-code compiled with 9.0.200 (or later)