### PR TITLE
Use ArgumentOutOfRangeException throw helpers and enable CA1512

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,9 @@ csharp_style_expression_bodied_properties = when_on_single_line:suggestion
 # Microsofts own MemberNotNull attribute expects an array
 dotnet_diagnostic.CS3016.severity = none
 
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
 ############################################################################################
 # IDE Analysis
 ############################################################################################

--- a/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RepeatAttribute.cs
@@ -121,11 +121,9 @@ namespace NUnit.Framework
             public RepeatedTestCommand(TestCommand innerCommand, int repeatCount, bool stopOnFailure, int requiredPassPercentage, bool stopWhenOverallResultDetermined)
                 : base(innerCommand)
             {
-                if (repeatCount < 1)
-                    throw new ArgumentOutOfRangeException(nameof(repeatCount), repeatCount, "Must be at least 1.");
-
-                if (requiredPassPercentage is < 1 or > 100)
-                    throw new ArgumentOutOfRangeException(nameof(requiredPassPercentage), requiredPassPercentage, "Must be between 1 and 100.");
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(repeatCount);
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(requiredPassPercentage);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(requiredPassPercentage, 100);
 
                 _repeatCount = repeatCount;
                 // When a pass threshold is set, all iterations must run regardless of StopOnFailure.

--- a/src/NUnitFramework/framework/Constraints/MultipleOfConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/MultipleOfConstraint.cs
@@ -17,7 +17,7 @@ namespace NUnit.Framework.Constraints
         /// <param name="multiple">An integer value greater than zero</param>
         public MultipleOfConstraint(int multiple)
         {
-            Guard.ArgumentInRange(multiple > 0, "Multiple must be greater than zero", nameof(multiple));
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(multiple);
             _multiple = (uint)multiple;
         }
 

--- a/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
+++ b/src/NUnitFramework/framework/Constraints/PropertiesComparerConfiguration.cs
@@ -211,10 +211,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public PropertiesComparerConfigurationUntyped WithMaximumGraphDepth(int depth)
         {
-            if (depth < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(depth), depth, "Depth must be at least 1");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depth);
             MaximumGraphDepth = depth;
             return this;
         }
@@ -385,10 +382,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>Self.</returns>
         public PropertiesComparerConfiguration<T> WithMaximumGraphDepth(int depth)
         {
-            if (depth < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(depth), depth, "Depth must be at least 1");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depth);
             MaximumGraphDepth = depth;
             return this;
         }

--- a/src/NUnitFramework/framework/Guard.cs
+++ b/src/NUnitFramework/framework/Guard.cs
@@ -15,22 +15,6 @@ namespace NUnit.Framework
     internal static class Guard
     {
         /// <summary>
-        /// Throws an ArgumentOutOfRangeException if the specified condition is not met.
-        /// </summary>
-        /// <param name="condition">The condition that must be met</param>
-        /// <param name="message">The exception message to be used</param>
-        /// <param name="paramName">The name of the argument</param>
-        public static void ArgumentInRange([DoesNotReturnIf(false)] bool condition, string message, string paramName)
-        {
-            if (!condition)
-                ThrowArgumentOutOfRangeException(message, paramName);
-
-            [DoesNotReturn]
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            static void ThrowArgumentOutOfRangeException(string message, string paramName) => throw new ArgumentOutOfRangeException(paramName, message);
-        }
-
-        /// <summary>
         /// Throws an ArgumentException if the specified condition is not met.
         /// </summary>
         /// <param name="condition">The condition that must be met</param>

--- a/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
@@ -14,6 +14,18 @@ namespace System
     {
         extension(ArgumentOutOfRangeException)
         {
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is zero.</summary>
+            /// <param name="value">The argument to validate as non-zero.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfZero<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
+            {
+                if (value.CompareTo(default(T)) == 0)
+                {
+                    ThrowZero(value, paramName);
+                }
+            }
+
             /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
             /// <param name="value">The argument to validate as non-negative.</param>
             /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
@@ -23,6 +35,31 @@ namespace System
                 if (value.CompareTo(default(T)) < 0)
                 {
                     ThrowNegative(value, paramName);
+                }
+            }
+
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative or zero.</summary>
+            /// <param name="value">The argument to validate as non-zero or greater.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfNegativeOrZero<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
+            {
+                if (value.CompareTo(default(T)) <= 0)
+                {
+                    ThrowNegativeOrZero(value, paramName);
+                }
+            }
+
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than <paramref name="other"/>.</summary>
+            /// <param name="value">The argument to validate as less than or equal to <paramref name="other"/>.</param>
+            /// <param name="other">The value to compare with <paramref name="value"/>.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfGreaterThan<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
+            {
+                if (value.CompareTo(other) > 0)
+                {
+                    ThrowGreater(value, other, paramName);
                 }
             }
 
@@ -38,15 +75,44 @@ namespace System
                     ThrowGreaterEqual(value, other, paramName);
                 }
             }
+
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than <paramref name="other"/>.</summary>
+            /// <param name="value">The argument to validate as greater than or equal to <paramref name="other"/>.</param>
+            /// <param name="other">The value to compare with <paramref name="value"/>.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfLessThan<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
+            {
+                if (value.CompareTo(other) < 0)
+                {
+                    ThrowLess(value, other, paramName);
+                }
+            }
         }
+
+        [DoesNotReturn]
+        private static void ThrowZero<T>(T value, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-zero.");
 
         [DoesNotReturn]
         private static void ThrowNegative<T>(T value, string? paramName) =>
             throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-negative.");
 
         [DoesNotReturn]
+        private static void ThrowNegativeOrZero<T>(T value, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be positive and non-zero.");
+
+        [DoesNotReturn]
+        private static void ThrowGreater<T>(T value, T other, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be less than or equal to {other}.");
+
+        [DoesNotReturn]
         private static void ThrowGreaterEqual<T>(T value, T other, string? paramName) =>
             throw new ArgumentOutOfRangeException(paramName, value, $"Value must be less than {other}.");
+
+        [DoesNotReturn]
+        private static void ThrowLess<T>(T value, T other, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be greater than or equal to {other}.");
     }
 }
 

--- a/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#if NETFRAMEWORK
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>
+    /// Extension methods for <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    internal static class ArgumentOutOfRangeExceptionExtensions
+    {
+        extension(ArgumentOutOfRangeException)
+        {
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
+            /// <param name="value">The argument to validate as non-negative.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            {
+                if (value < 0)
+                {
+                    ThrowNegative(value, paramName);
+                }
+            }
+
+            /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than or equal to <paramref name="other"/>.</summary>
+            /// <param name="value">The argument to validate as less than <paramref name="other"/>.</param>
+            /// <param name="other">The value to compare with <paramref name="value"/>.</param>
+            /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+            public static void ThrowIfGreaterThanOrEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
+            {
+                if (value.CompareTo(other) >= 0)
+                {
+                    ThrowGreaterEqual(value, other, paramName);
+                }
+            }
+        }
+
+        [DoesNotReturn]
+        private static void ThrowNegative(int value, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-negative.");
+
+        [DoesNotReturn]
+        private static void ThrowGreaterEqual<T>(T value, T other, string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be less than {other}.");
+    }
+}
+
+#endif

--- a/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
+++ b/src/NUnitFramework/framework/Internal/ArgumentOutOfRangeExceptionExtensions.cs
@@ -17,9 +17,10 @@ namespace System
             /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
             /// <param name="value">The argument to validate as non-negative.</param>
             /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
-            public static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            public static void ThrowIfNegative<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+                where T : IComparable<T>
             {
-                if (value < 0)
+                if (value.CompareTo(default(T)) < 0)
                 {
                     ThrowNegative(value, paramName);
                 }
@@ -40,7 +41,7 @@ namespace System
         }
 
         [DoesNotReturn]
-        private static void ThrowNegative(int value, string? paramName) =>
+        private static void ThrowNegative<T>(T value, string? paramName) =>
             throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-negative.");
 
         [DoesNotReturn]

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemQueue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -183,8 +184,8 @@ namespace NUnit.Framework.Internal.Execution
         /// <param name="priority">The priority at which to process the item</param>
         internal void Enqueue(WorkItem work, int priority)
         {
-            Guard.ArgumentInRange(priority >= 0 && priority < PRIORITY_LEVELS,
-                "Invalid priority specified", nameof(priority));
+            ArgumentOutOfRangeException.ThrowIfNegative(priority);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(priority, PRIORITY_LEVELS);
 
             do
             {

--- a/src/NUnitFramework/framework/Internal/Randomizer.cs
+++ b/src/NUnitFramework/framework/Internal/Randomizer.cs
@@ -156,7 +156,7 @@ namespace NUnit.Framework.Internal
         [CLSCompliant(false)]
         public uint NextUInt(uint min, uint max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
+            ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
             if (min == max)
                 return min;
@@ -259,7 +259,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public long NextLong(long min, long max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
+            ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
             if (min == max)
                 return min;
@@ -306,7 +306,7 @@ namespace NUnit.Framework.Internal
         [CLSCompliant(false)]
         public ulong NextULong(ulong min, ulong max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
+            ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
             ulong range = max - min;
 
@@ -401,7 +401,8 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public bool NextBool(double probability)
         {
-            Guard.ArgumentInRange(probability is >= 0.0 and <= 1.0, "Probability must be from 0.0 to 1.0", nameof(probability));
+            ArgumentOutOfRangeException.ThrowIfNegative(probability);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(probability, 1.0);
 
             return NextDouble() < probability;
         }
@@ -426,7 +427,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         public double NextDouble(double min, double max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
+            ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
             if (max == min)
                 return min;
@@ -661,7 +662,7 @@ namespace NUnit.Framework.Internal
         {
             if (max <= 1)
             {
-                Guard.ArgumentInRange(max > 0, "Maximum must be greater than zero.", nameof(max));
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(max);
                 return 0;
             }
 
@@ -736,7 +737,7 @@ namespace NUnit.Framework.Internal
         /// </remarks>
         public decimal NextDecimal(decimal min, decimal max)
         {
-            Guard.ArgumentInRange(max >= min, "Maximum value must be greater than or equal to minimum.", nameof(max));
+            ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
             // Check that the range is not greater than MaxValue without
             // first calculating it, since this would cause overflow

--- a/src/NUnitFramework/framework/Internal/ThreadUtility.cs
+++ b/src/NUnitFramework/framework/Internal/ThreadUtility.cs
@@ -114,8 +114,7 @@ namespace NUnit.Framework.Internal
         /// </summary>
         private static void DislodgeThreadInNativeMessageWait(Thread thread, int nativeId)
         {
-            if (nativeId == 0)
-                throw new ArgumentOutOfRangeException(nameof(nativeId), "Native thread ID must not be zero.");
+            ArgumentOutOfRangeException.ThrowIfZero(nativeId);
 
             // Schedule a thread pool thread to check on the aborting thread in case it's in a message pump native blocking wait
             Delay(ThreadAbortedCheckDelay, CheckOnAbortingThread, new CheckOnAbortingThreadState(thread, nativeId));

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -257,8 +257,7 @@ namespace NUnit.Options
         {
             if (_c.Option is null)
                 throw new InvalidOperationException("OptionContext.Option is null.");
-            if (index >= _c.Option.MaxValueCount)
-                throw new ArgumentOutOfRangeException(nameof(index));
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _c.Option.MaxValueCount);
             if (_c.Option.OptionValueType == OptionValueType.Required &&
                     index >= _values.Count)
             {
@@ -359,8 +358,7 @@ namespace NUnit.Options
                 throw new ArgumentNullException(nameof(prototype));
             if (prototype.Length == 0)
                 throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
-            if (maxValueCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxValueCount));
+            ArgumentOutOfRangeException.ThrowIfNegative(maxValueCount);
 
             _prototype = prototype;
             _names = prototype.Split('|');

--- a/src/NUnitFramework/tests/TestUtilities/CallbackWatcher.cs
+++ b/src/NUnitFramework/tests/TestUtilities/CallbackWatcher.cs
@@ -39,8 +39,7 @@ namespace NUnit.Framework.Tests.TestUtilities
         /// <exception cref="AssertionException">Thrown when <see cref="OnCallback"/> was not called the expected number of times between beginning and ending.</exception>
         public IDisposable ExpectCallback(int count = 1)
         {
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), _expectedCount, "Expected callback count must be greater than or equal to zero.");
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
 
             if (_expectedCount != 0)
                 throw new InvalidOperationException($"The previous {nameof(ExpectCallback)} scope must be disposed before calling again.");

--- a/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
+++ b/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
@@ -12,10 +12,8 @@ namespace NUnit.Framework.Tests.TestUtilities
         public static void RunParallel(Action action, int times, int maxParallelism, bool useThreadPool = true)
         {
             ArgumentNullException.ThrowIfNull(action);
-            if (times < 0)
-                throw new ArgumentOutOfRangeException(nameof(times), times, "Number of times to run must be greater than or equal to 0.");
-            if (maxParallelism < 1)
-                throw new ArgumentOutOfRangeException(nameof(maxParallelism), maxParallelism, "Max parallelism must be greater than or equal to 1.");
+            ArgumentOutOfRangeException.ThrowIfNegative(times);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxParallelism);
 
             if (times == 0)
                 return;


### PR DESCRIPTION
Fixes #5349

Replace the two ArgumentOutOfRangeException check-and-throw sites in
nunitlite Options.cs with ThrowIfNegative / ThrowIfGreaterThanOrEqual.
Add internal NETFRAMEWORK polyfills matching the existing ThrowIfNull
pattern, and enable CA1512 as a warning in .editorconfig.