### PR TITLE
Disable TimeoutCommand for anything but .NET Framework

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/CancelAfterCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/CancelAfterCommand.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Internal.Commands
         private readonly IDebugger _debugger;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TimeoutCommand"/> class.
+        /// Initializes a new instance of the <see cref="CancelAfterCommand"/> class.
         /// </summary>
         /// <param name="innerCommand">The inner command</param>
         /// <param name="timeout">Timeout value</param>

--- a/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TimeoutCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 #else
 using System;
-using System.Threading.Tasks;
 #endif
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Abstractions;
@@ -93,29 +92,9 @@ namespace NUnit.Framework.Internal.Commands
         /// <returns>A TestResult</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
-            try
-            {
-                using (new TestExecutionContext.IsolatedContext())
-                {
-                    var testExecution = Task.Run(() => innerCommand.Execute(TestExecutionContext.CurrentContext));
-                    var timedOut = Task.WaitAny(new Task[] { testExecution }, _timeout) == -1;
-
-                    if (timedOut && !_debugger.IsAttached)
-                    {
-                        context.CurrentResult.SetResult(
-                            ResultState.Failure,
-                            $"Test exceeded Timeout value of {_timeout}ms");
-                    }
-                    else
-                    {
-                        context.CurrentResult = testExecution.GetAwaiter().GetResult();
-                    }
-                }
-            }
-            catch (Exception exception)
-            {
-                context.CurrentResult.RecordException(exception, FailureSite.Test);
-            }
+            context.CurrentResult.SetResult(
+                ResultState.Error,
+                $"TargetFramework doesn't support timeout on tests.");
 
             return context.CurrentResult;
         }

--- a/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TimeoutTests.cs
@@ -1,3 +1,5 @@
+#if NETFRAMEWORK
+
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
@@ -16,10 +18,6 @@ namespace NUnit.Framework.Tests.Attributes
     [NonParallelizable]
     public class TimeoutTests : ThreadingTests
     {
-#if !NETFRAMEWORK
-#pragma warning disable CS0618 // Type or member is obsolete
-#endif
-
         private sealed class SampleTests
         {
             private const int TimeExceedingTimeout = 500;
@@ -344,13 +342,7 @@ namespace NUnit.Framework.Tests.Attributes
         internal sealed class Issue4723
         {
             [Test]
-#if NETFRAMEWORK
             [Timeout(2_000)] // Ok status will be Passed
-#else
-#pragma warning disable CS0618
-            [Timeout(2_000)] // Ok status will be Passed
-#pragma warning restore CS0618
-#endif
             public async Task Test_Timeout()
             {
                 await Task.Delay(1_000);
@@ -380,3 +372,5 @@ namespace NUnit.Framework.Tests.Attributes
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Fixes #4119 

TimeoutAttribute has been Obsolete since version 4.0.0 for anything but .NET Framework