### PR TITLE
Issue5026 inconclusive

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/BeforeAndAfterTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeAndAfterTestCommand.cs
@@ -37,8 +37,12 @@ namespace NUnit.Framework.Internal.Commands
                 BeforeTest(context);
 
                 // If the BeforeTest method fails, we don't run the test
-                if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped)
+                // An failing Assume sets the Status to Inconclusive, but with a FailureSite of SetUp
+                if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped &&
+                    context.CurrentResult.ResultState.Site != FailureSite.SetUp)
+                {
                     context.CurrentResult = innerCommand.Execute(context);
+                }
             });
 
             if (context.ExecutionStatus != TestExecutionStatus.AbortRequested)

--- a/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
@@ -29,8 +29,8 @@ namespace NUnit.Framework.Internal.Commands
 
             // If the BeforeTest method fails, we don't run the test
             // An failing Assume sets the Status to Inconclusive, but with a FailureSite of SetUp
-            if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped &&
-                context.CurrentResult.ResultState.Site != FailureSite.SetUp)
+            if ((context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped) &&
+                (context.CurrentResult.ResultState.Site != FailureSite.SetUp))
             {
                 context.CurrentResult = innerCommand.Execute(context);
             }

--- a/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/BeforeTestCommand.cs
@@ -28,8 +28,12 @@ namespace NUnit.Framework.Internal.Commands
             BeforeTest(context);
 
             // If the BeforeTest method fails, we don't run the test
-            if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped)
+            // An failing Assume sets the Status to Inconclusive, but with a FailureSite of SetUp
+            if (context.CurrentResult.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped &&
+                context.CurrentResult.ResultState.Site != FailureSite.SetUp)
+            {
                 context.CurrentResult = innerCommand.Execute(context);
+            }
 
             return context.CurrentResult;
         }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -68,10 +68,6 @@ namespace NUnit.Framework.Internal.Execution
                         default:
                         case RunState.Runnable:
                         case RunState.Explicit:
-                            // Assume success, since the result will otherwise
-                            // default to inconclusive.
-                            Result.SetResult(ResultState.Success);
-
                             if (Children.Count > 0)
                             {
                                 InitializeSetUpAndTearDownCommands();
@@ -80,20 +76,17 @@ namespace NUnit.Framework.Internal.Execution
 
                                 if (!CheckForCancellation())
                                 {
-                                    switch (Result.ResultState.Status)
+                                    if (Result.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped &&
+                                        Result.ResultState.Site != FailureSite.SetUp)
                                     {
-                                        case TestStatus.Passed:
-                                        case TestStatus.Warning:
-                                            RunChildren();
-                                            return;
+                                        RunChildren();
+                                        return;
                                         // Just return: completion event will take care
                                         // of OneTimeTearDown when all tests are done.
-
-                                        case TestStatus.Skipped:
-                                        case TestStatus.Inconclusive:
-                                        case TestStatus.Failed:
-                                            SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message, Result.StackTrace);
-                                            break;
+                                    }
+                                    else
+                                    {
+                                        SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message, Result.StackTrace);
                                     }
                                 }
 

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -76,8 +76,8 @@ namespace NUnit.Framework.Internal.Execution
 
                                 if (!CheckForCancellation())
                                 {
-                                    if (Result.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped &&
-                                        Result.ResultState.Site != FailureSite.SetUp)
+                                    if ((Result.ResultState.Status is not TestStatus.Failed and not TestStatus.Skipped) &&
+                                        (Result.ResultState.Site != FailureSite.SetUp))
                                     {
                                         RunChildren();
                                         return;

--- a/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/AssemblyLevelLifeCycleFixture.cs
@@ -189,7 +189,7 @@ namespace NUnit.TestData.LifeCycleTests
 
             [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 
-            [TestFixtureSource(""FixtureUnderTest"")]
+            [TestFixtureSource(""FixtureArgs"")]
             public class FixtureUnderTest
             {
                 private readonly int _initialValue;

--- a/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
+++ b/src/NUnitFramework/testdata/OneTimeSetUpTearDownData.cs
@@ -12,7 +12,9 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
     {
         public int SetUpCount = 0;
         public int TearDownCount = 0;
+        public int TestCount = 0;
         public bool ThrowInBaseSetUp = false;
+        public bool AssumeFailureInSetUp = false;
 
         [OneTimeSetUp]
         public virtual void Init()
@@ -20,6 +22,8 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
             SetUpCount++;
             if (ThrowInBaseSetUp)
                 throw new Exception("Error in base OneTimeSetUp");
+            if (AssumeFailureInSetUp)
+                Assume.That("1", Is.EqualTo("2"), "Assume");
         }
 
         [OneTimeTearDown]
@@ -31,11 +35,13 @@ namespace NUnit.TestData.OneTimeSetUpTearDownData
         [Test]
         public void Success()
         {
+            TestCount++;
         }
 
         [Test]
         public void EvenMoreSuccess()
         {
+            TestCount++;
         }
     }
 

--- a/src/NUnitFramework/testdata/SetUpData.cs
+++ b/src/NUnitFramework/testdata/SetUpData.cs
@@ -10,14 +10,21 @@ namespace NUnit.TestData.SetUpData
     {
         public bool WasSetUpCalled;
         public bool WasTearDownCalled;
+        public bool WasTestCalled;
         public bool ThrowInBaseSetUp;
+        public bool AssumeFailureInSetUp;
+        public bool AssertFailureInSetUp;
 
         [SetUp]
         public virtual void Init()
         {
             WasSetUpCalled = true;
             if (ThrowInBaseSetUp)
-                throw (new Exception("Exception in base setup"));
+                throw new Exception("Exception in base setup");
+            if (AssumeFailureInSetUp)
+                Assume.That("1", Is.EqualTo("2"), "Assume");
+            if (AssertFailureInSetUp)
+                Assert.That("1", Is.EqualTo("2"), "Assert");
         }
 
         [TearDown]
@@ -29,6 +36,7 @@ namespace NUnit.TestData.SetUpData
         [Test]
         public void Success()
         {
+            WasTestCalled = true;
         }
     }
 

--- a/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Internal/SetUpTearDownTests.cs
@@ -28,8 +28,60 @@ namespace NUnit.Framework.Tests.Internal
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             TestBuilder.RunTestFixture(fixture);
 
-            Assert.That(fixture.WasSetUpCalled, Is.True);
-            Assert.That(fixture.WasTearDownCalled, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fixture.WasSetUpCalled, Is.True);
+                Assert.That(fixture.WasTestCalled, Is.True);
+                Assert.That(fixture.WasTearDownCalled, Is.True);
+            }
+        }
+
+        [Test]
+        public void CheckTestIsNotCalledWhenSetupThrowsException()
+        {
+            SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
+            fixture.ThrowInBaseSetUp = true;
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed), "Result State");
+                Assert.That(fixture.WasSetUpCalled, Is.True);
+                Assert.That(fixture.WasTestCalled, Is.False);
+                Assert.That(fixture.WasTearDownCalled, Is.True);
+            }
+        }
+
+        [Test]
+        public void CheckTestIsNotCalledWhenSetupAssertFailure()
+        {
+            SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
+            fixture.AssertFailureInSetUp = true;
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed), "Result State");
+                Assert.That(fixture.WasSetUpCalled, Is.True);
+                Assert.That(fixture.WasTestCalled, Is.False);
+                Assert.That(fixture.WasTearDownCalled, Is.True);
+            }
+        }
+
+        [Test]
+        public void CheckTestIsNotCalledWhenSetupAssumeFailure()
+        {
+            SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
+            fixture.AssumeFailureInSetUp = true;
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Inconclusive), "Result State");
+                Assert.That(fixture.WasSetUpCalled, Is.True);
+                Assert.That(fixture.WasTestCalled, Is.False);
+                Assert.That(fixture.WasTearDownCalled, Is.True);
+            }
         }
 
         [Test]
@@ -86,12 +138,17 @@ namespace NUnit.Framework.Tests.Internal
         {
             DerivedClassWithSeparateSetUp fixture = new DerivedClassWithSeparateSetUp();
             fixture.ThrowInBaseSetUp = true;
-            TestBuilder.RunTestFixture(fixture);
+            ITestResult result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.That(fixture.WasSetUpCalled, Is.True, "Base SetUp Called");
-            Assert.That(fixture.WasTearDownCalled, Is.True, "Base TearDown Called");
-            Assert.That(fixture.WasDerivedSetUpCalled, Is.False, "Derived SetUp Called");
-            Assert.That(fixture.WasDerivedTearDownCalled, Is.False, "Derived TearDown Called");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed), "Result State");
+                Assert.That(fixture.WasSetUpCalled, Is.True, "Base SetUp Called");
+                Assert.That(fixture.WasTestCalled, Is.False, "Base Test Called");
+                Assert.That(fixture.WasTearDownCalled, Is.True, "Base TearDown Called");
+                Assert.That(fixture.WasDerivedSetUpCalled, Is.False, "Derived SetUp Called");
+                Assert.That(fixture.WasDerivedTearDownCalled, Is.False, "Derived TearDown Called");
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestExecutionContextTests.cs
@@ -327,7 +327,7 @@ namespace NUnit.Framework.Tests.Internal
         public void CanAccessResultState()
         {
             // This is copied in setup because it can change if any test fails
-            Assert.That(_fixtureResult, Is.EqualTo(ResultState.Success));
+            Assert.That(_fixtureResult, Is.EqualTo(ResultState.Inconclusive));
             Assert.That(_setupContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
             Assert.That(TestExecutionContext.CurrentContext.CurrentResult.ResultState, Is.EqualTo(ResultState.Inconclusive));
         }

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -224,7 +224,6 @@ namespace NUnit.Framework.Tests.Internal
             Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
             ITestResult result = TestBuilder.RunTest(suite, null);
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Inconclusive));
-
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Internal/TestFixtureTests.cs
@@ -219,7 +219,12 @@ namespace NUnit.Framework.Tests.Internal
         [Test]
         public void CanRunTestFixtureWithNoTests()
         {
-            TestAssert.IsRunnable(typeof(FixtureWithNoTests));
+            TestSuite suite = TestBuilder.MakeFixture(typeof(FixtureWithNoTests));
+            Assert.That(suite, Is.Not.Null, "Unable to construct fixture");
+            Assert.That(suite.RunState, Is.EqualTo(RunState.Runnable));
+            ITestResult result = TestBuilder.RunTest(suite, null);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Inconclusive));
+
         }
 
         [Test]


### PR DESCRIPTION
Fixes #5026 

A possibly controversial change is the default state of s suite going from `Passed` to `Inconclusive`.
It should only affect suites with no tests of which there should be not many.

An alternative approach could be to replace `Inconclusive` with `Skipped` if an Assume fails.