### PR TITLE
Add warning threshold support to MaxTimeAttribute (#5260)

### DIFF
--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -13,6 +13,12 @@ namespace NUnit.Framework
     public sealed class MaxTimeAttribute : PropertyAttribute, IWrapSetUpTearDown
     {
         private readonly int _milliseconds;
+
+        /// <summary>
+        /// Gets or sets an optional warning threshold in milliseconds.
+        /// If the test takes longer than this time, but less than the maximum time, a warning is issued.
+        /// </summary>
+        public int WarningTime { get; set; }
         /// <summary>
         /// Construct a MaxTimeAttribute, given a time in milliseconds.
         /// </summary>
@@ -27,7 +33,7 @@ namespace NUnit.Framework
 
         TestCommand ICommandWrapper.Wrap(TestCommand command)
         {
-            return new MaxTimeCommand(command, _milliseconds);
+            return new MaxTimeCommand(command, _milliseconds, WarningTime);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework
         /// Gets or sets an optional warning threshold in milliseconds.
         /// If the test takes longer than this time, but less than the maximum time, a warning is issued.
         /// </summary>
-        public int? WarningTime { get; set; }
+        public int WarningTime { get; set; }
         /// <summary>
         /// Construct a MaxTimeAttribute, given a time in milliseconds.
         /// </summary>

--- a/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/MaxTimeAttribute.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework
         /// Gets or sets an optional warning threshold in milliseconds.
         /// If the test takes longer than this time, but less than the maximum time, a warning is issued.
         /// </summary>
-        public int WarningTime { get; set; }
+        public int? WarningTime { get; set; }
         /// <summary>
         /// Construct a MaxTimeAttribute, given a time in milliseconds.
         /// </summary>

--- a/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
@@ -17,7 +17,8 @@ namespace NUnit.Framework.Internal.Commands
         /// </summary>
         /// <param name="innerCommand">The inner command.</param>
         /// <param name="maxTime">The max time allowed in milliseconds</param>
-        public MaxTimeCommand(TestCommand innerCommand, int maxTime)
+        ///  <param name="warningTime">Gets or sets an optional warning threshold in milliseconds </param>
+        public MaxTimeCommand(TestCommand innerCommand, int maxTime, int warningTime)
             : base(innerCommand)
         {
             AfterTest = context =>
@@ -42,6 +43,11 @@ namespace NUnit.Framework.Internal.Commands
                     {
                         result.SetResult(ResultState.Failure,
                             $"Elapsed time of {elapsedTime}ms exceeds maximum of {maxTime}ms");
+                    }
+                    else if (warningTime > 0 && elapsedTime > warningTime)
+                    {
+                        result.SetResult(ResultState.Warning,
+                            $"Elapsed time of {elapsedTime}ms exceeds warning threshold of {warningTime}ms");
                     }
                 }
             };

--- a/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
@@ -17,8 +17,18 @@ namespace NUnit.Framework.Internal.Commands
         /// </summary>
         /// <param name="innerCommand">The inner command.</param>
         /// <param name="maxTime">The max time allowed in milliseconds</param>
+        public MaxTimeCommand(TestCommand innerCommand, int maxTime)
+            : this(innerCommand, maxTime, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaxTimeCommand"/> class.
+        /// </summary>
+        /// <param name="innerCommand">The inner command.</param>
+        /// <param name="maxTime">The max time allowed in milliseconds</param>
         ///  <param name="warningTime">Gets or sets an optional warning threshold in milliseconds </param>
-        public MaxTimeCommand(TestCommand innerCommand, int maxTime, int warningTime)
+        public MaxTimeCommand(TestCommand innerCommand, int maxTime, int? warningTime)
             : base(innerCommand)
         {
             AfterTest = context =>
@@ -44,10 +54,10 @@ namespace NUnit.Framework.Internal.Commands
                         result.SetResult(ResultState.Failure,
                             $"Elapsed time of {elapsedTime}ms exceeds maximum of {maxTime}ms");
                     }
-                    else if (warningTime > 0 && elapsedTime > warningTime)
+                    else if (warningTime.HasValue && elapsedTime > warningTime)
                     {
                         result.SetResult(ResultState.Warning,
-                            $"Elapsed time of {elapsedTime}ms exceeds warning threshold of {warningTime}ms");
+                            $"Elapsed time of {elapsedTime}ms exceeds warning threshold of {warningTime.Value}ms");
                     }
                 }
             };

--- a/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/MaxTimeCommand.cs
@@ -18,7 +18,7 @@ namespace NUnit.Framework.Internal.Commands
         /// <param name="innerCommand">The inner command.</param>
         /// <param name="maxTime">The max time allowed in milliseconds</param>
         public MaxTimeCommand(TestCommand innerCommand, int maxTime)
-            : this(innerCommand, maxTime, null)
+            : this(innerCommand, maxTime, 0)
         {
         }
 
@@ -28,7 +28,7 @@ namespace NUnit.Framework.Internal.Commands
         /// <param name="innerCommand">The inner command.</param>
         /// <param name="maxTime">The max time allowed in milliseconds</param>
         ///  <param name="warningTime">Gets or sets an optional warning threshold in milliseconds </param>
-        public MaxTimeCommand(TestCommand innerCommand, int maxTime, int? warningTime)
+        public MaxTimeCommand(TestCommand innerCommand, int maxTime, int warningTime)
             : base(innerCommand)
         {
             AfterTest = context =>
@@ -54,10 +54,10 @@ namespace NUnit.Framework.Internal.Commands
                         result.SetResult(ResultState.Failure,
                             $"Elapsed time of {elapsedTime}ms exceeds maximum of {maxTime}ms");
                     }
-                    else if (warningTime.HasValue && elapsedTime > warningTime)
+                    else if (warningTime > 0 && elapsedTime > warningTime)
                     {
                         result.SetResult(ResultState.Warning,
-                            $"Elapsed time of {elapsedTime}ms exceeds warning threshold of {warningTime.Value}ms");
+                            $"Elapsed time of {elapsedTime}ms exceeds warning threshold of {warningTime}ms");
                     }
                 }
             };

--- a/src/NUnitFramework/testdata/MaxTimeFixture.cs
+++ b/src/NUnitFramework/testdata/MaxTimeFixture.cs
@@ -52,7 +52,7 @@ namespace NUnit.TestData
     [TestFixture]
     public class MaxTimeFixtureWithWarning
     {
-        [Test, MaxTime(100, WarningTime = 20)]
+        [Test, MaxTime(2000, WarningTime = 20)]
         public void WarningTimeExceeded()
         {
             Thread.Sleep(30);

--- a/src/NUnitFramework/testdata/MaxTimeFixture.cs
+++ b/src/NUnitFramework/testdata/MaxTimeFixture.cs
@@ -48,4 +48,14 @@ namespace NUnit.TestData
             throw new Exception("Exception message");
         }
     }
+
+    [TestFixture]
+    public class MaxTimeFixtureWithWarning
+    {
+        [Test, MaxTime(100, WarningTime = 20)]
+        public void WarningTimeExceeded()
+        {
+            Thread.Sleep(30);
+        }
+    }
 }

--- a/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/MaxTimeTests.cs
@@ -64,5 +64,14 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(result.ResultState, Is.EqualTo(ResultState.Error));
             Assert.That(result.Message, Does.Contain("Exception message"));
         }
+
+        [Test]
+        public void WarningThresholdExceeded()
+        {
+            ITestResult suiteResult = TestBuilder.RunTestFixture(typeof(MaxTimeFixtureWithWarning));
+            ITestResult result = suiteResult.Children.ToArray()[0];
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Warning));
+            Assert.That(result.Message, Does.Contain("exceeds warning threshold of 20ms"));
+        }
     }
 }


### PR DESCRIPTION
### Description
Resolves #5260.

This PR introduces the ability to set a warning threshold for the `[MaxTime]` attribute, issuing a `ResultState.Warning` if a test takes longer than the expected threshold but still passes within the maximum allowed time.

### Implementation Details
* Added `WarningThreshold` property to `MaxTimeAttribute`. Kept it as a named parameter to strictly preserve backward compatibility with existing constructors.
* Updated `MaxTimeCommand` to evaluate the elapsed time against the `WarningThreshold` and set the result to `Warning` if the condition is met and the test was otherwise successful.

### Testing
* Added a new mock fixture `MaxTimeFixtureWithWarning` in `NUnit.TestData` designed specifically to exceed the warning threshold while remaining under the maximum time limit.
* Validated the architecture in `MaxTimeTests.cs` using `TestBuilder.RunTestFixture` to guarantee the engine correctly outputs the `ResultState.Warning` and the expected failure message.