### PR TITLE
Add regression tests for Assert.Catch inside Assert.Multiple

### DIFF
--- a/src/NUnitFramework/testdata/AssertMultipleData.cs
+++ b/src/NUnitFramework/testdata/AssertMultipleData.cs
@@ -584,6 +584,36 @@ namespace NUnit.TestData.AssertMultipleData
             }
         }
 
+        /// <summary>
+        /// Reproduces issue #3849: Assert.Catch inside Assert.Multiple should report
+        /// a clear assertion failure when the exception type doesn't match, not throw
+        /// an InvalidCastException.
+        /// </summary>
+        [Test]
+        public void AssertCatchWithWrongExceptionType()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Catch<ArgumentException>(() => throw new InvalidOperationException("Test exception"));
+            });
+        }
+
+        /// <summary>
+        /// Reproduces issue #3849: Multiple Assert.Catch failures inside Assert.Multiple
+        /// should all be reported clearly.
+        /// </summary>
+        [Test]
+        public void AssertCatchWithMultipleFailures()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(1, Is.EqualTo(2));
+                Assert.Catch<ArgumentException>(() => throw new InvalidOperationException("First"));
+                Assert.Catch<ArgumentException>(() => { }); // No exception thrown
+                Assert.That("A", Is.EqualTo("B"));
+            });
+        }
+
         private static readonly object[] DetectFailuresInsideMultipleTestCases =
         [
             new object[] { 1, 1, string.Empty },

--- a/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
+++ b/src/NUnitFramework/tests/Assertions/AssertMultipleTests.cs
@@ -89,6 +89,45 @@ namespace NUnit.Framework.Tests.Assertions
             CheckResult(methodName, ResultState.Error, asserts, assertionMessages);
         }
 
+        /// <summary>
+        /// Issue #3849: Assert.Catch inside Assert.Multiple with wrong exception type
+        /// should report a clear assertion failure, not throw InvalidCastException.
+        /// </summary>
+        [Test]
+        public void AssertCatchInsideMultiple_WrongExceptionType_ShouldReportFailure()
+        {
+            ITestResult result = TestBuilder.RunTestCase(typeof(AssertMultipleFixture), nameof(AM.AssertCatchWithWrongExceptionType));
+
+            // The test should fail with a proper assertion message, not Error with InvalidCastException
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed), "Should be Failed, not Error");
+                Assert.That(result.ResultState, Is.Not.EqualTo(ResultState.Error), "Should not be Error state");
+                Assert.That(result.Message, Does.Not.Contain("InvalidCastException"), "Should not contain InvalidCastException");
+                Assert.That(result.Message, Does.Contain("ArgumentException").Or.Contain("InvalidOperationException"),
+                    "Should mention the expected or actual exception type");
+            });
+        }
+
+        /// <summary>
+        /// Issue #3849: Multiple failures including Assert.Catch inside Assert.Multiple
+        /// should all be reported clearly.
+        /// </summary>
+        [Test]
+        public void AssertCatchInsideMultiple_MultipleFailures_ShouldReportAll()
+        {
+            ITestResult result = TestBuilder.RunTestCase(typeof(AssertMultipleFixture), nameof(AM.AssertCatchWithMultipleFailures));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Failed), "Should be Failed");
+                Assert.That(result.ResultState, Is.Not.EqualTo(ResultState.Error), "Should not be Error state");
+                // Should have multiple assertion failures reported
+                Assert.That(result.AssertionResults.Count, Is.GreaterThanOrEqualTo(2),
+                    "Should report multiple assertion failures");
+            });
+        }
+
         [TestCase(nameof(AM.AssertPassInBlock), "Assert.Pass")]
         [TestCase(nameof(AM.AssertIgnoreInBlock), "Assert.Ignore")]
         [TestCase(nameof(AM.AssertInconclusiveInBlock), "Assert.Inconclusive")]


### PR DESCRIPTION
## Summary
- Adds regression tests for Issue #3849
- Verifies that `Assert.Catch` inside `Assert.Multiple` reports clear assertion failure messages
- Tests confirm that `InvalidCastException` is no longer thrown when exception types don't match

## Background
The original bug occurred because `Catch<TActual>` used explicit casting `(TActual?)Throws(...)` which throws `InvalidCastException` when the caught exception isn't of the expected type. The fix (already in main) uses `as TExpected` which returns null instead of throwing.

These tests serve as regression tests to ensure the fix remains in place.

## Test plan
- [x] Build succeeds
- [x] New tests pass (verifying correct behavior)
- [x] Tests would fail with the old behavior (verified against NUnit 4.0.1)

Fixes #3849

🤖 Generated with [Claude Code](https://claude.com/claude-code)