### PR TITLE
AI Slop: fix: mark TextOutputTests non-parallelizable (5246)

### DIFF
--- a/src/NUnitFramework/tests/TextOutputTests.cs
+++ b/src/NUnitFramework/tests/TextOutputTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework.Tests.TestUtilities;
 
 namespace NUnit.Framework.Tests
 {
+    [NonParallelizable]
     public class TextOutputTests : ITestListener
     {
         private const string SOME_TEXT = "Should go to the result";


### PR DESCRIPTION
## Summary
- Mark `TextOutputTests` as `[NonParallelizable]` because it redirects `Console.Out`, which is process-wide
- Prevents parallel tests from restoring stdout while adhoc-context tests are still running on thread pool threads

Fixes 5246

## Test plan
- [ ] CI passes
- [ ] `TextOutputTests` no longer flakes under parallel execution