### PR TITLE
AI Slop: chore: relax IDE0052 in test projects (5254)

### DIFF
--- a/src/NUnitFramework/testdata/AttributeInheritanceData.cs
+++ b/src/NUnitFramework/testdata/AttributeInheritanceData.cs
@@ -10,9 +10,7 @@ namespace NUnit.TestData.AttributeInheritanceData
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     internal class ConcernAttribute : TestFixtureAttribute
     {
-#pragma warning disable IDE0052 // Remove unread private members
         private readonly Type _typeOfConcern;
-#pragma warning restore IDE0052 // Remove unread private members
 
         public ConcernAttribute(Type typeOfConcern)
         {

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -19,9 +19,7 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
     [Order(1)]
     public class MultipleTestFixtureAttributesOrder1
     {
-#pragma warning disable IDE0052 // Remove unread private members
         private readonly string _s;
-#pragma warning restore IDE0052 // Remove unread private members
         public MultipleTestFixtureAttributesOrder1(string s)
         {
             _s = s;

--- a/src/NUnitFramework/testdata/TestFixtureSourceData.cs
+++ b/src/NUnitFramework/testdata/TestFixtureSourceData.cs
@@ -655,9 +655,7 @@ namespace NUnit.TestData.TestFixtureSourceData
 
     public class BaseClassUsingDerivedClassDataSource : DataSourcePrivateFieldInBaseClass
     {
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly int[] DataSource = { 2, 4 };
-#pragma warning restore IDE0052 // Remove unread private members
 
         public BaseClassUsingDerivedClassDataSource(int data) : base(data)
         {

--- a/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
+++ b/src/NUnitFramework/testdata/UnexpectedExceptionFixture.cs
@@ -78,9 +78,7 @@ namespace NUnit.TestData.UnexpectedExceptionFixture
 
     internal class CustomException : Exception
     {
-#pragma warning disable IDE0052 // Remove unread private members
         private readonly CustomType _custom;
-#pragma warning restore IDE0052 // Remove unread private members
 
         public CustomException(string msg, CustomType custom)
             : base(msg)

--- a/src/NUnitFramework/tests.editorconfig
+++ b/src/NUnitFramework/tests.editorconfig
@@ -18,4 +18,5 @@ dotnet_diagnostic.NUnit2009.severity = silent
 dotnet_diagnostic.NUnit1028.severity = warning
 
 # IDE0052: Remove unread private members
-dotnet_diagnostic.IDE0052.severity = warning
+# Test fixtures often declare members referenced only via reflection or TestCaseSource.
+dotnet_diagnostic.IDE0052.severity = silent

--- a/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
+++ b/src/NUnitFramework/tests/Assertions/NullableTypesTests.cs
@@ -191,10 +191,8 @@ namespace NUnit.Framework.Tests.Assertions
 
         private readonly struct MyStruct
         {
-#pragma warning disable IDE0052 // Remove unread private members
             private readonly int _i;
             private readonly string _s;
-#pragma warning restore IDE0052 // Remove unread private members
 
             public MyStruct(int i, string s)
             {

--- a/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AndConstraintTests.cs
@@ -27,10 +27,8 @@ namespace NUnit.Framework.Tests.Constraints
             _messageWriter.Dispose();
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 42 };
         private static readonly object[] FailureData = new object[] { new object[] { 37, "37" }, new object[] { 53, "53" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCombineTestsWithAndOperator()

--- a/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AnyOfConstraintTests.cs
@@ -18,10 +18,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<anyof 1 2 3>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 1, 2, 3 };
         private static readonly object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { "A", "\"A\"" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void ItemIsPresent_IgnoreCase()

--- a/src/NUnitFramework/tests/Constraints/AttributeExistsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/AttributeExistsConstraintTests.cs
@@ -16,13 +16,11 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<attributeexists NUnit.Framework.TestFixtureAttribute>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { typeof(AttributeExistsConstraintTests) };
         private static readonly object[] FailureData = new object[]
         {
             new TestCaseData(typeof(D2), "<" + typeof(D2).FullName + ">")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void NonAttributeThrowsException()

--- a/src/NUnitFramework/tests/Constraints/BasicConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/BasicConstraintTests.cs
@@ -16,10 +16,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<null>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object?[] SuccessData = new object?[] { null };
         private static readonly object[] FailureData = new object[] { new object[] { "hello", "\"hello\"" } };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]
@@ -34,7 +32,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<true>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { true, 2 + 2 == 4 };
         private static readonly object[] FailureData = new object[]
         {
@@ -43,7 +40,6 @@ namespace NUnit.Framework.Tests.Constraints
             new object[] { false, "False" },
             new object[] { 2 + 2 == 5, "False" }
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]
@@ -58,7 +54,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<false>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { false, 2 + 2 == 5 };
         private static readonly object[] FailureData = new object[]
         {
@@ -67,7 +62,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(true, "True"),
             new TestCaseData(2 + 2 == 4, "True")
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]
@@ -82,7 +76,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<nan>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { double.NaN, float.NaN };
         private static readonly object[] FailureData = new object[]
         {
@@ -94,7 +87,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(float.PositiveInfinity, double.PositiveInfinity.ToString()),
             new TestCaseData(float.NegativeInfinity, double.NegativeInfinity.ToString())
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]
@@ -109,7 +101,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<multipleof>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 3, 9 };
         private static readonly object[] FailureData = new object[]
         {
@@ -118,6 +109,5 @@ namespace NUnit.Framework.Tests.Constraints
             new object[] { false, "False" },
             new object[] { 2, "2" }
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 }

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -41,7 +41,6 @@ namespace NUnit.Framework.Tests.Constraints
             //SetValueTrueAfterDelay(300);
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { true };
         private static readonly object[] FailureData = new object[]
         {
@@ -49,7 +48,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(0, "0"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         private static readonly Func<object> DelegateReturningValue;
         private static readonly Func<object> DelegateReturningFalse;

--- a/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
+++ b/src/NUnitFramework/tests/Constraints/EmptyConstraintTest.cs
@@ -22,7 +22,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<empty>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             string.Empty,
@@ -46,7 +45,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(System.Collections.Immutable.ImmutableArray.Create(1), "< 1 >"),
             new TestCaseData(new EnumerableWithIndependentCount(0, new[] { 1 }), "< 1 >"),
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [TestCase(null)]
         [TestCase(5)]
@@ -157,7 +155,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<emptystring>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             string.Empty
@@ -167,7 +164,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData("Hello", "\"Hello\""),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]

--- a/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EndsWithConstraintTests.cs
@@ -18,7 +18,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<endswith \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "hello", "I said hello" };
         private static readonly object[] FailureData = new object[]
         {
@@ -28,7 +27,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RespectsCulture()
@@ -116,7 +114,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<endswith \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "HELLO", "I said Hello" };
         private static readonly object[] FailureData = new object[]
         {
@@ -127,7 +124,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RespectsCulture()

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -28,7 +28,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<equal 4>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 4, 4.0f, 4.0d, 4.0000m };
         private static readonly object[] FailureData = new object[]
         {
@@ -38,7 +37,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(double.NaN, double.NaN.ToString()),
             new TestCaseData(double.PositiveInfinity, double.PositiveInfinity.ToString())
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void Complex_PassesEquality()

--- a/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ExactTypeConstraintTests.cs
@@ -30,14 +30,12 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = $"<typeof {typeof(D1)}>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { new D1() };
         private static readonly object[] FailureData = new object[]
         {
             new TestCaseData(new B(), "<" + typeof(B).FullName + ">"),
             new TestCaseData(new D2(), "<" + typeof(D2).FullName + ">")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         private class B
         {

--- a/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanConstraintTests.cs
@@ -19,10 +19,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<greaterthan 5>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 6, 5.001 };
         private static readonly object[] FailureData = new object[] { new object[] { 4, "4" }, new object[] { 5, "5" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/GreaterThanOrEqualConstraintTests.cs
@@ -19,10 +19,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<greaterthanorequal 5>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 6, 5 };
         private static readonly object[] FailureData = new object[] { new object[] { 4, "4" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/InstanceOfTypeConstraintTests.cs
@@ -30,13 +30,11 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = $"<instanceof {typeof(D1)}>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { new D1(), new D2() };
         private static readonly object[] FailureData = new object[]
         {
             new TestCaseData(new B(), "<" + typeof(B).FullName + ">")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         private class B
         {

--- a/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanConstraintTests.cs
@@ -19,10 +19,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<lessthan 5>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 4, 4.999 };
         private static readonly object[] FailureData = new object[] { new object[] { 6, "6" }, new object[] { 5, "5" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/LessThanOrEqualConstraintTests.cs
@@ -19,10 +19,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<lessthanorequal 5>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 4, 5 };
         private static readonly object[] FailureData = new object[] { new object[] { 6, "6" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCompareIComparables()

--- a/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/NotConstraintTests.cs
@@ -16,10 +16,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<not <equal null>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 42, "Hello" };
         private static readonly object?[] FailureData = new object?[] { new object?[] { null, "null" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void NotHonorsIgnoreCaseUsingConstructors()

--- a/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/OrConstraintTests.cs
@@ -16,10 +16,8 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<or <equal 42> <equal 99>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 99, 42 };
         private static readonly object[] FailureData = new object[] { new object[] { 37, "37" } };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void CanCombineTestsWithOrOperator()

--- a/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PathConstraintTests.cs
@@ -39,7 +39,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<samepath \"C:\\folder1\\file.tmp\" ignorecase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"C:\folder1\file.tmp",
@@ -54,7 +53,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(@"C:\folder2\file.tmp", "\"C:\\folder2\\file.tmp\""),
             new TestCaseData(@"C:\folder1\.\folder2\..\file.temp", "\"C:\\folder1\\.\\folder2\\..\\file.temp\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RootPathEquality()
@@ -75,7 +73,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<samepath ""/folder1/folder2"" respectcase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"/folder1/folder2",
@@ -98,7 +95,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(@"/Folder1/FOLDER2", "\"/Folder1/FOLDER2\""),
             new TestCaseData(@"/FOLDER1/./junk/../FOLDER2", "\"/FOLDER1/./junk/../FOLDER2\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RootPathEquality()
@@ -119,7 +115,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<subpath ""C:\folder1\folder2"" ignorecase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"C:\folder1\folder2\folder3",
@@ -139,7 +134,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(@"C:\FOLDER1\.\junk\..\Folder2", "\"C:\\FOLDER1\\.\\junk\\..\\Folder2\""),
             new TestCaseData(@"C:/folder1/folder2", "\"C:/folder1/folder2\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void SubPathOfRoot()
@@ -160,7 +154,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<subpath ""/folder1/folder2"" respectcase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"/folder1/folder2/folder3",
@@ -181,7 +174,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData("/folder1/junk/../folder2", "\"/folder1/junk/../folder2\""),
             new TestCaseData(@"\folder1\folder2", "\"\\folder1\\folder2\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void SubPathOfRoot()
@@ -202,7 +194,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<samepathorunder ""C:\folder1\folder2"" ignorecase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"C:\folder1\folder2",
@@ -222,7 +213,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(@"C:\folder1\folder3", "\"C:\\folder1\\folder3\""),
             new TestCaseData(@"C:\folder1\.\folder2\..\file.temp", "\"C:\\folder1\\.\\folder2\\..\\file.temp\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixture]
@@ -237,7 +227,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<samepathorunder ""/folder1/folder2"" respectcase>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[]
         {
             @"/folder1/folder2",
@@ -258,6 +247,5 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData("/folder1/./folder2/../folder3", "\"/folder1/./folder2/../folder3\""),
             new TestCaseData("/folder1", "\"/folder1\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 }

--- a/src/NUnitFramework/tests/Constraints/PropertyTests.cs
+++ b/src/NUnitFramework/tests/Constraints/PropertyTests.cs
@@ -64,7 +64,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<propertyexists Length>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { Array.Empty<int>(), "hello", typeof(Array) };
         private static readonly object[] FailureData = new object[]
         {
@@ -72,7 +71,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(new List<int>(), "<System.Collections.Generic.List`1[System.Int32]>"),
             new TestCaseData(typeof(int), "<System.Int32>")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void NullDataThrowsArgumentNullException()
@@ -120,14 +118,12 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<property Length <equal 5>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { new int[5], "hello" };
         private static readonly object[] FailureData = new object[]
         {
             new TestCaseData(new int[3], "3"),
             new TestCaseData("goodbye", "7")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void NullDataThrowsArgumentNullException()

--- a/src/NUnitFramework/tests/Constraints/SameAsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/SameAsTest.cs
@@ -19,7 +19,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<sameas System.Object>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { Obj1 };
         private static readonly object[] FailureData = new object[]
         {
@@ -27,6 +26,5 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(3, "3"),
             new TestCaseData("Hello", "\"Hello\"")
         };
-#pragma warning restore IDE0052 // Remove unread private members
     }
 }

--- a/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/StartsWithConstraintTests.cs
@@ -18,7 +18,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<startswith \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "hello", "hello there" };
         private static readonly object[] FailureData = new object[]
         {
@@ -29,7 +28,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RespectsCulture()
@@ -117,7 +115,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<startswith \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "Hello", "HELLO there" };
         private static readonly object[] FailureData = new object[]
         {
@@ -128,7 +125,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void RespectsCulture()

--- a/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/SubstringConstraintTests.cs
@@ -18,7 +18,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<substring \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "hello", "hello there", "I said hello", "say hello to fred" };
         private static readonly object[] FailureData = new object[]
         {
@@ -28,7 +27,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [TestCase(" ss ", "ß", StringComparison.CurrentCulture)]
         [TestCase(" SS ", "ß", StringComparison.CurrentCulture)]
@@ -129,7 +127,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<substring \"hello\">";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { "Hello", "HellO there", "I said HELLO", "say hello to fred" };
         private static readonly object[] FailureData = new object[]
         {
@@ -138,7 +135,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(string.Empty, "<string.Empty>"),
             new TestCaseData(null, "null")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [TestCase("ss ", "ß")]
         [TestCase("ß ", "ß")]

--- a/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsConstraintTests.cs
@@ -33,7 +33,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<throws <typeof System.ArgumentException>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData =
         [
             (Action)TestDelegates.ThrowsArgumentException
@@ -44,7 +43,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData((Action)TestDelegates.ThrowsNothing, "no exception thrown"),
             new TestCaseData((Action)TestDelegates.ThrowsSystemException, "<System.Exception: my message" + Environment.NewLine)
         ];
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixtureSource(nameof(GetInstanceOfTypeConstraints))]
@@ -72,7 +70,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<throws <instanceof NUnit.Framework.Tests.TestUtilities.TestDelegates+BaseException>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData =
         [
             (Action)TestDelegates.ThrowsBaseException,
@@ -84,7 +81,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData((Action)TestDelegates.ThrowsNothing, "no exception thrown"),
             new TestCaseData((Action)TestDelegates.ThrowsNullReferenceException, "<System.NullReferenceException: my message")
         ];
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     [TestFixtureSource(nameof(GetExceptionTypeConstraints))]
@@ -115,7 +111,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = @"<throws <and <typeof System.ArgumentException> <property ParamName <equalstring ""myParam"">>>>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData =
         [
             (Action)TestDelegates.ThrowsArgumentException
@@ -126,7 +121,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData((Action)TestDelegates.ThrowsNothing, "no exception thrown"),
             new TestCaseData((Action)TestDelegates.ThrowsSystemException, "<System.Exception: my message" + Environment.NewLine)
         ];
-#pragma warning restore IDE0052 // Remove unread private members
     }
 
     public abstract class ThrowsConstraintTestBase : ConstraintTestBaseNoData

--- a/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Tests.Constraints
             }
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData =
         [
             (Action)TestDelegates.ThrowsArgumentException
@@ -41,7 +40,6 @@ namespace NUnit.Framework.Tests.Constraints
         [
             new TestCaseData((Action)TestDelegates.ThrowsNothing, "no exception thrown"),
         ];
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public static void CatchesAsyncException()

--- a/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/UniqueItemsConstraintTests.cs
@@ -23,7 +23,6 @@ namespace NUnit.Framework.Tests.Constraints
             ExpectedDescription = "all items unique";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = { new[] { 1, 3, 17, -2, 34 }, Array.Empty<object>() };
         private static readonly object[] FailureData =
         {
@@ -33,7 +32,6 @@ namespace NUnit.Framework.Tests.Constraints
                 "< 1, 3, 17, 3, 34 >" + Environment.NewLine + "  Not unique items: < 3 >"
             }
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test, SetCulture("")]
         [TestCaseSource(nameof(IgnoreCaseData))]

--- a/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
+++ b/src/NUnitFramework/tests/Constraints/XmlSerializableTest.cs
@@ -18,7 +18,6 @@ namespace NUnit.Framework.Tests.Constraints
             StringRepresentation = "<xmlserializable>";
         }
 
-#pragma warning disable IDE0052 // Remove unread private members
         private static readonly object[] SuccessData = new object[] { 1, "a", new List<string>() };
         private static readonly object[] FailureData = new object[]
         {
@@ -26,7 +25,6 @@ namespace NUnit.Framework.Tests.Constraints
             new TestCaseData(new InternalClass(), "<" + typeof(InternalClass).FullName + ">"),
             new TestCaseData(new InternalWithSerializableAttributeClass(), "<" + typeof(InternalWithSerializableAttributeClass).FullName + ">")
         };
-#pragma warning restore IDE0052 // Remove unread private members
 
         [Test]
         public void NullArgumentThrowsException()


### PR DESCRIPTION
## Summary
- Silence `IDE0052` in `tests.editorconfig` instead of warning/error
- Test projects frequently keep private members for reflection and `TestCaseSource` usage

Fixes 5254

## Test plan
- [ ] CI passes
- [ ] No new IDE0052 suppressions needed for common test patterns