### PR TITLE
Add PartitionFilter.TryCreate() test coverage

### DIFF
--- a/src/NUnitFramework/framework/Internal/Filters/PartitionFilter.cs
+++ b/src/NUnitFramework/framework/Internal/Filters/PartitionFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -50,7 +51,7 @@ namespace NUnit.Framework.Internal.Filters
         /// <param name="value">The partition value (eg, 1/10 to indicate partition 1 of 10)</param>
         /// <param name="partitionFilter">The created PartitionFilter if the parsing succeeded</param>
         /// <returns>True on successful parsing, or False if there is an error</returns>
-        public static bool TryCreate(string value, out PartitionFilter? partitionFilter)
+        public static bool TryCreate(string value, [NotNullWhen(true)] out PartitionFilter? partitionFilter)
         {
             // Split our numberWithCount into two parts, such that "1/10" becomes PartitionNumber 1, PartitionCount 10
             string[] parts = value.Split('/');

--- a/src/NUnitFramework/tests/Internal/Filters/PartitionFilterTests.cs
+++ b/src/NUnitFramework/tests/Internal/Filters/PartitionFilterTests.cs
@@ -106,5 +106,24 @@ namespace NUnit.Framework.Tests.Internal.Filters
             Assert.DoesNotThrow(() => _filter.ComputePartitionNumber(_testFixtureWithWithLongTestCaseNames.Tests[0]));
             Assert.DoesNotThrow(() => _filter.ComputePartitionNumber(_testFixtureWithWithLongTestCaseNames.Tests[1]));
         }
+
+        [TestCase("1/1n")]
+        [TestCase("1")]
+        public void TryCreateFailure(string input)
+        {
+            Assert.That(PartitionFilter.TryCreate(input, out var filter), Is.False);
+        }
+
+        [TestCase("1/2")]
+        [TestCase(" 1/2")]
+        [TestCase("1/2 ")]
+        public void TryCreateSuccess(string input)
+        {
+            var result = PartitionFilter.TryCreate(input, out var filter);
+
+            Assert.That(result, Is.True);
+            Assert.That(filter!.PartitionNumber, Is.EqualTo(1));
+            Assert.That(filter.PartitionCount, Is.EqualTo(2));
+        }
     }
 }


### PR DESCRIPTION
I was browsing the codebase when I noticed there wasn't any direct test coverage over this function. So I've added it 😀