### PR TITLE
Make TestParameters.ArgDisplayNames getter public, #3822

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestParameters.cs
+++ b/src/NUnitFramework/framework/Internal/TestParameters.cs
@@ -142,10 +142,10 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The list of display names to use as the parameters in the test name.
         /// </summary>
-        internal string[]? ArgDisplayNames
+        public string[]? ArgDisplayNames
         {
             get;
-            set
+            internal set
             {
                 Guard.OperationValid(TestName is null || value is null,
                     "Argument display names cannot be set when TestName is set.");


### PR DESCRIPTION
This PR makes the `TestParameters.ArgDisplayNames` property getter public, so that users (and primarily for my use case, extenders) of the library can easily access the values without having to use reflection.

Note that it was discussed in #3822 that the setter could be made `protected` and force all sets to go through the fluent methods, however, those do not exist on all types (such as TestFixtureParameters, at least), so to keep it simple I stuck to leaving the setter `internal`.

Fixes #3822