### PR TITLE
Add a FieldsComparer

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EqualsComparer.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (equalityComparer.CompareProperties &&
+            if ((equalityComparer.CompareProperties || equalityComparer.CompareFields) &&
                 (TypeHelper.HasCompilerGeneratedEquals(xType) || TypeHelper.HasCompilerGeneratedEquals(yType)))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.

--- a/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/EquatablesComparer.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Constraints.Comparers
             Type xType = x.GetType();
             Type yType = y.GetType();
 
-            if (equalityComparer.CompareProperties &&
+            if ((equalityComparer.CompareProperties || equalityComparer.CompareFields) &&
                 (TypeHelper.HasCompilerGeneratedEquals(xType) || TypeHelper.HasCompilerGeneratedEquals(yType)))
             {
                 // For record types, when CompareProperties is requested, we ignore generated Equals method and compare by properties.

--- a/src/NUnitFramework/framework/Constraints/Comparers/FieldsComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/FieldsComparer.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace NUnit.Framework.Constraints.Comparers
+{
+    /// <summary>
+    /// Comparator for two instances of the same type, comparing each field.
+    /// </summary>
+    internal static class FieldsComparer
+    {
+        public static EqualMethodResult Equal(object x, object y, ref Tolerance tolerance, ComparisonState state, NUnitEqualityComparer equalityComparer)
+        {
+            Type xType = x.GetType();
+            Type yType = y.GetType();
+
+            if (xType != yType)
+            {
+                // Both operands need to be the same type.
+                return EqualMethodResult.TypesNotSupported;
+            }
+
+            if (xType.IsPrimitive || yType.IsPrimitive)
+            {
+                // We should never get here if the order in NUnitEqualityComparer is correct.
+                // We don't do built-in value types
+                return EqualMethodResult.TypesNotSupported;
+            }
+
+            FieldsComparerConfiguration configuration = equalityComparer.CompareFieldsConfiguration ?? FieldsComparerConfiguration.Default;
+
+            FieldInfo[] fields = GetFieldsToCompare(xType, configuration.OnlyCompareInitAndReadonlyFields);
+
+            if (fields.Length == 0)
+            {
+                // There is nothing to compare if there are no fields.
+                return EqualMethodResult.TypesNotSupported;
+            }
+
+            var fieldNames = new HashSet<string>(fields.Select(p => p.Name));
+
+            ComparisonState comparisonState = state.PushComparison(x, y);
+
+            BitArray redoWithoutTolerance = new BitArray(fields.Length);
+            int toleranceNotSupportedCount = 0;
+
+            for (int i = 0; i < fields.Length; i++)
+            {
+                FieldInfo field = fields[i];
+                object? xFieldValue = field.GetValue(x);
+                object? yFieldValue = field.GetValue(y);
+
+                Tolerance toleranceToApply = tolerance;
+
+                if (tolerance.IsUnsetOrDefault)
+                {
+                    if (xFieldValue is TimeSpan or DateTime or DateTimeOffset)
+                    {
+                        toleranceToApply = configuration.TimeSpanTolerance;
+                    }
+                    else if (Numerics.IsFloatingPointNumeric(xFieldValue))
+                    {
+                        toleranceToApply = configuration.FloatingPointTolerance;
+                    }
+                    else if (Numerics.IsFixedPointNumeric(xFieldValue))
+                    {
+                        toleranceToApply = configuration.FixedPointTolerance;
+                    }
+                }
+
+                EqualMethodResult result = equalityComparer.AreEqual(xFieldValue, yFieldValue, ref toleranceToApply, comparisonState);
+
+                if (result == EqualMethodResult.ComparedNotEqual || result == EqualMethodResult.TypesNotSupported)
+                {
+                    return FieldNotEqualResult(equalityComparer, i, xType.Name, field.Name, xFieldValue, yFieldValue);
+                }
+
+                if (result == EqualMethodResult.ToleranceNotSupported)
+                {
+                    redoWithoutTolerance.Set(i, true);
+                    toleranceNotSupportedCount++;
+                }
+            }
+
+            if (toleranceNotSupportedCount == fields.Length)
+            {
+                // If none of the properties supported the tolerance don't retry without it
+                return EqualMethodResult.ToleranceNotSupported;
+            }
+
+            if (toleranceNotSupportedCount != 0)
+            {
+                Tolerance noTolerance = Tolerance.Exact;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    if (redoWithoutTolerance.Get(i))
+                    {
+                        FieldInfo field = fields[i];
+                        object? xFieldValue = field.GetValue(x);
+                        object? yFieldValue = field.GetValue(y);
+
+                        EqualMethodResult result = equalityComparer.AreEqual(xFieldValue, yFieldValue, ref noTolerance, comparisonState);
+                        if (result == EqualMethodResult.ComparedNotEqual)
+                        {
+                            return FieldNotEqualResult(equalityComparer, i, xType.Name, field.Name, xFieldValue, yFieldValue);
+                        }
+                    }
+                }
+            }
+
+            return EqualMethodResult.ComparedEqual;
+
+            FieldInfo[] GetFieldsToCompare(Type type, bool onlyCompareInitAndReadonlyFields)
+            {
+                return type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                           .Where(field => field.IsInitOnly || !onlyCompareInitAndReadonlyFields)
+                           .ToArray();
+            }
+        }
+
+        private static EqualMethodResult FieldNotEqualResult(NUnitEqualityComparer equalityComparer, int i, string typeName, string fieldName, object? xFieldValue, object? yFieldValue)
+        {
+            var fp = new NUnitEqualityComparer.FailurePoint
+            {
+                Position = i,
+                PropertyName = $"{typeName}.{fieldName}",
+                ExpectedHasData = true,
+                ExpectedValue = xFieldValue,
+                ActualHasData = true,
+                ActualValue = yFieldValue
+            };
+            equalityComparer.FailurePoints.Insert(0, fp);
+            return EqualMethodResult.ComparedNotEqual;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraint.cs
@@ -95,6 +95,14 @@ namespace NUnit.Framework.Constraints
         public bool ComparingProperties => _comparer.CompareProperties;
 
         /// <summary>
+        /// Gets a value indicating whether to compare separate fields.
+        /// </summary>
+        /// <value>
+        ///   <see langword="true"/> if comparing separate fields; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool ComparingFields => _comparer.CompareFields;
+
+        /// <summary>
         /// Gets a value indicating whether or not to clip strings.
         /// </summary>
         /// <value>
@@ -425,6 +433,7 @@ namespace NUnit.Framework.Constraints
         /// </remarks>
         public EqualConstraint UsingPropertiesComparer()
         {
+            _comparer.CompareFields = false;
             _comparer.CompareProperties = true;
             _comparer.ComparePropertiesConfiguration = null;
             return this;
@@ -440,6 +449,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="configure">Function to configure the <see cref="PropertiesComparerConfiguration"/></param>
         public EqualConstraint UsingPropertiesComparer(Func<PropertiesComparerConfigurationUntyped, PropertiesComparerConfigurationUntyped> configure)
         {
+            _comparer.CompareFields = false;
             _comparer.CompareProperties = true;
             _comparer.ComparePropertiesConfiguration = configure(new PropertiesComparerConfigurationUntyped());
             return this;
@@ -457,6 +467,37 @@ namespace NUnit.Framework.Constraints
         {
             Comparer.CompareProperties = true;
             Comparer.ComparePropertiesConfiguration = configure(new PropertiesComparerConfiguration<T>());
+            return this;
+        }
+
+        /// <summary>
+        /// Enables comparing of instance fields.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        public EqualConstraint UsingFieldsComparer()
+        {
+            _comparer.CompareProperties = false;
+            _comparer.CompareFields = true;
+            _comparer.CompareFieldsConfiguration = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables comparing of instance properties.
+        /// </summary>
+        /// <remarks>
+        /// This allows comparing classes that don't implement <see cref="IEquatable{T}"/>
+        /// without having to compare each property separately in own code.
+        /// </remarks>
+        /// <param name="configure">Function to configure the <see cref="FieldsComparerConfiguration"/></param>
+        public EqualConstraint UsingFieldsComparer(Func<FieldsComparerConfiguration, FieldsComparerConfiguration> configure)
+        {
+            _comparer.CompareProperties = false;
+            _comparer.CompareFields = true;
+            _comparer.CompareFieldsConfiguration = configure(new FieldsComparerConfiguration());
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/EqualConstraintResult.cs
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Constraints
         private readonly bool _caseInsensitive;
         private readonly bool _ignoringWhiteSpace;
         private readonly bool _ignoringLineEndingFormat;
-        private readonly bool _comparingProperties;
+        private readonly bool _comparingPropertiesOrFields;
         private readonly bool _clipStrings;
         private readonly IList<NUnitEqualityComparer.FailurePoint> _failurePoints;
 
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
             _caseInsensitive = constraint.CaseInsensitive;
             _ignoringWhiteSpace = constraint.IgnoringWhiteSpace;
             _ignoringLineEndingFormat = constraint.IgnoringLineEndingFormat;
-            _comparingProperties = constraint.ComparingProperties;
+            _comparingPropertiesOrFields = constraint.ComparingProperties || constraint.ComparingFields;
             _clipStrings = constraint.ClipStrings;
             _failurePoints = constraint.HasFailurePoints ? constraint.FailurePoints : Array.Empty<NUnitEqualityComparer.FailurePoint>();
         }
@@ -68,7 +68,7 @@ namespace NUnit.Framework.Constraints
         {
             _expectedValue = constraint.Arguments[0];
             _tolerance = tolerance;
-            _comparingProperties = false;
+            _comparingPropertiesOrFields = false;
             _caseInsensitive = false;
             _ignoringWhiteSpace = false;
             _ignoringLineEndingFormat = false;
@@ -84,7 +84,7 @@ namespace NUnit.Framework.Constraints
         {
             _expectedValue = constraint.Arguments[0];
             _tolerance = Tolerance.Default;
-            _comparingProperties = false;
+            _comparingPropertiesOrFields = false;
             _caseInsensitive = false;
             _ignoringWhiteSpace = false;
             _ignoringLineEndingFormat = false;
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Constraints
         {
             _expectedValue = constraint.Arguments[0];
             _tolerance = Tolerance.Exact;
-            _comparingProperties = false;
+            _comparingPropertiesOrFields = false;
             _caseInsensitive = caseInsensitive;
             _ignoringWhiteSpace = ignoringWhiteSpace;
             _ignoringLineEndingFormat = ignoringLineEndingFormat;
@@ -136,7 +136,7 @@ namespace NUnit.Framework.Constraints
                 DisplayEnumerableDifferences(writer, expectedEnumerable, actualEnumerable, depth);
             else if (expected is Stream expectedStream && actual is Stream actualStream)
                 DisplayStreamDifferences(writer, expectedStream, actualStream, depth);
-            else if (_comparingProperties && IsPropertyFailurePoint(depth))
+            else if (_comparingPropertiesOrFields && IsPropertyOrFieldFailurePoint(depth))
                 DisplayPropertyDifferences(writer, expected, actual, depth);
             else if (_tolerance is not null)
                 writer.DisplayDifferences(expected, actual, _tolerance);
@@ -373,7 +373,7 @@ namespace NUnit.Framework.Constraints
             }
         }
 
-        private bool IsPropertyFailurePoint(int depth)
+        private bool IsPropertyOrFieldFailurePoint(int depth)
         {
             return _failurePoints.Count > depth &&
                    _failurePoints[depth].PropertyName is not null;

--- a/src/NUnitFramework/framework/Constraints/FieldsComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/FieldsComparerConfiguration.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace NUnit.Framework.Constraints
+{
+    /// <summary>
+    /// Class to configure how to compare fields
+    /// </summary>
+    public class FieldsComparerConfiguration
+    {
+        /// <summary>
+        /// The global fallback configuration for comparing fields.
+        /// </summary>
+        internal static FieldsComparerConfiguration Default { get; } = new();
+
+        /// <summary>
+        /// Gets and sets the option to compare only readonly and init only fields.
+        /// This ignores all fields that are not set during initialization of an object,
+        /// which are often used for caching or other internal purposes and should not be relevant for equality of objects.
+        /// </summary>
+        internal bool OnlyCompareInitAndReadonlyFields { get; set; }
+
+        /// <summary>
+        /// Gets and sets the tolerance to apply for time values.
+        /// </summary>
+        internal Tolerance TimeSpanTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Gets and sets the tolerance to apply for numeric values.
+        /// </summary>
+        internal Tolerance FloatingPointTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Gets and sets the tolerance to apply for numeric values.
+        /// </summary>
+        internal Tolerance FixedPointTolerance { get; set; } = Tolerance.Default;
+
+        /// <summary>
+        /// Set the tolerance to apply based upon the type of the tolerance.
+        /// </summary>
+        /// <remarks>
+        /// This method accepts a <see cref="TimeSpan"/>, a numeric value or a <see cref="Tolerance"/> instance.
+        /// </remarks>
+        /// <param name="amount"></param>
+        protected void SetTolerance(object amount)
+        {
+            if (amount is not Tolerance instance)
+                instance = new Tolerance(amount);
+
+            if (instance.Amount is TimeSpan)
+            {
+                TimeSpanTolerance = instance;
+            }
+            else if (Numerics.IsFloatingPointNumeric(instance.Amount) || instance.Mode == ToleranceMode.Ulps)
+            {
+                FloatingPointTolerance = instance;
+            }
+            else
+            {
+                FixedPointTolerance = instance;
+            }
+        }
+
+        /// <summary>
+        /// Set the <see cref="FieldsComparerConfiguration.OnlyCompareInitAndReadonlyFields"/> property.
+        /// </summary>
+        /// <returns>Self.</returns>
+        public FieldsComparerConfiguration CompareOnlyInitAndReadonlyFields()
+        {
+            OnlyCompareInitAndReadonlyFields = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a tolerance for all numeric comparisons.
+        /// </summary>
+        /// <param name="amount">The tolerance to apply.</param>
+        /// <returns>Self.</returns>
+        public FieldsComparerConfiguration Within(object amount)
+        {
+            SetTolerance(amount);
+            return this;
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/NUnitEqualityComparer.cs
@@ -83,6 +83,14 @@ namespace NUnit.Framework.Constraints
         private PropertiesComparerConfiguration? _comparePropertiesConfiguration;
 
         /// <summary>
+        /// If true, when a class does not implement <see cref="IEquatable{T}"/>
+        /// it will be compared property by fields.
+        /// </summary>
+        private bool _compareFields;
+
+        private FieldsComparerConfiguration? _compareFieldsConfiguration;
+
+        /// <summary>
         /// Comparison objects used in comparisons for some constraints.
         /// </summary>
         private List<EqualityAdapter>? _externalComparers;
@@ -144,12 +152,31 @@ namespace NUnit.Framework.Constraints
         }
 
         /// <summary>
-        /// Gets and sets the names of properties to exclude from comparison.
+        /// Gets and sets the the configuration for comparing properties.
         /// </summary>
         public PropertiesComparerConfiguration? ComparePropertiesConfiguration
         {
             get => _comparePropertiesConfiguration;
             set => _comparePropertiesConfiguration = value;
+        }
+
+        /// <summary>
+        /// Gets and sets a flag indicating whether an instance fields
+        /// should be compared when determining equality.
+        /// </summary>
+        public bool CompareFields
+        {
+            get => _compareFields;
+            set => _compareFields = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the the configuration for comparing fields.
+        /// </summary>
+        public FieldsComparerConfiguration? CompareFieldsConfiguration
+        {
+            get => _compareFieldsConfiguration;
+            set => _compareFieldsConfiguration = value;
         }
 
         /// <summary>
@@ -203,7 +230,7 @@ namespace NUnit.Framework.Constraints
             EqualMethodResult result = AreEqual(x, y, ref tolerance, new ComparisonState(true));
 
             switch (result)
-            {
+            { 
                 case EqualMethodResult.TypesNotSupported:
                     throw new NotSupportedException($"No comparer found for instances of type '{GetType(x)}' and '{GetType(y)}'");
                 case EqualMethodResult.ToleranceNotSupported:
@@ -258,6 +285,10 @@ namespace NUnit.Framework.Constraints
             if (_compareProperties)
             {
                 return PropertiesComparer.Equal(x, y, ref tolerance, state, this);
+            }
+            if (_compareFields)
+            {
+                return FieldsComparer.Equal(x, y, ref tolerance, state, this);
             }
 
             if (tolerance.HasVariance)

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -903,9 +903,11 @@ namespace NUnit.Framework.Tests.Assertions
             var d2 = new DistanceRecord(42);
 
             Assert.That(d2, Is.Not.EqualTo(d1), "Record Equals");
+            Assert.That(d2, Is.Not.EqualTo(d1).UsingFieldsComparer(), "FieldsComparer");
             Assert.That(d2, Is.Not.EqualTo(d1).UsingPropertiesComparer(), "PropertiesComparer");
 
             Assert.That(d2.Length, Is.EqualTo(d1.Length), "Record Equals");
+            Assert.That(d2.Length, Is.EqualTo(d1.Length).UsingFieldsComparer(), "FieldsComparer");
             Assert.That(d2.Length, Is.EqualTo(d1.Length).UsingPropertiesComparer(), "PropertiesComparer");
         }
 
@@ -916,9 +918,11 @@ namespace NUnit.Framework.Tests.Assertions
             var d2 = new DistanceStructWithAutoReadOnlyPropery(42);
 
             Assert.That(d2, Is.Not.EqualTo(d1), "ValueType Equals");
+            Assert.That(d2, Is.Not.EqualTo(d1).UsingFieldsComparer(), "FieldsComparer");
             Assert.That(d2, Is.Not.EqualTo(d1).UsingPropertiesComparer(), "PropertiesComparer");
 
             Assert.That(d2.Length, Is.EqualTo(d1.Length), "ValueType Equals");
+            Assert.That(d2.Length, Is.EqualTo(d1.Length).UsingFieldsComparer(), "FieldsComparer");
             Assert.That(d2.Length, Is.EqualTo(d1.Length).UsingPropertiesComparer(), "PropertiesComparer");
         }
 
@@ -928,7 +932,11 @@ namespace NUnit.Framework.Tests.Assertions
             var d1 = new DistanceStructWithManualReadOnlyPropery(-42);
             var d2 = new DistanceStructWithManualReadOnlyPropery(42);
 
+            Assert.That(d2, Is.Not.EqualTo(d1), "ValueType Equals");
+            Assert.That(d2, Is.Not.EqualTo(d1).UsingFieldsComparer(), "FieldsComparer");
+
             Assert.That(d2.Length, Is.EqualTo(d1.Length), "ValueType Equals");
+            Assert.That(d2.Length, Is.EqualTo(d1.Length).UsingFieldsComparer(), "FieldsComparer");
 
             // The PropertiesComparer does not support properties on structs that are not auto read-only
             // because we can't distinguish between properties with a local field and properties that do calculations.


### PR DESCRIPTION
This addresses manual properties with some backing field.

At work we use something like this as it solves both issues:
1. It doesn't matter what the backing field is.
2. Calculating properties are ignored as they don't have a backing field.

By default it compares all fields, but this can be limited to read-only properties with:
`UsingFieldsComparer(c => c.CompareOnlyInitAndReadonlyFields())`

This can be reversed if we want to change the defaults.

One option is to not make a new `FieldsComparer` but use fields in the `PropertiesComparer`.
The problem will then be with different types if the backing fields have different names.

