### PR TITLE
DictionaryContainsKeyConstraint no longer derives from CollectionItemsEqualConstraint

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DictionaryContainsKeyConstraint.cs
@@ -18,7 +18,6 @@ namespace NUnit.Framework.Constraints
         private const string ContainsMethodName = nameof(IDictionary.Contains);
         private const string ContainsKeyMethodName = nameof(IDictionary<,>.ContainsKey);
 
-        private readonly bool _isDeprecatedMode = false;
         /// <summary>
         /// Construct a DictionaryContainsKeyConstraint
         /// </summary>

--- a/src/NUnitFramework/framework/nunit.framework.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Allows use of nameof in unconstrained generic types, like in nameof(IDictionary<,>.ContainsKey) -->
+    <LangVersion>preview</LangVersion>
     <TargetFrameworks>$(NUnitLibraryFrameworks)</TargetFrameworks>
     <RootNamespace>NUnit.Framework</RootNamespace>
     <IsTestProject>false</IsTestProject>


### PR DESCRIPTION
Fixes #4981 

Now we no longer get `IgnoreCase` etc., options that don't work.
It hasn't used that functionality for 6+ years.