### PR TITLE
Set Assemblyversion to Minver default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ project.lock.json
 .fake
 .claude/settings.local.json
 
+/.claude/plans/*.md

--- a/src/NUnitFramework/Directory.Build.targets
+++ b/src/NUnitFramework/Directory.Build.targets
@@ -1,14 +1,11 @@
-﻿<Project>
+<Project>
 
   <Target Name="CheckConfiguration" BeforeTargets="Compile">
     <Error Condition="'$(AssemblyConfiguration)' == ''" Text="Missing AssemblyConfiguration for '$(TargetFramework)'" />
   </Target>
 
-  <!-- Override AssemblyVersion to use major.minor.0.0 for binary compatibility -->
-  <Target Name="SetAssemblyVersion" AfterTargets="MinVer" Condition="'$(MinVerMajor)' != ''">
-    <PropertyGroup>
-      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).0.0</AssemblyVersion>
-    </PropertyGroup>
+  <!-- Show AssemblyVersion, should be in form major.0.0.0 for binary compatibility -->
+  <Target Name="ShowAssemblyVersion" AfterTargets="MinVer" Condition="'$(MinVerMajor)' != ''">
     <!-- Only show version info once for main framework project (first TFM) -->
     <Message Importance="high" Text="AssemblyVersion: $(AssemblyVersion)" Condition="'$(MSBuildProjectName)' == 'nunit.framework' AND '$(TargetFramework)' == 'net462'" />
     <Message Importance="high" Text="FileVersion: $(FileVersion)" Condition="'$(MSBuildProjectName)' == 'nunit.framework' AND '$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION

Fixes #5228

Anything we do from version 5.0 that changes binary compatibility has to update the major version number.

Minver default is Major.0.0.0. 

When running `dotnet build` (also with `-v normal`) the Setup displays the Informational version.  This target doesn't display directly in the console.  If you redirect to a file it is there, or if you pip and filter the output like:
`dotnet build -v normal | grep ShowAssemblyVersion -A3`
