### PR TITLE
Issue4954 equal to date time

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Reflection;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Constraints.Comparers
@@ -26,8 +25,8 @@ namespace NUnit.Framework.Constraints.Comparers
                 return EqualMethodResult.TypesNotSupported;
             }
 
-            bool xOverridesEqualsObject = OverridesEqualsObject(xType);
-            bool yOverridesEqualsObject = OverridesEqualsObject(yType);
+            bool xOverridesEqualsObject = TypeHelper.OverridesEqualsObject(xType);
+            bool yOverridesEqualsObject = TypeHelper.OverridesEqualsObject(yType);
 
             if (xOverridesEqualsObject || yOverridesEqualsObject)
             {
@@ -52,16 +51,6 @@ namespace NUnit.Framework.Constraints.Comparers
             }
 
             return EqualMethodResult.TypesNotSupported;
-        }
-
-        private static readonly Type[] EqualsObjectParameterTypes = { typeof(object) };
-
-        private static bool OverridesEqualsObject(Type type)
-        {
-            // Check for Equals(object) override
-            var equalsObject = type.GetMethod(nameof(type.Equals), BindingFlags.Instance | BindingFlags.Public,
-                                  null, EqualsObjectParameterTypes, null);
-            return equalsObject is not null && equalsObject.DeclaringType != (type.IsValueType ? typeof(ValueType) : typeof(object));
         }
     }
 }

--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -17,20 +17,38 @@ namespace NUnit.Framework.Constraints.Comparers
                 return EqualMethodResult.TypesNotSupported;
 
             Type xType = x.GetType();
+            Type yType = y.GetType();
 
-            if (equalityComparer.CompareProperties && TypeHelper.HasCompilerGeneratedEquals(xType))
+            if (equalityComparer.CompareProperties &&
+                (TypeHelper.HasCompilerGeneratedEquals(xType) || TypeHelper.HasCompilerGeneratedEquals(yType)))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
                 return EqualMethodResult.TypesNotSupported;
             }
 
-            if (OverridesEqualsObject(xType))
+            bool xOverridesEqualsObject = OverridesEqualsObject(xType);
+            bool yOverridesEqualsObject = OverridesEqualsObject(yType);
+
+            if (xOverridesEqualsObject || yOverridesEqualsObject)
             {
                 if (tolerance.HasVariance)
                     return EqualMethodResult.ToleranceNotSupported;
 
-                return x.Equals(y) ?
-                    EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
+                bool result;
+                if (xOverridesEqualsObject && yOverridesEqualsObject)
+                {
+                    result = x.Equals(y) || y.Equals(x);
+                }
+                else if (xOverridesEqualsObject)
+                {
+                    result = x.Equals(y);
+                }
+                else // yOverridesEqualsObject
+                {
+                    result = y.Equals(x);
+                }
+
+                return result ? EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
             }
 
             return EqualMethodResult.TypesNotSupported;

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -19,7 +19,8 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (equalityComparer.CompareProperties && TypeHelper.HasCompilerGeneratedEquals(xType))
+            if (equalityComparer.CompareProperties &&
+                (TypeHelper.HasCompilerGeneratedEquals(xType) || TypeHelper.HasCompilerGeneratedEquals(yType)))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.
                 return EqualMethodResult.TypesNotSupported;

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
@@ -62,6 +62,10 @@ namespace NUnit.Framework.Constraints
             {
                 return ApplyTo(t);
             }
+            else if (actual is IEquatable<T>)
+            {
+                throw new NotSupportedException($"Specified Tolerance not supported for instances of type '{actual.GetType()}' and '{typeof(T)}'");
+            }
 
             return new ConstraintResult(this, actual, false);
         }

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraint{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraint{T}.cs
@@ -95,21 +95,24 @@ namespace NUnit.Framework.Constraints
             {
                 return ApplyTo(t);
             }
-
-            return new ConstraintResult(this, actual, false);
+            else if (actual is IEquatable<T> equatable)
+            {
+                return new ConstraintResult(this, actual, equatable.Equals(_expected));
+            }
+            else
+            {
+                // We fall back to pre 4.3 EqualConstraint behavior
+                // But if the actual value cannot be convert to a DateTime nor can be compared to one
+                // not sure if that makes any difference.
+                return new EqualConstraint(_expected).ApplyTo(actual);
+            }
         }
 
         /// <summary>
         /// The Description of what this constraint tests, for
         /// use in messages and in the ConstraintResult.
         /// </summary>
-        public override string Description
-        {
-            get
-            {
-                return MsgUtils.FormatValue(_expected);
-            }
-        }
+        public override string Description => MsgUtils.FormatValue(_expected);
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Internal/TypeHelper.cs
+++ b/src/NUnitFramework/framework/Internal/TypeHelper.cs
@@ -397,5 +397,15 @@ namespace NUnit.Framework.Internal
 
             return equalsMethod?.GetCustomAttribute<CompilerGeneratedAttribute>() is not null;
         }
+
+        private static readonly Type[] EqualsObjectParameterTypes = { typeof(object) };
+
+        internal static bool OverridesEqualsObject(Type type)
+        {
+            // Check for Equals(object) override
+            var equalsObject = type.GetMethod(nameof(type.Equals), BindingFlags.Instance | BindingFlags.Public,
+                null, EqualsObjectParameterTypes, null);
+            return equalsObject is not null && equalsObject.DeclaringType != (type.IsValueType ? typeof(ValueType) : typeof(object));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4954 

This PR also adds a reciproke test to EqualConstraint:

EqualConstraint now tries both x.Equals(y) and y.Equals(x)

This matches the behaviour of EquatablesConstraint which tries both:
x.IEquatable<y> and y.IEquatable<x>
