### PR TITLE
Restore backward compatibility for Is.EqualTo<T>(T? expected)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -445,6 +445,21 @@ namespace NUnit.Framework.Constraints
             return this;
         }
 
+        /// <summary>
+        /// Enables comparing a subset of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        /// <param name="configure">Function to configure the <see cref="PropertiesComparerConfiguration"/></param>
+        public virtual EqualConstraint UsingPropertiesComparer<T>(Func<PropertiesComparerConfiguration<T>, PropertiesComparerConfiguration<T>> configure)
+        {
+            Comparer.CompareProperties = true;
+            Comparer.ComparePropertiesConfiguration = configure(new PropertiesComparerConfiguration<T>());
+            return this;
+        }
+
         #endregion
 
         #region Public Methods

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint{T}.cs
@@ -40,6 +40,17 @@ namespace NUnit.Framework.Constraints
             return this;
         }
 
+        /// <inheritdoc/>
+        public override EqualConstraint UsingPropertiesComparer<TParam>(Func<PropertiesComparerConfiguration<TParam>, PropertiesComparerConfiguration<TParam>> configure)
+        {
+            if (typeof(TParam) != typeof(T))
+                throw new ArgumentException($"The type parameter {typeof(TParam).Name} does not match the type parameter {typeof(T).Name} of this constraint.", nameof(configure));
+
+            Comparer.CompareProperties = true;
+            Comparer.ComparePropertiesConfiguration = configure(new PropertiesComparerConfiguration<TParam>());
+            return this;
+        }
+
         #endregion
 
     }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -172,7 +172,18 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two items for equality
         /// </summary>
-        public static EqualConstraint<T> EqualTo<T>(T? expected)
+        /// <remarks>
+        /// Do not change the return type of this method to <see cref="EqualConstraint{T}"/> as that breaks backward compatibility.
+        /// </remarks>
+        public static EqualConstraint EqualTo<T>(T? expected)
+        {
+            return new EqualConstraint<T>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two items for equality
+        /// </summary>
+        public static EqualConstraint<T> EqualToGeneric<T>(T? expected)
         {
             return new EqualConstraint<T>(expected);
         }
@@ -180,7 +191,18 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests two collections for equality.
         /// </summary>
-        public static EqualConstraint<T> EqualTo<T>(IEnumerable<T>? expected)
+        /// <remarks>
+        /// Do not change the return type of this method to <see cref="EqualConstraint{T}"/> as that breaks backward compatibility.
+        /// </remarks>
+        public static EqualConstraint EqualTo<T>(IEnumerable<T>? expected)
+        {
+            return new EqualConstraint<T>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two collections for equality.
+        /// </summary>
+        public static EqualConstraint<T> EqualToGeneric<T>(IEnumerable<T>? expected)
         {
             return new EqualConstraint<T>(expected);
         }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -181,28 +181,12 @@ namespace NUnit.Framework
         }
 
         /// <summary>
-        /// Returns a constraint that tests two items for equality
-        /// </summary>
-        public static EqualConstraint<T> EqualToGeneric<T>(T? expected)
-        {
-            return new EqualConstraint<T>(expected);
-        }
-
-        /// <summary>
         /// Returns a constraint that tests two collections for equality.
         /// </summary>
         /// <remarks>
         /// Do not change the return type of this method to <see cref="EqualConstraint{T}"/> as that breaks backward compatibility.
         /// </remarks>
         public static EqualConstraint EqualTo<T>(IEnumerable<T>? expected)
-        {
-            return new EqualConstraint<T>(expected);
-        }
-
-        /// <summary>
-        /// Returns a constraint that tests two collections for equality.
-        /// </summary>
-        public static EqualConstraint<T> EqualToGeneric<T>(IEnumerable<T>? expected)
         {
             return new EqualConstraint<T>(expected);
         }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -600,7 +600,7 @@ namespace NUnit.Framework.Tests.Assertions
                                 nameof(ClassWithSomeToleranceAwareMembers.ValueC))));
 
                 Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero),
-                            Is.EqualTo(instance).UsingPropertiesComparer(c => c.Excluding(
+                            Is.EqualToGeneric(instance).UsingPropertiesComparer(c => c.Excluding(
                                 x => x.ValueA,
                                 x => x.ValueB,
                                 x => x.ValueC)));
@@ -611,7 +611,7 @@ namespace NUnit.Framework.Tests.Assertions
                                 c => c.Using(nameof(ClassWithSomeToleranceAwareMembers.Chained))));
 
                 Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero),
-                            Is.EqualTo(instance)
+                            Is.EqualToGeneric(instance)
                               .UsingPropertiesComparer(c => c.Using(x => x.Chained)));
 
                 // Property names work on nested classes!
@@ -1060,14 +1060,14 @@ namespace NUnit.Framework.Tests.Assertions
             var usPerson = new USPerson("John Doe", new USAddress("10", "CSI", "Las Vegas", "89030"));
 
             // We can supply a Value for the missing property 'Country'
-            Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer(
+            Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer<Person>(
                 c => c.Map<USPerson>(x => x.Address, y => y.USAddress)
                       .Map<Address, USAddress>(x => x.AreaCode, y => y.ZipCode)
                       .Map<Address>(x => x.Country, "U.S.A.")));
 
             // Or we can exclude the 'Country' property.
             // However this would also pass when the source country is not U.S.A.
-            Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer(
+            Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer<Person>(
                 c => c.Map<USPerson>(x => x.Address, y => y.USAddress)
                       .Map<Address, USAddress>(x => x.AreaCode, y => y.ZipCode)
                       .Excluding<Address>(x => x.Country)));
@@ -1080,7 +1080,7 @@ namespace NUnit.Framework.Tests.Assertions
             var usPerson = new USPerson("John Doe", new USAddress("10", "CSI", "Las Vegas", "89031"));
 
             Assert.That(() =>
-                Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer(
+                Assert.That(usPerson, Is.EqualTo(person).UsingPropertiesComparer<Person>(
                     c => c.Map<USPerson>(x => x.Address, y => y.USAddress)
                           .Map<Address, USAddress>(x => x.AreaCode, y => y.ZipCode)
                           .Map<Address>(x => x.Country, "U.S.A."))),
@@ -1089,6 +1089,19 @@ namespace NUnit.Framework.Tests.Assertions
                           .And.Message.Contains("at property Address.AreaCode => USAddress.ZipCode")
                           .And.Message.Contains("Expected: \"89030\"")
                           .And.Message.Contains("But was:  \"89031\""));
+        }
+
+        [Test]
+        public void CompareWrongTypes()
+        {
+            var person1 = new Person("John Doe", new Address("10", "CSI", "Las Vegas", "89030", "U.S.A."));
+            var person2 = new Person("John Doe", new Address("10", "CSI", "Las Vegas", "89030", "U.S.A."));
+
+            Assert.That(() =>
+                Assert.That(person1, Is.EqualTo(person2).UsingPropertiesComparer<USPerson>(
+                    c => c.Excluding(x => x.USAddress))),
+                    Throws.ArgumentException.With.Message.Contains(
+                    "The type parameter USPerson does not match the type parameter Person of this constraint."));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -600,7 +600,8 @@ namespace NUnit.Framework.Tests.Assertions
                                 nameof(ClassWithSomeToleranceAwareMembers.ValueC))));
 
                 Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero),
-                            Is.EqualToGeneric(instance).UsingPropertiesComparer(c => c.Excluding(
+                            Is.EqualTo(instance)
+                              .UsingPropertiesComparer<ClassWithSomeToleranceAwareMembers>(c => c.Excluding(
                                 x => x.ValueA,
                                 x => x.ValueB,
                                 x => x.ValueC)));
@@ -611,8 +612,8 @@ namespace NUnit.Framework.Tests.Assertions
                                 c => c.Using(nameof(ClassWithSomeToleranceAwareMembers.Chained))));
 
                 Assert.That(new ClassWithSomeToleranceAwareMembers(2, 1.1, "1.1", zero),
-                            Is.EqualToGeneric(instance)
-                              .UsingPropertiesComparer(c => c.Using(x => x.Chained)));
+                            Is.EqualTo(instance)
+                              .UsingPropertiesComparer<ClassWithSomeToleranceAwareMembers>(c => c.Using(x => x.Chained)));
 
                 // Property names work on nested classes!
                 var alsmostZero = new ClassWithSomeToleranceAwareMembers(1, 0.0, string.Empty, null);


### PR DESCRIPTION
Fixes #5011 

Unfortunately this make UsingPropertiesComparer less elegant for the advanced case. 
This either requires changing `EqualTo` into  `EqualToGeneric`
Or passing the type to `UsingPropertiesComparer<Person>`

I'm open to different naming suggestions to EqualToGeneric.
Alternatively have `IsGeneric.EqualTo` where we put all new generic versions.
