### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/NUnit.Nuget.Publish.yml
+++ b/.github/workflows/NUnit.Nuget.Publish.yml
@@ -12,7 +12,8 @@ jobs:
   build-windows:
     name: Windows Build
     runs-on: windows-latest
-
+    permissions:
+      id-token: write
     steps:
     - name: ⤵️ Checkout Source
       uses: actions/checkout@v4
@@ -53,9 +54,14 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
 
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish nupkg and snupkg to Nuget.org
       run: |
           foreach($file in (Get-ChildItem package -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.PUBLISH_NUGET_ORG }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+              dotnet nuget push $file --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           }
- 


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (NUnit in this case).  
- The old `secrets.PUBLISH_NUGET_ORG` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `NUnit`).  
   - **Repository owner:** your GitHub org/user (e.g. `nunit`).  
   - **Repository name:** repository name (e.g. `nunit`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `NUnit.Nuget.Publish.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.