### PR TITLE
Add generic type constraints

### DIFF
--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static Exception? CatchAsync(AsyncTestDelegate code, string message, params object?[]? args)
         {
-            return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
+            return ThrowsAsync(new InstanceOfTypeConstraint<Exception>(), code, message, args);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         public static Exception? CatchAsync(AsyncTestDelegate code)
         {
-            return ThrowsAsync(new InstanceOfTypeConstraint(typeof(Exception)), code);
+            return ThrowsAsync(new InstanceOfTypeConstraint<Exception>(), code);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace NUnit.Framework
         public static TActual? CatchAsync<TActual>(AsyncTestDelegate code, string message, params object?[]? args)
             where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
+            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint<TActual>(), code, message, args);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace NUnit.Framework
         public static TActual? CatchAsync<TActual>(AsyncTestDelegate code)
             where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint(typeof(TActual)), code);
+            return (TActual?)ThrowsAsync(new InstanceOfTypeConstraint<TActual>(), code);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -117,7 +117,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static Exception? CatchAsync(AsyncTestDelegate code, string message, params object?[]? args)
         {
-            return ThrowsAsync(new InstanceOfTypeConstraint<Exception>(), code, message, args);
+            return CatchAsync<Exception>(code, message, args);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -89,7 +89,7 @@ namespace NUnit.Framework
         public static TActual? ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object?[]? args)
             where TActual : Exception
         {
-            return (TActual?)ThrowsAsync(typeof(TActual), code, message, args);
+            return (TActual?)ThrowsAsync(new ExceptionTypeConstraint<TActual>(), code, message, args);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.Async.cs
@@ -127,7 +127,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         public static Exception? CatchAsync(AsyncTestDelegate code)
         {
-            return ThrowsAsync(new InstanceOfTypeConstraint<Exception>(), code);
+            return CatchAsync<Exception>(code);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         public static Exception? Catch(TestDelegate code)
         {
-            return Throws(new InstanceOfTypeConstraint<Exception>(), code);
+            return Catch<Exception>(code);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static Exception? Catch(TestDelegate code, string message, params object?[]? args)
         {
-            return Throws(new InstanceOfTypeConstraint<Exception>(), code, message, args);
+            return Throws<Exception>(code, message, args);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -118,7 +118,7 @@ namespace NUnit.Framework
         /// <param name="args">Arguments to be used in formatting the message</param>
         public static Exception? Catch(TestDelegate code, string message, params object?[]? args)
         {
-            return Throws(new InstanceOfTypeConstraint(typeof(Exception)), code, message, args);
+            return Throws(new InstanceOfTypeConstraint<Exception>(), code, message, args);
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace NUnit.Framework
         /// <param name="code">A TestDelegate</param>
         public static Exception? Catch(TestDelegate code)
         {
-            return Throws(new InstanceOfTypeConstraint(typeof(Exception)), code);
+            return Throws(new InstanceOfTypeConstraint<Exception>(), code);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace NUnit.Framework
         public static TActual? Catch<TActual>(TestDelegate code, string message, params object?[]? args)
             where TActual : System.Exception
         {
-            return (TActual?)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code, message, args);
+            return (TActual?)Throws(new InstanceOfTypeConstraint<TActual>(), code, message, args);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace NUnit.Framework
         public static TActual? Catch<TActual>(TestDelegate code)
             where TActual : System.Exception
         {
-            return (TActual?)Throws(new InstanceOfTypeConstraint(typeof(TActual)), code);
+            return (TActual?)Throws(new InstanceOfTypeConstraint<TActual>(), code);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Assert.Exceptions.cs
+++ b/src/NUnitFramework/framework/Assert.Exceptions.cs
@@ -91,7 +91,7 @@ namespace NUnit.Framework
         public static TActual? Throws<TActual>(TestDelegate code, string message, params object?[]? args)
             where TActual : Exception
         {
-            return (TActual?)Throws(typeof(TActual), code, message, args);
+            return (TActual?)Throws(new ExceptionTypeConstraint<TActual>(), code, message, args);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/AssignableFromConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AssignableFromConstraint.cs
@@ -8,6 +8,21 @@ namespace NUnit.Framework.Constraints
     /// AssignableFromConstraint is used to test that an object
     /// can be assigned from a given Type.
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public class AssignableFromConstraint<TExpected> : AssignableFromConstraint
+    {
+        /// <summary>
+        /// Construct an AssignableFromConstraint for the type provided
+        /// </summary>
+        public AssignableFromConstraint() : base(typeof(TExpected))
+        {
+        }
+    }
+
+    /// <summary>
+    /// AssignableFromConstraint is used to test that an object
+    /// can be assigned from a given Type.
+    /// </summary>
     public class AssignableFromConstraint : TypeConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/AssignableToConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/AssignableToConstraint.cs
@@ -8,6 +8,21 @@ namespace NUnit.Framework.Constraints
     /// AssignableToConstraint is used to test that an object
     /// can be assigned to a given Type.
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public class AssignableToConstraint<TExpected> : AssignableToConstraint
+    {
+        /// <summary>
+        /// Construct an AssignableToConstraint for the type provided
+        /// </summary>
+        public AssignableToConstraint() : base(typeof(TExpected))
+        {
+        }
+    }
+
+    /// <summary>
+    /// AssignableToConstraint is used to test that an object
+    /// can be assigned to a given Type.
+    /// </summary>
     public class AssignableToConstraint : TypeConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -679,9 +679,9 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether the actual
         /// value is of the exact type supplied as an argument.
         /// </summary>
-        public ExactTypeConstraint TypeOf<TExpected>()
+        public ExactTypeConstraint<TExpected> TypeOf<TExpected>()
         {
-            return Append(new ExactTypeConstraint(typeof(TExpected)));
+            return Append(new ExactTypeConstraint<TExpected>());
         }
 
         #endregion
@@ -701,9 +701,9 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether the actual value
         /// is of the type supplied as an argument or a derived type.
         /// </summary>
-        public InstanceOfTypeConstraint InstanceOf<TExpected>()
+        public InstanceOfTypeConstraint<TExpected> InstanceOf<TExpected>()
         {
-            return Append(new InstanceOfTypeConstraint(typeof(TExpected)));
+            return Append(new InstanceOfTypeConstraint<TExpected>());
         }
 
         #endregion
@@ -723,9 +723,9 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether the actual value
         /// is assignable from the type supplied as an argument.
         /// </summary>
-        public AssignableFromConstraint AssignableFrom<TExpected>()
+        public AssignableFromConstraint<TExpected> AssignableFrom<TExpected>()
         {
-            return Append(new AssignableFromConstraint(typeof(TExpected)));
+            return Append(new AssignableFromConstraint<TExpected>());
         }
 
         #endregion
@@ -745,9 +745,9 @@ namespace NUnit.Framework.Constraints
         /// Returns a constraint that tests whether the actual value
         /// is assignable from the type supplied as an argument.
         /// </summary>
-        public AssignableToConstraint AssignableTo<TExpected>()
+        public AssignableToConstraint<TExpected> AssignableTo<TExpected>()
         {
-            return Append(new AssignableToConstraint(typeof(TExpected)));
+            return Append(new AssignableToConstraint<TExpected>());
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/ExactTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExactTypeConstraint.cs
@@ -8,6 +8,22 @@ namespace NUnit.Framework.Constraints
     /// ExactTypeConstraint is used to test that an object
     /// is of the exact type provided in the constructor
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public class ExactTypeConstraint<TExpected> : ExactTypeConstraint
+    {
+        /// <summary>
+        /// Construct an ExactTypeConstraint for a given Type
+        /// </summary>
+        public ExactTypeConstraint()
+            : base(typeof(TExpected))
+        {
+        }
+    }
+
+    /// <summary>
+    /// ExactTypeConstraint is used to test that an object
+    /// is of the exact type provided in the constructor
+    /// </summary>
     public class ExactTypeConstraint : TypeConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionTypeConstraint.cs
@@ -10,6 +10,23 @@ namespace NUnit.Framework.Constraints
     /// used to provided detailed info about the exception thrown in
     /// an error message.
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public class ExceptionTypeConstraint<TExpected> : ExceptionTypeConstraint
+        where TExpected : Exception
+    {
+        /// <summary>
+        /// Constructs an ExceptionTypeConstraint
+        /// </summary>
+        public ExceptionTypeConstraint() : base(typeof(TExpected))
+        {
+        }
+    }
+
+    /// <summary>
+    /// ExceptionTypeConstraint is a special version of ExactTypeConstraint
+    /// used to provided detailed info about the exception thrown in
+    /// an error message.
+    /// </summary>
     public class ExceptionTypeConstraint : ExactTypeConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/InstanceOfTypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/InstanceOfTypeConstraint.cs
@@ -8,6 +8,22 @@ namespace NUnit.Framework.Constraints
     /// InstanceOfTypeConstraint is used to test that an object
     /// is of the same type provided or derived from it.
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public class InstanceOfTypeConstraint<TExpected> : InstanceOfTypeConstraint
+    {
+        /// <summary>
+        /// Construct an InstanceOfTypeConstraint for the type provided
+        /// </summary>
+        public InstanceOfTypeConstraint()
+            : base(typeof(TExpected))
+        {
+        }
+    }
+
+    /// <summary>
+    /// InstanceOfTypeConstraint is used to test that an object
+    /// is of the same type provided or derived from it.
+    /// </summary>
     public class InstanceOfTypeConstraint : TypeConstraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/TypeConstraint.cs
@@ -8,6 +8,23 @@ namespace NUnit.Framework.Constraints
     /// TypeConstraint is the abstract base for constraints
     /// that take a Type as their expected value.
     /// </summary>
+    /// <typeparam name="TExpected">The expected Type used by the constraint</typeparam>
+    public abstract class TypeConstraint<TExpected> : TypeConstraint
+    {
+        /// <summary>
+        /// Construct a TypeConstraint for a given Type
+        /// </summary>
+        /// <param name="descriptionPrefix">Prefix used in forming the constraint description</param>
+        protected TypeConstraint(string descriptionPrefix)
+            : base(typeof(TExpected), descriptionPrefix)
+        {
+        }
+    }
+
+    /// <summary>
+    /// TypeConstraint is the abstract base for constraints
+    /// that take a Type as their expected value.
+    /// </summary>
     public abstract class TypeConstraint : Constraint
     {
 #pragma warning disable IDE1006

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -418,9 +418,9 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual
         /// value is of the exact type supplied as an argument.
         /// </summary>
-        public static ExactTypeConstraint TypeOf<TExpected>()
+        public static ExactTypeConstraint<TExpected> TypeOf<TExpected>()
         {
-            return new ExactTypeConstraint(typeof(TExpected));
+            return new ExactTypeConstraint<TExpected>();
         }
 
         #endregion
@@ -440,9 +440,9 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual value
         /// is of the type supplied as an argument or a derived type.
         /// </summary>
-        public static InstanceOfTypeConstraint InstanceOf<TExpected>()
+        public static InstanceOfTypeConstraint<TExpected> InstanceOf<TExpected>()
         {
-            return new InstanceOfTypeConstraint(typeof(TExpected));
+            return new InstanceOfTypeConstraint<TExpected>();
         }
 
         #endregion
@@ -462,9 +462,9 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual value
         /// is assignable from the type supplied as an argument.
         /// </summary>
-        public static AssignableFromConstraint AssignableFrom<TExpected>()
+        public static AssignableFromConstraint<TExpected> AssignableFrom<TExpected>()
         {
-            return new AssignableFromConstraint(typeof(TExpected));
+            return new AssignableFromConstraint<TExpected>();
         }
 
         #endregion
@@ -484,9 +484,9 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual value
         /// is assignable to the type supplied as an argument.
         /// </summary>
-        public static AssignableToConstraint AssignableTo<TExpected>()
+        public static AssignableToConstraint<TExpected> AssignableTo<TExpected>()
         {
-            return new AssignableToConstraint(typeof(TExpected));
+            return new AssignableToConstraint<TExpected>();
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -418,6 +418,7 @@ namespace NUnit.Framework
         /// Returns a constraint that tests whether the actual
         /// value is of the exact type supplied as an argument.
         /// </summary>
+        /// <typeparam name="TExpected">The expected Type</typeparam>
         public static ExactTypeConstraint<TExpected> TypeOf<TExpected>()
         {
             return new ExactTypeConstraint<TExpected>();

--- a/src/NUnitFramework/framework/Throws.cs
+++ b/src/NUnitFramework/framework/Throws.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Reflection;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework
@@ -35,7 +36,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying an expected TargetInvocationException
         /// </summary>
-        public static ExactTypeConstraint TargetInvocationException => TypeOf(typeof(System.Reflection.TargetInvocationException));
+        public static ExactTypeConstraint<TargetInvocationException> TargetInvocationException => TypeOf<TargetInvocationException>();
 
         #endregion
 
@@ -44,7 +45,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying an expected ArgumentException
         /// </summary>
-        public static ExactTypeConstraint ArgumentException => TypeOf(typeof(System.ArgumentException));
+        public static ExactTypeConstraint<ArgumentException> ArgumentException => TypeOf<ArgumentException>();
 
         #endregion
 
@@ -53,7 +54,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying an expected ArgumentNullException
         /// </summary>
-        public static ExactTypeConstraint ArgumentNullException => TypeOf(typeof(System.ArgumentNullException));
+        public static ExactTypeConstraint<ArgumentNullException> ArgumentNullException => TypeOf<ArgumentNullException>();
 
         #endregion
 
@@ -62,7 +63,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying an expected InvalidOperationException
         /// </summary>
-        public static ExactTypeConstraint InvalidOperationException => TypeOf(typeof(System.InvalidOperationException));
+        public static ExactTypeConstraint<InvalidOperationException> InvalidOperationException => TypeOf<InvalidOperationException>();
 
         #endregion
 
@@ -88,10 +89,10 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying the exact type of exception expected
         /// </summary>
-        public static ExactTypeConstraint TypeOf<TExpected>()
+        public static ExactTypeConstraint<TExpected> TypeOf<TExpected>()
             where TExpected : Exception
         {
-            return TypeOf(typeof(TExpected));
+            return Exception.TypeOf<TExpected>();
         }
 
         #endregion
@@ -109,10 +110,10 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying the type of exception expected
         /// </summary>
-        public static InstanceOfTypeConstraint InstanceOf<TExpected>()
+        public static InstanceOfTypeConstraint<TExpected> InstanceOf<TExpected>()
             where TExpected : Exception
         {
-            return InstanceOf(typeof(TExpected));
+            return Exception.InstanceOf<TExpected>();
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Throws.cs
+++ b/src/NUnitFramework/framework/Throws.cs
@@ -36,7 +36,7 @@ namespace NUnit.Framework
         /// <summary>
         /// Creates a constraint specifying an expected TargetInvocationException
         /// </summary>
-        public static ExactTypeConstraint<TargetInvocationException> TargetInvocationException => TypeOf<TargetInvocationException>();
+        public static ExactTypeConstraint TargetInvocationException => TypeOf<TargetInvocationException>();
 
         #endregion
 

--- a/src/NUnitFramework/tests/Constraints/AssignableFromConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AssignableFromConstraintTests.cs
@@ -1,13 +1,27 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
+    [TestFixtureSource(nameof(GetAssignableFromConstraints))]
     public class AssignableFromConstraintTests : ConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new AssignableFromConstraint(typeof(D1));
+        private static IEnumerable<TestFixtureData> GetAssignableFromConstraints()
+        {
+            yield return new TestFixtureData(new AssignableFromConstraint<D1>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new AssignableFromConstraint(typeof(D1)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public AssignableFromConstraintTests(AssignableFromConstraint constraint)
+        {
+            TheConstraint = constraint;
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()

--- a/src/NUnitFramework/tests/Constraints/AssignableToConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AssignableToConstraintTests.cs
@@ -1,13 +1,27 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
+    [TestFixtureSource(nameof(GetAssignableToConstraints))]
     public class AssignableToConstraintTests : ConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new AssignableToConstraint(typeof(D1));
+        private static IEnumerable<TestFixtureData> GetAssignableToConstraints()
+        {
+            yield return new TestFixtureData(new AssignableToConstraint<D1>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new AssignableToConstraint(typeof(D1)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public AssignableToConstraintTests(AssignableToConstraint constraint)
+        {
+            TheConstraint = constraint;
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()

--- a/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
@@ -1,13 +1,27 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
+    [TestFixtureSource(nameof(GetExactTypeConstraints))]
     public class ExactTypeConstraintTests : ConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new ExactTypeConstraint(typeof(D1));
+        private static IEnumerable<TestFixtureData> GetExactTypeConstraints()
+        {
+            yield return new TestFixtureData(new ExactTypeConstraint<D1>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new ExactTypeConstraint(typeof(D1)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public ExactTypeConstraintTests(ExactTypeConstraint constraint)
+        {
+            TheConstraint = constraint;
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()

--- a/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
@@ -1,13 +1,27 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
+    [TestFixtureSource(nameof(GetInstanceOfTypeConstraints))]
     public class InstanceOfTypeConstraintTests : ConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new InstanceOfTypeConstraint(typeof(D1));
+        private static IEnumerable<TestFixtureData> GetInstanceOfTypeConstraints()
+        {
+            yield return new TestFixtureData(new InstanceOfTypeConstraint<D1>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new InstanceOfTypeConstraint(typeof(D1)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public InstanceOfTypeConstraintTests(InstanceOfTypeConstraint constraint)
+        {
+            TheConstraint = constraint;
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -1,17 +1,30 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Tests.TestUtilities;
 
 namespace NUnit.Framework.Tests.Constraints
 {
-    [TestFixture]
+    [TestFixtureSource(nameof(GetExceptionTypeConstraints))]
     public class ThrowsConstraintTest_ExactType : ThrowsConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new ThrowsConstraint(
-                new ExceptionTypeConstraint(typeof(ArgumentException)));
+        private static IEnumerable<TestFixtureData> GetExceptionTypeConstraints()
+        {
+            yield return new TestFixtureData(new ExceptionTypeConstraint<ArgumentException>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new ExceptionTypeConstraint(typeof(ArgumentException)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public ThrowsConstraintTest_ExactType(ExceptionTypeConstraint constraint)
+        {
+            TheConstraint = new ThrowsConstraint(constraint);
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()
@@ -34,11 +47,23 @@ namespace NUnit.Framework.Tests.Constraints
 #pragma warning restore IDE0052 // Remove unread private members
     }
 
-    [TestFixture]
+    [TestFixtureSource(nameof(GetInstanceOfTypeConstraints))]
     public class ThrowsConstraintTest_InstanceOfType : ThrowsConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new ThrowsConstraint(
-                new InstanceOfTypeConstraint(typeof(TestDelegates.BaseException)));
+        private static IEnumerable<TestFixtureData> GetInstanceOfTypeConstraints()
+        {
+            yield return new TestFixtureData(new InstanceOfTypeConstraint<TestDelegates.BaseException>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new InstanceOfTypeConstraint(typeof(TestDelegates.BaseException)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public ThrowsConstraintTest_InstanceOfType(InstanceOfTypeConstraint constraint)
+        {
+            TheConstraint = new ThrowsConstraint(constraint);
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()
@@ -62,12 +87,26 @@ namespace NUnit.Framework.Tests.Constraints
 #pragma warning restore IDE0052 // Remove unread private members
     }
 
+    [TestFixtureSource(nameof(GetExceptionTypeConstraints))]
     public class ThrowsConstraintTest_WithConstraint : ThrowsConstraintTestBase
     {
-        protected override Constraint TheConstraint { get; } = new ThrowsConstraint(
+        private static IEnumerable<TestFixtureData> GetExceptionTypeConstraints()
+        {
+            yield return new TestFixtureData(new ExceptionTypeConstraint<ArgumentException>())
+                .SetArgDisplayNames("generic");
+            yield return new TestFixtureData(new ExceptionTypeConstraint(typeof(ArgumentException)))
+                .SetArgDisplayNames("non-generic");
+        }
+
+        public ThrowsConstraintTest_WithConstraint(ExceptionTypeConstraint constraint)
+        {
+            TheConstraint = new ThrowsConstraint(
                 new AndConstraint(
-                    new ExceptionTypeConstraint(typeof(ArgumentException)),
+                    constraint,
                     new PropertyConstraint("ParamName", new EqualStringConstraint("myParam"))));
+        }
+
+        protected override Constraint TheConstraint { get; }
 
         [SetUp]
         public void SetUp()


### PR DESCRIPTION
A bit more incremental work towards generic constraints.

Fixes #5007 
Contributes to #53

This PR adds generic classes and overloads for all things under the `TypeConstraint` hierarchy. Each generic type was extended from it's non-generic counterpart as a way of avoiding duplication of logic. The thought behind this decision is that it simplifies short-term future maintenance while still allowing us a way to establish API signatures with some generic support without having to make an entire generic constraint resolver... yet. The tradeoff would be that all type logic is deferred to non-generic functions, resulting in a negligible difference from ideal performance as we'd lose the ability for some JIT-time constant folding in some cases on some runtimes. I felt this was an acceptable tradeoff to allow another piece of the generic API work to proceed.