### PR TITLE
Add SameAs<T> to constraintexpression

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -577,6 +577,15 @@ namespace NUnit.Framework.Constraints
             return Append(new SameAsConstraint(expected));
         }
 
+        /// <summary>
+        /// Returns a constraint that tests that two references are the same object
+        /// </summary>
+        public static SameAsConstraint<T> SameAs<T>(T? expected)
+            where T : class?
+        {
+            return new SameAsConstraint<T>(expected);
+        }
+
         #endregion
 
         #region GreaterThan


### PR DESCRIPTION
Fixes #5194 
Adds `SameAs<T>` to ConstraintExpression for parity with `Is`