### PR TITLE
Improve error message for mismatched tolerance + Use appropriate tolerance for PropertiesComparer

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DateTimeOffsetsComparer.cs
@@ -16,9 +16,13 @@ namespace NUnit.Framework.Constraints.Comparers
 
             bool result;
 
-            if (tolerance?.Amount is TimeSpan amount)
+            if (tolerance.Amount is TimeSpan amount)
             {
                 result = (xOffset - yOffset).Duration() <= amount;
+            }
+            else if (tolerance.Mode != ToleranceMode.Unset)
+            {
+                return EqualMethodResult.ToleranceNotSupported;
             }
             else
             {

--- a/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/NumericsComparer.cs
@@ -12,6 +12,9 @@ namespace NUnit.Framework.Constraints.Comparers
             if (!Numerics.IsNumericType(x) || !Numerics.IsNumericType(y))
                 return EqualMethodResult.TypesNotSupported;
 
+            if (!Numerics.IsNumericType(tolerance.Amount))
+                return EqualMethodResult.ToleranceNotSupported;
+
             return Numerics.AreEqual(x, y, ref tolerance) ?
                 EqualMethodResult.ComparedEqual : EqualMethodResult.ComparedNotEqual;
         }

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -93,11 +93,16 @@ namespace NUnit.Framework.Constraints.Comparers
 
                 Tolerance toleranceToApply = tolerance;
 
-                if (configuration.ToleranceForType is not null &&
-                    xPropertyValue is not null &&
-                    configuration.ToleranceForType.TryGetValue(xPropertyValue.GetType(), out Tolerance? typeTolerance))
+                if (tolerance.IsUnsetOrDefault)
                 {
-                    toleranceToApply = typeTolerance;
+                    if (xPropertyValue is TimeSpan or DateTime or DateTimeOffset)
+                    {
+                        toleranceToApply = configuration.TimeSpanTolerance;
+                    }
+                    else
+                    {
+                        toleranceToApply = configuration.NumericTolerance;
+                    }
                 }
 
                 EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref toleranceToApply, comparisonState);

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -91,7 +91,16 @@ namespace NUnit.Framework.Constraints.Comparers
                 (string xPropertyName, object? xPropertyValue, string yPropertyName, object? yPropertyValue) =
                     GetPropertyNamesAndValues(i);
 
-                EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref tolerance, comparisonState);
+                Tolerance toleranceToApply = tolerance;
+
+                if (configuration.ToleranceForType is not null &&
+                    xPropertyValue is not null &&
+                    configuration.ToleranceForType.TryGetValue(xPropertyValue.GetType(), out Tolerance? typeTolerance))
+                {
+                    toleranceToApply = typeTolerance;
+                }
+
+                EqualMethodResult result = equalityComparer.AreEqual(xPropertyValue, yPropertyValue, ref toleranceToApply, comparisonState);
 
                 if (result == EqualMethodResult.ComparedNotEqual || result == EqualMethodResult.TypesNotSupported)
                 {

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -99,9 +99,21 @@ namespace NUnit.Framework.Constraints.Comparers
                     {
                         toleranceToApply = configuration.TimeSpanTolerance;
                     }
-                    else
+                    else if (Numerics.IsFloatingPointNumeric(xPropertyValue))
                     {
-                        toleranceToApply = configuration.NumericTolerance;
+                        toleranceToApply = configuration.FloatingPointTolerance;
+                        if (toleranceToApply.IsUnsetOrDefault)
+                        {
+                            toleranceToApply = configuration.FixedPointTolerance;
+                        }
+                    }
+                    else if (Numerics.IsFixedPointNumeric(xPropertyValue))
+                    {
+                        toleranceToApply = configuration.FixedPointTolerance;
+                        if (toleranceToApply.IsUnsetOrDefault)
+                        {
+                            toleranceToApply = configuration.FloatingPointTolerance;
+                        }
                     }
                 }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -102,18 +102,10 @@ namespace NUnit.Framework.Constraints.Comparers
                     else if (Numerics.IsFloatingPointNumeric(xPropertyValue))
                     {
                         toleranceToApply = configuration.FloatingPointTolerance;
-                        if (toleranceToApply.IsUnsetOrDefault)
-                        {
-                            toleranceToApply = configuration.FixedPointTolerance;
-                        }
                     }
                     else if (Numerics.IsFixedPointNumeric(xPropertyValue))
                     {
                         toleranceToApply = configuration.FixedPointTolerance;
-                        if (toleranceToApply.IsUnsetOrDefault)
-                        {
-                            toleranceToApply = configuration.FloatingPointTolerance;
-                        }
                     }
                 }
 

--- a/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericConstraint.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+
 namespace NUnit.Framework.Constraints
 {
     /// <summary>
@@ -8,8 +10,10 @@ namespace NUnit.Framework.Constraints
     /// considered equal if both are null, or if both have the same
     /// value. NUnit has special semantics for some object types.
     /// </summary>
+#pragma warning disable CS3024 // Constraint type is not CLS-compliant
     public class EqualNumericConstraint<T> : EqualNumericWithoutUsingConstraint<T>, IEqualWithUsingConstraint<T>
-        where T : struct
+#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+        where T : unmanaged, IConvertible
     {
         #region Constructor
 

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -11,8 +11,10 @@ namespace NUnit.Framework.Constraints
     /// considered equal if both are null, or if both have the same
     /// value. NUnit has special semantics for some object types.
     /// </summary>
+#pragma warning disable CS3024 // Constraint type is not CLS-compliant
     public class EqualNumericWithoutUsingConstraint<T> : Constraint
-        where T : struct
+#pragma warning restore CS3024 // Constraint type is not CLS-compliant
+        where T : unmanaged, IConvertible
     {
         #region Static and Instance Fields
 

--- a/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualTimeBasedConstraintWithTimeSpanTolerance{T}.cs
@@ -64,7 +64,7 @@ namespace NUnit.Framework.Constraints
             }
             else if (actual is IEquatable<T>)
             {
-                throw new NotSupportedException($"Specified Tolerance not supported for instances of type '{actual.GetType()}' and '{typeof(T)}'");
+                throw new NotSupportedException($"Specified Tolerance of type {_tolerance} not supported for instances of type '{actual.GetType()}' and '{typeof(T)}'");
             }
 
             return new ConstraintResult(this, actual, false);

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -192,7 +192,7 @@ namespace NUnit.Framework.Constraints
                 case EqualMethodResult.TypesNotSupported:
                     throw new NotSupportedException($"No comparer found for instances of type '{GetType(x)}' and '{GetType(y)}'");
                 case EqualMethodResult.ToleranceNotSupported:
-                    throw new NotSupportedException($"Specified Tolerance not supported for instances of type '{GetType(x)}' and '{GetType(y)}'");
+                    throw new NotSupportedException($"Specified Tolerance of type {tolerance.Amount.GetType()} not supported for instances of type '{GetType(x)}' and '{GetType(y)}'");
                 case EqualMethodResult.ComparedEqual:
                     return true;
                 case EqualMethodResult.ComparisonPending:

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -61,9 +61,36 @@ namespace NUnit.Framework.Constraints
         internal Dictionary<Type, Dictionary<string, object?>>? PropertyNameToValueMapForType { get; set; }
 
         /// <summary>
-        /// Gets and sets the mapping of property name to values.
+        /// Gets and sets the tolerance to apply for time values.
         /// </summary>
-        internal Dictionary<Type, Tolerance>? ToleranceForType { get; set; }
+        internal Tolerance TimeSpanTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Gets and sets the tolerance to apply for numeric values.
+        /// </summary>
+        internal Tolerance NumericTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Set the tolerance to apply based upon the type of the tolerance.
+        /// </summary>
+        /// <remarks>
+        /// This method accepts a <see cref="TimeSpan"/>, a numeric value or a <see cref="Tolerance"/> instance.
+        /// </remarks>
+        /// <param name="amount"></param>
+        protected void SetTolerance(object amount)
+        {
+            if (amount is not Tolerance instance)
+                instance = new Tolerance(amount);
+
+            if (instance.Amount is TimeSpan)
+            {
+                TimeSpanTolerance = instance;
+            }
+            else
+            {
+                NumericTolerance = instance;
+            }
+        }
     }
 
     // new HashSet<string>(properties) is clearer to me then [.. properties]
@@ -152,11 +179,14 @@ namespace NUnit.Framework.Constraints
             return AllowDifferentTypes();
         }
 
-        /// <inheritdoc/>
-        public PropertiesComparerConfigurationUntyped Within<TProperty>(object tolerance)
+        /// <summary>
+        /// Specify a tolerance for all numeric comparisons.
+        /// </summary>
+        /// <param name="amount">The tolerance to apply.</param>
+        /// <returns>Self.</returns>
+        public PropertiesComparerConfigurationUntyped Within(object amount)
         {
-            ToleranceForType ??= new Dictionary<Type, Tolerance>();
-            ToleranceForType[typeof(TProperty)] = new Tolerance(tolerance);
+            SetTolerance(amount);
             return this;
         }
     }
@@ -308,11 +338,14 @@ namespace NUnit.Framework.Constraints
             return AllowDifferentTypes();
         }
 
-        /// <inheritdoc/>
-        public PropertiesComparerConfiguration<T> Within<TProperty>(object tolerance)
+        /// <summary>
+        /// Specify a tolerance for all numeric comparisons.
+        /// </summary>
+        /// <param name="amount">The tolerance to apply.</param>
+        /// <returns>Self.</returns>
+        public PropertiesComparerConfiguration<T> Within(object amount)
         {
-            ToleranceForType ??= new Dictionary<Type, Tolerance>();
-            ToleranceForType[typeof(TProperty)] = new Tolerance(tolerance);
+            SetTolerance(amount);
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -59,6 +59,11 @@ namespace NUnit.Framework.Constraints
         /// Gets and sets the mapping of property name to values.
         /// </summary>
         internal Dictionary<Type, Dictionary<string, object?>>? PropertyNameToValueMapForType { get; set; }
+
+        /// <summary>
+        /// Gets and sets the mapping of property name to values.
+        /// </summary>
+        internal Dictionary<Type, Tolerance>? ToleranceForType { get; set; }
     }
 
     // new HashSet<string>(properties) is clearer to me then [.. properties]
@@ -145,6 +150,14 @@ namespace NUnit.Framework.Constraints
         {
             PropertyNameMap = properties.ToDictionary(x => x.From, x => x.To);
             return AllowDifferentTypes();
+        }
+
+        /// <inheritdoc/>
+        public PropertiesComparerConfigurationUntyped Within<TProperty>(object tolerance)
+        {
+            ToleranceForType ??= new Dictionary<Type, Tolerance>();
+            ToleranceForType[typeof(TProperty)] = new Tolerance(tolerance);
+            return this;
         }
     }
 
@@ -293,6 +306,14 @@ namespace NUnit.Framework.Constraints
             }
             nameToValueMapping.Add(GetNameFromExpression(from), value);
             return AllowDifferentTypes();
+        }
+
+        /// <inheritdoc/>
+        public PropertiesComparerConfiguration<T> Within<TProperty>(object tolerance)
+        {
+            ToleranceForType ??= new Dictionary<Type, Tolerance>();
+            ToleranceForType[typeof(TProperty)] = new Tolerance(tolerance);
+            return this;
         }
 
         private static string GetNameFromExpression<TExpression>(Expression<Func<TExpression, object?>> expression)

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -68,7 +68,12 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Gets and sets the tolerance to apply for numeric values.
         /// </summary>
-        internal Tolerance NumericTolerance { get; set; } = Tolerance.Default;
+        internal Tolerance FloatingPointTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Gets and sets the tolerance to apply for numeric values.
+        /// </summary>
+        internal Tolerance FixedPointTolerance { get; set; } = Tolerance.Default;
 
         /// <summary>
         /// Set the tolerance to apply based upon the type of the tolerance.
@@ -86,9 +91,13 @@ namespace NUnit.Framework.Constraints
             {
                 TimeSpanTolerance = instance;
             }
+            else if (Numerics.IsFloatingPointNumeric(instance.Amount) || instance.Mode == ToleranceMode.Ulps)
+            {
+                FloatingPointTolerance = instance;
+            }
             else
             {
-                NumericTolerance = instance;
+                FixedPointTolerance = instance;
             }
         }
     }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -483,6 +483,39 @@ namespace NUnit.Framework.Tests.Assertions
                         Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
         }
 
+        [TestCase(40, 42)]
+        public void AssertThatWithInvalidTolerance(object actual, object expected)
+        {
+            Assert.That(() => Assert.That(actual, Is.EqualTo(expected).Within(1).Seconds),
+                        Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+        }
+
+        [Test]
+        public async Task AssertThatWithInvalidTolerance()
+        {
+            DateTime expected = DateTime.UtcNow;
+
+            await Task.Delay(500);
+
+            DateTime actual = DateTime.UtcNow;
+
+            Assert.That(actual, Is.EqualTo(expected).Within(1).Seconds);
+            Assert.That(() => Assert.That(actual, Is.EqualTo((object)expected).Within(1)),
+                        Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Tolerance"));
+        }
+
+        [Test]
+        public async Task AssertPropertiesComparerOnlyUsesToleranceWhereAppropriate()
+        {
+            var expected = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+            await Task.Delay(500);
+            var actual = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+
+            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer().Within(1.0).Seconds);
+        }
+
+        private record RecordWithOneTimespanToleranceAwareMember(int Id, string Name, DateTimeOffset Start);
+
         [Test]
         public void AssertThatEqualsWithClassWithSomeToleranceAwareMembers()
         {

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Tests.TestUtilities;
 using NUnit.TestData;
@@ -507,9 +508,9 @@ namespace NUnit.Framework.Tests.Assertions
         [Test]
         public async Task AssertPropertiesComparerOnlyUsesToleranceWhereAppropriate()
         {
-            var expected = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+            var expected = new RecordWithDifferentToleranceAwareMembers(1, "Name", 1.80, DateTimeOffset.UtcNow);
             await Task.Delay(500);
-            var actual = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+            var actual = new RecordWithDifferentToleranceAwareMembers(1, "Name", 1.80, DateTimeOffset.UtcNow);
 
 #pragma warning disable NUnit2047 // Incompatible types for Within constraint
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer().Within(1.0).Seconds);
@@ -519,19 +520,39 @@ namespace NUnit.Framework.Tests.Assertions
         [Test]
         public async Task AssertPropertiesComparerOnlyUsesToleranceWhereSpecified()
         {
-            var expected = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+            var expected = new RecordWithDifferentToleranceAwareMembers(1, "Name", 1.80, DateTimeOffset.UtcNow);
             await Task.Delay(500);
-            var actual = new RecordWithOneTimespanToleranceAwareMember(2, "Name", DateTimeOffset.UtcNow);
+            var actual = new RecordWithDifferentToleranceAwareMembers(2, "Name", 1.81, DateTimeOffset.UtcNow);
 
+            // Fails because of Id and Height field
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(TimeSpan.FromSeconds(1))));
+
+            // Fails because of Star field
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(1)));
+
+            // Succeeds, but uses 1 tolerance for Height
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(1).Within(TimeSpan.FromSeconds(1))));
+            // Succeeds, uses 1.0 tolerance for Id
+            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within(1.0).Within(TimeSpan.FromSeconds(1))));
+
+            // Succeeds, uses 1 tolerance for Id and 0.1 tolerance for Height
+            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within(1).Within(0.02).Within(TimeSpan.FromSeconds(1))));
+
+            // Succeeds, used 1 tolerance for Id and 1% tolerance for Height
+            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within(1).Within(new Tolerance(1.0).Percent).Within(TimeSpan.FromSeconds(1))));
+
+            // Fails because Height tolerance is too small
+            Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within(1).Within(0.001).Within(TimeSpan.FromSeconds(1))));
         }
 
-        private record RecordWithOneTimespanToleranceAwareMember(int Id, string Name, DateTimeOffset Start);
+        private record RecordWithDifferentToleranceAwareMembers(int Id, string Name, double Height, DateTimeOffset Start);
 
         [Test]
         public void AssertThatEqualsWithClassWithSomeToleranceAwareMembers()

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -528,20 +528,20 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(TimeSpan.FromSeconds(1))));
 
-            // Fails because of Star field
+            // Fails because of Start field
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(1)));
 
-            // Succeeds, but uses 1 tolerance for Height
-            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+            // Fails because of Height field
+            Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(1).Within(TimeSpan.FromSeconds(1))));
-            // Succeeds, uses 1.0 tolerance for Id
-            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+            // Fails because of Id field
+            Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
                 c => c.Within(1.0).Within(TimeSpan.FromSeconds(1))));
 
             // Succeeds, uses 1 tolerance for Id and 0.1 tolerance for Height
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
-                c => c.Within(1).Within(0.02).Within(TimeSpan.FromSeconds(1))));
+                c => c.Within(1).Within(0.1).Within(TimeSpan.FromSeconds(1))));
 
             // Succeeds, used 1 tolerance for Id and 1% tolerance for Height
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -511,7 +511,24 @@ namespace NUnit.Framework.Tests.Assertions
             await Task.Delay(500);
             var actual = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
 
+#pragma warning disable NUnit2047 // Incompatible types for Within constraint
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer().Within(1.0).Seconds);
+#pragma warning restore NUnit2047 // Incompatible types for Within constraint
+        }
+
+        [Test]
+        public async Task AssertPropertiesComparerOnlyUsesToleranceWhereSpecified()
+        {
+            var expected = new RecordWithOneTimespanToleranceAwareMember(1, "Name", DateTimeOffset.UtcNow);
+            await Task.Delay(500);
+            var actual = new RecordWithOneTimespanToleranceAwareMember(2, "Name", DateTimeOffset.UtcNow);
+
+            Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within<DateTimeOffset>(TimeSpan.FromSeconds(1))));
+            Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within<int>(1)));
+            Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
+                c => c.Within<int>(1).Within<DateTimeOffset>(TimeSpan.FromSeconds(1))));
         }
 
         private record RecordWithOneTimespanToleranceAwareMember(int Id, string Name, DateTimeOffset Start);

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -524,11 +524,11 @@ namespace NUnit.Framework.Tests.Assertions
             var actual = new RecordWithOneTimespanToleranceAwareMember(2, "Name", DateTimeOffset.UtcNow);
 
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
-                c => c.Within<DateTimeOffset>(TimeSpan.FromSeconds(1))));
+                c => c.Within(TimeSpan.FromSeconds(1))));
             Assert.That(actual, Is.Not.EqualTo(expected).UsingPropertiesComparer(
-                c => c.Within<int>(1)));
+                c => c.Within(1)));
             Assert.That(actual, Is.EqualTo(expected).UsingPropertiesComparer(
-                c => c.Within<int>(1).Within<DateTimeOffset>(TimeSpan.FromSeconds(1))));
+                c => c.Within(1).Within(TimeSpan.FromSeconds(1))));
         }
 
         private record RecordWithOneTimespanToleranceAwareMember(int Id, string Name, DateTimeOffset Start);

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -480,13 +480,13 @@ namespace NUnit.Framework.Tests.Constraints
                     Assert.That(myDateTime, Is.EqualTo(nowOffset));
                     Assert.That(() => Assert.That(myDateTime, Is.EqualTo(nowUtc).Within(timeZoneOffset)),
                                 Throws.InstanceOf<NotSupportedException>()
-                                      .With.Message.Contains("Tolerance not supported"));
+                                      .With.Message.Contains("Tolerance"));
 
                     // Pre special DateTimeConstraints behaviour
                     Assert.That(myDateTime, new EqualConstraint(nowOffset));
                     Assert.That(() => Assert.That(myDateTime, new EqualConstraint(nowUtc).Within(timeZoneOffset)),
                                 Throws.InstanceOf<NotSupportedException>()
-                                      .With.Message.Contains("Tolerance not supported"));
+                                      .With.Message.Contains("Tolerance"));
                 }
             }
 


### PR DESCRIPTION
Fixes #4968 

@OsirisTerje This PR contain 2 fixes:

1. The generic version of NumericEqualityComparer were calling the object overloads of Numerics.AreEqual due to mismatch of constraints.
2. Checks the type of the Tolerance.Amount before applying it. That way we get a NotSupported instead of a InvalidCastException

The latter fixes the issue #4968 where the user expected the `TimeSpan` tolerance to be only applied to the `DateTime` value because the numeric comparisons now reject the tolerance and the PropertiesComparer will retry that without the tolerance value.

Further it contains 2 commit with different versions of new API to specify multiple tolerance to the PropertiesComparer

1. `c => c.Within<int>(1).Within<DateTimeOffset>(TimeSpan.FromSeconds(1))`
2. `c => c.Within(1).Within(TimeSpan.FromSeconds(1))`

The first requires specifying the type the users want to apply the specified tolerance to.
As there are basically only two types, the seconds allows specifying multiple tolerances and based upon the type applies it to either DateTime like values or numeric values.

The latter option is more compact.
It doesn't allow different tolerances between floating and fixed point. For most practical tolerances (close to zero) the integer tolerance will be zero.
It doesn't allow different tolerance between `DateTime(Offset)` and `TimeSpan`. Not sure if that matters.

Let me know which option you prefer.