### PR TITLE
In DefaultConstraint ignore TActual if it is object.

### DIFF
--- a/src/NUnitFramework/framework/Constraints/DefaultConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/DefaultConstraint.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace NUnit.Framework.Constraints
@@ -17,7 +18,25 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            var isDefault = RuntimeHelpers.Equals(actual, default(TActual));
+            if (actual is null)
+            {
+                // Null is always considered the default value.
+                return new ConstraintResult(this, actual, true);
+            }
+
+            // We ignore TActual if it is object as that type is used a lot in non-generic contexts.
+            Type actualType = typeof(TActual) == typeof(object) ? actual.GetType() : typeof(TActual);
+            if (!actualType.IsValueType)
+            {
+                // For reference types, as actual is not null, it cannot be default.
+                return new ConstraintResult(this, actual, false);
+            }
+
+            object? defaultValue = typeof(TActual) == typeof(object)
+                ? Activator.CreateInstance(actualType) // Create a default instance of the actual type.
+                : default(TActual);
+
+            var isDefault = RuntimeHelpers.Equals(actual, defaultValue);
             return new ConstraintResult(this, actual, isDefault);
         }
     }

--- a/src/NUnitFramework/tests/Constraints/DefaultConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DefaultConstraintTests.cs
@@ -23,11 +23,11 @@ namespace NUnit.Framework.Tests.Constraints
         [Test] public void Success_NullableInt() => AssertSuccess(default(int?));
         [Test] public void Success_Long() => AssertSuccess(default(long));
         [Test] public void Success_ImmutableArray() => AssertSuccess(default(ImmutableArray<int>));
+        [Test] public void Success_BoxedInt() => AssertSuccess((object)default(int));
 
         [Test] public void Failure_NewObject() => AssertFailure(new object());
         [Test] public void Failure_EmptyString() => AssertFailure(string.Empty);
         [Test] public void Failure_NullableInt_Zero() => AssertFailure((int?)0);
-        [Test] public void Failure_BoxedInt_Zero() => AssertFailure((object)0);
         [Test] public void Failure_Int_NonZero() => AssertFailure(1);
         [Test] public void Failure_Double_NaN() => AssertFailure(double.NaN);
         [Test] public void Failure_ImmutableArray_Empty() => AssertFailure(ImmutableArray.Create<int>());
@@ -47,6 +47,13 @@ namespace NUnit.Framework.Tests.Constraints
         {
             var constraintResult = TheConstraint.ApplyTo(actual);
             Assert.That(!constraintResult.IsSuccess);
+        }
+
+        [Test]
+        public void EqualDefault()
+        {
+            var instance = 0;
+            Assert.That(instance, Is.InstanceOf<int>().And.Default);
         }
     }
 }

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -246,5 +246,25 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That((object)type, Has.Property("Namespace").EqualTo("System"), "GetType()");
             });
         }
+
+        [Test]
+        public void PropertyIsCastToPropertyType()
+        {
+            var defaultLength = string.Empty;
+            var nonDefaultLength = "1";
+
+            Assert.Multiple(() =>
+            {
+                // Verify that property is cast to the property's actual type.
+
+                Assert.That(defaultLength.Length, Is.Zero);
+                Assert.That(defaultLength.Length, Is.Default);
+                Assert.That(defaultLength, Has.Property("Length").Default);
+
+                Assert.That(nonDefaultLength.Length, Is.EqualTo(1));
+                Assert.That(nonDefaultLength.Length, Is.Not.Default);
+                Assert.That(nonDefaultLength, Has.Property("Length").Not.Default);
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes #4998 

There is one change of behaviour from previous:

```csharp
object instance = 0;
Assert.That(instance, Is.Not.Default);
```

Previously this passed because `instance != null`, now it fails because `object` is ignored.
Instead the underlying type is checked and `0 == default(int)`