### PR TITLE
Use ArgumentNullException throw helper and remove CA1510 diagnostic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,9 @@ csharp_style_expression_bodied_properties = when_on_single_line:suggestion
 # Microsofts own MemberNotNull attribute expects an array
 dotnet_diagnostic.CS3016.severity = none
 
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
 ############################################################################################
 # IDE Analysis
 ############################################################################################

--- a/src/NUnitFramework/nunitlite/CommandLineOptions.cs
+++ b/src/NUnitFramework/nunitlite/CommandLineOptions.cs
@@ -32,8 +32,7 @@ namespace NUnit.Common
         internal CommandLineOptions(IDefaultOptionsProvider defaultOptionsProvider, bool requireInputFile, params string[] args)
         {
             // Apply default options
-            if (defaultOptionsProvider is null)
-                throw new ArgumentNullException(nameof(defaultOptionsProvider));
+            ArgumentNullException.ThrowIfNull(defaultOptionsProvider);
 
             TeamCity = defaultOptionsProvider.TeamCity;
 

--- a/src/NUnitFramework/nunitlite/Options.cs
+++ b/src/NUnitFramework/nunitlite/Options.cs
@@ -355,8 +355,7 @@ namespace NUnit.Options
 
         protected Option(string prototype, string description, int maxValueCount)
         {
-            if (prototype is null)
-                throw new ArgumentNullException(nameof(prototype));
+            ArgumentNullException.ThrowIfNull(prototype);
             if (prototype.Length == 0)
                 throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
             if (maxValueCount < 0)
@@ -607,8 +606,7 @@ namespace NUnit.Options
 
         protected override string GetKeyForItem(Option item)
         {
-            if (item is null)
-                throw new ArgumentNullException(nameof(item));
+            ArgumentNullException.ThrowIfNull(item);
             if (item.Names is not null && item.Names.Length > 0)
                 return item.Names[0];
             // This should never happen, as it's invalid for Option to be
@@ -642,8 +640,7 @@ namespace NUnit.Options
 
         private void AddImpl(Option option)
         {
-            if (option is null)
-                throw new ArgumentNullException(nameof(option));
+            ArgumentNullException.ThrowIfNull(option);
             List<string> added = new List<string>(option.Names.Length);
             try
             {
@@ -675,8 +672,7 @@ namespace NUnit.Options
             public ActionOption(string prototype, string description, int count, Action<OptionValueCollection> action)
                 : base(prototype, description, count)
             {
-                if (action is null)
-                    throw new ArgumentNullException(nameof(action));
+                ArgumentNullException.ThrowIfNull(action);
                 _action = action;
             }
 
@@ -693,8 +689,7 @@ namespace NUnit.Options
 
         public OptionSet Add(string prototype, string description, Action<string> action)
         {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
+            ArgumentNullException.ThrowIfNull(action);
             Option p = new ActionOption(prototype, description, 1,
                     delegate(OptionValueCollection v) { action(v[0]); });
             base.Add(p);
@@ -708,8 +703,7 @@ namespace NUnit.Options
 
         public OptionSet Add(string prototype, string description, OptionAction<string, string> action)
         {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
+            ArgumentNullException.ThrowIfNull(action);
             Option p = new ActionOption(prototype, description, 2,
                     delegate(OptionValueCollection v) { action(v[0], v[1]); });
             base.Add(p);
@@ -723,8 +717,7 @@ namespace NUnit.Options
             public ActionOption(string prototype, string description, Action<T> action)
                 : base(prototype, description, 1)
             {
-                if (action is null)
-                    throw new ArgumentNullException(nameof(action));
+                ArgumentNullException.ThrowIfNull(action);
                 _action = action;
             }
 
@@ -741,8 +734,7 @@ namespace NUnit.Options
             public ActionOption(string prototype, string description, OptionAction<TKey, TValue> action)
                 : base(prototype, description, 2)
             {
-                if (action is null)
-                    throw new ArgumentNullException(nameof(action));
+                ArgumentNullException.ThrowIfNull(action);
                 _action = action;
             }
 
@@ -825,8 +817,7 @@ namespace NUnit.Options
 
         protected bool GetOptionParts(string argument, out string flag, out string name, out string sep, out string value)
         {
-            if (argument is null)
-                throw new ArgumentNullException(nameof(argument));
+            ArgumentNullException.ThrowIfNull(argument);
 
             flag = name = sep = value = null;
             Match m = ValueOption.Match(argument);

--- a/src/NUnitFramework/nunitlite/Tokenizer.cs
+++ b/src/NUnitFramework/nunitlite/Tokenizer.cs
@@ -98,8 +98,7 @@ namespace NUnit.Common
 
         public Tokenizer(string input)
         {
-            if (input is null)
-                throw new ArgumentNullException(nameof(input));
+            ArgumentNullException.ThrowIfNull(input);
 
             _input = input;
             _index = 0;

--- a/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
+++ b/src/NUnitFramework/tests/Assertions/LowTrustFixture.cs
@@ -161,8 +161,7 @@ namespace NUnit.Framework.Tests.Assertions
         }
         public object? Run(MethodInfo method, params object[] parameters)
         {
-            if (method is null)
-                throw new ArgumentNullException(nameof(method));
+            ArgumentNullException.ThrowIfNull(method);
             if (_appDomain is null)
                 throw new ObjectDisposedException(null);
 

--- a/src/NUnitFramework/tests/Extensions.cs
+++ b/src/NUnitFramework/tests/Extensions.cs
@@ -15,8 +15,7 @@ namespace NUnit.Framework.Tests
         /// </summary>
         public static void AssertPassed(this ITestResult result)
         {
-            if (result is null)
-                throw new ArgumentNullException(nameof(result));
+            ArgumentNullException.ThrowIfNull(result);
 
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
         }

--- a/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
+++ b/src/NUnitFramework/tests/Syntax/ThrowsTests.cs
@@ -160,8 +160,10 @@ namespace NUnit.Framework.Tests.Syntax
         {
             public MyClass(string s)
             {
+#pragma warning disable CA1510 // Use ArgumentNullException throw helper -- Intentionally parameterless for test assertions
                 if (s is null)
                     throw new ArgumentNullException();
+#pragma warning restore CA1510
             }
         }
     }

--- a/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
+++ b/src/NUnitFramework/tests/TestUtilities/StressUtility.cs
@@ -11,8 +11,7 @@ namespace NUnit.Framework.Tests.TestUtilities
     {
         public static void RunParallel(Action action, int times, int maxParallelism, bool useThreadPool = true)
         {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
+            ArgumentNullException.ThrowIfNull(action);
             if (times < 0)
                 throw new ArgumentOutOfRangeException(nameof(times), times, "Number of times to run must be greater than or equal to 0.");
             if (maxParallelism < 1)


### PR DESCRIPTION
Fixes #5348

Replace all 14 explicit null-check-and-throw sites with
ArgumentNullException.ThrowIfNull across nunitlite and test projects.
Suppress CA1510 inline in ThrowsTests.cs where a parameterless
ArgumentNullException is thrown intentionally for test assertions.
Enable CA1510 as a warning in .editorconfig to catch future occurrences.