### PR TITLE
AI Slop: fix: report meaningful CLR version in NUnitLite output (2435)

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -328,7 +328,7 @@ namespace NUnit.Framework.Api
             targetNode.InsertChildNode(0, env);
 
             env.AddAttribute("framework-version", typeof(FrameworkController).Assembly.GetName().Version?.ToString() ?? "Unknown");
-            env.AddAttribute("clr-version", Environment.Version.ToString());
+            env.AddAttribute("clr-version", RuntimeFramework.ClrVersionDisplayString);
             env.AddAttribute("os-version", OSPlatform.OSDescription);
             env.AddAttribute("platform", Environment.OSVersion.Platform.ToString());
             env.AddAttribute("cwd", Directory.GetCurrentDirectory());

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -440,12 +440,6 @@ namespace NUnit.Framework.Internal
         {
             description = null;
 
-#if NETSTANDARD2_0
-            Type? runtimeInfoType = Type.GetType("System.Runtime.InteropServices.RuntimeInformation,System.Runtime.InteropServices.RuntimeInformation", false);
-            if (runtimeInfoType is null)
-                return false;
-#endif
-
             try
             {
                 description = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;

--- a/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
+++ b/src/NUnitFramework/framework/Internal/RuntimeFramework.cs
@@ -242,6 +242,26 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public string DisplayName { get; private set; }
 
+        /// <summary>
+        /// Returns a string suitable for displaying the CLR/runtime version in reports.
+        /// Uses <see cref="System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription"/>
+        /// when available to avoid reporting misleading 4.0.0.0 versions on .NET Core runtimes.
+        /// </summary>
+        public static string ClrVersionDisplayString
+        {
+            get
+            {
+                var framework = CurrentFramework;
+                if (framework.Runtime == RuntimeType.Mono && !string.IsNullOrEmpty(framework.DisplayName))
+                    return framework.DisplayName;
+
+                if (TryGetFrameworkDescription(out string? description))
+                    return description;
+
+                return Environment.Version.ToString();
+            }
+        }
+
         #endregion
 
         #region Public Methods
@@ -414,6 +434,27 @@ namespace NUnit.Framework.Internal
                    v1.Minor == v2.Minor &&
                   (v1.Build < 0 || v2.Build < 0 || v1.Build == v2.Build) &&
                   (v1.Revision < 0 || v2.Revision < 0 || v1.Revision == v2.Revision);
+        }
+
+        private static bool TryGetFrameworkDescription([NotNullWhen(true)] out string? description)
+        {
+            description = null;
+
+#if NETSTANDARD2_0
+            Type? runtimeInfoType = Type.GetType("System.Runtime.InteropServices.RuntimeInformation,System.Runtime.InteropServices.RuntimeInformation", false);
+            if (runtimeInfoType is null)
+                return false;
+#endif
+
+            try
+            {
+                description = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+                return !string.IsNullOrEmpty(description);
+            }
+            catch (TypeLoadException)
+            {
+                return false;
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/NUnitFramework/nunitlite/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -95,7 +95,7 @@ namespace NUnitLite
             _xmlWriter.WriteAttributeString("nunit-version",
                                            assemblyName.Version.ToString());
             _xmlWriter.WriteAttributeString("clr-version",
-                Environment.Version.ToString());
+                RuntimeFramework.ClrVersionDisplayString);
             _xmlWriter.WriteAttributeString("os-version",
                                            OSPlatform.OSDescription);
             _xmlWriter.WriteAttributeString("platform",

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -159,7 +159,7 @@ namespace NUnitLite
 
             WriteSectionHeader("Runtime Environment");
             Writer.WriteLabelLine("   OS Version: ", OSPlatform.OSDescription);
-            Writer.WriteLabelLine("  CLR Version: ", Environment.Version);
+            Writer.WriteLabelLine("  CLR Version: ", RuntimeFramework.ClrVersionDisplayString);
             Writer.WriteLine();
         }
 

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -37,14 +37,14 @@ namespace NUnit.Framework.Tests.Internal
         }
 
         [Test]
-        public void ClrVersionDisplayString_UsesFrameworkDescriptionOnNetCore()
+        public void ClrVersionDisplayString_UsesFrameworkDescription()
         {
-#if NETCOREAPP
-            Assert.That(RuntimeFramework.ClrVersionDisplayString, Does.Contain(".NET"));
-            Assert.That(RuntimeFramework.ClrVersionDisplayString, Is.Not.EqualTo(Environment.Version.ToString()));
-#else
-            Assert.Ignore("Only applies to .NET Core and later runtimes");
-#endif
+            string display = RuntimeFramework.ClrVersionDisplayString;
+            Assert.Multiple(() =>
+            {
+                Assert.That(display, Does.Contain(".NET"));
+                Assert.That(display, Is.Not.EqualTo("4.0.0.0"));
+            });
         }
 
         [Test]

--- a/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
+++ b/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs
@@ -31,6 +31,23 @@ namespace NUnit.Framework.Tests.Internal
         }
 
         [Test]
+        public void ClrVersionDisplayString_IsNotEmpty()
+        {
+            Assert.That(RuntimeFramework.ClrVersionDisplayString, Is.Not.Empty);
+        }
+
+        [Test]
+        public void ClrVersionDisplayString_UsesFrameworkDescriptionOnNetCore()
+        {
+#if NETCOREAPP
+            Assert.That(RuntimeFramework.ClrVersionDisplayString, Does.Contain(".NET"));
+            Assert.That(RuntimeFramework.ClrVersionDisplayString, Is.Not.EqualTo(Environment.Version.ToString()));
+#else
+            Assert.Ignore("Only applies to .NET Core and later runtimes");
+#endif
+        }
+
+        [Test]
         [TestCaseSource(nameof(NetcoreRuntimes))]
         public void SpecifyingNetCoreVersioningThrowsPlatformException(string netcoreRuntime)
         {


### PR DESCRIPTION
## Summary
- Add `RuntimeFramework.ClrVersionDisplayString` that prefers `RuntimeInformation.FrameworkDescription` over `Environment.Version`
- Use it in NUnitLite runtime output, NUnit 2 XML environment metadata, and `FrameworkController` environment element
- Avoids misleading `4.0.0.0` reporting on .NET Core runtimes

Fixes 2435

## Test plan
- [ ] CI passes (`RuntimeFrameworkTests`)
- [ ] NUnitLite runtime header shows `.NET` description on modern runtimes