### PR TITLE
Fix NUnitLite ArgumentException in AOT/single-file publish

### DIFF
--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -22,17 +22,11 @@ namespace NUnit.Framework.Internal
 
         /// <summary>
         /// Gets the path from which an assembly was loaded.
+        /// For builds where this is not possible, returns
+        /// the name of the assembly.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
-        /// <returns>
-        /// The path from which the assembly was loaded. When the assembly's
-        /// <see cref="Assembly.Location"/> is available, that file path is
-        /// returned. When <see cref="Assembly.Location"/> is empty — which
-        /// happens in single-file/AOT publish scenarios and in some hosting
-        /// environments such as Blazor — the application base directory (see
-        /// <see cref="AppContext.BaseDirectory"/>) is returned instead, so that
-        /// callers receive a usable directory path rather than an empty string.
-        /// </returns>
+        /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
 #if NETFRAMEWORK
@@ -46,16 +40,7 @@ namespace NUnit.Framework.Internal
                 return GetAssemblyPathFromCodeBase(codeBase);
 #endif
 
-            var location = assembly.Location;
-            if (!string.IsNullOrEmpty(location))
-                return location;
-
-            // Assembly.Location is empty in single-file/AOT publish scenarios
-            // (and in some other hosting environments such as Blazor). Fall back
-            // to the application base directory so callers don't receive an
-            // empty string, which would otherwise cause an ArgumentException
-            // downstream (e.g. Path.GetDirectoryName("")). See issue #4987.
-            return AppContext.BaseDirectory;
+            return assembly.Location;
         }
 
         #endregion
@@ -69,7 +54,21 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetDirectoryName(Assembly assembly)
         {
-            return Path.GetDirectoryName(GetAssemblyPath(assembly))!;
+            var path = GetAssemblyPath(assembly);
+            // GetAssemblyPath returns an empty string when the assembly has no
+            // on-disk location (single-file/AOT publish, Blazor, dynamic
+            // assemblies). On .NET 5+, Path.GetDirectoryName(string.Empty)
+            // returns null, and the previous null-forgiving `!` suppressed the
+            // warning so the null propagated until a downstream caller (e.g.
+            // Path.Combine(TestContext.TestDirectory, ...)) threw. Fall back to
+            // the application base directory in that case so callers always get
+            // a usable, non-null directory. See issue #4987.
+            if (path.Length == 0)
+            {
+                return AppContext.BaseDirectory;
+            }
+
+            return Path.GetDirectoryName(path)!;
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -22,11 +22,17 @@ namespace NUnit.Framework.Internal
 
         /// <summary>
         /// Gets the path from which an assembly was loaded.
-        /// For builds where this is not possible, returns
-        /// the name of the assembly.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
-        /// <returns>The path.</returns>
+        /// <returns>
+        /// The path from which the assembly was loaded. When the assembly's
+        /// <see cref="Assembly.Location"/> is available, that file path is
+        /// returned. When <see cref="Assembly.Location"/> is empty — which
+        /// happens in single-file/AOT publish scenarios and in some hosting
+        /// environments such as Blazor — the application base directory (see
+        /// <see cref="AppContext.BaseDirectory"/>) is returned instead, so that
+        /// callers receive a usable directory path rather than an empty string.
+        /// </returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
 #if NETFRAMEWORK

--- a/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
+++ b/src/NUnitFramework/framework/Internal/AssemblyHelper.cs
@@ -40,7 +40,16 @@ namespace NUnit.Framework.Internal
                 return GetAssemblyPathFromCodeBase(codeBase);
 #endif
 
-            return assembly.Location;
+            var location = assembly.Location;
+            if (!string.IsNullOrEmpty(location))
+                return location;
+
+            // Assembly.Location is empty in single-file/AOT publish scenarios
+            // (and in some other hosting environments such as Blazor). Fall back
+            // to the application base directory so callers don't receive an
+            // empty string, which would otherwise cause an ArgumentException
+            // downstream (e.g. Path.GetDirectoryName("")). See issue #4987.
+            return AppContext.BaseDirectory;
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.IO;
+using System.Reflection;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Tests.Internal
@@ -59,5 +60,27 @@ namespace NUnit.Framework.Tests.Internal
             string localPath = AssemblyHelper.GetAssemblyPathFromCodeBase(uri);
             Assert.That(localPath, Is.SamePath(expectedPath));
         }
+
+        // A dynamic assembly (created via AssemblyBuilder.DefineDynamicAssembly)
+        // has an empty Location, which is the same condition seen in single-file
+        // and AOT publish scenarios. GetAssemblyPath must fall back to
+        // AppContext.BaseDirectory in that case rather than returning an empty
+        // string (which would cause an ArgumentException downstream). See #4987.
+#if !NETFRAMEWORK
+        [Test]
+        public void GetAssemblyPath_FallsBackToBaseDirectoryWhenLocationIsEmpty()
+        {
+            var assemblyName = new AssemblyName("AssemblyHelperTests_EmptyLocationDynamicAssembly");
+            var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.RunAndCollect);
+
+            // Sanity check: a dynamic assembly has no on-disk location.
+            Assert.That(dynamicAssembly.Location, Is.EqualTo(string.Empty));
+
+            string path = AssemblyHelper.GetAssemblyPath(dynamicAssembly);
+            Assert.That(path, Is.EqualTo(AppContext.BaseDirectory));
+        }
+#endif
     }
 }

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.IO;
+#if NET5_0_OR_GREATER
 using System.Reflection;
 using System.Reflection.Emit;
+#endif
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Tests.Internal
@@ -62,25 +64,34 @@ namespace NUnit.Framework.Tests.Internal
             Assert.That(localPath, Is.SamePath(expectedPath));
         }
 
-        // A dynamic assembly (created via AssemblyBuilder.DefineDynamicAssembly)
-        // has an empty Location, which is the same condition seen in single-file
-        // and AOT publish scenarios. GetAssemblyPath must fall back to
-        // AppContext.BaseDirectory in that case rather than returning an empty
-        // string (which would cause an ArgumentException downstream). See #4987.
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
         [Test]
-        public void GetAssemblyPath_FallsBackToBaseDirectoryWhenLocationIsEmpty()
+        public void GetAssemblyPath_ReturnsEmpty_WhenAssemblyHasNoLocation()
         {
-            var assemblyName = new AssemblyName("AssemblyHelperTests_EmptyLocationDynamicAssembly");
             var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
-                assemblyName,
+                new AssemblyName("AssemblyHelperTests_EmptyLocation"),
                 AssemblyBuilderAccess.RunAndCollect);
 
-            // Sanity check: a dynamic assembly has no on-disk location.
             Assert.That(dynamicAssembly.Location, Is.EqualTo(string.Empty));
+            Assert.That(AssemblyHelper.GetAssemblyPath(dynamicAssembly), Is.EqualTo(string.Empty));
+        }
 
-            string path = AssemblyHelper.GetAssemblyPath(dynamicAssembly);
-            Assert.That(path, Is.EqualTo(AppContext.BaseDirectory));
+        // GetDirectoryName previously did Path.GetDirectoryName(GetAssemblyPath(assembly))!
+        // and on .NET 5+ Path.GetDirectoryName("") returns null — the null-forgiving
+        // `!` hid it until a downstream caller (e.g. Path.Combine(TestContext.TestDirectory,
+        // ...)) threw. This pins the fix: GetDirectoryName must return a non-null,
+        // non-empty directory for an assembly with no location. See #4987.
+        [Test]
+        public void GetDirectoryName_ReturnsNonEmpty_WhenAssemblyHasNoLocation()
+        {
+            var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("AssemblyHelperTests_EmptyLocation"),
+                AssemblyBuilderAccess.RunAndCollect);
+
+            Assert.That(dynamicAssembly.Location, Is.EqualTo(string.Empty));
+            var directory = AssemblyHelper.GetDirectoryName(dynamicAssembly);
+            Assert.That(directory, Is.Not.Null);
+            Assert.That(directory, Is.Not.EqualTo(string.Empty));
         }
 #endif
     }

--- a/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitFramework/tests/Internal/AssemblyHelperTests.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Framework.Tests.Internal


### PR DESCRIPTION
Fixes #4987

## Root cause

`Assembly.Location` returns an empty string in single-file/AOT publish scenarios (and in other hosting environments such as Blazor, as noted in #4320). `AssemblyHelper.GetAssemblyPath` returned `assembly.Location` directly, so downstream callers such as `Path.GetDirectoryName(GetAssemblyPath(assembly))` (in `GetDirectoryName`) received an empty string and threw:

```
System.ArgumentException: Argument name must not be the empty string (Parameter 'name')
```

## Fix

In `GetAssemblyPath`, return `assembly.Location` only when it is non-empty; otherwise fall back to `AppContext.BaseDirectory`.

`AppContext.BaseDirectory` is already used elsewhere in this same file (the assembly-name resolution path), so this is consistent with existing behavior and gives downstream `Path.GetDirectoryName` a valid directory instead of an empty string, avoiding the crash.

The `NETFRAMEWORK` `CodeBase` path is unchanged.

## Notes

- @vpenades suggested `System.AppContext.BaseDirectory` / `System.Environment.ProcessPath` as fallbacks; this uses `AppContext.BaseDirectory` since it's already an established pattern in this file.
- @stevenaw noted the same `Assembly.Location` issue affects NUnitLite under Blazor (#4320); this fallback should help both cases since `AppContext.BaseDirectory` is meaningful in both AOT and Blazor hosts.
- Minimal change: one method, one new fallback branch. No new dependencies.