### PR TITLE
AI Slop: test: add direct coverage for RetryExceptions and IgnoreReason (5279)

### DIFF
--- a/src/NUnitFramework/tests/Attributes/AssemblyMarkerAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/AssemblyMarkerAttributeTests.cs
@@ -12,11 +12,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var attributeUsage = typeof(NonTestAssemblyAttribute).GetCustomAttribute<AttributeUsageAttribute>();
 
+            Assert.That(attributeUsage, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(new NonTestAssemblyAttribute(), Is.InstanceOf<NUnitAttribute>());
-                Assert.That(attributeUsage, Is.Not.Null);
-                Assert.That(attributeUsage!.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
+                Assert.That(attributeUsage.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
                 Assert.That(attributeUsage.AllowMultiple, Is.False);
                 Assert.That(attributeUsage.Inherited, Is.False);
             });
@@ -27,11 +27,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var attributeUsage = typeof(TestAssemblyDirectoryResolveAttribute).GetCustomAttribute<AttributeUsageAttribute>();
 
+            Assert.That(attributeUsage, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(new TestAssemblyDirectoryResolveAttribute(), Is.InstanceOf<NUnitAttribute>());
-                Assert.That(attributeUsage, Is.Not.Null);
-                Assert.That(attributeUsage!.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
+                Assert.That(attributeUsage.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
                 Assert.That(attributeUsage.AllowMultiple, Is.False);
                 Assert.That(attributeUsage.Inherited, Is.False);
             });

--- a/src/NUnitFramework/tests/Attributes/AssemblyMarkerAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/AssemblyMarkerAttributeTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Framework.Tests.Attributes
+{
+    public class AssemblyMarkerAttributeTests
+    {
+        [Test]
+        public void NonTestAssemblyAttribute_CanBeAppliedToAssembly()
+        {
+            var attributeUsage = typeof(NonTestAssemblyAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new NonTestAssemblyAttribute(), Is.InstanceOf<NUnitAttribute>());
+                Assert.That(attributeUsage, Is.Not.Null);
+                Assert.That(attributeUsage!.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
+                Assert.That(attributeUsage.AllowMultiple, Is.False);
+                Assert.That(attributeUsage.Inherited, Is.False);
+            });
+        }
+
+        [Test]
+        public void TestAssemblyDirectoryResolveAttribute_CanBeAppliedToAssembly()
+        {
+            var attributeUsage = typeof(TestAssemblyDirectoryResolveAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new TestAssemblyDirectoryResolveAttribute(), Is.InstanceOf<NUnitAttribute>());
+                Assert.That(attributeUsage, Is.Not.Null);
+                Assert.That(attributeUsage!.ValidOn, Is.EqualTo(AttributeTargets.Assembly));
+                Assert.That(attributeUsage.AllowMultiple, Is.False);
+                Assert.That(attributeUsage.Inherited, Is.False);
+            });
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -137,9 +137,9 @@ namespace NUnit.Framework.Tests.Attributes
                 nameof(RetryWithRetryExceptionFixture.RetriesOnAllowedException));
             Assert.That(method, Is.Not.Null);
 
-            var attribute = method!.GetCustomAttribute<RetryAttribute>();
+            var attribute = method.GetCustomAttribute<RetryAttribute>();
             Assert.That(attribute, Is.Not.Null);
-            Assert.That(attribute!.RetryExceptions,
+            Assert.That(attribute.RetryExceptions,
                 Is.EquivalentTo(new[] { typeof(TimeoutException), typeof(OperationCanceledException) }));
         }
 

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.TestData.RepeatingTests;
@@ -110,6 +111,36 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(fixture.Count + 1, Is.EqualTo(fixture.TearDownResults.Count), "expected the CurrentRepeatCount property to be one less than the number of executions");
                 Assert.That(result.FailCount, Is.EqualTo(0), "expected that the test passed final retry");
             }
+        }
+
+        [Test]
+        public void RetryExceptions_DefaultsToEmptyArray()
+        {
+            var attribute = new RetryAttribute(3);
+
+            Assert.That(attribute.RetryExceptions, Is.Empty);
+        }
+
+        [Test]
+        public void RetryExceptions_IsPreservedWhenConfigured()
+        {
+            var exceptions = new[] { typeof(TimeoutException), typeof(IOException) };
+            var attribute = new RetryAttribute(3) { RetryExceptions = exceptions };
+
+            Assert.That(attribute.RetryExceptions, Is.EqualTo(exceptions));
+        }
+
+        [Test]
+        public void RetryExceptions_IsReadFromDecoratedTestMethod()
+        {
+            MethodInfo? method = typeof(RetryWithRetryExceptionFixture).GetMethod(
+                nameof(RetryWithRetryExceptionFixture.RetriesOnAllowedException));
+            Assert.That(method, Is.Not.Null);
+
+            var attribute = method!.GetCustomAttribute<RetryAttribute>();
+            Assert.That(attribute, Is.Not.Null);
+            Assert.That(attribute!.RetryExceptions,
+                Is.EquivalentTo(new[] { typeof(TimeoutException), typeof(OperationCanceledException) }));
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RetryAttributeTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.IO;
 using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace NUnit.Framework.Tests.Attributes
+{
+    public class TestCaseSourceAttributeTests
+    {
+        private static readonly object?[] MethodParams = { 1, "two" };
+
+        [Test]
+        public void MethodParams_IsNullWhenNotProvided()
+        {
+            var attribute = new TestCaseSourceAttribute("SourceName");
+
+            Assert.That(attribute.MethodParams, Is.Null);
+        }
+
+        [Test]
+        public void MethodParams_IsPreservedWhenProvidedWithSourceName()
+        {
+            var attribute = new TestCaseSourceAttribute("SourceName", MethodParams);
+
+            Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
+        }
+
+        [Test]
+        public void MethodParams_IsPreservedWhenProvidedWithSourceTypeAndSourceName()
+        {
+            var attribute = new TestCaseSourceAttribute(typeof(TestCaseSourceAttributeTests), "SourceName", MethodParams);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attribute.SourceType, Is.EqualTo(typeof(TestCaseSourceAttributeTests)));
+                Assert.That(attribute.SourceName, Is.EqualTo("SourceName"));
+                Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
+            });
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-
 namespace NUnit.Framework.Tests.Attributes
 {
     public class TestCaseSourceAttributeTests

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
@@ -6,24 +6,29 @@ namespace NUnit.Framework.Tests.Attributes
 {
     public class TestCaseSourceAttributeTests
     {
+        private const string SourceName = "SourceName";
         private static readonly object?[] MethodParams = { 1, "two" };
 
         [Test]
         public void MethodParams_IsNullWhenNotProvided()
         {
-            var attribute = new TestCaseSourceAttribute("SourceName");
+            var attribute = new TestCaseSourceAttribute(SourceName);
 
-            Assert.That(attribute.MethodParams, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(attribute.SourceName, Is.EqualTo(SourceName));
+                Assert.That(attribute.MethodParams, Is.Null);
+            });
         }
 
         [Test]
         public void MethodParams_IsPreservedWhenProvidedWithSourceName()
         {
-            var attribute = new TestCaseSourceAttribute("SourceName", MethodParams);
+            var attribute = new TestCaseSourceAttribute(SourceName, MethodParams);
 
             Assert.Multiple(() =>
             {
-                Assert.That(attribute.SourceName, Is.EqualTo("SourceName"));
+                Assert.That(attribute.SourceName, Is.EqualTo(SourceName));
                 Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
             });
         }
@@ -31,12 +36,12 @@ namespace NUnit.Framework.Tests.Attributes
         [Test]
         public void MethodParams_IsPreservedWhenProvidedWithSourceTypeAndSourceName()
         {
-            var attribute = new TestCaseSourceAttribute(typeof(TestCaseSourceAttributeTests), "SourceName", MethodParams);
+            var attribute = new TestCaseSourceAttribute(typeof(TestCaseSourceAttributeTests), SourceName, MethodParams);
 
             Assert.Multiple(() =>
             {
                 Assert.That(attribute.SourceType, Is.EqualTo(typeof(TestCaseSourceAttributeTests)));
-                Assert.That(attribute.SourceName, Is.EqualTo("SourceName"));
+                Assert.That(attribute.SourceName, Is.EqualTo(SourceName));
                 Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
             });
         }

--- a/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestCaseSourceAttributeTests.cs
@@ -21,7 +21,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var attribute = new TestCaseSourceAttribute("SourceName", MethodParams);
 
-            Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
+            Assert.Multiple(() =>
+            {
+                Assert.That(attribute.SourceName, Is.EqualTo("SourceName"));
+                Assert.That(attribute.MethodParams, Is.EqualTo(MethodParams));
+            });
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/TestFixtureAttributeTests.cs
@@ -89,5 +89,13 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(attr.TypeArgs, Is.Not.Null);
             });
         }
+
+        [Test]
+        public void IgnoreReason_IsPreservedWhenSet()
+        {
+            var attribute = new TestFixtureAttribute { IgnoreReason = "Don't run this fixture" };
+
+            Assert.That(attribute.IgnoreReason, Is.EqualTo("Don't run this fixture"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add unit tests for `RetryAttribute.RetryExceptions`: default empty array, configured values, and metadata read from a decorated test method
- Add a dedicated `TestFixtureAttribute.IgnoreReason` property test

Part of the attribute test coverage work tracked in 5279.

## Test plan
- [ ] CI passes (RetryAttributeTests, TestFixtureAttributeTests)