### PR TITLE
Apply internal string optimizations

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionOrderedConstraint.cs
@@ -266,7 +266,7 @@ namespace NUnit.Framework.Constraints
                     sb.Append(" " + step.ComparerName);
             }
 
-            sb.Append(">");
+            sb.Append('>');
 
             return sb.ToString();
         }

--- a/src/NUnitFramework/framework/Constraints/Constraint.cs
+++ b/src/NUnitFramework/framework/Constraints/Constraint.cs
@@ -152,16 +152,16 @@ namespace NUnit.Framework.Constraints
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append("<");
+            sb.Append('<');
             sb.Append(DisplayName.ToLower());
 
             foreach (object? arg in arguments)
             {
-                sb.Append(" ");
+                sb.Append(' ');
                 sb.Append(Displayable(arg));
             }
 
-            sb.Append(">");
+            sb.Append('>');
 
             return sb.ToString();
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -24,23 +24,23 @@ namespace NUnit.Framework.Constraints
         private readonly IList<NUnitEqualityComparer.FailurePoint> _failurePoints;
 
         #region Message Strings
-        private static readonly string StringsDiffer_1 =
+        private const string StringsDiffer_1 =
             "String lengths are both {0}. Strings differ at index {1}.";
-        private static readonly string StringsDiffer_2 =
+        private const string StringsDiffer_2 =
             "Expected string length {0} but was {1}. Strings differ at index {2}.";
-        private static readonly string StreamsDiffer_1 =
+        private const string StreamsDiffer_1 =
             "Stream lengths are both {0}. Streams differ at offset {1}.";
-        private static readonly string StreamsDiffer_2 =
+        private const string StreamsDiffer_2 =
             "Expected Stream length {0} but was {1}."; // Streams differ at offset {2}.";
-        private static readonly string UnSeekableStreamsDiffer =
+        private const string UnSeekableStreamsDiffer =
             "Streams differ at offset {0}.";
-        private static readonly string CollectionType_1 =
+        private const string CollectionType_1 =
             "Expected and actual are both {0}";
-        private static readonly string CollectionType_2 =
+        private const string CollectionType_2 =
             "Expected is {0}, actual is {1}";
-        private static readonly string ValuesDiffer_1 =
+        private const string ValuesDiffer_1 =
             "Values differ at index {0}";
-        private static readonly string ValuesDiffer_2 =
+        private const string ValuesDiffer_2 =
             "Values differ at expected index {0}, actual index {1}";
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualNumericWithoutUsingConstraint.cs
@@ -192,7 +192,7 @@ namespace NUnit.Framework.Constraints
                     sb.Append(MsgUtils.FormatValue(_tolerance.Amount));
                     if (_tolerance.Mode != ToleranceMode.Linear)
                     {
-                        sb.Append(" ");
+                        sb.Append(' ');
                         sb.Append(_tolerance.Mode.ToString());
                     }
                 }

--- a/src/NUnitFramework/framework/Constraints/MsgUtils.cs
+++ b/src/NUnitFramework/framework/Constraints/MsgUtils.cs
@@ -45,17 +45,17 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Formatting strings used for expected and actual values
         /// </summary>
-        private static readonly string Fmt_Null = "null";
+        private const string Fmt_Null = "null";
 
-        private static readonly string Fmt_EmptyString = "<string.Empty>";
-        private static readonly string Fmt_EmptyCollection = "<empty>";
-        private static readonly string Fmt_String = "\"{0}\"";
-        private static readonly string Fmt_Char = "'{0}'";
-        private static readonly string Fmt_DateTime = "yyyy-MM-dd HH:mm:ss.FFFFFFF";
-        private static readonly string Fmt_DateTimeOffset = "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz";
-        private static readonly string Fmt_ValueType = "{0}";
-        private static readonly string Fmt_Default = "<{0}>";
-        private static readonly string Fmt_ExceptionThrown = "<! {0} !>";
+        private const string Fmt_EmptyString = "<string.Empty>";
+        private const string Fmt_EmptyCollection = "<empty>";
+        private const string Fmt_String = "\"{0}\"";
+        private const string Fmt_Char = "'{0}'";
+        private const string Fmt_DateTime = "yyyy-MM-dd HH:mm:ss.FFFFFFF";
+        private const string Fmt_DateTimeOffset = "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz";
+        private const string Fmt_ValueType = "{0}";
+        private const string Fmt_Default = "<{0}>";
+        private const string Fmt_ExceptionThrown = "<! {0} !>";
 
         /// <summary>
         /// Current head of chain of value formatters. Public for testing.
@@ -323,7 +323,7 @@ namespace NUnit.Framework.Constraints
 
             StringBuilder sb = new StringBuilder();
             if (printParentheses)
-                sb.Append("(");
+                sb.Append('(');
 
             for (int i = 0; i < numberOfGenericArgs; i++)
             {
@@ -337,7 +337,7 @@ namespace NUnit.Framework.Constraints
                 sb.Append(formattedValue);
             }
             if (printParentheses)
-                sb.Append(")");
+                sb.Append(')');
 
             return sb.ToString();
         }
@@ -569,7 +569,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (r > 0)
                     sb.Append(',');
-                sb.Append(indices[r].ToString());
+                sb.Append(indices[r]);
             }
             sb.Append(']');
             return sb.ToString();

--- a/src/NUnitFramework/framework/Internal/Logging/Logger.cs
+++ b/src/NUnitFramework/framework/Internal/Logging/Logger.cs
@@ -10,8 +10,8 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class Logger : ILogger
     {
-        private static readonly string TIME_FMT = "HH:mm:ss.fff";
-        private static readonly string TRACE_FMT = "{0} {1,-5} [{2,2}] {3}: {4}";
+        private const string TIME_FMT = "HH:mm:ss.fff";
+        private const string TRACE_FMT = "{0} {1,-5} [{2,2}] {3}: {4}";
 
         private readonly string _name;
         private readonly string _fullname;

--- a/src/NUnitFramework/framework/Internal/OSPlatform.cs
+++ b/src/NUnitFramework/framework/Internal/OSPlatform.cs
@@ -276,7 +276,7 @@ namespace NUnit.Framework.Internal
                     break;
             }
 
-            sb.Append(" ").Append(Version);
+            sb.Append(' ').Append(Version);
             return sb.ToString();
         }
 

--- a/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
+++ b/src/NUnitFramework/framework/Internal/TestNameGenerator.cs
@@ -297,7 +297,7 @@ namespace NUnit.Framework.Internal
                     for (int i = 0; i < arglist.Length; i++)
                     {
                         if (i > 0)
-                            sb.Append(",");
+                            sb.Append(',');
                         sb.Append(GetDisplayString(arglist[i], _maxStringLength));
                     }
 


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/5154
Targeting 4.6

Note that I limited the changing from `static readonly string` to `const string` to only private types as changing public types like that would obviously break consumers.