### PR TITLE
Second Proposed Solution for Issue 4998

### DIFF
--- a/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AllItemsConstraint.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
             int index = 0;
             foreach (object item in enumerable)
             {
-                if (!BaseConstraint.ApplyTo(item).IsSuccess)
+                if (!Reflect.InvokeApplyTo(BaseConstraint, item?.GetType(), item).IsSuccess)
                 {
                     return new EachItemConstraintResult(this, actual, item, index);
                 }

--- a/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactCountConstraint.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (_itemConstraint is not null)
                 {
-                    if (_itemConstraint.ApplyTo(item).IsSuccess)
+                    if (Reflect.InvokeApplyTo(_itemConstraint, item?.GetType(), item).IsSuccess)
                         matchCount++;
                 }
                 else

--- a/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NoItemConstraint.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Constraints
             int index = 0;
             foreach (object item in enumerable)
             {
-                if (BaseConstraint.ApplyTo(item).IsSuccess)
+                if (Reflect.InvokeApplyTo(BaseConstraint, item?.GetType(), item).IsSuccess)
                 {
                     return new EachItemConstraintResult(this, actual, item, index);
                 }

--- a/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertyConstraint.cs
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Constraints
             }
 
             _propValue = property.GetValue(actual, null);
-            var baseResult = BaseConstraint.ApplyTo(_propValue);
+            var baseResult = Reflect.InvokeApplyTo(BaseConstraint, property.PropertyType, _propValue);
             return new PropertyConstraintResult(this, baseResult);
         }
 

--- a/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SomeItemsConstraint.cs
@@ -46,7 +46,7 @@ namespace NUnit.Framework.Constraints
 
             foreach (object item in enumerable)
             {
-                if (BaseConstraint.ApplyTo(item).IsSuccess)
+                if (Reflect.InvokeApplyTo(BaseConstraint, item?.GetType(), item).IsSuccess)
                     return new ConstraintResult(this, actual, ConstraintStatus.Success);
             }
 

--- a/src/NUnitFramework/tests/Constraints/ConstraintCastingTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ConstraintCastingTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+
+#pragma warning disable NUnit2046 // Use Constraint for better assertion messages in case of failure
+namespace NUnit.Framework.Tests.Constraints
+{
+    /// <summary>
+    /// A test fixture that ensures constraints cast their associated property,
+    /// collection item, etc. to its actual type instead of just <see cref="object"/>.
+    /// </summary>
+    [TestFixture]
+    public class ConstraintCastingTests
+    {
+        [Test]
+        public void LengthPropertyConstraint()
+        {
+            var defaultLength = string.Empty;
+            var nonDefaultLength = "1";
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(defaultLength.Length, Is.Zero);
+                Assert.That(defaultLength.Length, Is.Default);
+                Assert.That(defaultLength, Has.Length.Default);
+                Assert.That(defaultLength, Has.Property("Length").Default);
+
+                Assert.That(nonDefaultLength.Length, Is.Not.Zero);
+                Assert.That(nonDefaultLength.Length, Is.Not.Default);
+                Assert.That(nonDefaultLength, Has.Length.Not.Default);
+                Assert.That(nonDefaultLength, Has.Property("Length").Not.Default);
+            }
+        }
+
+        [Test]
+        public void CountPropertyConstraint()
+        {
+            var defaultCount = new List<int>();
+            var nonDefaultCount = new List<int>() { 0 };
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(defaultCount.Count, Is.Zero);
+                Assert.That(defaultCount.Count, Is.Default);
+                Assert.That(defaultCount, Has.Count.Default);
+                Assert.That(defaultCount, Has.Property("Count").Default);
+
+                Assert.That(nonDefaultCount.Count, Is.Not.Zero);
+                Assert.That(nonDefaultCount.Count, Is.Not.Default);
+                Assert.That(nonDefaultCount, Has.Count.Not.Default);
+                Assert.That(nonDefaultCount, Has.Property("Count").Not.Default);
+            }
+        }
+
+        [Test]
+        public void ExactConstraint()
+        {
+            var oneDefaultItems = new List<int>() { default };
+            var noDefaultItems = new List<int>() { 1 };
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(oneDefaultItems.Single(), Is.Zero);
+                Assert.That(oneDefaultItems.Single(), Is.Default);
+                Assert.That(oneDefaultItems, Has.One.Default);
+                Assert.That(oneDefaultItems, Has.Exactly(1).Default);
+
+                Assert.That(noDefaultItems.Single(), Is.Not.Zero);
+                Assert.That(noDefaultItems.Single(), Is.Not.Default);
+                Assert.That(noDefaultItems, Has.One.Not.Default);
+                Assert.That(noDefaultItems, Has.Exactly(1).Not.Default);
+            }
+        }
+
+        [Test]
+        public void SomeItemsConstraint()
+        {
+            var someDefaultItems = new List<int>() { default, 1, 2, 3 };
+            var noDefaultItems = new List<int>() { 1, 2, 3 };
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(someDefaultItems.Any(x => x == default), Is.True);
+                Assert.That(someDefaultItems, Has.Some.Default);
+
+                Assert.That(noDefaultItems.Any(x => x == default), Is.False);
+                Assert.That(noDefaultItems, Has.Some.Not.Default);
+            }
+        }
+
+        [Test]
+        public void AllItemsConstraint()
+        {
+            var allDefaultItems = new List<int>() { default, default, default };
+            var noDefaultItems = new List<int>() { 1, 2, 3 };
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(allDefaultItems.All(x => x == default), Is.True);
+                Assert.That(allDefaultItems, Has.All.Default);
+
+                Assert.That(noDefaultItems.All(x => x == default), Is.False);
+                Assert.That(noDefaultItems, Has.All.Not.Default);
+            }
+        }
+
+        [Test]
+        public void NoItemConstraint()
+        {
+            var allDefaultItems = new List<int>() { default, default, default };
+            var noDefaultItems = new List<int>() { 1, 2, 3 };
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(allDefaultItems.All(x => x == default), Is.True);
+                Assert.That(allDefaultItems, Has.None.Not.Default);
+
+                Assert.That(noDefaultItems.All(x => x == default), Is.False);
+                Assert.That(noDefaultItems, Has.None.Default);
+            }
+        }
+    }
+}
+#pragma warning restore NUnit2046 // Use Constraint for better assertion messages in case of failure


### PR DESCRIPTION
This proposal is similar to the [first one](https://github.com/nunit/nunit/pull/4999); however, it's a bit cleaner and is applied to more constraints.

As of writing this, some constraints cast the actual value to an `object`, which ends up causing inconsistencies / unexpected behavior when interacting with other constraints, in particular `DefaultConstraint`. `DefaultConstraint` was designed to match BCL behavior, so modifying it has caused a lot of discussion. Although it's a roundabout way of doing it, this proposal maintains the `DefaultConstraint's` behavior and resolves #4998, so it seems like a reasonable compromise.

As of writing this the following constraints have been modified:
- `AllItemsConstraint`
- `ExactCountConstraint`
- `NoItemConstraint`
- `PropertyConstraint`
- `SomeItemsConstraint`

If I missed any, let me know and I'll get them in. Feel free to edit as needed.