### PR TITLE
Add myget publish release4x

### DIFF
--- a/.github/workflows/NUnit.Myget.Publish.yml
+++ b/.github/workflows/NUnit.Myget.Publish.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - release
+      - release/*
       - myget
   workflow_dispatch:
   


### PR DESCRIPTION
Companion PR to https://github.com/nunit/nunit/pull/5147

Originally I had thought we just let this merge naturally across branches, but it might also make sense to _start_ that after 4.5.1 goes out so that the entirety of released changes can sync up. I am cherry-picking it here early to get it into `release/4.6`. 