### PR TITLE
chore: Remove TODOs related to old NUnit.Analyzer issues and bump package

### DIFF
--- a/src/NUnitFramework/Directory.Packages.props
+++ b/src/NUnitFramework/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <PackageVersion Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.9.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
   <!-- Specific dependencies -->

--- a/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
+++ b/src/NUnitFramework/tests/Internal/GenericTestMethodTests.cs
@@ -119,9 +119,6 @@ namespace NUnit.Framework.Tests.Internal
             });
         }
 
-        // TOOD: Remove when https://github.com/nunit/nunit.analyzers/issues/632 is fixed and released
-#pragma warning disable NUnit1031 // The individual arguments provided by a ValuesAttribute must match the type of the corresponding parameter of the method
-
         [Test]
         public void Combinatorial_OneTypeParameterOnTwoArgs<T>(
             [Values(5, 5.0)] T x,
@@ -145,7 +142,6 @@ namespace NUnit.Framework.Tests.Internal
                 Assert.That(y, Is.EqualTo(2));
             });
         }
-#pragma warning restore NUnit1031 // The individual arguments provided by a ValuesAttribute must match the type of the corresponding parameter of the method
 
         [Test]
         public void Combinatorial_IncompatibleArgsAreNotRunnable()

--- a/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
+++ b/src/NUnitFramework/tests/Internal/WorkItemQueueTests.cs
@@ -147,8 +147,7 @@ namespace NUnit.Framework.Tests.Internal
 
             var fixtureItem = WorkItemBuilder.CreateWorkItem(testFixture, TestFilter.Empty, new DebuggerProxy());
             Assert.That(fixtureItem, Is.Not.Null);
-            // TODO: Remove '!' when https://github.com/nunit/nunit.analyzers/issues/535 is released
-            var tearDown = new CompositeWorkItem.OneTimeTearDownWorkItem((CompositeWorkItem)fixtureItem!);
+            var tearDown = new CompositeWorkItem.OneTimeTearDownWorkItem((CompositeWorkItem)fixtureItem);
             EnqueueWorkItem("Test1");
             _queue.Enqueue(tearDown);
             EnqueueWorkItem("Test2");

--- a/src/NUnitFramework/tests/TestContextTests.cs
+++ b/src/NUnitFramework/tests/TestContextTests.cs
@@ -379,12 +379,11 @@ namespace NUnit.Framework.Tests
             Assert.That(() => TestContext.AddTestAttachment(_tempFilePath, "Description"), Throws.Nothing);
         }
 
-        // TODO: Update when https://github.com/nunit/nunit.analyzers/issues/631 is fixed and released.
-        [TestCase(null)]
+        [TestCase(null!)]
         [TestCase("bad|path.png", IncludePlatform = "Win")]
-        public void InvalidFilePathsThrowsArgumentException(string? filePath)
+        public void InvalidFilePathsThrowsArgumentException(string filePath)
         {
-            Assert.That(() => TestContext.AddTestAttachment(filePath!), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => TestContext.AddTestAttachment(filePath), Throws.InstanceOf<ArgumentException>());
         }
 
         [Test]


### PR DESCRIPTION
I didn't add the NUnit.Analyzers to nunit.testdata as there were ~60 compile errors due to test cases that checks how the framework handles bad data. So I've left that as future work.