### PR TITLE
Fix a few cases for how exceptions are passed to AfterX hooks

### DIFF
--- a/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
+++ b/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
@@ -167,7 +167,7 @@ namespace NUnit.Framework.Internal.ExecutionHooks
 
         internal void OnAfterTestActionBeforeTest(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
-            AfterTestActionBeforeTest.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+            AfterTestActionBeforeTest.InvokeHandlers(new HookData(context, hookedMethod, PrepareException(exceptionContext)));
         }
 
         internal void OnBeforeTestActionAfterTest(TestExecutionContext context, IMethodInfo hookedMethod)
@@ -177,7 +177,7 @@ namespace NUnit.Framework.Internal.ExecutionHooks
 
         internal void OnAfterTestActionAfterTest(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
-            AfterTestActionAfterTest.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+            AfterTestActionAfterTest.InvokeHandlers(new HookData(context, hookedMethod, PrepareException(exceptionContext)));
         }
 
         private static Exception? PrepareException(Exception? exception)

--- a/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
+++ b/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
@@ -137,7 +137,7 @@ namespace NUnit.Framework.Internal.ExecutionHooks
 
         internal void OnAfterEverySetUp(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
-            AfterEverySetUp.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+            AfterEverySetUp.InvokeHandlers(new HookData(context, hookedMethod, PrepareException(exceptionContext)));
         }
 
         internal void OnBeforeTest(TestExecutionContext context, IMethodInfo hookedMethod)
@@ -157,7 +157,7 @@ namespace NUnit.Framework.Internal.ExecutionHooks
 
         internal void OnAfterEveryTearDown(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
-            AfterEveryTearDown.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+            AfterEveryTearDown.InvokeHandlers(new HookData(context, hookedMethod, PrepareException(exceptionContext)));
         }
 
         internal void OnBeforeTestActionBeforeTest(TestExecutionContext context, IMethodInfo hookedMethod)

--- a/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
+++ b/src/NUnitFramework/framework/Internal/ExecutionHooks/ExecutionHooks.cs
@@ -147,7 +147,7 @@ namespace NUnit.Framework.Internal.ExecutionHooks
 
         internal void OnAfterTest(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
-            AfterTest.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+            AfterTest.InvokeHandlers(new HookData(context, hookedMethod, PrepareException(exceptionContext)));
         }
 
         internal void OnBeforeEveryTearDown(TestExecutionContext context, IMethodInfo hookedMethod)
@@ -178,6 +178,12 @@ namespace NUnit.Framework.Internal.ExecutionHooks
         internal void OnAfterTestActionAfterTest(TestExecutionContext context, IMethodInfo hookedMethod, Exception? exceptionContext = null)
         {
             AfterTestActionAfterTest.InvokeHandlers(new HookData(context, hookedMethod, exceptionContext));
+        }
+
+        private static Exception? PrepareException(Exception? exception)
+        {
+            exception = exception?.Unwrap();
+            return exception is SuccessException ? null : exception;
         }
     }
 }

--- a/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
+++ b/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Internal.ExecutionHooks;
 
 namespace NUnit.TestData.ExecutionHooks
 {
@@ -78,6 +81,32 @@ namespace NUnit.TestData.ExecutionHooks
 
         [OneTimeTearDown]
         public void OneTimeTearDown() => TestLog.LogCurrentMethod();
+    }
+
+    public class TestThrowsExceptionPassesExceptionToAfterHook
+    {
+        public Dictionary<string, Exception> Errors { get; } = [];
+
+        [Test]
+        [ExceptionLogging]
+        public void WrappedExceptionExample() => throw new InvalidOperationException();
+
+        [Test]
+        [ExceptionLogging]
+        public void AssertPassedExample() => Assert.Pass();
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ExceptionLoggingAttribute : ExecutionHookAttribute
+    {
+        public override void AfterTestHook(HookData hookData)
+        {
+            if (hookData.Exception is not null)
+            {
+                var fixture = hookData.Context.Test.Parent!.Fixture as TestThrowsExceptionPassesExceptionToAfterHook;
+                fixture!.Errors[hookData.Context.Test.Name] = hookData.Exception;
+            }
+        }
     }
 
     public class TestFailsWithAssertHooksProceedsToExecuteFixture

--- a/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
+++ b/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
@@ -83,20 +83,35 @@ namespace NUnit.TestData.ExecutionHooks
         public void OneTimeTearDown() => TestLog.LogCurrentMethod();
     }
 
+    [ExceptionLogging]
+    public class TestLifeCycleThrowsExceptionPassesExceptionToAfterHook
+    {
+        public Dictionary<string, Exception> SetupErrors { get; } = [];
+        public Dictionary<string, Exception> TearDownErrors { get; } = [];
+
+        [SetUp]
+        public void SetUp() => throw new InvalidOperationException(nameof(SetUp));
+
+        [TearDown]
+        public void TearDown() => throw new InvalidOperationException(nameof(TearDown));
+
+        [Test]
+        public void EmptyTest() { }
+    }
+
+    [ExceptionLogging]
     public class TestThrowsExceptionPassesExceptionToAfterHook
     {
-        public Dictionary<string, Exception> Errors { get; } = [];
+        public Dictionary<string, Exception> TestErrors { get; } = [];
 
         [Test]
-        [ExceptionLogging]
-        public void WrappedExceptionExample() => throw new InvalidOperationException();
+        public void WrappedExceptionExample() => throw new InvalidOperationException(nameof(WrappedExceptionExample));
 
         [Test]
-        [ExceptionLogging]
         public void AssertPassedExample() => Assert.Pass();
     }
 
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class)]
     public sealed class ExceptionLoggingAttribute : ExecutionHookAttribute
     {
         public override void AfterTestHook(HookData hookData)
@@ -104,7 +119,25 @@ namespace NUnit.TestData.ExecutionHooks
             if (hookData.Exception is not null)
             {
                 var fixture = hookData.Context.Test.Parent!.Fixture as TestThrowsExceptionPassesExceptionToAfterHook;
-                fixture!.Errors[hookData.Context.Test.Name] = hookData.Exception;
+                fixture!.TestErrors[hookData.Context.Test.Name] = hookData.Exception;
+            }
+        }
+
+        public override void AfterEverySetUpHook(HookData hookData)
+        {
+            if (hookData.Exception is not null)
+            {
+                var fixture = hookData.Context.Test.Parent!.Fixture as TestLifeCycleThrowsExceptionPassesExceptionToAfterHook;
+                fixture!.SetupErrors[hookData.Context.Test.Name] = hookData.Exception;
+            }
+        }
+
+        public override void AfterEveryTearDownHook(HookData hookData)
+        {
+            if (hookData.Exception is not null)
+            {
+                var fixture = hookData.Context.Test.Parent!.Fixture as TestLifeCycleThrowsExceptionPassesExceptionToAfterHook;
+                fixture!.TearDownErrors[hookData.Context.Test.Name] = hookData.Exception;
             }
         }
     }

--- a/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
+++ b/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.ExecutionHooks;
 
 namespace NUnit.TestData.ExecutionHooks
@@ -96,7 +97,9 @@ namespace NUnit.TestData.ExecutionHooks
         public void TearDown() => throw new InvalidOperationException(nameof(TearDown));
 
         [Test]
-        public void EmptyTest() { }
+        public void EmptyTest()
+        {
+        }
     }
 
     [ExceptionLogging]
@@ -109,6 +112,44 @@ namespace NUnit.TestData.ExecutionHooks
 
         [Test]
         public void AssertPassedExample() => Assert.Pass();
+    }
+
+    [ExceptionLogging]
+    public class TestActionThrowsExceptionPassesExceptionToAfterHook
+    {
+        public Dictionary<string, Exception> BeforeTestActionErrors { get; } = [];
+        public Dictionary<string, Exception> AfterTestActionErrors { get; } = [];
+
+        [Test]
+        [BeforeTestActionThrowsException]
+        [AfterTestActionThrowsException]
+        public void TestActionTest()
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class BeforeTestActionThrowsExceptionAttribute : Attribute, ITestAction
+    {
+        public void BeforeTest(ITest test) => throw new InvalidOperationException(nameof(BeforeTest));
+
+        public void AfterTest(ITest test)
+        {
+        }
+
+        public ActionTargets Targets => ActionTargets.Test;
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class AfterTestActionThrowsExceptionAttribute : Attribute, ITestAction
+    {
+        public void BeforeTest(ITest test)
+        {
+        }
+
+        public void AfterTest(ITest test) => throw new InvalidOperationException(nameof(AfterTest));
+
+        public ActionTargets Targets => ActionTargets.Test;
     }
 
     [AttributeUsage(AttributeTargets.Class)]
@@ -138,6 +179,24 @@ namespace NUnit.TestData.ExecutionHooks
             {
                 var fixture = hookData.Context.Test.Parent!.Fixture as TestLifeCycleThrowsExceptionPassesExceptionToAfterHook;
                 fixture!.TearDownErrors[hookData.Context.Test.Name] = hookData.Exception;
+            }
+        }
+
+        public override void AfterTestActionBeforeTestHook(HookData hookData)
+        {
+            if (hookData.Exception is not null)
+            {
+                var fixture = hookData.Context.Test.Parent!.Fixture as TestActionThrowsExceptionPassesExceptionToAfterHook;
+                fixture!.BeforeTestActionErrors[hookData.Context.Test.Name] = hookData.Exception;
+            }
+        }
+
+        public override void AfterTestActionAfterTestHook(HookData hookData)
+        {
+            if (hookData.Exception is not null)
+            {
+                var fixture = hookData.Context.Test.Parent!.Fixture as TestActionThrowsExceptionPassesExceptionToAfterHook;
+                fixture!.AfterTestActionErrors[hookData.Context.Test.Name] = hookData.Exception;
             }
         }
     }

--- a/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
             var obj = new TestActionThrowsExceptionPassesExceptionToAfterHook();
             var result = TestBuilder.RunTestFixture(obj);
 
-            var hookName = nameof(BeforeTestActionThrowsExceptionAttribute.AfterTest);
+            var hookName = nameof(AfterTestActionThrowsExceptionAttribute.AfterTest);
             var testName = nameof(TestActionThrowsExceptionPassesExceptionToAfterHook.TestActionTest);
 
             var ex = obj.AfterTestActionErrors[testName];

--- a/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
@@ -28,13 +28,35 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         }
 
         [Test]
+        public void TestSetUpThrowsException_HooksReceiveException()
+        {
+            var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
+            var ex = obj.SetupErrors[testName];
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void TestTearDownThrowsException_HooksReceiveException()
+        {
+            var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
+            var ex = obj.TearDownErrors[testName];
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
         public void TestThrowsException_HooksReceiveOriginalException()
         {
             var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
             var result = TestBuilder.RunTestFixture(obj);
 
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
-            var ex = obj.Errors[testName];
+            var ex = obj.TestErrors[testName];
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
         }
 
@@ -45,7 +67,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
             var result = TestBuilder.RunTestFixture(obj);
 
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.AssertPassedExample);
-            Assert.That(obj.Errors, Does.Not.ContainKey(testName));
+            Assert.That(obj.TestErrors, Does.Not.ContainKey(testName));
         }
     }
 }

--- a/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestSetUpThrowsException_HooksReceiveException()
         {
             var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var hookName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.SetUp);
             var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
@@ -44,7 +44,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestTearDownThrowsException_HooksReceiveException()
         {
             var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var hookName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.TearDown);
             var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
@@ -57,7 +57,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestThrowsException_HooksReceiveOriginalException()
         {
             var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var hookName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
@@ -70,7 +70,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestThrowsSuccessException_HooksReceiveNoException()
         {
             var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.AssertPassedExample);
             Assert.That(obj.TestErrors, Does.Not.ContainKey(testName));
@@ -80,7 +80,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestActionBeforeTestThrowsException_HooksReceiveOriginalException()
         {
             var obj = new TestActionThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var hookName = nameof(BeforeTestActionThrowsExceptionAttribute.BeforeTest);
             var testName = nameof(TestActionThrowsExceptionPassesExceptionToAfterHook.TestActionTest);
@@ -93,7 +93,7 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
         public void TestActionAfterTestThrowsException_HooksReceiveOriginalException()
         {
             var obj = new TestActionThrowsExceptionPassesExceptionToAfterHook();
-            var result = TestBuilder.RunTestFixture(obj);
+            TestBuilder.RunTestFixture(obj);
 
             var hookName = nameof(AfterTestActionThrowsExceptionAttribute.AfterTest);
             var testName = nameof(TestActionThrowsExceptionPassesExceptionToAfterHook.TestActionTest);

--- a/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
 using NUnit.Framework.Tests.TestUtilities;
 using NUnit.TestData.ExecutionHooks;
 
@@ -24,6 +25,27 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
                 nameof(TestThrowsExceptionHooksProceedsToExecuteFixture.TearDown),
                 nameof(TestThrowsExceptionHooksProceedsToExecuteFixture.OneTimeTearDown)
             ]));
+        }
+
+        [Test]
+        public void TestThrowsException_HooksReceiveOriginalException()
+        {
+            var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
+            var ex = obj.Errors[testName];
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void TestThrowsSuccessException_HooksReceiveNoException()
+        {
+            var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.AssertPassedExample);
+            Assert.That(obj.Errors, Does.Not.ContainKey(testName));
         }
     }
 }

--- a/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/ExceptionHandling/TestThrowsExceptionHooksProceedsToExecuteTests.cs
@@ -33,9 +33,11 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
             var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
             var result = TestBuilder.RunTestFixture(obj);
 
+            var hookName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.SetUp);
             var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
+
             var ex = obj.SetupErrors[testName];
-            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>().And.Message.EqualTo(hookName));
         }
 
         [Test]
@@ -44,9 +46,11 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
             var obj = new TestLifeCycleThrowsExceptionPassesExceptionToAfterHook();
             var result = TestBuilder.RunTestFixture(obj);
 
+            var hookName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.TearDown);
             var testName = nameof(TestLifeCycleThrowsExceptionPassesExceptionToAfterHook.EmptyTest);
+
             var ex = obj.TearDownErrors[testName];
-            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>().And.Message.EqualTo(hookName));
         }
 
         [Test]
@@ -55,9 +59,11 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
             var obj = new TestThrowsExceptionPassesExceptionToAfterHook();
             var result = TestBuilder.RunTestFixture(obj);
 
+            var hookName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.WrappedExceptionExample);
+
             var ex = obj.TestErrors[testName];
-            Assert.That(ex, Is.TypeOf<InvalidOperationException>());
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>().And.Message.EqualTo(hookName));
         }
 
         [Test]
@@ -68,6 +74,32 @@ namespace NUnit.Framework.Tests.ExecutionHooks.ExceptionHandling
 
             var testName = nameof(TestThrowsExceptionPassesExceptionToAfterHook.AssertPassedExample);
             Assert.That(obj.TestErrors, Does.Not.ContainKey(testName));
+        }
+
+        [Test]
+        public void TestActionBeforeTestThrowsException_HooksReceiveOriginalException()
+        {
+            var obj = new TestActionThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var hookName = nameof(BeforeTestActionThrowsExceptionAttribute.BeforeTest);
+            var testName = nameof(TestActionThrowsExceptionPassesExceptionToAfterHook.TestActionTest);
+
+            var ex = obj.BeforeTestActionErrors[testName];
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>().And.Message.EqualTo(hookName));
+        }
+
+        [Test]
+        public void TestActionAfterTestThrowsException_HooksReceiveOriginalException()
+        {
+            var obj = new TestActionThrowsExceptionPassesExceptionToAfterHook();
+            var result = TestBuilder.RunTestFixture(obj);
+
+            var hookName = nameof(BeforeTestActionThrowsExceptionAttribute.AfterTest);
+            var testName = nameof(TestActionThrowsExceptionPassesExceptionToAfterHook.TestActionTest);
+
+            var ex = obj.AfterTestActionErrors[testName];
+            Assert.That(ex, Is.TypeOf<InvalidOperationException>().And.Message.EqualTo(hookName));
         }
     }
 }


### PR DESCRIPTION
Fixes #5237 (`Assert.Pass()` shouldnt populate `Exception` property)
Fixes #5238 (Unwrap the exception before populating the hook data property)