### PR TITLE
AI Slop: fix: avoid repeating OneTimeSetUp failure details on child tests (5266)

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -84,7 +84,9 @@ namespace NUnit.Framework.Internal.Execution
                                     }
                                     else
                                     {
-                                        SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + Result.Message, Result.StackTrace);
+                                        GetChildSkipDetails(Result.ResultState, Result.Message, Result.StackTrace,
+                                            out var childMessage, out var childStackTrace);
+                                        SkipChildren(this, Result.ResultState.WithSite(FailureSite.Parent), childMessage, childStackTrace);
                                     }
                                 }
 
@@ -290,7 +292,27 @@ namespace NUnit.Framework.Internal.Execution
         private void SkipFixture(ResultState resultState, string message, string? stackTrace)
         {
             Result.SetResult(resultState.WithSite(FailureSite.SetUp), message, StackFilter.DefaultFilter.Filter(stackTrace));
-            SkipChildren(this, resultState.WithSite(FailureSite.Parent), "OneTimeSetUp: " + message, stackTrace);
+            GetChildSkipDetails(resultState, message, stackTrace, out var childMessage, out var childStackTrace);
+            SkipChildren(this, resultState.WithSite(FailureSite.Parent), childMessage, childStackTrace);
+        }
+
+        private static void GetChildSkipDetails(
+            ResultState resultState,
+            string message,
+            string? stackTrace,
+            out string childMessage,
+            out string? childStackTrace)
+        {
+            if (resultState.Status is TestStatus.Failed or TestStatus.Inconclusive)
+            {
+                childMessage = TestResult.PARENT_ONE_TIME_SETUP_FAILED_MESSAGE;
+                childStackTrace = null;
+            }
+            else
+            {
+                childMessage = "OneTimeSetUp: " + message;
+                childStackTrace = stackTrace;
+            }
         }
 
         private void SkipChildren(CompositeWorkItem workItem, ResultState resultState, string message, string? stackTrace)

--- a/src/NUnitFramework/framework/Internal/Results/TestResult.cs
+++ b/src/NUnitFramework/framework/Internal/Results/TestResult.cs
@@ -41,6 +41,12 @@ namespace NUnit.Framework.Internal
         internal const string USER_CANCELLED_MESSAGE = "Test run cancelled by user";
 
         /// <summary>
+        /// Message used for child tests when a parent OneTimeSetUp fails.
+        /// Full exception details remain on the parent result only.
+        /// </summary>
+        internal const string PARENT_ONE_TIME_SETUP_FAILED_MESSAGE = "Failed because OneTimeSetUp failed in parent fixture";
+
+        /// <summary>
         /// Error prefix for when there are multiple faiures and/or warnings.
         /// </summary>
         internal const string MULTIPLE_FAILURES_OR_WARNINGS_MESSAGE = "Multiple failures or warnings in test:";

--- a/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
+++ b/src/NUnitFramework/tests/Attributes/OneTimeSetUpTearDownTests.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
-        public void FailedSetUpStacktracePropogatesToTestResult()
+        public void FailedSetUpStacktraceRemainsOnParentOnly()
         {
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             fixture.ThrowInBaseSetUp = true;
@@ -143,7 +143,8 @@ namespace NUnit.Framework.Tests.Attributes
             foreach (var childResult in result.Children)
             {
                 Assert.That(childResult.ResultState.Site, Is.EqualTo(FailureSite.Parent));
-                Assert.That(childResult.StackTrace, Is.EqualTo(result.StackTrace));
+                Assert.That(childResult.Message, Is.EqualTo(TestResult.PARENT_ONE_TIME_SETUP_FAILED_MESSAGE));
+                Assert.That(childResult.StackTrace, Is.Null);
             }
 
             Assert.That(fixture.SetUpCount, Is.EqualTo(1));
@@ -152,7 +153,7 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
-        public void AssumeFailureSetUpPropogatesToTestResult()
+        public void AssumeFailureSetUpDetailsRemainOnParentOnly()
         {
             SetUpAndTearDownFixture fixture = new SetUpAndTearDownFixture();
             fixture.AssumeFailureInSetUp = true;
@@ -167,7 +168,8 @@ namespace NUnit.Framework.Tests.Attributes
             foreach (var childResult in result.Children)
             {
                 Assert.That(childResult.ResultState.Site, Is.EqualTo(FailureSite.Parent));
-                Assert.That(childResult.StackTrace, Is.EqualTo(result.StackTrace));
+                Assert.That(childResult.Message, Is.EqualTo(TestResult.PARENT_ONE_TIME_SETUP_FAILED_MESSAGE));
+                Assert.That(childResult.StackTrace, Is.Null);
             }
 
             Assert.That(fixture.SetUpCount, Is.EqualTo(1));


### PR DESCRIPTION
## Summary
- When a parent fixture or SetUpFixture fails in `OneTimeSetUp`, child tests now receive a short parent-failure message without the stack trace
- Full exception details remain on the failing parent result only, reducing noisy console output in large suites

Fixes 5266

## Test plan
- [ ] CI passes (`FailedSetUpStacktraceRemainsOnParentOnly`, `AssumeFailureSetUpDetailsRemainOnParentOnly`)