### PR TITLE
Issue5249 RetryException gives Inconclusive instead of Failure without SetupTeardown

### DIFF
--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -112,7 +112,7 @@ namespace NUnit.Framework
                         }
                     }
 
-                    if (context.CurrentResult.ResultState != ResultState.Failure &&
+                    if (IsRetryException(caughtException) is false && context.CurrentResult.ResultState != ResultState.Failure &&
                         IsRetryException(context.CurrentResult.RecordedException) is false)
                     {
                         break;

--- a/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
@@ -111,8 +111,7 @@ namespace NUnit.Framework
                             break;
                         }
                     }
-
-                    if (IsRetryException(caughtException) is false && context.CurrentResult.ResultState != ResultState.Failure &&
+                    else if (context.CurrentResult.ResultState != ResultState.Failure &&
                         IsRetryException(context.CurrentResult.RecordedException) is false)
                     {
                         break;

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -236,4 +236,14 @@ namespace NUnit.TestData.RepeatingTests
             throw new NullReferenceException("Failure due to badly written test");
         }
     }
+
+    public class RetryWithRetryExceptionFixtureWithoutSetupTearDown
+    {
+        [Test]
+        [Retry(tryCount: 3, RetryExceptions = [typeof(Exception)])]
+        public void RetriesButEventuallyFails()
+        {
+            throw new NullReferenceException("Failure due to badly written test");
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/RetryFixture.cs
+++ b/src/NUnitFramework/testdata/RetryFixture.cs
@@ -239,10 +239,13 @@ namespace NUnit.TestData.RepeatingTests
 
     public class RetryWithRetryExceptionFixtureWithoutSetupTearDown
     {
+        public int Count;
+
         [Test]
         [Retry(tryCount: 3, RetryExceptions = [typeof(Exception)])]
         public void RetriesButEventuallyFails()
         {
+            Count++;
             throw new NullReferenceException("Failure due to badly written test");
         }
     }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -53,9 +53,9 @@ namespace NUnit.Framework.Tests.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
+            Assert.That(fixture.TearDownResults, Has.Count.EqualTo(results.Length));
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(fixture.TearDownResults, Has.Count.EqualTo(results.Length));
                 for (int i = 0; i < results.Length; i++)
                     Assert.That(fixture.TearDownResults[i], Is.EqualTo(results[i]), $"Teardown {i} received incorrect result");
             }
@@ -95,7 +95,7 @@ namespace NUnit.Framework.Tests.Attributes
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
-                Assert.That(1, Is.EqualTo(result.FailCount), "expected that the test failed all retries");
+                Assert.That(result.FailCount, Is.EqualTo(1), "expected that the test failed all retries");
             }
         }
 
@@ -108,7 +108,7 @@ namespace NUnit.Framework.Tests.Attributes
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
-                Assert.That(0, Is.EqualTo(result.FailCount), "expected that the test passed final retry");
+                Assert.That(result.FailCount, Is.EqualTo(0), "expected that the test passed final retry");
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -118,7 +118,12 @@ namespace NUnit.Framework.Tests.Attributes
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed after 2nd retry");
             Assert.That(fixture.Count, Is.EqualTo(1), "expected that the test stopped after 2nd retry");
-            Assert.That(result.Message, Does.Contain(typeof(OperationCanceledException).Name), "expected that the final exception was the OperationCanceledException");
+using (Assert.EnterMultipleScope())
+{
+    Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed after 2nd retry");
+    Assert.That(fixture.Count, Is.EqualTo(1), "expected that the test stopped after 2nd retry");
+    Assert.That(result.Message, Does.Contain(typeof(OperationCanceledException).Name), "expected that the final exception was the OperationCanceledException");
+}
         }
 
         [Test]
@@ -138,9 +143,12 @@ namespace NUnit.Framework.Tests.Attributes
             RetryWithRetryExceptionFixtureWithoutSetupTearDown fixture = (RetryWithRetryExceptionFixtureWithoutSetupTearDown)Reflect.Construct(typeof(RetryWithRetryExceptionFixtureWithoutSetupTearDown));
             ITestResult result = TestBuilder.RunTestCase(fixture, "RetriesButEventuallyFails");
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
-            Assert.That(fixture.Count, Is.EqualTo(3), "expected that the test executes all three tries");
-            Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
+                Assert.That(fixture.Count, Is.EqualTo(3), "expected that the test executes all three tries");
+                Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -27,13 +27,15 @@ namespace NUnit.Framework.Tests.Attributes
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
             ITestResult result = TestBuilder.RunTestFixture(fixture);
-
-            Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
-            Assert.That(fixture.FixtureSetupCount, Is.EqualTo(1));
-            Assert.That(fixture.FixtureTeardownCount, Is.EqualTo(1));
-            Assert.That(fixture.SetupCount, Is.EqualTo(nTries));
-            Assert.That(fixture.TeardownCount, Is.EqualTo(nTries));
-            Assert.That(fixture.Count, Is.EqualTo(nTries));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
+                Assert.That(fixture.FixtureSetupCount, Is.EqualTo(1));
+                Assert.That(fixture.FixtureTeardownCount, Is.EqualTo(1));
+                Assert.That(fixture.SetupCount, Is.EqualTo(nTries));
+                Assert.That(fixture.TeardownCount, Is.EqualTo(nTries));
+                Assert.That(fixture.Count, Is.EqualTo(nTries));
+            }
         }
 
         [TestCase(typeof(RetrySucceedsOnFirstTryFixture), "Passed")]
@@ -51,9 +53,12 @@ namespace NUnit.Framework.Tests.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(fixtureType);
             ITestResult result = TestBuilder.RunTestFixture(fixture);
 
-            Assert.That(fixture.TearDownResults, Has.Count.EqualTo(results.Length));
-            for (int i = 0; i < results.Length; i++)
-                Assert.That(fixture.TearDownResults[i], Is.EqualTo(results[i]), $"Teardown {i} received incorrect result");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fixture.TearDownResults, Has.Count.EqualTo(results.Length));
+                for (int i = 0; i < results.Length; i++)
+                    Assert.That(fixture.TearDownResults[i], Is.EqualTo(results[i]), $"Teardown {i} received incorrect result");
+            }
         }
 
         [TestCase(nameof(RetryWithoutSetUpOrTearDownFixture.SucceedsOnThirdTry), "Passed", 3)]
@@ -63,9 +68,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var fixture = (RetryWithoutSetUpOrTearDownFixture)Reflect.Construct(typeof(RetryWithoutSetUpOrTearDownFixture));
             ITestResult result = TestBuilder.RunTestCase(fixture, methodName);
-
-            Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
-            Assert.That(fixture.Count, Is.EqualTo(nTries));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState.ToString(), Is.EqualTo(outcome));
+                Assert.That(fixture.Count, Is.EqualTo(nTries));
+            }
         }
 
         [Test]
@@ -85,9 +92,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, "NeverPasses");
-
-            Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.That(1, Is.EqualTo(result.FailCount), "expected that the test failed all retries");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
+                Assert.That(1, Is.EqualTo(result.FailCount), "expected that the test failed all retries");
+            }
         }
 
         [Test]
@@ -96,8 +105,11 @@ namespace NUnit.Framework.Tests.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryTestVerifyAttempt));
             ITestResult result = TestBuilder.RunTestCase(fixture, "PassesOnLastRetry");
 
-            Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
-            Assert.That(0, Is.EqualTo(result.FailCount), "expected that the test passed final retry");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
+                Assert.That(0, Is.EqualTo(result.FailCount), "expected that the test passed final retry");
+            }
         }
 
         [Test]
@@ -106,8 +118,11 @@ namespace NUnit.Framework.Tests.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryWithRetryExceptionFixture));
             ITestResult result = TestBuilder.RunTestCase(fixture, "RetriesOnAllowedException");
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Success), "expected that the test passed final retry");
-            Assert.That(fixture.Count, Is.EqualTo(2), "expected that the test needed 3 tries");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Success), "expected that the test passed final retry");
+                Assert.That(fixture.Count, Is.EqualTo(2), "expected that the test needed 3 tries");
+            }
         }
 
         [Test]
@@ -116,14 +131,12 @@ namespace NUnit.Framework.Tests.Attributes
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryWithRetryExceptionFixture));
             ITestResult result = TestBuilder.RunTestCase(fixture, "OnlyRetriesOnAllowedException");
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed after 2nd retry");
-            Assert.That(fixture.Count, Is.EqualTo(1), "expected that the test stopped after 2nd retry");
-using (Assert.EnterMultipleScope())
-{
-    Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed after 2nd retry");
-    Assert.That(fixture.Count, Is.EqualTo(1), "expected that the test stopped after 2nd retry");
-    Assert.That(result.Message, Does.Contain(typeof(OperationCanceledException).Name), "expected that the final exception was the OperationCanceledException");
-}
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed after 2nd retry");
+                Assert.That(fixture.Count, Is.EqualTo(1), "expected that the test stopped after 2nd retry");
+                Assert.That(result.Message, Does.Contain(typeof(OperationCanceledException).Name), "expected that the final exception was the OperationCanceledException");
+            }
         }
 
         [Test]
@@ -132,9 +145,12 @@ using (Assert.EnterMultipleScope())
             RepeatingTestsFixtureBase fixture = (RepeatingTestsFixtureBase)Reflect.Construct(typeof(RetryWithRetryExceptionFixture));
             ITestResult result = TestBuilder.RunTestCase(fixture, "RetriesButEventuallyFails");
 
-            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
-            Assert.That(fixture.Count, Is.EqualTo(2), "expected that the test stopped after 3rd retry");
-            Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
+                Assert.That(fixture.Count, Is.EqualTo(2), "expected that the test stopped after 3rd retry");
+                Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
+            }
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -131,5 +131,15 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(fixture.Count, Is.EqualTo(2), "expected that the test stopped after 3rd retry");
             Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
         }
+
+        [Test]
+        public void RetryOnAllowedExceptionTooManyRetriesWithoutSetupTeardown()
+        {
+            object fixture = Reflect.Construct(typeof(RetryWithRetryExceptionFixtureWithoutSetupTearDown));
+            ITestResult result = TestBuilder.RunTestCase(fixture, "RetriesButEventuallyFails");
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
+            Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -135,10 +135,11 @@ namespace NUnit.Framework.Tests.Attributes
         [Test]
         public void RetryOnAllowedExceptionTooManyRetriesWithoutSetupTeardown()
         {
-            object fixture = Reflect.Construct(typeof(RetryWithRetryExceptionFixtureWithoutSetupTearDown));
+            RetryWithRetryExceptionFixtureWithoutSetupTearDown fixture = (RetryWithRetryExceptionFixtureWithoutSetupTearDown)Reflect.Construct(typeof(RetryWithRetryExceptionFixtureWithoutSetupTearDown));
             ITestResult result = TestBuilder.RunTestCase(fixture, "RetriesButEventuallyFails");
 
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Error), "expected that the test failed every retry");
+            Assert.That(fixture.Count, Is.EqualTo(3), "expected that the test executes all three tries");
             Assert.That(result.Message, Does.Contain(typeof(NullReferenceException).Name), "expected that the final exception was the NullReferenceException");
         }
     }


### PR DESCRIPTION
Fixes #5249

As the `RetryAttribute` does not record exceptions until the last try, the `ResultState` of the run stays at the default `Inconclusive` which stops the execution [here](https://github.com/nunit/nunit/compare/main...ackhack:nunit:fix/simple?expand=1#diff-992e9e12fb8a81342f53f63f5813376f4ac8016a1b5dc46a100b324fd10be47bR115).

Updating `RetryCommand.Execute` to not stop when `caughtException` is not one of the `RetryExceptions` fixes this issue.

The existing unit test about this circumstance called `RetryOnAllowedExceptionTooManyRetries` only works because the fixture has `Setup` and `Teardown` methods.

`RetryExceptions` behave differently when running inside a `SetUpTearDownCommand` (derived from `BeforeAndAfterTestCommand`) opposed to the `RetryCommand` directly as `BeforeAndAfterTestCommand` uses `DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone` which records the exception while `RetryCommand` itself does not.

I added a unit test that checks that exact circumstance called `RetryOnAllowedExceptionTooManyRetriesWithoutSetupTeardown`.