### PR TITLE
Ensure tests can be loaded and run from dynamic assemblies

### DIFF
--- a/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
+++ b/src/NUnitFramework/framework/Api/DefaultTestAssemblyBuilder.cs
@@ -55,10 +55,22 @@ namespace NUnit.Framework.Api
         {
             Log.Debug("Loading {0} in AppDomain {1}", assembly.FullName!, AppDomain.CurrentDomain.FriendlyName);
 
-            string assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
-            string? suiteName = string.IsNullOrEmpty(assemblyPath) || assemblyPath.Equals("<Unknown>")
-                ? AssemblyHelper.GetAssemblyName(assembly).Name
-                : assemblyPath;
+            string? suiteName = assembly.GetName().Name;
+
+            try
+            {
+                string? assemblyPath = AssemblyHelper.GetAssemblyPath(assembly);
+
+                // Prioritize naming the suite after the assembly path instead of assembly name if possible
+                if (!string.IsNullOrEmpty(assemblyPath) && !assemblyPath.Equals("<Unknown>"))
+                {
+                    suiteName = assemblyPath;
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // Can not infer assembly path for dynamically generated assemblies
+            }
 
             if (string.IsNullOrEmpty(suiteName))
             {

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework.Api;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Tests.TestUtilities;
 using NUnit.Tests;
 using NUnit.Tests.Assemblies;
 using NUnit.Tests.Singletons;
@@ -60,34 +59,6 @@ namespace NUnit.Framework.Tests.Api
             Assert.That(result.RunState, Is.EqualTo(Framework.Interfaces.RunState.Runnable), (string)result.Properties.Get(PropertyNames.SkipReason)!);
 
             return result.TestCaseCount;
-        }
-
-        [TestCase((string?)null)]
-        [TestCase("DynamicallyCompiledAssembly")]
-        public void LoadDynamicAssembly(string? assemblyName)
-        {
-            var compiler = new TestCompiler();
-            const string code = @"
-                using NUnit.Framework;
-
-                namespace DynamicAssembly
-                {
-                    public class DynamicFixture
-                    {
-                        [Test]
-                        public void Test1() { }
-    
-                        [Test]
-                        public void Test2() { }
-                    }
-                }";
-
-            var asm = compiler.GenerateInMemoryAssembly(code, assemblyName);
-            var suite = _builder.Build(asm, new Dictionary<string, object>());
-
-            Assert.That(suite.Name, Is.Not.Null.And.Not.Empty);
-            Assert.That(suite.Tests[0].Name, Is.EqualTo("DynamicAssembly"));
-            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
         }
     }
 }

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework.Api;
 using NUnit.Framework.Internal;
+using NUnit.Framework.Tests.TestUtilities;
 using NUnit.Tests;
 using NUnit.Tests.Assemblies;
 using NUnit.Tests.Singletons;
@@ -59,6 +60,34 @@ namespace NUnit.Framework.Tests.Api
             Assert.That(result.RunState, Is.EqualTo(Framework.Interfaces.RunState.Runnable), (string)result.Properties.Get(PropertyNames.SkipReason)!);
 
             return result.TestCaseCount;
+        }
+
+        [TestCase((string?)null)]
+        [TestCase("DynamicallyCompiledAssembly")]
+        public void LoadDynamicAssembly(string? assemblyName)
+        {
+            var compiler = new TestCompiler();
+            const string code = @"
+                using NUnit.Framework;
+
+                namespace DynamicAssembly
+                {
+                    public class DynamicFixture
+                    {
+                        [Test]
+                        public void Test1() { }
+    
+                        [Test]
+                        public void Test2() { }
+                    }
+                }";
+
+            var asm = compiler.GenerateInMemoryAssembly(code, assemblyName);
+            var suite = _builder.Build(asm, new Dictionary<string, object>());
+
+            Assert.That(suite.Name, Is.Not.Null.And.Not.Empty);
+            Assert.That(suite.Tests[0].Name, Is.EqualTo("DynamicAssembly"));
+            Assert.That(suite.TestCaseCount, Is.EqualTo(2));
         }
     }
 }

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -876,6 +876,7 @@ namespace NUnit.Framework.Tests.Api
 
             var suite = _runner.Load(asm, EmptySettings);
 
+            Assert.That(suite.Name, Is.Not.Null.And.Not.Empty);
             Assert.That(suite.Tests[0].Name, Is.EqualTo(DynamicAssemblyName));
             Assert.That(suite.TestCaseCount, Is.EqualTo(ExpectedDynamicTestCount));
 

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -842,8 +842,9 @@ namespace NUnit.Framework.Tests.Api
 
         private const int ExpectedDynamicTestCount = 2;
         private const string DynamicAssemblyName = "DynamicAssembly";
+        private const string DynamicNamespaceName = "DynamicNamespace";
         private const string DynamicCode = @"
-                namespace DynamicAssembly
+                namespace " + DynamicNamespaceName + @"
                 {
                     public class DynamicFixture
                     {
@@ -877,7 +878,7 @@ namespace NUnit.Framework.Tests.Api
             var suite = _runner.Load(asm, EmptySettings);
 
             Assert.That(suite.Name, Is.Not.Null.And.Not.Empty);
-            Assert.That(suite.Tests[0].Name, Is.EqualTo(DynamicAssemblyName));
+            Assert.That(suite.Tests[0].Name, Is.EqualTo(DynamicNamespaceName));
             Assert.That(suite.TestCaseCount, Is.EqualTo(ExpectedDynamicTestCount));
 
             var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
@@ -893,7 +894,7 @@ namespace NUnit.Framework.Tests.Api
                 properties like name, codebase, location, etc.
                 Structure of the contained class:
 
-                namespace DynamicAssembly
+                namespace DynamicNamespace
                 {
                     public class DynamicFixture
                     {
@@ -914,7 +915,7 @@ namespace NUnit.Framework.Tests.Api
 
             // Create the DynamicFixture class
             var typeBuilder = moduleBuilder.DefineType(
-                $"{DynamicAssemblyName}.DynamicFixture",
+                $"{DynamicNamespaceName}.DynamicFixture",
                 TypeAttributes.Public);
 
             CreateEmptyTestMethod(typeBuilder, "Test1");

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -898,10 +898,8 @@ namespace NUnit.Framework.Tests.Api
                     {
                         [NUnit.Framework.Test]
                         public void Test1() { }
-
-                        [NUnit.Framework..Test]
+                        [NUnit.Framework.Test]
                         public void Test2() { }
-                    }
                 }
              */
 
@@ -933,10 +931,10 @@ namespace NUnit.Framework.Tests.Api
 
                 // Create method
                 var testMethod = typeBuilder.DefineMethod(
-                methodName,
-                MethodAttributes.Public,
-                typeof(void),
-                Type.EmptyTypes);
+                    methodName,
+                    MethodAttributes.Public,
+                    typeof(void),
+                    Type.EmptyTypes);
 
                 var testMethodIL = testMethod.GetILGenerator();
                 testMethodIL.Emit(OpCodes.Ret);

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Threading;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
@@ -835,6 +836,116 @@ namespace NUnit.Framework.Tests.Api
             });
         }
 
+        #endregion
+
+        #region Dynamic Assemblies
+
+        private const int ExpectedDynamicTestCount = 2;
+        private const string DynamicAssemblyName = "DynamicAssembly";
+        private const string DynamicCode = @"
+                namespace DynamicAssembly
+                {
+                    public class DynamicFixture
+                    {
+                        [NUnit.Framework.Test]
+                        public void Test1() { }
+
+                        [NUnit.Framework.Test]
+                        public void Test2() { }
+                    }
+                }
+        ";
+
+        [Test]
+        public void LoadAndRunDynamicAssembly_ReflectionEmit()
+        {
+            LoadAndRunDynamicAssembly(CreateDynamicAssembly_ReflectionEmit);
+        }
+
+        [Test]
+        public void LoadAndRunDynamicAssembly_Roslyn()
+        {
+            LoadAndRunDynamicAssembly(() => new TestCompiler().GenerateInMemoryAssembly(DynamicCode, DynamicAssemblyName));
+        }
+
+        private void LoadAndRunDynamicAssembly(Func<Assembly> assemblyGenerator)
+        {
+            var asm = assemblyGenerator();
+
+            Assert.That(asm.GetName().Name, Is.EqualTo(DynamicAssemblyName));
+
+            var suite = _runner.Load(asm, EmptySettings);
+
+            Assert.That(suite.Tests[0].Name, Is.EqualTo(DynamicAssemblyName));
+            Assert.That(suite.TestCaseCount, Is.EqualTo(ExpectedDynamicTestCount));
+
+            var result = _runner.Run(TestListener.NULL, TestFilter.Empty);
+
+            Assert.That(result.PassCount, Is.EqualTo(ExpectedDynamicTestCount));
+            Assert.That(result.FailCount, Is.Zero);
+        }
+
+        private static Assembly CreateDynamicAssembly_ReflectionEmit()
+        {
+            /*
+                Builds an assembly and class dynamically so that we have full control over assembly attributes and
+                properties like name, codebase, location, etc.
+                Structure of the contained class:
+
+                namespace DynamicAssembly
+                {
+                    public class DynamicFixture
+                    {
+                        [NUnit.Framework.Test]
+                        public void Test1() { }
+
+                        [NUnit.Framework..Test]
+                        public void Test2() { }
+                    }
+                }
+             */
+
+            // Create assembly and module
+            var assemblyName = new AssemblyName(DynamicAssemblyName);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.RunAndCollect);
+
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(DynamicAssemblyName);
+
+            // Create the DynamicFixture class
+            var typeBuilder = moduleBuilder.DefineType(
+                $"{DynamicAssemblyName}.DynamicFixture",
+                TypeAttributes.Public);
+
+            CreateEmptyTestMethod(typeBuilder, "Test1");
+            CreateEmptyTestMethod(typeBuilder, "Test2");
+
+            // Create the type
+            typeBuilder.CreateType();
+
+            return assemblyBuilder;
+
+            static void CreateEmptyTestMethod(TypeBuilder typeBuilder, string methodName)
+            {
+                var testAttributeType = typeof(TestAttribute);
+                var testAttributeConstructor = testAttributeType.GetConstructor(Type.EmptyTypes)!;
+
+                // Create method
+                var testMethod = typeBuilder.DefineMethod(
+                methodName,
+                MethodAttributes.Public,
+                typeof(void),
+                Type.EmptyTypes);
+
+                var testMethodIL = testMethod.GetILGenerator();
+                testMethodIL.Emit(OpCodes.Ret);
+
+                // Apply [Test] attribute to method
+                var testAttrBuilder = new CustomAttributeBuilder(testAttributeConstructor, Array.Empty<object>());
+                testMethod.SetCustomAttribute(testAttrBuilder);
+            }
+        }
         #endregion
     }
 }

--- a/src/NUnitFramework/tests/TestUtilities/TestCompiler.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestCompiler.cs
@@ -79,7 +79,7 @@ namespace NUnit.Framework.Tests.TestUtilities
             }
         }
 
-        private EmitResult CompileCode(string code, Stream stream, string? assemblyName)
+        private EmitResult CompileCode(string code, Stream stream, string assemblyName)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(code);
             var compilation = CSharpCompilation.Create(
@@ -102,7 +102,7 @@ namespace NUnit.Framework.Tests.TestUtilities
         public Assembly GenerateInMemoryAssembly(string code)
             => GenerateInMemoryAssembly(code, DefaultAssemblyName);
 
-        public Assembly GenerateInMemoryAssembly(string code, string? assemblyName)
+        public Assembly GenerateInMemoryAssembly(string code, string assemblyName)
         {
             using var ms = new MemoryStream();
             var result = CompileCode(code, ms, assemblyName);

--- a/src/NUnitFramework/tests/TestUtilities/TestCompiler.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestCompiler.cs
@@ -78,12 +78,10 @@ namespace NUnit.Framework.Tests.TestUtilities
                 }
             }
         }
-        private EmitResult CompileCode(string code, Stream stream)
+
+        private EmitResult CompileCode(string code, Stream stream, string? assemblyName)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(code);
-
-            var assemblyName = $"InMemoryAssembly_{Guid.NewGuid():N}";
-
             var compilation = CSharpCompilation.Create(
                 assemblyName,
                 syntaxTrees: [syntaxTree],
@@ -93,16 +91,21 @@ namespace NUnit.Framework.Tests.TestUtilities
             return compilation.Emit(stream);
         }
 
+        private string DefaultAssemblyName => $"InMemoryAssembly_{Guid.NewGuid():N}";
+
         public EmitResult CompileCode(string code)
         {
             using var ms = new MemoryStream();
-            return CompileCode(code, ms);
+            return CompileCode(code, ms, DefaultAssemblyName);
         }
 
         public Assembly GenerateInMemoryAssembly(string code)
+            => GenerateInMemoryAssembly(code, DefaultAssemblyName);
+
+        public Assembly GenerateInMemoryAssembly(string code, string? assemblyName)
         {
             using var ms = new MemoryStream();
-            var result = CompileCode(code, ms);
+            var result = CompileCode(code, ms, assemblyName);
 
             if (result.Success)
             {


### PR DESCRIPTION
Fixes #4320 

Note that the code updates here are to accommodate CodeBase throwing an exception on property access as that is the default behavior when using reflection emit on net462. On modern .NET we use `Location` instead as `CodeBase` is deprecated. Location is an empty string instead of null for either dynamic assembly option on .NET