### PR TITLE
DRAFT: Update MacOS runner from 14 to 15

### DIFF
--- a/.github/workflows/NUnit.CI.yml
+++ b/.github/workflows/NUnit.CI.yml
@@ -94,7 +94,7 @@ jobs:
 
   build-macos:
     name: MacOS Build
-    runs-on: macos-15
+    runs-on: macos-15-large
 
     steps:
     - name: ⤵️ Checkout Source

--- a/.github/workflows/NUnit.CI.yml
+++ b/.github/workflows/NUnit.CI.yml
@@ -94,7 +94,7 @@ jobs:
 
   build-macos:
     name: MacOS Build
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: ⤵️ Checkout Source


### PR DESCRIPTION
Testing out compatibility of the MacOS 15 runners on our suite. I'll be trying the ARM image first (`macos-15`) and then falling back to the non-arm version if that doesn't work (`macos-15-large`).

I'll be making an issue to track this once a stable configuration is found