### PR TITLE
WIP Add failing test for IEquatable+IEnumerable error messages

### DIFF
--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
 using NUnit.Framework.Tests.TestUtilities.Comparers;
 using NUnit.Framework.Constraints.Comparers;
 using System.Threading.Tasks;
@@ -1196,6 +1197,77 @@ namespace NUnit.Framework.Tests.Constraints
             }
 
             private class Type3 : Type2;
+        }
+
+        #endregion
+
+        #region Issue 4140 - IEnumerable + IEquatable error messages
+
+        /// <summary>
+        /// Issue #4140: When a class implements both IEquatable&lt;T&gt; and IEnumerable&lt;T&gt;,
+        /// the error message should provide meaningful details about the difference,
+        /// not just "Expected and actual are both {type}".
+        /// </summary>
+        public class IEnumerableWithIEquatableErrorMessages
+        {
+            /// <summary>
+            /// When comparing two objects that implement both IEquatable and IEnumerable
+            /// and they differ, the error message should show what values differ.
+            /// </summary>
+            [Test]
+            public void ErrorMessage_ShouldShowValueDifference_WhenIEquatableAndIEnumerable()
+            {
+                var expected = new TestEnumerableEquatable("expected", 1);
+                var actual = new TestEnumerableEquatable("actual", 1);
+
+                var constraint = new EqualConstraint(expected);
+                var result = constraint.ApplyTo(actual);
+
+                Assert.That(result.IsSuccess, Is.False, "Objects should not be equal");
+
+                var msgWriter = new TextMessageWriter();
+                result.WriteMessageTo(msgWriter);
+                string message = msgWriter.ToString();
+
+                // The error message should NOT be the generic "Expected and actual are both" message
+                // It should contain information about what differs
+                Assert.That(message, Does.Not.Contain("Expected and actual are both"),
+                    "Error message should not use generic 'Expected and actual are both' format");
+
+                // The message should contain some indication of the expected or actual values
+                Assert.That(message, Does.Contain("expected").Or.Contain("actual"),
+                    "Error message should contain information about the differing values");
+            }
+
+            /// <summary>
+            /// Test class implementing both IEquatable and IEnumerable
+            /// </summary>
+            private class TestEnumerableEquatable : IEnumerable<int>, IEquatable<TestEnumerableEquatable>
+            {
+                private readonly string _name;
+                private readonly int[] _values;
+
+                public TestEnumerableEquatable(string name, params int[] values)
+                {
+                    _name = name;
+                    _values = values;
+                }
+
+                public bool Equals(TestEnumerableEquatable? other)
+                {
+                    return other is not null && _name == other._name;
+                }
+
+                public override bool Equals(object? obj) => obj is TestEnumerableEquatable other && Equals(other);
+
+                public override int GetHashCode() => _name.GetHashCode();
+
+                public override string ToString() => $"TestEnumerableEquatable({_name}, [{string.Join(", ", _values)}])";
+
+                public IEnumerator<int> GetEnumerator() => ((IEnumerable<int>)_values).GetEnumerator();
+
+                IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1234,9 +1234,11 @@ namespace NUnit.Framework.Tests.Constraints
                 Assert.That(message, Does.Not.Contain("Expected and actual are both"),
                     "Error message should not use generic 'Expected and actual are both' format");
 
-                // The message should contain some indication of the expected or actual values
-                Assert.That(message, Does.Contain("expected").Or.Contain("actual"),
-                    "Error message should contain information about the differing values");
+                // The message should contain the ToString() output of the objects
+                // showing the actual differing values, not just the type name
+                Assert.That(message,
+                    Does.Contain("TestEnumerableEquatable(expected").Or.Contain("TestEnumerableEquatable(actual"),
+                    "Error message should contain the ToString() representation of the differing values");
             }
 
             /// <summary>


### PR DESCRIPTION
## Summary
- Adds failing test for Issue #4140
- Test verifies that error messages for classes implementing both `IEquatable<T>` and `IEnumerable<T>` should show meaningful value differences

## Background
When a class implements both `IEquatable<T>` and `IEnumerable<T>`, NUnit's `IsEqualTo` assertions produce a generic error message:
```
Expected and actual are both <TypeName>
```

Instead of the helpful message that shows what values differ:
```
Expected: <expected value>
But was:  <actual value>
```

This makes debugging impossible because users can't tell what actually differed between the objects. The issue is particularly common with C# `record` types (which auto-implement `IEquatable<T>`) and built-in types like `ImmutableArray`.

## Test plan
- [x] Build succeeds
- [x] Test **fails** (demonstrating the bug exists)

The fix would likely involve adjusting how the `EqualConstraint` determines which comparison method to use when both interfaces are present.

Fixes #4140

🤖 Generated with [Claude Code](https://claude.com/claude-code)