### PR TITLE
Fix parameter name mismatch in TestFilter.FromXml

### DIFF
--- a/src/NUnitFramework/framework/Internal/TestFilter.cs
+++ b/src/NUnitFramework/framework/Internal/TestFilter.cs
@@ -199,7 +199,7 @@ namespace NUnit.Framework.Internal
                     break;
             }
 
-            throw new ArgumentException("Invalid filter element: " + node.Name, "xmlNode");
+            throw new ArgumentException("Invalid filter element: " + node.Name, nameof(node));
         }
 
         private static string NodeValue(TNode node)

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -447,7 +447,7 @@ namespace NUnit.Framework.Tests.Api
             var ex = Assert.Throws<ArgumentException>(() =>
                 TestFilter.FromXml("<filter><invalidElement>foo</invalidElement></filter>"));
 
-            Assert.That(ex.ParamName, Is.EqualTo("xmlNode"));
+            Assert.That(ex.ParamName, Is.EqualTo("node"));
             Assert.That(ex?.Message, Does.StartWith(string.Format(InvalidFilterElementMessage, "invalidElement")));
         }
 


### PR DESCRIPTION
This PR addresses a minor parameter name mismatch in TestFilter.FromXml(TNode? node):
Refactors the hardcoded "xmlNode" parameter name argument passed to the thrown ArgumentException to use nameof(node).
Updates the corresponding unit test assertion in TestAssemblyRunnerTests to expect "node" instead of "xmlNode".