### PR TITLE
Remove non-generic SameAs constraint + overload

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -572,9 +572,10 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Returns a constraint that tests that two references are the same object
         /// </summary>
-        public SameAsConstraint SameAs(object? expected)
+        public SameAsConstraint<T> SameAs<T>(T? expected)
+            where T : class?
         {
-            return Append(new SameAsConstraint(expected));
+            return Append(new SameAsConstraint<T>(expected));
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/SameAsConstraint.cs
@@ -6,24 +6,16 @@ namespace NUnit.Framework.Constraints
     /// SameAsConstraint tests whether an object is identical to
     /// the object passed to its constructor
     /// </summary>
-    public class SameAsConstraint<T>(T? expected) : SameAsConstraint(expected)
+    public class SameAsConstraint<T> : Constraint
             where T : class?
     {
-    }
-
-    /// <summary>
-    /// SameAsConstraint tests whether an object is identical to
-    /// the object passed to its constructor
-    /// </summary>
-    public class SameAsConstraint : Constraint
-    {
-        private readonly object? _expected;
+        private readonly T? _expected;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SameAsConstraint"/> class.
+        /// Initializes a new instance of the <see cref="SameAsConstraint{T}"/> class.
         /// </summary>
         /// <param name="expected">The expected object.</param>
-        public SameAsConstraint(object? expected) : base(expected)
+        public SameAsConstraint(T? expected) : base(expected)
         {
             _expected = expected;
         }

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -332,14 +332,6 @@ namespace NUnit.Framework
         /// <summary>
         /// Returns a constraint that tests that two references are the same object
         /// </summary>
-        public static SameAsConstraint SameAs(object? expected)
-        {
-            return new SameAsConstraint(expected);
-        }
-
-        /// <summary>
-        /// Returns a constraint that tests that two references are the same object
-        /// </summary>
         public static SameAsConstraint<T> SameAs<T>(T? expected)
             where T : class?
         {

--- a/src/NUnitFramework/tests/Assertions/SameFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/SameFixture.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Linq;
+using NUnit.Framework.Tests.TestUtilities;
 
 namespace NUnit.Framework.Tests.Assertions
 {
@@ -35,24 +37,43 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
-        public void SameValueTypes()
-        {
-            int index = 2;
-            var expectedMessage =
-                "  Expected: same as 2" + Environment.NewLine +
-                "  But was:  2" + Environment.NewLine;
-#pragma warning disable NUnit2040 // Non-reference types for SameAs constraint
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(index, Is.SameAs(index)));
-#pragma warning restore NUnit2040 // Non-reference types for SameAs constraint
-            Assert.That(ex?.Message, Does.Contain(expectedMessage));
-        }
-
-        [Test]
         public void ShouldNotCallToStringOnClassForPassingTests()
         {
             var actual = new ThrowsIfToStringIsCalled(1);
 
             Assert.That(actual, Is.SameAs(actual));
         }
+
+        [Test]
+        public void SameValueTypes_CantCompile()
+        {
+            var testCompiler = new TestCompiler(typeof(Assert));
+            var result = testCompiler.CompileCode(ValueTypeCode);
+
+            Assert.That(result.Success, Is.False);
+
+            var error = result.Diagnostics.First(x => x.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(error.Id, Is.EqualTo("CS0452"));
+                Assert.That(error.GetMessage(), Does.StartWith("The type 'int' must be a reference type in order to use it as parameter 'T'"));
+            }
+        }
+
+        private const string ValueTypeCode = @"
+            using NUnit.Framework;
+
+            [TestFixture]
+            public class SameAsValueTypeFixture
+            {
+                [Test]
+                public void SameValueTypes()
+                {
+                    int index = 2;
+                    Assert.That(2, Is.SameAs(index));
+                }
+            }
+            ";
     }
 }

--- a/src/NUnitFramework/tests/Constraints/SameAsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/SameAsTest.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework.Tests.Constraints
         private static readonly object Obj1 = new object();
         private static readonly object Obj2 = new object();
 
-        protected override Constraint TheConstraint { get; } = new SameAsConstraint(Obj1);
+        protected override Constraint TheConstraint { get; } = new SameAsConstraint<object>(Obj1);
 
         [SetUp]
         public void SetUp()


### PR DESCRIPTION
Fixes #5145

This PR brings the changes from #2933 into v5 and completes removal of the non-generic overloads and classes for `SameAs` so that all consumers now must satisfy the `where T : class?` constraint. It also changes the valuetype-focused test to validate that a compile-time error is now thrown. Changes have been locally built with tests passing.