### PR TITLE
Properties Comparer Recursion Limit

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
@@ -12,18 +12,26 @@ namespace NUnit.Framework.Constraints.Comparers
         public bool TopLevelComparison { get; }
 
         /// <summary>
+        /// The number of items on the comparison stack
+        ///
+        /// This is maintained separately to the _comparisons collection because there is no O(1) count operation on ImmutableStack
+        /// </summary>
+        public int StackDepth { get; }
+
+        /// <summary>
         /// A list of tracked comparisons
         /// </summary>
         private readonly ImmutableStack<Comparison> _comparisons;
 
         public ComparisonState(bool topLevelComparison)
-            : this(topLevelComparison, ImmutableStack<Comparison>.Empty)
+            : this(topLevelComparison, 0, ImmutableStack<Comparison>.Empty)
         {
         }
 
-        private ComparisonState(bool topLevelComparison, ImmutableStack<Comparison> comparisons)
+        private ComparisonState(bool topLevelComparison, int stackDepth, ImmutableStack<Comparison> comparisons)
         {
             TopLevelComparison = topLevelComparison;
+            StackDepth = stackDepth;
             _comparisons = comparisons;
         }
 
@@ -31,6 +39,7 @@ namespace NUnit.Framework.Constraints.Comparers
         {
             return new ComparisonState(
                 false,
+                StackDepth + 1,
                 _comparisons.Push(new Comparison(x, y)));
         }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/ComparisonState.cs
@@ -13,8 +13,6 @@ namespace NUnit.Framework.Constraints.Comparers
 
         /// <summary>
         /// The number of items on the comparison stack
-        ///
-        /// This is maintained separately to the _comparisons collection because there is no O(1) count operation on ImmutableStack
         /// </summary>
         public int StackDepth { get; }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -83,7 +83,7 @@ namespace NUnit.Framework.Constraints.Comparers
 
             if (comparisonState.StackDepth > configuration.MaximumGraphDepth)
             {
-                throw new InvalidOperationException(
+                throw new InconclusiveException(
                     $"This object graph is deeper than the configured maximum of {configuration.MaximumGraphDepth}.  This may be caused by the compared objects having recursive properties.");
             }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/PropertiesComparer.cs
@@ -81,6 +81,12 @@ namespace NUnit.Framework.Constraints.Comparers
 
             ComparisonState comparisonState = state.PushComparison(x, y);
 
+            if (comparisonState.StackDepth > configuration.MaximumGraphDepth)
+            {
+                throw new InvalidOperationException(
+                    $"This object graph is deeper than the configured maximum of {configuration.MaximumGraphDepth}.  This may be caused by the compared objects having recursive properties.");
+            }
+
             BitArray redoWithoutTolerance = new BitArray(xProperties.Length);
             int toleranceNotSupportedCount = 0;
 

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -61,6 +61,11 @@ namespace NUnit.Framework.Constraints
         internal Dictionary<Type, Dictionary<string, object?>>? PropertyNameToValueMapForType { get; set; }
 
         /// <summary>
+        /// Gets and sets the maximum graph depth
+        /// </summary>
+        internal int MaximumGraphDepth { get; set; } = 32;
+
+        /// <summary>
         /// Gets and sets the tolerance to apply for time values.
         /// </summary>
         internal Tolerance TimeSpanTolerance { get; set; } = Tolerance.Default;
@@ -196,6 +201,21 @@ namespace NUnit.Framework.Constraints
         public PropertiesComparerConfigurationUntyped Within(object amount)
         {
             SetTolerance(amount);
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a maximum graph depth
+        /// </summary>
+        /// <param name="depth">The deepest graph that can be compared.</param>
+        /// <returns>Self.</returns>
+        public PropertiesComparerConfigurationUntyped WithMaximumGraphDepth(int depth)
+        {
+            if (depth < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1");
+            }
+            MaximumGraphDepth = depth;
             return this;
         }
     }
@@ -355,6 +375,17 @@ namespace NUnit.Framework.Constraints
         public PropertiesComparerConfiguration<T> Within(object amount)
         {
             SetTolerance(amount);
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a maximum graph depth
+        /// </summary>
+        /// <param name="depth">The deepest graph that can be compared.</param>
+        /// <returns>Self.</returns>
+        public PropertiesComparerConfiguration<T> WithMaximumGraphDepth(int depth)
+        {
+            MaximumGraphDepth = depth;
             return this;
         }
 

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -385,6 +385,10 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public PropertiesComparerConfiguration<T> WithMaximumGraphDepth(int depth)
         {
+            if (depth < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1");
+            }
             MaximumGraphDepth = depth;
             return this;
         }

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -213,7 +213,7 @@ namespace NUnit.Framework.Constraints
         {
             if (depth < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1");
+                throw new ArgumentOutOfRangeException(nameof(depth), depth, "Depth must be at least 1");
             }
             MaximumGraphDepth = depth;
             return this;
@@ -387,7 +387,7 @@ namespace NUnit.Framework.Constraints
         {
             if (depth < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1");
+                throw new ArgumentOutOfRangeException(nameof(depth), depth, "Depth must be at least 1");
             }
             MaximumGraphDepth = depth;
             return this;

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -1115,5 +1115,75 @@ namespace NUnit.Framework.Tests.Assertions
                 .With.Message.Contains("Expected: not equal to \"abc\"")
                 .And.Message.Contains("But was:  \"abc\""));
         }
+
+        private readonly struct InfinitelyRecursiveTestStructure
+        {
+            public int Value1 { get; init; }
+            public int Value2 { get; init; }
+            public InfinitelyRecursiveTestStructure Product => new InfinitelyRecursiveTestStructure() { Value1 = Value1 * Value2 };
+        }
+
+        [Test]
+        public void PropertyComparerThrowsExceptionForInfinitelyRecursiveGraph()
+        {
+            var objectA = new InfinitelyRecursiveTestStructure() { Value1 = 2 };
+            var objectB = new InfinitelyRecursiveTestStructure() { Value1 = 2 };
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                 Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer());
+            });
+        }
+
+        private readonly struct DepthThreeTestStructure
+        {
+            public DepthThreeTestStructure()
+            {
+            }
+            public readonly struct GrandChild
+            {
+                public int Value { get; init; }
+            }
+            public readonly struct Child
+            {
+                public Child()
+                {
+                }
+                public GrandChild MyGrandChild { get; init; } = new();
+            }
+            public Child FirstChild { get; init; } = new();
+        }
+
+        [Test]
+        public void PropertyComparerThrowsExceptionForDepthThreeWhenConfiguredForMaxDepthTwo()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer(cfg => cfg.WithMaximumGraphDepth(2)));
+            });
+        }
+
+        [Test]
+        public void PropertyComparerDoesNotThrowExceptionForDepthThreeWhenConfiguredForMaxDepthThree()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.DoesNotThrow(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer(cfg => cfg.WithMaximumGraphDepth(3)));
+            });
+        }
+
+        [Test]
+        public void PropertyComparerMaxDepthCannotBeSetToLessThanOne()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer(cfg => cfg.WithMaximumGraphDepth(0)));
+            });
+        }
     }
 }

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -1128,7 +1128,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var objectA = new InfinitelyRecursiveTestStructure() { Value1 = 2 };
             var objectB = new InfinitelyRecursiveTestStructure() { Value1 = 2 };
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<InconclusiveException>(() =>
             {
                  Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer());
             });
@@ -1158,7 +1158,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var objectA = new DepthThreeTestStructure();
             var objectB = new DepthThreeTestStructure();
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<InconclusiveException>(() =>
             {
                 Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer(cfg => cfg.WithMaximumGraphDepth(2)));
             });
@@ -1169,7 +1169,7 @@ namespace NUnit.Framework.Tests.Assertions
         {
             var objectA = new DepthThreeTestStructure();
             var objectB = new DepthThreeTestStructure();
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<InconclusiveException>(() =>
             {
                 Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer<DepthThreeTestStructure>(cfg => cfg.WithMaximumGraphDepth(2)));
             });

--- a/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertThatTests.cs
@@ -1165,6 +1165,17 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
+        public void PropertyComparerThrowsExceptionForDepthThreeWhenConfiguredForMaxDepthTwoWithGenericConfiguration()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer<DepthThreeTestStructure>(cfg => cfg.WithMaximumGraphDepth(2)));
+            });
+        }
+
+        [Test]
         public void PropertyComparerDoesNotThrowExceptionForDepthThreeWhenConfiguredForMaxDepthThree()
         {
             var objectA = new DepthThreeTestStructure();
@@ -1176,6 +1187,17 @@ namespace NUnit.Framework.Tests.Assertions
         }
 
         [Test]
+        public void PropertyComparerDoesNotThrowExceptionForDepthThreeWhenConfiguredForMaxDepthThreeWithGenericConfiguration()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.DoesNotThrow(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer<DepthThreeTestStructure>(cfg => cfg.WithMaximumGraphDepth(3)));
+            });
+        }
+
+        [Test]
         public void PropertyComparerMaxDepthCannotBeSetToLessThanOne()
         {
             var objectA = new DepthThreeTestStructure();
@@ -1183,6 +1205,17 @@ namespace NUnit.Framework.Tests.Assertions
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer(cfg => cfg.WithMaximumGraphDepth(0)));
+            });
+        }
+
+        [Test]
+        public void PropertyComparerMaxDepthCannotBeSetToLessThanOneWithGenericConfiguration()
+        {
+            var objectA = new DepthThreeTestStructure();
+            var objectB = new DepthThreeTestStructure();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Assert.That(objectA, Is.EqualTo(objectB).UsingPropertiesComparer<DepthThreeTestStructure>(cfg => cfg.WithMaximumGraphDepth(0)));
             });
         }
     }


### PR DESCRIPTION
Fixes #5211

This is a simple recursion limit to the properties comparer, to fix #5211,.  The prime aim being to prevent the test runner suffering a stack overflow and crashing.   Object graphs that exceed the configured limit will cause an exception to be thrown during comparison.

Some notes:
* I'm a first-time contributor to nunit, please review thoroughly but kindly :-)
* I have worked on the assumption that I can use pushes to the comparison state stack as a proxy for object graph depth - this works in my tests but I may have overlooked something.
* I throw `InvalidOperationException` when the depth limit is exceeded, which is a terribly bland exception type.   I don't suppose it matters much what gets thrown, but if there are better choices than this then we should change.