### PR TITLE
AI Slop: chore: mark non-generic CollectionTally as obsolete (5263)

### DIFF
--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraint.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#pragma warning disable CS0618 // CollectionTally is obsolete until removal in NUnit 6.0 (#5230)
+
 using System;
 using System.Collections;
 using NUnit.Framework.Internal;

--- a/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionEquivalentConstraintResult.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#pragma warning disable CS0618 // CollectionTally is obsolete until removal in NUnit 6.0 (#5230)
+
 using System;
 
 namespace NUnit.Framework.Constraints

--- a/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionItemsEqualConstraint.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#pragma warning disable CS0618 // CollectionTally is obsolete until removal in NUnit 6.0 (#5230)
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NUnitFramework/framework/Constraints/CollectionTally.cs
+++ b/src/NUnitFramework/framework/Constraints/CollectionTally.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,10 +11,12 @@ namespace NUnit.Framework.Constraints
 {
     /// <summary><see cref="CollectionTally"/> counts (tallies) the number of occurrences
     /// of each object in one or more enumerations.</summary>
+    [Obsolete("This type is obsolete and will be removed in NUnit 6.0.")]
     public sealed class CollectionTally
     {
         /// <summary>The result of a <see cref="CollectionTally"/>.</summary>
         [DebuggerDisplay("Missing = {MissingItems.Count}, Extra = {ExtraItems.Count}")]
+        [Obsolete("This type is obsolete and will be removed in NUnit 6.0.")]
         public sealed class CollectionTallyResult
         {
             /// <summary>Items that were not in the expected collection.</summary>
@@ -32,7 +35,9 @@ namespace NUnit.Framework.Constraints
             /// <summary>
             /// Converts a generic CollectionTallyResult to the non-generic version.
             /// </summary>
+#pragma warning disable CS0618 // CollectionTally is obsolete until removal in NUnit 6.0 (#5230)
             internal static CollectionTallyResult FromGenericResult<T>(CollectionTally<T>.CollectionTallyResult genericResult)
+#pragma warning restore CS0618
             {
                 var missingItems = new List<object?>(genericResult.MissingItems.Count);
                 foreach (var item in genericResult.MissingItems)
@@ -42,7 +47,9 @@ namespace NUnit.Framework.Constraints
                 foreach (var item in genericResult.ExtraItems)
                     extraItems.Add(item);
 
+#pragma warning disable CS0618 // CollectionTally is obsolete until removal in NUnit 6.0 (#5230)
                 return new CollectionTallyResult(missingItems, extraItems);
+#pragma warning restore CS0618
             }
         }
 

--- a/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
+++ b/src/NUnitFramework/framework/Constraints/Comparers/DictionariesComparer.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Constraints.Comparers
             if (xDictionary.Count != yDictionary.Count)
                 return EqualMethodResult.ComparedNotEqual;
 
-            CollectionTally tally = new CollectionTally(equalityComparer, xDictionary.Keys);
+            CollectionTally<object> tally = new(xDictionary.Keys, equalityComparer);
             tally.TryRemove(yDictionary.Keys);
             if ((tally.Result.MissingItems.Count > 0) || (tally.Result.ExtraItems.Count > 0))
                 return EqualMethodResult.ComparedNotEqual;

--- a/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
+++ b/src/NUnitFramework/tests/Internal/CollectionTallyTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Internal;
 
@@ -105,6 +106,14 @@ namespace NUnit.Framework.Tests.Internal
             Assert.That(_collectionTally.Result.MissingItems, Has.Count.EqualTo(2));
             Assert.That(_collectionTally.Result.ExtraItems, Has.Count.EqualTo(1));
             Assert.That(_collectionTally.Result.ExtraItems.Contains("notFound2"), Is.True);
+        }
+
+        [Test]
+        public void NonGenericCollectionTallyIsObsolete()
+        {
+            var obsolete = typeof(CollectionTally).GetCustomAttribute<ObsoleteAttribute>();
+            Assert.That(obsolete, Is.Not.Null);
+            Assert.That(obsolete!.Message, Does.Contain("NUnit 6.0"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Mark public `CollectionTally` and `CollectionTallyResult` as obsolete ahead of removal in NUnit 6.0
- Migrate internal `DictionariesComparer` usage to `CollectionTally<object>`
- Suppress expected internal bridge usages until #5230 completes the removal

Addresses 5263

## Test plan
- [ ] CI passes (`CollectionTallyTests.NonGenericCollectionTallyIsObsolete`)