### PR TITLE
Update branch filter for release in workflow

### DIFF
--- a/.github/workflows/NUnit.Myget.Publish.yml
+++ b/.github/workflows/NUnit.Myget.Publish.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - release
+      - release/*
       - myget
   workflow_dispatch:
   


### PR DESCRIPTION
Permits MyGet publishing for `release/*` branches such as `release/4.6` and `release/5.X`.

I'm targeting main for now so that we can then sync these and all other changes up via:
- `main` -> `release/4.6`
- `release/4.6` -> `release/5.X`

Alternately, if we prefer not to publish 5.x changes yet I can update the branch filter to just `release/4.*`