### PR TITLE
Issue5178 generic array parameter

### DIFF
--- a/src/NUnitFramework/framework/Internal/Extensions/ArgumentsExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/Extensions/ArgumentsExtensions.cs
@@ -138,15 +138,8 @@ namespace NUnit.Framework.Internal.Extensions
                 if (argsNeeded > 1)
                     return true;
 
-                // Single parameter from here on.
-
-                // The parameter is of type object, so the array is the argument, not a container.
-                if (paramType == typeof(object))
-                    return false;
-
-                // Classic argument-container pattern: new object[] { actualArg }
-                // Unpack and let the count mismatch produce a clear error.
-                return true;
+                // We expect a single argument, so we shouldn't unpack.
+                return false;
             }
         }
 

--- a/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseSourceAttributeFixture.cs
@@ -329,6 +329,21 @@ namespace NUnit.TestData.TestCaseSourceAttributeFixture
             where T : notnull
             => Assert.That(data.GetType(), Is.EqualTo(typeof(int[][])));
 
+        [TestCaseSource(nameof(IntegerArrays))]
+        public static void MethodWithSingleParameter(int i)
+        {
+        }
+
+        [TestCaseSource(nameof(IntegerArrays))]
+        public static void MethodWithThreeParameters(int i, int j, int k)
+        {
+        }
+
+        private static readonly object[] IntegerArrays =
+        {
+            new int[] { 1, 2, 3 },
+        };
+
         private class D1
         {
         }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceTests.cs
@@ -164,6 +164,30 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(n / d, Is.EqualTo(q));
         }
 
+        [Test]
+        public void SourceShouldNotUnpackArgumentsAsIntArray()
+        {
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithSingleParameter)).Tests[0];
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.Runnable));
+            ITestResult result = TestBuilder.RunTest(testMethod, null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
+                Assert.That(result.Message, Is.EqualTo("System.ArgumentException : Object of type 'System.Int32[]' cannot be converted to type 'System.Int32'."));
+            });
+        }
+
+        [Test]
+        public void SourceShouldUnpackArgumentsAsIntArray()
+        {
+            var testMethod = (TestMethod)TestBuilder.MakeParameterizedMethodSuite(
+                typeof(TestCaseSourceAttributeFixture), nameof(TestCaseSourceAttributeFixture.MethodWithThreeParameters)).Tests[0];
+            Assert.That(testMethod.RunState, Is.EqualTo(RunState.Runnable));
+            ITestResult result = TestBuilder.RunTest(testMethod, null);
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success));
+        }
+
         [TestCaseSource(nameof(MyArrayData))]
         public void SourceMayReturnArrayForArray(int[] array)
         {

--- a/src/NUnitFramework/tests/Internal/Extensions/ArgumentExtensionsTest.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/ArgumentExtensionsTest.cs
@@ -157,11 +157,11 @@ namespace NUnit.Framework.Internal.Extensions
         }
 
         [Test]
-        public void ShouldUnpackArrayAsArguments_SingleParam_NonAssignableType_ReturnsTrue()
+        public void ShouldUnpackArrayAsArguments_SingleParam_NonAssignableType_ReturnsFalse()
         {
-            // int[] is not assignable to int — unpack (will produce a count-mismatch error downstream)
+            // int[] is not assignable to int
             var parameters = new MethodWrapper(GetType(), nameof(MethodWithIntegerParameter)).GetParameters();
-            Assert.That(parameters.ShouldUnpackArrayAsArguments(new int[] { 1, 2, 3 }), Is.True);
+            Assert.That(parameters.ShouldUnpackArrayAsArguments(new int[] { 1, 2, 3 }), Is.False);
         }
 
         private void MethodWithNoParameters()


### PR DESCRIPTION
Fixes #5178 

See discussion in issue.
There is a new match on generic argument and when the method only expects a single argument, don't unpack.
