### PR TITLE
Simplify asserting ArgumentException.ParamName

### DIFF
--- a/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
+++ b/src/NUnitFramework/framework/Constraints/ConstraintExpression.cs
@@ -230,7 +230,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a new ConstraintExpression, which will apply the following
         /// constraint to the Message property of the object being tested.
         /// </summary>
-        public ResolvableConstraintExpression Message => Property("Message");
+        public ResolvableConstraintExpression Message => Property(nameof(Exception.Message));
 
         #endregion
 
@@ -240,7 +240,7 @@ namespace NUnit.Framework.Constraints
         /// Returns a new ConstraintExpression, which will apply the following
         /// constraint to the InnerException property of the object being tested.
         /// </summary>
-        public ResolvableConstraintExpression InnerException => Property("InnerException");
+        public ResolvableConstraintExpression InnerException => Property(nameof(Exception.InnerException));
 
         #endregion
 

--- a/src/NUnitFramework/framework/Constraints/ExceptionConstraintExtensions.cs
+++ b/src/NUnitFramework/framework/Constraints/ExceptionConstraintExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Provides extension methods for creating constraint expressions targeting Exception-related
+    /// constraints types in tests.
+    /// </summary>
+    public static class ExceptionConstraintExtensions
+    {
+        extension<T>(ExactTypeConstraint<T> value)
+            where T : ArgumentException
+        {
+            /// <summary>
+            /// Gets a constraint expression for the ParamName property.
+            /// </summary>
+            public ResolvableConstraintExpression ParamName => value.With.Property(nameof(ArgumentException.ParamName));
+        }
+
+        extension<T>(InstanceOfTypeConstraint<T> value)
+            where T : ArgumentException
+        {
+            /// <summary>
+            /// Gets a constraint expression for the ParamName property.
+            /// </summary>
+            public ResolvableConstraintExpression ParamName => value.With.Property(nameof(ArgumentException.ParamName));
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/ThrowsExceptionConstraintTests.cs
@@ -70,5 +70,25 @@ namespace NUnit.Framework.Tests.Constraints
         {
             Assert.That<Task<int>>(() => throw new Exception(), Throws.Exception);
         }
+
+        [Test]
+        public static void ArgumentExceptionParameterNameAndMessage()
+        {
+            var ex = new ArgumentNullException("myMessage", "myParam");
+
+            Assert.That(
+                () => throw ex,
+                Throws.ArgumentNullException.ParamName.EqualTo(ex.ParamName).And.Message.EqualTo(ex.Message));
+        }
+
+        [Test]
+        public static void DerivedArgumentExceptionParameterNameAndMessage()
+        {
+            var ex = new ArgumentNullException("myMessage", "myParam");
+
+            Assert.That(
+                () => throw ex,
+                Throws.InstanceOf<ArgumentException>().ParamName.EqualTo(ex.ParamName).And.Message.EqualTo(ex.Message));
+        }
     }
 }


### PR DESCRIPTION
Fixes #3947 

I'm putting this up for consideration on the design. One notable decision is that it is not placed on the `Constraint` base class. This allows it to only appear for ArgumentException or derived classes, however it carries the limitation that it must appear first in the constraint chain since it can't appear on the non-generic `ConstraintBuilder` or otherwise follow a `With`, `And` or `Or` constraint expression.

I've put this up for consideration despite these limitations as those will persist until the generic constraint feature can be completed (#53 ). That feature will undoubtedly require a major release, at which point we will allow have the flexibility to then adjust the ArgumentException-specific `ParamName` convenience members accordingly.

Note that it is also by design that this will only "light up" when using generic-based exception-related constraint APIs. Generic APIs are required to restrict this to types known at compile-time, and ParamName can already be easily accessed through the generic "classic" APIs as they will already return the strongly-typed Argument Exception instance to further assert against