### PR TITLE
Add `mainthread` argument parsing to nunitlite

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/CommandLineTests.cs
@@ -169,6 +169,7 @@ namespace NUnitLite.Tests
         [TestCase("WaitBeforeExit", "wait")]
         [TestCase("NoHeader", "noheader|noh")]
         [TestCase("TeamCity", "teamcity")]
+        [TestCase("RunOnMainThread", "mainthread")]
         public void CanRecognizeBooleanOptions(string propertyName, string pattern)
         {
             Console.WriteLine("Testing " + propertyName);

--- a/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/MakeRunSettingsTests.cs
@@ -16,6 +16,7 @@ namespace NUnitLite.Tests
             new TestCaseData("--work=results", "WorkDirectory", Path.GetFullPath("results")),
             new TestCaseData("--seed=1234", "RandomSeed", 1234),
             new TestCaseData("--workers=8", "NumberOfTestWorkers", 8),
+            new TestCaseData("--mainthread", "RunOnMainThread", true),
             new TestCaseData("--prefilter=A.B.C", "LOAD", new[] { "A.B.C" }),
             new TestCaseData("--test=A.B.C", "LOAD", new[] { "A.B.C" }),
             new TestCaseData("--test=A.B.C(arg)", "LOAD", new[] { "A.B.C" }),

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -166,6 +166,8 @@ namespace NUnit.Common
         public int NumberOfTestWorkers { get; private set; } = -1;
         public bool NumberOfTestWorkersSpecified => NumberOfTestWorkers >= 0;
 
+        public bool RunOnMainThread { get; private set; }
+
         public bool StopOnError { get; private set; }
 
         public bool WaitBeforeExit { get; private set; }
@@ -371,6 +373,9 @@ namespace NUnit.Common
 
             Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
                 v => NumberOfTestWorkers = RequiredInt(v, "--workers"));
+
+            Add("mainthread", "Run tests on the same thread as the NUnitLite runner.",
+                v => RunOnMainThread = v is not null);
 
             Add("stoponerror", "Stop run immediately upon any test failure or error.",
                 v => StopOnError = v is not null);

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -359,6 +359,9 @@ namespace NUnitLite
             if (options.NumberOfTestWorkers >= 0)
                 runSettings[FrameworkPackageSettings.NumberOfTestWorkers] = options.NumberOfTestWorkers;
 
+            if (options.RunOnMainThread)
+                runSettings[FrameworkPackageSettings.RunOnMainThread] = true;
+
             if (options.InternalTraceLevel is not null)
                 runSettings[FrameworkPackageSettings.InternalTraceLevel] = options.InternalTraceLevel;
 


### PR DESCRIPTION
Fixes #4240 

Add argument parsing of a new "mainthread" command line argument to NUnitlite to allow explicit specification of the "RunOnMainThread" framework setting, allowing explicit control over if the tests run on the main application thread.