### PR TITLE
Fix for cross-type equivalency checks

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -256,10 +256,12 @@ namespace NUnit.Framework.Constraints
             }
             else
             {
-                var underlyingType = expected.GetType().FindPrimaryEnumerableInterfaceGenericTypeArgument();
-                if (underlyingType is not null && underlyingType == actual.GetType().FindPrimaryEnumerableInterfaceGenericTypeArgument())
+                var expectedUnderlyingType = expected.GetType().FindPrimaryEnumerableInterfaceGenericTypeArgument();
+                var actualUnderlyingType = actual.GetType().FindPrimaryEnumerableInterfaceGenericTypeArgument();
+
+                if (expectedUnderlyingType is not null && expectedUnderlyingType == actualUnderlyingType)
                 {
-                    var method = TallyResultCoreMethod.MakeGenericMethod(underlyingType);
+                    var method = TallyResultCoreMethod.MakeGenericMethod(expectedUnderlyingType);
                     return (CollectionTally.CollectionTallyResult)method.Invoke(null, [expected, actual, comparer])!;
                 }
 

--- a/src/NUnitFramework/framework/Constraints/CollectionTally{T}.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally{T}.cs
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Constraints
         {
             bool contentsArePrimitive = typeof(T).IsPrimitive;
             bool contentsAreSortable = typeof(T) != typeof(object) && (contentsArePrimitive || c.IsSortable());
-            bool fuzzyCompare = comparer.IsModified || !(contentsArePrimitive || typeof(T).CanUseDefaultEquality());
+            bool fuzzyCompare = typeof(T) == typeof(object) || comparer.IsModified || !(contentsArePrimitive || typeof(T).CanUseDefaultEquality());
 
             IEqualityComparer<T> equalityComparer = fuzzyCompare ? new NUnitEqualityComparerAdapter<T>(comparer) : EqualityComparer<T>.Default;
             StrategyKey key = new(contentsArePrimitive, contentsAreSortable, fuzzyCompare);
@@ -72,7 +72,7 @@ namespace NUnit.Framework.Constraints
             bool contentsArePrimitive = false;
             // When T is object, we can't rely on sorting because the runtime types may vary and produce unpredictable sort orders
             bool contentsAreSortable = typeof(T) != typeof(object) && (contentsArePrimitive || c.IsSortable());
-            bool fuzzyCompare = comparer.IsModified;
+            bool fuzzyCompare = typeof(T) == typeof(object) || comparer.IsModified;
             if (!fuzzyCompare)
             {
                 var underlyingType = c.GetType().FindPrimaryEnumerableInterfaceGenericTypeArgument();

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -294,14 +294,23 @@ public class CollectionEquivalentConstraintTests
         Assert.That(constraint.ApplyTo(hash).IsSuccess);
     }
 
-    [Test]
-    public void WorksWithArraysOfCompatibleYetDifferentTypes()
+    [TestCaseSource(nameof(ArrayCompatibilitySource))]
+    public void WorksWithArraysOfCompatibleYetDifferentTypes<T1, T2>(T1 actual, T2 expected)
+        where T1 : IEnumerable
+        where T2 : IEnumerable
     {
-        var longs = new long[] { 1L, 2L, 3L };
-        var ints = new int[] { 1, 2, 3 };
+        Assert.That(actual, Is.EquivalentTo(expected));
+        Assert.That(expected, Is.EquivalentTo(actual));
+    }
 
-        Assert.That(longs, Is.EquivalentTo(ints));
-        Assert.That(ints, Is.EquivalentTo(longs));
+    private static IEnumerable<TestCaseParameters> ArrayCompatibilitySource()
+    {
+        yield return new TestCaseData<long[], int[]>([1L, 2L, 3L], [1, 2, 3]);
+        yield return new TestCaseData<long[], object[]>([1L, 2L, 3L], [1, 2, 3]);
+        yield return new TestCaseData<object[], object[]>([1L, 2L, 3L], [1, 2, 3]);
+        yield return new TestCaseData<int[], double[]>([1, 2, 3], [1.0d, 2.0d, 3.0d]);
+        yield return new TestCaseData<decimal[], double[]>([1.0m, 2.0m, 3.0m], [1.0d, 2.0d, 3.0d]);
+        yield return new TestCaseData<string, char[]>("NUnit", ['t', 'i', 'n', 'U', 'N']);
     }
 
     [Test]

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -305,6 +305,18 @@ public class CollectionEquivalentConstraintTests
     }
 
     [Test]
+    public void FailureWithIncompatibleActualValue()
+    {
+        var expected = new int[] { 1, 2, 3 };
+        var actual = new { hello = "world" };
+
+        var ex = Assert.Throws<ArgumentException>(() => Assert.That(actual, Is.EquivalentTo(expected)));
+
+        Assert.That(ex!.ParamName, Is.EqualTo("actual"));
+        Assert.That(ex.Message, Does.Contain(actual.GetType().Name));
+    }
+
+    [Test]
     public void FailureMessageWithHashSetAndArray()
     {
         var hash = new HashSet<string>(new[] { "presto", "abracadabra", "hocuspocus" });

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -312,7 +312,8 @@ public class CollectionEquivalentConstraintTests
 
         var ex = Assert.Throws<ArgumentException>(() => Assert.That(actual, Is.EquivalentTo(expected)));
 
-        Assert.That(ex!.ParamName, Is.EqualTo("actual"));
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex.ParamName, Is.EqualTo("actual"));
         Assert.That(ex.Message, Does.Contain(actual.GetType().Name));
     }
 

--- a/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintTests.cs
@@ -295,6 +295,16 @@ public class CollectionEquivalentConstraintTests
     }
 
     [Test]
+    public void WorksWithArraysOfCompatibleYetDifferentTypes()
+    {
+        var longs = new long[] { 1L, 2L, 3L };
+        var ints = new int[] { 1, 2, 3 };
+
+        Assert.That(longs, Is.EquivalentTo(ints));
+        Assert.That(ints, Is.EquivalentTo(longs));
+    }
+
+    [Test]
     public void FailureMessageWithHashSetAndArray()
     {
         var hash = new HashSet<string>(new[] { "presto", "abracadabra", "hocuspocus" });


### PR DESCRIPTION
Fixes #5258

A ~quick copilot-guided~ targeted fix for cross-type equivalency checks. ~Creating this as a draft for now.~