### PR TITLE
Introducing NUnit Hook Extensions

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
@@ -17,6 +17,7 @@ namespace NUnit.Framework.Internal.Commands
         /// <returns>The result of the test execution.</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
+            context.HookExtension?.OnBeforeTest(context);
             innerCommand.Execute(context);
             return context.CurrentResult;
         }

--- a/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Internal.Commands
+{
+    internal class HookDelegatingTestCommand : DelegatingTestCommand
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HookDelegatingTestCommand"/> class.
+        /// </summary>
+        /// <param name="innerCommand">The inner test command to delegate to.</param>
+        public HookDelegatingTestCommand(TestCommand innerCommand) : base(innerCommand) { }
+
+        /// <summary>
+        /// Executes the test command within the provided context
+        /// </summary>
+        /// <param name="context">The test execution context.</param>
+        /// <returns>The result of the test execution.</returns>
+        public override TestResult Execute(TestExecutionContext context)
+        {
+            innerCommand.Execute(context);
+            return context.CurrentResult;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestCommand.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+
 namespace NUnit.Framework.Internal.Commands
 {
     internal class HookDelegatingTestCommand : DelegatingTestCommand
@@ -17,8 +19,26 @@ namespace NUnit.Framework.Internal.Commands
         /// <returns>The result of the test execution.</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
-            context.HookExtension?.OnBeforeTest(context);
-            innerCommand.Execute(context);
+            var afterTestExecutedWithExceptionContext = false;
+
+            try
+            {
+                context.HookExtension?.OnBeforeTest(context);
+                innerCommand.Execute(context);
+            }
+            catch (Exception ex)
+            {
+                afterTestExecutedWithExceptionContext = true;
+                context.HookExtension?.OnAfterTest(context);
+                throw;
+            }
+
+            // Ensure that after test hooks are not again executed when there are exceptions from inner command
+            if (!afterTestExecutedWithExceptionContext)
+            {
+                context.HookExtension?.OnAfterTest(context);
+            }
+
             return context.CurrentResult;
         }
     }

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Internal.Execution
                 Test.RunState == RunState.Explicit && Filter.IsExplicitMatch(Test))
             {
                 // Command to execute test
-                TestCommand command = new TestMethodCommand(_testMethod);
+                TestCommand command = new HookDelegatingTestCommand(new TestMethodCommand(_testMethod));
 
                 var method = MethodInfoCache.Get(_testMethod.Method);
 

--- a/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
@@ -27,5 +27,10 @@ namespace NUnit.Framework.Internal.HookExtensions
         public HookExtension(HookExtension other) : this()
         {
         }
+
+        internal void OnBeforeTest(TestExecutionContext context)
+        {
+            BeforeTestHook.InvokeHandlers(this, new MethodHookEventArgs(context));
+        }
     }
 }

--- a/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+namespace NUnit.Framework.Internal.HookExtensions
+{
+    /// <summary>
+    /// Hook Extension interface to run custom code synchronously before or after any test activity.
+    /// </summary>
+    public class HookExtension
+    {
+        /// <summary>
+        /// Default ctor of <see cref="HookExtension"/> class.
+        /// </summary>
+        public HookExtension()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HookExtension"/> class by copying hooks from another instance.
+        /// </summary>
+        /// <param name="other">The instance of <see cref="HookExtension"/> to copy hooks from.</param>
+        public HookExtension(HookExtension other) : this()
+        {
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
@@ -12,7 +12,13 @@ namespace NUnit.Framework.Internal.HookExtensions
         /// </summary>
         public HookExtension()
         {
+            BeforeTestHook = new TestHook();
         }
+
+        /// <summary>
+        /// Gets or sets the hook event that is triggered before a test method is executed.
+        /// </summary>
+        public TestHook BeforeTestHook { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HookExtension"/> class by copying hooks from another instance.

--- a/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/HookExtension.cs
@@ -13,12 +13,18 @@ namespace NUnit.Framework.Internal.HookExtensions
         public HookExtension()
         {
             BeforeTestHook = new TestHook();
+            AfterTestHook = new TestHook();
         }
 
         /// <summary>
         /// Gets or sets the hook event that is triggered before a test method is executed.
         /// </summary>
         public TestHook BeforeTestHook { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hook event that is triggered after a test method is executed.
+        /// </summary>
+        public TestHook AfterTestHook { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HookExtension"/> class by copying hooks from another instance.
@@ -31,6 +37,11 @@ namespace NUnit.Framework.Internal.HookExtensions
         internal void OnBeforeTest(TestExecutionContext context)
         {
             BeforeTestHook.InvokeHandlers(this, new MethodHookEventArgs(context));
+        }
+
+        internal void OnAfterTest(TestExecutionContext context)
+        {
+            AfterTestHook.InvokeHandlers(this, new MethodHookEventArgs(context));
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/HookExtensions/MethodHookEventArgs.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/MethodHookEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Internal.HookExtensions
+{
+    internal class MethodHookEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MethodHookEventArgs"/> class.
+        /// </summary>
+        /// <param name="context">The test execution context.</param>
+        public MethodHookEventArgs(TestExecutionContext context)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets the test execution context.
+        /// </summary>
+        public TestExecutionContext Context { get; }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/HookExtensions/TestHook.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/TestHook.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NUnit.Framework.Internal.HookExtensions
 {
@@ -20,6 +21,26 @@ namespace NUnit.Framework.Internal.HookExtensions
         {
             lock (_handlers)
                 _handlers.Add(handler);
+        }
+
+        internal void InvokeHandlers(object? sender, EventArgs e)
+        {
+            if (!_handlers.Any())
+            {
+                return;
+            }
+            Delegate[] syncHandlers;
+
+            lock (_handlers)
+                syncHandlers = _handlers.ToArray();
+
+            foreach (var handler in syncHandlers)
+            {
+                if (handler is EventHandler syncHandler)
+                {
+                    syncHandler(sender, e);
+                }
+            }
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/HookExtensions/TestHook.cs
+++ b/src/NUnitFramework/framework/Internal/HookExtensions/TestHook.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.Framework.Internal.HookExtensions
+{
+    /// <summary>
+    /// Event that supports both synchronous and asynchronous handlers.
+    /// </summary>
+    public class TestHook
+    {
+        private readonly List<Delegate> _handlers = new();
+
+        /// <summary>
+        /// Adds a test hook handler.
+        /// </summary>
+        /// <param name="handler">The event handler to be attached to the handler</param>
+        public void AddHandler(EventHandler handler)
+        {
+            lock (_handlers)
+                _handlers.Add(handler);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
+++ b/src/NUnitFramework/framework/Internal/TestExecutionContext.cs
@@ -12,6 +12,7 @@ using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Execution;
 using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework.Internal.HookExtensions;
 
 #if NETFRAMEWORK
 using System.Runtime.Remoting.Messaging;
@@ -69,6 +70,8 @@ namespace NUnit.Framework.Internal
 
         private SandboxedThreadState _sandboxedThreadState;
 
+        private HookExtension _hookExtension;
+
         #endregion
 
         #region Constructors
@@ -102,7 +105,10 @@ namespace NUnit.Framework.Internal
             _priorContext = other;
 
             CurrentTest = other.CurrentTest;
-
+            if (other.HookExtension is not null)
+            {
+                _hookExtension = new HookExtension(other.HookExtension);
+            }
             CurrentResult = other.CurrentResult;
             TestObject = other.TestObject;
             _listener = other._listener;
@@ -397,6 +403,11 @@ namespace NUnit.Framework.Internal
         /// Currently only being executed in a test using the <see cref="RetryAttribute"/>
         /// </summary>
         public int CurrentRepeatCount { get; set; }
+
+        /// <summary>
+        /// Hook Extension to support high level test extensions.
+        /// </summary>
+        public HookExtension? HookExtension => _hookExtension ??= new HookExtension();
 
         #endregion
 

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <IsTestProject>false</IsTestProject>
-    <NoWarn/>
+    <NoWarn />
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RepeatableTestsWithTimeoutAttributesTests.cs
@@ -69,6 +69,11 @@ namespace NUnit.Framework.Tests.Attributes
 
             command = GetInnerCommand(applyChangesToContextCommand);
 
+            Assert.That(command, Is.TypeOf(typeof(HookDelegatingTestCommand)));
+            HookDelegatingTestCommand hookDelegatingTestCommandCommand = (HookDelegatingTestCommand)command;
+
+            command = GetInnerCommand(hookDelegatingTestCommandCommand);
+
             Assert.That(command, Is.TypeOf(typeof(TestMethodCommand)));
         }
 
@@ -98,7 +103,10 @@ namespace NUnit.Framework.Tests.Attributes
 
             command = GetInnerCommand(applyChangesToContextCommand);
 
-            Assert.That(command, Is.TypeOf(typeof(TestMethodCommand)));
+            Assert.That(command, Is.TypeOf(typeof(HookDelegatingTestCommand)));
+            HookDelegatingTestCommand hookDelegatingTestCommandCommand = (HookDelegatingTestCommand)command;
+
+            command = GetInnerCommand(hookDelegatingTestCommandCommand);
         }
 
         private TestCommand GetInnerCommand(DelegatingTestCommand command)

--- a/src/NUnitFramework/tests/HookExtension/Creation/TestHooksCreationTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Creation/TestHooksCreationTests.cs
@@ -19,12 +19,21 @@ namespace NUnit.Framework.Tests.HookExtension.Creation
             }
         }
 
+        internal class ActivateAfterTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.AfterTestHook.AddHandler((sender, eventArgs) => { });
+            }
+        }
+
         [Explicit]
         [TestFixture]
         private class SomeEmptyTest
         {
             [Test]
             [ActivateBeforeTestHooks]
+            [ActivateAfterTestHooks]
             public void EmptyTest() { }
         }
 
@@ -51,6 +60,19 @@ namespace NUnit.Framework.Tests.HookExtension.Creation
 
             Assert.That(work.Context.HookExtension, Is.Not.Null);
             Assert.That(work.Context.HookExtension.BeforeTestHook, Is.Not.Null);
+        }
+
+        [Test]
+        public void AfterTestHookAdded()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(SomeEmptyTest), nameof(SomeEmptyTest.EmptyTest));
+            var work = TestBuilder.CreateWorkItem(test) as SimpleWorkItem;
+
+            Assert.That(work, Is.Not.Null);
+            TestCommand command = work.MakeTestCommand();
+
+            Assert.That(work.Context.HookExtension, Is.Not.Null);
+            Assert.That(work.Context.HookExtension.AfterTestHook, Is.Not.Null);
         }
     }
 }

--- a/src/NUnitFramework/tests/HookExtension/Creation/TestHooksCreationTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Creation/TestHooksCreationTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Tests.TestUtilities;
+
+namespace NUnit.Framework.Tests.HookExtension.Creation
+{
+    [TestFixture]
+    internal class TestHooksCreationTests
+    {
+        internal class ActivateBeforeTestHooks: NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.BeforeTestHook.AddHandler((sender, eventArgs) => { });
+            }
+        }
+
+        [Explicit]
+        [TestFixture]
+        private class SomeEmptyTest
+        {
+            [Test]
+            [ActivateBeforeTestHooks]
+            public void EmptyTest() { }
+        }
+
+        [Test]
+        public void NewHooksAppliedToContext()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(SomeEmptyTest), nameof(SomeEmptyTest.EmptyTest));
+            var work = TestBuilder.CreateWorkItem(test) as SimpleWorkItem;
+
+            Assert.That(work, Is.Not.Null);
+            TestCommand command = work.MakeTestCommand();
+
+            Assert.That(command, Is.TypeOf(typeof(ApplyChangesToContextCommand)));
+        }
+
+        [Test]
+        public void BeforeTestHookAdded()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(SomeEmptyTest), nameof(SomeEmptyTest.EmptyTest));
+            var work = TestBuilder.CreateWorkItem(test) as SimpleWorkItem;
+
+            Assert.That(work, Is.Not.Null);
+            TestCommand command = work.MakeTestCommand();
+
+            Assert.That(work.Context.HookExtension, Is.Not.Null);
+            Assert.That(work.Context.HookExtension.BeforeTestHook, Is.Not.Null);
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/Execution/AfterTestHookTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/AfterTestHookTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnitLite;
+
+namespace NUnit.Framework.Tests.HookExtension.Execution
+{
+    internal class AfterTestHookTests
+    {
+        internal class ActivateAfterTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.AfterTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        [Explicit]
+        [TestFixture]
+        private class SomeEmptyTest
+        {
+            [OneTimeSetUp]
+            public void OneTimeSetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [Test]
+            [ActivateAfterTestHooks]
+            public void EmptyTest()
+            {
+                TestLog.LogCurrentMethod();
+            }
+        }
+
+        [Test]
+        public void ExecutionProceedsAfterTheAfterTestHookCompletes()
+        {
+            TestLog.Logs.Clear();
+
+            new AutoRun(typeof(SomeEmptyTest).Assembly).Execute([
+                "--where",
+                $"class == {typeof(SomeEmptyTest).FullName}"
+            ]);
+
+            Assert.That(TestLog.Logs, Is.EqualTo([
+
+                nameof(SomeEmptyTest.OneTimeSetUp),
+                nameof(SomeEmptyTest.SetUp),
+                nameof(SomeEmptyTest.EmptyTest),
+
+                nameof(ActivateAfterTestHooks.ApplyToContext),
+
+                nameof(SomeEmptyTest.TearDown),
+                nameof(SomeEmptyTest.OneTimeTearDown)
+            ]));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/Execution/BeforeTestHookTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/BeforeTestHookTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnitLite;
+
+namespace NUnit.Framework.Tests.HookExtension.Execution
+{
+    [TestFixture]
+    internal class BeforeTestHookTests
+    {
+        internal class ActivateBeforeTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.BeforeTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        [Explicit]
+        [TestFixture]
+        private class SomeEmptyTest
+        {
+            [OneTimeSetUp]
+            public void OneTimeSetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [Test]
+            [ActivateBeforeTestHooks]
+            public void EmptyTest()
+            {
+                TestLog.LogCurrentMethod();
+            }
+        }
+
+        [Test]
+        public void ExecutionProceedsAfterBeforeTestHookCompletes()
+        {
+            TestLog.Logs.Clear();
+
+            new AutoRun(typeof(SomeEmptyTest).Assembly).Execute([
+                "--where",
+                $"class == {typeof(SomeEmptyTest).FullName}"
+            ]);
+
+            Assert.That(TestLog.Logs, Is.EqualTo([
+            
+                nameof(SomeEmptyTest.OneTimeSetUp),
+                nameof(SomeEmptyTest.SetUp),
+                
+                nameof(ActivateBeforeTestHooks.ApplyToContext),
+
+                nameof(SomeEmptyTest.EmptyTest),
+                nameof(SomeEmptyTest.TearDown),
+                nameof(SomeEmptyTest.OneTimeTearDown)
+            ]));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/Execution/CombinedHookTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/CombinedHookTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Threading;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnitLite;
+
+namespace NUnit.Framework.Tests.HookExtension.Execution
+{
+    internal class CombinedHookTests
+    {
+        internal class ActivateAfterTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.AfterTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        internal class ActivateLongRunningAfterTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.AfterTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    Thread.Sleep(500);
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        internal class ActivateBeforeTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.BeforeTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        internal class ActivateLongRunningBeforeTestHooks : NUnitAttribute, IApplyToContext
+        {
+            public virtual void ApplyToContext(TestExecutionContext context)
+            {
+                context?.HookExtension?.BeforeTestHook.AddHandler((sender, eventArgs) =>
+                {
+                    Thread.Sleep(500);
+                    TestLog.LogCurrentMethod();
+                });
+            }
+        }
+
+        [Explicit]
+        [TestFixture]
+        private class SomeEmptyTest
+        {
+            [OneTimeSetUp]
+            public void OneTimeSetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [Test]
+            [ActivateBeforeTestHooks]
+            [ActivateLongRunningBeforeTestHooks]
+            [ActivateAfterTestHooks]
+            [ActivateLongRunningAfterTestHooks]
+            public void EmptyTest()
+            {
+                TestLog.LogCurrentMethod();
+            }
+        }
+
+        [Test]
+        public void ExecutionProceedsAfterTheAfterTestHookCompletes()
+        {
+            TestLog.Logs.Clear();
+
+            new AutoRun(typeof(SomeEmptyTest).Assembly).Execute([
+                "--where",
+                $"class == {typeof(SomeEmptyTest).FullName}"
+            ]);
+
+            Assert.That(TestLog.Logs, Is.EqualTo([
+
+                nameof(SomeEmptyTest.OneTimeSetUp),
+                nameof(SomeEmptyTest.SetUp),
+                nameof(ActivateBeforeTestHooks.ApplyToContext),
+                nameof(ActivateLongRunningBeforeTestHooks.ApplyToContext),
+                
+                nameof(SomeEmptyTest.EmptyTest),
+
+                nameof(ActivateAfterTestHooks.ApplyToContext),
+                nameof(ActivateLongRunningAfterTestHooks.ApplyToContext),
+                nameof(SomeEmptyTest.TearDown),
+                nameof(SomeEmptyTest.OneTimeTearDown)
+            ]));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/Execution/HookDelegatingTestCommandTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/HookDelegatingTestCommandTests.cs
@@ -10,6 +10,7 @@ namespace NUnit.Framework.Tests.HookExtension.Execution
     [TestFixture]
     internal class HookDelegatingTestCommandTests
     {
+        [Explicit]
         [TestFixture]
         private class SomeEmptyTest
         {

--- a/src/NUnitFramework/tests/HookExtension/Execution/HookDelegatingTestCommandTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/HookDelegatingTestCommandTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Reflection;
+using NUnit.Framework.Internal.Commands;
+using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Tests.TestUtilities;
+
+namespace NUnit.Framework.Tests.HookExtension.Execution
+{
+    [TestFixture]
+    internal class HookDelegatingTestCommandTests
+    {
+        [TestFixture]
+        private class SomeEmptyTest
+        {
+            [Test]
+            public void EmptyTest() { }
+        }
+
+        [Test]
+        public void InnerCommandIsAlwaysExecuted()
+        {
+            var test = TestBuilder.MakeTestFromMethod(typeof(SomeEmptyTest), nameof(SomeEmptyTest.EmptyTest));
+            var work = TestBuilder.CreateWorkItem(test) as SimpleWorkItem;
+
+            Assert.That(work, Is.Not.Null);
+            TestCommand command = work.MakeTestCommand();
+
+            Assert.That(command, Is.TypeOf(typeof(HookDelegatingTestCommand)));
+            HookDelegatingTestCommand hookDelegatingTestCommandCommand = (HookDelegatingTestCommand)command;
+
+            command = GetInnerCommand(hookDelegatingTestCommandCommand);
+
+            Assert.That(command, Is.TypeOf(typeof(TestMethodCommand)));
+        }
+
+        private TestCommand GetInnerCommand(DelegatingTestCommand command)
+        {
+            FieldInfo? innerCommand =
+                command.GetType().GetField("innerCommand", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(innerCommand, Is.Not.Null);
+            return (TestCommand)innerCommand.GetValue(command)!;
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/Execution/TestActionAndHookTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/Execution/TestActionAndHookTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnitLite;
+
+namespace NUnit.Framework.Tests.HookExtension.Execution
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    internal class SomeTestActionAttribute : Attribute, ITestAction
+    {
+        public void BeforeTest(ITest test)
+        {
+            TestLog.LogCurrentMethod("BeforeTest_Action");
+        }
+
+        public void AfterTest(ITest test)
+        {
+            TestLog.LogCurrentMethod("AfterTest_Action");
+        }
+
+        public ActionTargets Targets { get; }
+    }
+
+    internal class ActivateAfterTestHooks : NUnitAttribute, IApplyToContext
+    {
+        public virtual void ApplyToContext(TestExecutionContext context)
+        {
+            context?.HookExtension?.AfterTestHook.AddHandler((sender, eventArgs) => { TestLog.LogCurrentMethod(); });
+        }
+    }
+
+    internal class ActivateBeforeTestHooks : NUnitAttribute, IApplyToContext
+    {
+        public virtual void ApplyToContext(TestExecutionContext context)
+        {
+            context?.HookExtension?.BeforeTestHook.AddHandler((sender, eventArgs) => { TestLog.LogCurrentMethod(); });
+        }
+    }
+
+    internal class TestActionAndHookTests
+    {
+        [Explicit]
+        [TestFixture]
+        [SomeTestAction]
+        private class SomeEmptyTest
+        {
+            [OneTimeSetUp]
+            public void OneTimeSetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [OneTimeTearDown]
+            public void OneTimeTearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                TestLog.LogCurrentMethod();
+            }
+
+            [Test]
+            [ActivateBeforeTestHooks]
+            [ActivateAfterTestHooks]
+            public void EmptyTest()
+            {
+                TestLog.LogCurrentMethod();
+            }
+        }
+
+        [Test]
+        public void ExecutionProceedsAfterTheAfterTestHookCompletes()
+        {
+            TestLog.Logs.Clear();
+
+            new AutoRun(typeof(SomeEmptyTest).Assembly).Execute([
+                "--where",
+                $"class == {typeof(SomeEmptyTest).FullName}"
+            ]);
+            
+            Assert.That(TestLog.Logs, Is.EqualTo([
+
+                nameof(SomeEmptyTest.OneTimeSetUp),
+                "BeforeTest_Action",
+                nameof(SomeEmptyTest.SetUp),
+                nameof(ActivateBeforeTestHooks.ApplyToContext),
+                nameof(SomeEmptyTest.EmptyTest),
+                nameof(ActivateAfterTestHooks.ApplyToContext),
+                nameof(SomeEmptyTest.TearDown),
+                "AfterTest_Action",
+                nameof(SomeEmptyTest.OneTimeTearDown)
+            ]));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/HookExtension/TestLog.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestLog.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace NUnit.Framework.Tests.HookExtension
+{
+    internal static class TestLog
+    {
+        private static readonly AsyncLocal<List<string>> _logs = new AsyncLocal<List<string>>();
+        private static readonly object logLock = new object();
+
+        // Each aync context gets its own instance of Logs
+        public static List<string> Logs
+        {
+            get
+            {
+                lock (logLock)
+                {
+                    if (_logs.Value == null)
+                    {
+                        _logs.Value = new List<string>();
+                    }
+
+                    return _logs.Value;
+                }
+            }
+        }
+
+        public static void Log(string infoToLog)
+        {
+            Logs.Add(infoToLog);
+        }
+
+        public static void LogCurrentMethod([CallerMemberName] string callerMethodName = "")
+        {
+            Log(callerMethodName);
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR introduces NUnit Hook Extensions, a new feature that allows users to reliably execute custom actions before and after any test-relevant method - such as setups, teardowns, test actions, and test methods.

# Motivation
In our organization, NUnit is the backbone of a massive test suite: ~730,000 tests producing ~13 million results daily. Beyond unit testing, we use NUnit for high-level system tests involving UI interactions. These tests generate detailed diagnostic protocols (logs, screenshots, crash dumps, etc.) to support developers in analyzing failures.

To create such protocols, we need precise control over test execution stages - for example, triggering a custom action after a test completes but before [TearDown] begins. Existing extension points in NUnit do not provide this level of granularity. Hook Extensions fill this gap in a flexible and lightweight way.

# Usage Example
A custom extension can be added by e.g. an `IApplyToContext` attribute. The Hook Extension will be accessible for the user by the `TestExecutionContext`.

``` CSharp
public class TestProtocolWriter : NUnitAttribute, IApplyToContext
{
    public void ApplyToContext(TestExecutionContext context)
    {
        context.HookExtension.BeforeAnySetUpsHook.AddHandler((sender, eventArgs) =>
        {
            // Do custom actions
            TestProtocolLogger.Log(...);
        });
    }
}
```
The Hook Extension itself will look like this:
``` CSharp
public class HookExtension
{
    // For [SetUp] and [OneTimeSetUp]
    public TestHook<MethodHookEventArgs> BeforeAnySetUpsHook { get; set; }
    public TestHook<MethodHookEventArgs> AfterAnySetUpsHook { get; set; }

    // For [Test] and [TestCase]
    public TestHook<MethodHookEventArgs> BeforeTestHook { get; set; }
    public TestHook<MethodHookEventArgs> AfterTestHook { get; set; }

    // For [TearDown] and [OneTimeTearDown]
    public TestHook<MethodHookEventArgs> BeforeAnyTearDownsHook { get; set; }
    public TestHook<MethodHookEventArgs> AfterAnyTearDownsHook { get; set; }

    // For BeforeTest() and AfterTest() of ITestAction
    public TestHook<MethodHookEventArgs> BeforeTestActionBeforeTestHook { get; set; }
    public TestHook<MethodHookEventArgs> AfterTestActionBeforeTestHook { get; set; }
    public TestHook<MethodHookEventArgs> BeforeTestActionAfterTestHook { get; set; }
    public TestHook<MethodHookEventArgs> AfterTestActionAfterTestHook { get; set; }
}
```

# Final implementation
The final implementation of this HookExtension includes the following features:

### Hook calls before and after
* Test methods
* [SetUp] / [TearDown]
* [OneTimeSetUp] / [OneTimeTearDown]
* BeforeTest() and AfterTest() of ITestAction

### Execution mode of Hooks
* Synchronous
* Asynchronous

### Test outcome
* Helper methods for calculating the current test outcome inside the Hooks

# Pull Request and Slicing
 
In order to support a smooth integration we have **split the feature into multiple vertical slices**, making them easier to understand and to review. This PR represents the first vertical slice, including the following features (for a branch containing the complete feature look [here](https://github.com/Siemens-Healthineers/nunit/tree/HookExtensions)):
 
## Content of Hook Extension Slice 1
 
### Hook calls before and after
* Test methods

### Execution
* Synchronous

# Previous discussions and other stakeholders
* The original Github Issue where we started the discussions: https://github.com/nunit/nunit/issues/4744
* The original WIP Pull Request (will be set to closed): https://github.com/nunit/nunit/pull/4769
* Discussion block about error handling inside the hooks: https://github.com/nunit/nunit/pull/4769#issuecomment-2343739654
* Discussion block about Synchronous / Asynchronous execution: https://github.com/nunit/nunit/issues/4744#issuecomment-2312744124

There are also other NUnit users who became aware of our proposal. We showed them our ideas and they were very interested in our approach. 
* Colleagues from a big company who could make use of hooks: https://github.com/nunit/nunit/issues/4744#issuecomment-2603941796
* Another user who could potentially make use of hooks: https://github.com/nunit/nunit/issues/4701#issuecomment-2219725999