### PR TITLE
Treat an exception as an assertion failure and always add it to the assertion list.

### DIFF
--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -30,7 +30,7 @@ namespace NUnit.Framework.Interfaces
         }
 
         /// <summary> Where did the failure occur.</summary>
-        public FailureSite Site;
+        public FailureSite Site { get; }
 
         /// <summary> The pass/fail status of the assertion</summary>
         public AssertionStatus Status { get; }

--- a/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
+++ b/src/NUnitFramework/framework/Interfaces/AssertionResult.cs
@@ -14,11 +14,23 @@ namespace NUnit.Framework.Interfaces
         /// Construct an AssertionResult
         /// </summary>
         public AssertionResult(AssertionStatus status, string message, string? stackTrace)
+            : this(FailureSite.Test, status, message, stackTrace)
         {
+        }
+
+        /// <summary>
+        /// Construct an AssertionResult
+        /// </summary>
+        public AssertionResult(FailureSite site, AssertionStatus status, string message, string? stackTrace)
+        {
+            Site = site;
             Status = status;
             Message = message;
             StackTrace = stackTrace;
         }
+
+        /// <summary> Where did the failure occur.</summary>
+        public FailureSite Site;
 
         /// <summary> The pass/fail status of the assertion</summary>
         public AssertionStatus Status { get; }

--- a/src/NUnitFramework/framework/Internal/Commands/BeforeAndAfterTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeAndAfterTestCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {
@@ -34,7 +35,10 @@ namespace NUnit.Framework.Internal.Commands
             RunTestMethodInThreadAbortSafeZone(context, () =>
             {
                 BeforeTest(context);
-                context.CurrentResult = innerCommand.Execute(context);
+
+                // If the BeforeTest method fails, we don't run the test
+                if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped)
+                    context.CurrentResult = innerCommand.Execute(context);
             });
 
             if (context.ExecutionStatus != TestExecutionStatus.AbortRequested)

--- a/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {
@@ -26,7 +27,11 @@ namespace NUnit.Framework.Internal.Commands
 
             BeforeTest(context);
 
-            return context.CurrentResult = innerCommand.Execute(context);
+            // If the BeforeTest method fails, we don't run the test
+            if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped)
+                context.CurrentResult = innerCommand.Execute(context);
+
+            return context.CurrentResult;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeSetUpCommand.cs
@@ -19,10 +19,7 @@ namespace NUnit.Framework.Internal.Commands
             Guard.ArgumentValid(Test is TestSuite && Test.TypeInfo is not null,
                 "OneTimeSetUpCommand must reference a TestFixture or SetUpFixture", nameof(innerCommand));
 
-            BeforeTest = context =>
-            {
-                setUpTearDown.RunSetUp(context);
-            };
+            BeforeTest = setUpTearDown.RunSetUp;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/OneTimeTearDownCommand.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-
 namespace NUnit.Framework.Internal.Commands
 {
     /// <summary>
@@ -22,19 +20,7 @@ namespace NUnit.Framework.Internal.Commands
             Guard.ArgumentValid(innerCommand.Test is TestSuite, "OneTimeTearDownCommand may only apply to a TestSuite", nameof(innerCommand));
             Guard.ArgumentNotNull(setUpTearDownItem, nameof(setUpTearDownItem));
 
-            AfterTest = context =>
-            {
-                TestResult suiteResult = context.CurrentResult;
-
-                try
-                {
-                    setUpTearDownItem.RunTearDown(context);
-                }
-                catch (Exception ex)
-                {
-                    suiteResult.RecordTearDownException(ex);
-                }
-            };
+            AfterTest = setUpTearDownItem.RunTearDown;
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs
@@ -49,8 +49,15 @@ namespace NUnit.Framework.Internal.Commands
         {
             _setUpWasRun = true;
 
-            foreach (IMethodInfo setUpMethod in _setUpMethods)
-                RunSetUpOrTearDownMethod(context, setUpMethod);
+            try
+            {
+                foreach (IMethodInfo setUpMethod in _setUpMethods)
+                    RunSetUpOrTearDownMethod(context, setUpMethod);
+            }
+            catch (Exception ex)
+            {
+                context.CurrentResult.RecordException(ex, FailureSite.SetUp);
+            }
         }
 
         /// <summary>
@@ -81,7 +88,7 @@ namespace NUnit.Framework.Internal.Commands
                 }
                 catch (Exception ex)
                 {
-                    context.CurrentResult.RecordTearDownException(ex);
+                    context.CurrentResult.RecordException(ex, FailureSite.TearDown);
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -48,7 +48,7 @@ namespace NUnit.Framework.Internal.Commands
                 Assert.That(result, Is.EqualTo(_testMethod.ExpectedResult));
 
             if (context.MultipleAssertLevel > 0)
-                context.CurrentResult.SetResult(ResultState.Error, $"Test completed with {context.MultipleAssertLevel} active assertion scopes.");
+                context.CurrentResult.SetResult(ResultState.Error, $"Test completed with {context.MultipleAssertLevel} active assertion scope(s).");
             else
                 context.CurrentResult.SetResult(ResultState.Success);
 

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -483,8 +483,7 @@ namespace NUnit.Framework.Internal
         {
             var result = new ExceptionResult(ex, site);
 
-            if (ex is NUnitException nUnitException && nUnitException.InnerException is ResultStateException ||
-                ex is ResultStateException)
+            if (ex is NUnitException { InnerException: ResultStateException } or ResultStateException)
             {
                 SetResult(result.ResultState, result.Message, result.StackTrace);
             }
@@ -705,23 +704,23 @@ namespace NUnit.Framework.Internal
 
         private AssertionStatus ResultStateToAssertionStatus(ResultState resultState)
         {
-            if (resultState.Status == TestStatus.Failed)
+            switch (resultState.Status)
             {
-                if (resultState.Label == ResultState.Error.Label)
-                    return AssertionStatus.Error;
-                else if (resultState.Label == ResultState.Failure.Label)
-                    return AssertionStatus.Failed;
+                case TestStatus.Skipped:
+                case TestStatus.Inconclusive:
+                    return AssertionStatus.Inconclusive;
+                default:
+                case TestStatus.Passed:
+                    return AssertionStatus.Passed;
+                case TestStatus.Warning:
+                    return AssertionStatus.Warning;
+                case TestStatus.Failed:
+                    if (resultState.Label == ResultState.Error.Label)
+                        return AssertionStatus.Error;
+                    if (resultState.Label == ResultState.Failure.Label)
+                        return AssertionStatus.Failed;
+                    return AssertionStatus.Inconclusive;
             }
-            else if (resultState.Status == TestStatus.Warning)
-            {
-                return AssertionStatus.Warning;
-            }
-            else if (resultState.Status == TestStatus.Passed)
-            {
-                return AssertionStatus.Passed;
-            }
-
-            return AssertionStatus.Inconclusive;
         }
 
         /// <summary>

--- a/src/NUnitFramework/testdata/SetUpData.cs
+++ b/src/NUnitFramework/testdata/SetUpData.cs
@@ -167,6 +167,7 @@ namespace NUnit.TestData.SetUpData
     public class SetupAndTearDownExceptionFixture
     {
         public Exception? SetupException;
+        public Exception? TestException;
         public Exception? TearDownException;
 
         [SetUp]
@@ -186,6 +187,8 @@ namespace NUnit.TestData.SetUpData
         [Test]
         public void TestOne()
         {
+            if (TestException is not null)
+                throw TestException;
         }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertIgnoreTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertIgnoreTests.cs
@@ -57,10 +57,13 @@ namespace NUnit.Framework.Tests.Assertions
             ITestResult fixtureResult = TestBuilder.RunTestFixture(typeof(IgnoreInSetUpFixture));
 
             // TODO: Decide whether to pass Ignored state to containing fixture
-            //Assert.AreEqual(ResultState.Ignored, fixtureResult.ResultState);
+            Assert.That(fixtureResult.ResultState, Is.EqualTo(ResultState.Ignored.WithSite(FailureSite.Child)));
 
+            ResultState ignoredInSetUp = ResultState.Ignored.WithSite(FailureSite.SetUp);
             foreach (var testResult in fixtureResult.Children)
-                Assert.That(testResult.ResultState, Is.EqualTo(ResultState.Ignored));
+            {
+                Assert.That(testResult.ResultState, Is.EqualTo(ignoredInSetUp));
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -63,12 +63,11 @@ namespace NUnit.Framework.Tests.Assertions
             CheckResult(methodName, ResultState.Warning, asserts, assertionMessages);
         }
 
-        [TestCase(nameof(AM.ExceptionThrown), 0)]
+        [TestCase(nameof(AM.ExceptionThrown), 0, "Simulated Error")]
         [TestCase(nameof(AM.ExceptionThrownAfterWarning), 0, "WARNING", "Simulated Error")]
         public void AssertMultipleErrorTests(string methodName, int asserts, params string[] assertionMessages)
         {
-            ITestResult result = CheckResult(methodName, ResultState.Error, asserts, assertionMessages);
-            Assert.That(result.Message, Does.StartWith("System.Exception : Simulated Error"));
+            _ = CheckResult(methodName, ResultState.Error, asserts, assertionMessages);
         }
 
         [TestCase(nameof(AM.AssertPassInBlock), "Assert.Pass")]
@@ -77,17 +76,22 @@ namespace NUnit.Framework.Tests.Assertions
         [TestCase(nameof(AM.AssumptionInBlock), "Assume.That")]
         public void AssertMultiple_InvalidAssertThrowsException(string methodName, string invalidAssert)
         {
-            ITestResult result = CheckResult(methodName, ResultState.Error, 0);
-            Assert.That(result.Message, Contains.Substring($"{invalidAssert} may not be used in a multiple assertion block."));
+            _ = CheckResult(methodName, ResultState.Error, 0,
+                $"{invalidAssert} may not be used in a multiple assertion block.");
         }
 
-        [TestCase(nameof(AM.NonReleasedScope), 2, "Test completed with 1 active assertion scopes")]
-        [TestCase(nameof(AM.NonReleasedScopes), 3, "Test completed with 2 active assertion scopes")]
-        [TestCase(nameof(AM.ScopeReleasedOutOfOrder), 3, "The assertion scope was disposed out of order")]
-        public void NonOrOutOfOrderReleaseScope(string methodName, int asserts, string errorMessage)
+        [TestCase(nameof(AM.NonReleasedScope), 2, "Test completed with 1 active assertion scope(s)")]
+        [TestCase(nameof(AM.NonReleasedScopes), 3, "Test completed with 2 active assertion scope(s)")]
+        public void NonReleaseScope(string methodName, int asserts, string errorMessage)
         {
             ITestResult result = CheckResult(methodName, ResultState.Error, asserts);
             Assert.That(result.Message, Contains.Substring(errorMessage));
+        }
+
+        [TestCase(nameof(AM.ScopeReleasedOutOfOrder), 3, "The assertion scope was disposed out of order")]
+        public void OutOfOrderReleaseScope(string methodName, int asserts, string errorMessage)
+        {
+            _ = CheckResult(methodName, ResultState.Error, asserts, errorMessage);
         }
 
         [Test]
@@ -125,7 +129,7 @@ namespace NUnit.Framework.Tests.Assertions
                     --numFailures;
 
                 if (numFailures > 1)
-                    Assert.That(result.Message, Contains.Substring("Multiple failures or warnings in test:"));
+                    Assert.That(result.Message, Contains.Substring(TestResult.MULTIPLE_FAILURES_OR_WARNINGS_MESSAGE));
 
                 int i = 0;
                 foreach (var assertion in result.AssertionResults)

--- a/src/NUnitFramework/tests/Attributes/CancelAfterTests.cs
+++ b/src/NUnitFramework/tests/Attributes/CancelAfterTests.cs
@@ -175,7 +175,7 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));
+                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.SetUp));
                 Assert.That(result.Message, Does.Contain("50ms"));
                 Assert.That(fixture.TearDownWasRun, "TearDown was not run");
             });
@@ -192,7 +192,7 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.Test));
+                Assert.That(result.ResultState.Site, Is.EqualTo(FailureSite.TearDown));
                 Assert.That(result.Message, Does.Contain("50ms"));
                 Assert.That(fixture.TearDownWasRun, "Base TearDown should not have been run but was");
             });

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -135,8 +135,8 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [TestCase(typeof(RepeatWithoutStopSucceedsOnFirstTryFixture), "Passed", 3)]
-        [TestCase(typeof(RepeatWithoutStopSucceedsOnSecondTryFixture), "Passed", 3)]
-        [TestCase(typeof(RepeatWithoutStopSucceedsOnThirdTryFixture), "Passed", 3)]
+        [TestCase(typeof(RepeatWithoutStopSucceedsOnSecondTryFixture), "Failed(Child)", 3)]
+        [TestCase(typeof(RepeatWithoutStopSucceedsOnThirdTryFixture), "Failed(Child)", 3)]
         [TestCase(typeof(RepeatWithoutStopFailsEveryTimeFixture), "Failed(Child)", 3)]
         [TestCase(typeof(RepeatWithoutStopWithIgnoreAttributeFixture), "Skipped:Ignored(Child)", 0)]
         [TestCase(typeof(RepeatWithoutStopIgnoredOnFirstTryFixture), "Skipped:Ignored(Child)", 3)]

--- a/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatAttributeTests.cs
@@ -135,8 +135,8 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [TestCase(typeof(RepeatWithoutStopSucceedsOnFirstTryFixture), "Passed", 3)]
-        [TestCase(typeof(RepeatWithoutStopSucceedsOnSecondTryFixture), "Failed(Child)", 3)]
-        [TestCase(typeof(RepeatWithoutStopSucceedsOnThirdTryFixture), "Failed(Child)", 3)]
+        [TestCase(typeof(RepeatWithoutStopSucceedsOnSecondTryFixture), "Passed", 3)]
+        [TestCase(typeof(RepeatWithoutStopSucceedsOnThirdTryFixture), "Passed", 3)]
         [TestCase(typeof(RepeatWithoutStopFailsEveryTimeFixture), "Failed(Child)", 3)]
         [TestCase(typeof(RepeatWithoutStopWithIgnoreAttributeFixture), "Skipped:Ignored(Child)", 0)]
         [TestCase(typeof(RepeatWithoutStopIgnoredOnFirstTryFixture), "Skipped:Ignored(Child)", 3)]

--- a/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
+++ b/src/NUnitFramework/tests/Internal/AsyncSetupTeardownTests.cs
@@ -34,11 +34,13 @@ namespace NUnit.Framework.Tests.Internal
         }
 
         [Test]
-        public void FailingSetupShouldLetExceptionBubbleUpUnwrapped()
+        public void FailingSetupShouldShouldRecordFailureInTestContext()
         {
             var item = new SetUpTearDownItem(Failure.ToList(), Empty);
 
-            Assert.Throws<InvalidOperationException>(() => item.RunSetUp(_context));
+            item.RunSetUp(_context);
+
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.SetUpError));
         }
 
         [Test]
@@ -49,16 +51,17 @@ namespace NUnit.Framework.Tests.Internal
             item.RunSetUp(_context);
             item.RunTearDown(_context);
 
-            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.Error));
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.TearDownError));
         }
 
         [Test]
-        public void SuccessfulThenFailingSetupShouldLetExceptionBubbleUpUnwrapped()
+        public void SuccessfulThenFailingSetupShouldRecordFailureInTestContext()
         {
             var item = new SetUpTearDownItem(Success.Concat(Failure).ToList(), Empty);
 
-            Assert.Throws<InvalidOperationException>(() => item.RunSetUp(_context));
+            item.RunSetUp(_context);
             Assert.That(_testObject.SuccessfulAsyncMethodRuns, Is.EqualTo(1));
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.SetUpError));
         }
 
         [Test]
@@ -69,7 +72,7 @@ namespace NUnit.Framework.Tests.Internal
             item.RunSetUp(_context);
             item.RunTearDown(_context);
 
-            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.Error));
+            Assert.That(_context.CurrentResult.ResultState, Is.EqualTo(ResultState.TearDownError));
         }
 
         private IEnumerable<IMethodInfo> Success

--- a/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
+++ b/src/NUnitFramework/tests/Internal/Results/TestResultApiTests.cs
@@ -18,9 +18,9 @@ namespace NUnit.Framework.Tests.Internal.Results
 
         private static IEnumerable<Action<TestResult, Exception>> RecordExceptionMethods => new Action<TestResult, Exception>[]
         {
-            (result, exception) => result.RecordException(exception),
+            (result, exception) => result.RecordException(exception, FailureSite.SetUp),
             (result, exception) => result.RecordException(exception, FailureSite.Test),
-            (result, exception) => result.RecordTearDownException(exception)
+            (result, exception) => result.RecordException(exception, FailureSite.TearDown)
         };
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
+++ b/src/NUnitFramework/tests/Internal/UnexpectedExceptionTests.cs
@@ -202,7 +202,7 @@ namespace NUnit.Framework.Tests.Internal
             var result = new TestCaseResult(new TestMethod(new MethodWrapper(typeof(UnexpectedExceptionTests), nameof(DummyMethod))));
 
             var ex = RecordPossiblyDangerousException(() =>
-                result.RecordException(new RecursivelyThrowingException(), FailureSite.Test));
+                result.RecordException(new RecursivelyThrowingException()));
 
             Assert.That(ex is null); // Careful not to pass ex to Assert.That and crash the test run rather than failing
 

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -271,7 +271,7 @@ namespace NUnit.Framework.Tests
                 SetUpFailure = true
             };
             TestBuilder.RunTestFixture(fixture);
-            Assert.That(fixture.StateList, Is.EqualTo("Inconclusive=>=>Failed"));
+            Assert.That(fixture.StateList, Is.EqualTo("Inconclusive=>=>Failed(SetUp)"));
         }
 
         [Test]
@@ -293,7 +293,7 @@ namespace NUnit.Framework.Tests
                 SetUpIgnore = true
             };
             TestBuilder.RunTestFixture(fixture);
-            Assert.That(fixture.StateList, Is.EqualTo("Inconclusive=>=>Skipped:Ignored"));
+            Assert.That(fixture.StateList, Is.EqualTo("Inconclusive=>=>Skipped:Ignored(SetUp)"));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4537 

There is a change in `RepeatAttribute` behaviour:

1. If an exception is thrown and `StopOnFailure` is false, the test continues executing.
2. Test result are reset between runs. So if the last run passes, the test succeeds. Previously it would fail.

The above are side effects of #4861 and only affect the code when `StopOnFailure` is set to false.
