### PR TITLE
Ensure the approach to testing path constraints is consistent across OSes and sub-constraint

### DIFF
--- a/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
@@ -63,8 +63,8 @@ namespace NUnit.Framework.Tests.Constraints
         }
     }
 
-    [TestFixture, Platform("Unix")]
-    public class SamePathTest_Linux : StringConstraintTests
+    [TestFixture]
+    public class SamePathTest_Linux : UnixConstraintTests
     {
         protected override Constraint TheConstraint { get; } = new SamePathConstraint(@"/folder1/folder2").RespectCase;
 


### PR DESCRIPTION
Relates to #1001

Fixes a minor inconsistency in how the pathing constraint tests are structured. This was something I noticed while looking into the broader concerns of #1001 and not something worth having a separate, dedicated issue over.