### PR TITLE
Ignore Generic Parameters in PreFilter

### DIFF
--- a/src/NUnitFramework/framework/Internal/PreFilter.cs
+++ b/src/NUnitFramework/framework/Internal/PreFilter.cs
@@ -140,41 +140,43 @@ namespace NUnit.Framework.Internal
 
             public bool Match(Type type)
             {
-                return MatchElementType(type) ||
+                string typeName = TypeFullNameWithoutGenericArgs(type);
+
+                return MatchElementType(typeName) ||
                        MatchSetUpFixture(type);
             }
 
-            private bool MatchElementType(Type type)
+            private bool MatchElementType(string typeName)
             {
                 switch (_elementType)
                 {
                     default:
                     case FilterElementType.Unknown:
-                        return MatchUnknownElement(type);
+                        return MatchUnknownElement(typeName);
                     case FilterElementType.Fixture:
-                        return MatchFixtureElement(type);
+                        return MatchFixtureElement(typeName);
                     case FilterElementType.Namespace:
-                        return MatchNamespaceElement(type);
+                        return MatchNamespaceElement(typeName);
                     case FilterElementType.Method:
-                        return MatchMethodElement(type);
+                        return MatchMethodElement(typeName);
                 }
             }
 
-            private bool MatchUnknownElement(Type type)
+            private bool MatchUnknownElement(string typeName)
             {
-                if (MatchFixtureElement(type))
+                if (MatchFixtureElement(typeName))
                 {
                     _elementType = FilterElementType.Fixture;
                     return true;
                 }
 
-                if (MatchNamespaceElement(type))
+                if (MatchNamespaceElement(typeName))
                 {
                     _elementType = FilterElementType.Namespace;
                     return true;
                 }
 
-                if (MatchMethodElement(type))
+                if (MatchMethodElement(typeName))
                 {
                     _elementType = FilterElementType.Method;
                     return true;
@@ -183,19 +185,28 @@ namespace NUnit.Framework.Internal
                 return false;
             }
 
-            private bool MatchFixtureElement(Type type)
+            private bool MatchFixtureElement(string typeName)
             {
-                return type.FullName == Text;
+                return typeName == Text;
             }
 
-            private bool MatchNamespaceElement(Type type)
+            private bool MatchNamespaceElement(string typeName)
             {
-                return type.FullName?.StartsWith(Text + ".") is true;
+                return typeName.StartsWith(Text + ".") is true;
             }
 
-            private bool MatchMethodElement(Type type)
+            private bool MatchMethodElement(string typeName)
             {
-                return type.FullName == ClassName;
+                return typeName == ClassName;
+            }
+
+            private static string TypeFullNameWithoutGenericArgs(Type type)
+            {
+                string fullName = type.FullName ?? string.Empty;
+                int genericMarker = fullName.IndexOf('`');
+                return genericMarker > 0
+                    ? fullName.Substring(0, genericMarker)
+                    : fullName;
             }
 
             private bool MatchSetUpFixture(Type type)

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -36,6 +36,7 @@ namespace NUnit.Framework.Tests.Api
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture", ExpectedResult = MockTestFixture.Tests)]
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture", "NUnit.Tests.FixtureWithTestCases", ExpectedResult = MockTestFixture.Tests + FixtureWithTestCases.Tests)]
         [TestCase("NUnit.Tests.Singletons.OneTestCase", ExpectedResult = OneTestCase.Tests)]
+        [TestCase("NUnit.Tests.GenericFixture", ExpectedResult = GenericFixtureConstants.Tests)]
         // Method filters
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", ExpectedResult = 1)]
         [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", "NUnit.Tests.Singletons.OneTestCase.TestCase", ExpectedResult = 2)]


### PR DESCRIPTION
Fixes #5093 

This changes comparison on `type.FullName` with a string dropping the generic parameters part (after the `)
