### PR TITLE
Add nint/nuint (IntPtr/UIntPtr) to numeric type coercion

### DIFF
--- a/src/NUnitFramework/framework/Constraints/Numerics.cs
+++ b/src/NUnitFramework/framework/Constraints/Numerics.cs
@@ -89,6 +89,10 @@ namespace NUnit.Framework.Constraints
                     return true;
                 if (obj is char)
                     return true;
+                if (obj is IntPtr)
+                    return true;
+                if (obj is UIntPtr)
+                    return true;
             }
             return false;
         }
@@ -114,6 +118,10 @@ namespace NUnit.Framework.Constraints
                 if (type == typeof(ushort))
                     return true;
                 if (type == typeof(char))
+                    return true;
+                if (type == typeof(IntPtr))
+                    return true;
+                if (type == typeof(UIntPtr))
                     return true;
             }
             return false;
@@ -148,6 +156,12 @@ namespace NUnit.Framework.Constraints
 
             if (expected is decimal || actual is decimal)
                 return AreEqual(Convert.ToDecimal(expected), Convert.ToDecimal(actual), tolerance);
+
+            if (expected is UIntPtr || actual is UIntPtr)
+                return AreEqual(Convert.ToUInt64(expected), Convert.ToUInt64(actual), tolerance);
+
+            if (expected is IntPtr || actual is IntPtr)
+                return AreEqual(Convert.ToInt64(expected), Convert.ToInt64(actual), tolerance);
 
             if (expected is ulong || actual is ulong)
                 return AreEqual(Convert.ToUInt64(expected), Convert.ToUInt64(actual), tolerance);
@@ -185,6 +199,12 @@ namespace NUnit.Framework.Constraints
 
             if (expected is decimal || actual is decimal)
                 return AreEqual(expected.ToDecimal(null), actual.ToDecimal(null), tolerance);
+
+            if (expected is UIntPtr || actual is UIntPtr)
+                return AreEqual(expected.ToUInt64(null), actual.ToUInt64(null), tolerance);
+
+            if (expected is IntPtr || actual is IntPtr)
+                return AreEqual(expected.ToInt64(null), actual.ToInt64(null), tolerance);
 
             if (expected is ulong || actual is ulong)
                 return AreEqual(expected.ToUInt64(null), actual.ToUInt64(null), tolerance);
@@ -460,6 +480,12 @@ namespace NUnit.Framework.Constraints
             if (expected is float || actual is float)
                 return Convert.ToSingle(expected).CompareTo(Convert.ToSingle(actual));
 
+            if (expected is UIntPtr || actual is UIntPtr)
+                return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));
+
+            if (expected is IntPtr || actual is IntPtr)
+                return Convert.ToInt64(expected).CompareTo(Convert.ToInt64(actual));
+
             if (expected is ulong || actual is ulong)
                 return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));
 
@@ -517,6 +543,18 @@ namespace NUnit.Framework.Constraints
             {
                 var difference = Convert.ToDouble(expected) - Convert.ToDouble(actual);
                 return isAbsolute ? difference : difference / Convert.ToDouble(expected) * 100;
+            }
+
+            if (expected is UIntPtr || actual is UIntPtr)
+            {
+                var difference = Convert.ToUInt64(expected) - Convert.ToUInt64(actual);
+                return isAbsolute ? difference : difference / (double)Convert.ToUInt64(expected) * 100;
+            }
+
+            if (expected is IntPtr || actual is IntPtr)
+            {
+                var difference = Convert.ToInt64(expected) - Convert.ToInt64(actual);
+                return isAbsolute ? difference : difference / (double)Convert.ToInt64(expected) * 100;
             }
 
             if (expected is ulong || actual is ulong)

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -322,22 +322,6 @@ namespace NUnit.Framework
             return new EqualNumericConstraint<sbyte>(expected);
         }
 
-        /// <summary>
-        /// Returns a constraint that tests two numbers for equality
-        /// </summary>
-        public static EqualNumericConstraint<nint> EqualTo(nint expected)
-        {
-            return new EqualNumericConstraint<nint>(expected);
-        }
-
-        /// <summary>
-        /// Returns a constraint that tests two numbers for equality
-        /// </summary>
-        public static EqualNumericConstraint<nuint> EqualTo(nuint expected)
-        {
-            return new EqualNumericConstraint<nuint>(expected);
-        }
-
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 #pragma warning restore CS3002 // Return type is not CLS-compliant
 

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -322,6 +322,22 @@ namespace NUnit.Framework
             return new EqualNumericConstraint<sbyte>(expected);
         }
 
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<nint> EqualTo(nint expected)
+        {
+            return new EqualNumericConstraint<nint>(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that tests two numbers for equality
+        /// </summary>
+        public static EqualNumericConstraint<nuint> EqualTo(nuint expected)
+        {
+            return new EqualNumericConstraint<nuint>(expected);
+        }
+
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 #pragma warning restore CS3002 // Return type is not CLS-compliant
 

--- a/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/EqualConstraintTests.cs
@@ -1701,23 +1701,22 @@ namespace NUnit.Framework.Tests.Constraints
         {
             get
             {
-                var ptr = new System.IntPtr(0);
                 var exampleTestA = new ExampleTest.ClassA(0);
                 var exampleTestB = new ExampleTest.ClassB(0);
                 var clipTestA = new ExampleTest.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Clip.ReallyLongClassNameShouldBeHere();
                 var clipTestB = new ExampleTest.Clip.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Outer.Middle.Inner.Clip.ReallyLongClassNameShouldBeHere();
-                yield return new object[] { 0, ptr };
                 yield return new object[] { exampleTestA, exampleTestB };
                 yield return new object[] { clipTestA, clipTestB };
             }
         }
         [Test]
-        public void SameValueDifferentTypeExactMessageMatch()
+        public void IntPtrNowCoercesAsNumericAndEqualsInt32()
         {
-#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
-            var ex = Assert.Throws<AssertionException>(() => Assert.That(new IntPtr(0), Is.EqualTo(0)));
-#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
-            Assert.That(ex?.Message, Does.Contain("  Expected: 0 (Int32)" + NL + "  But was:  0 (IntPtr)" + NL));
+            // Issue #5340: IntPtr (nint) is now a recognized numeric type,
+            // so an IntPtr with value 0 compares equal to the integer 0
+            // via numeric coercion, rather than failing on type mismatch.
+            Assert.That(new IntPtr(0), Is.EqualTo(0));
+            Assert.That((nint)42, Is.EqualTo(42));
         }
 
         private class Dummy

--- a/src/NUnitFramework/tests/Constraints/NumericsTest.cs
+++ b/src/NUnitFramework/tests/Constraints/NumericsTest.cs
@@ -24,6 +24,8 @@ namespace NUnit.Framework.Tests.Constraints
         [TestCase(123456789UL)]
         [TestCase(1234.5678f)]
         [TestCase(1234.5678)]
+        [TestCase((nint)123456789)]
+        [TestCase((nuint)123456789U)]
         [Test]
         public void CanMatchWithoutToleranceMode(object value)
         {
@@ -49,6 +51,12 @@ namespace NUnit.Framework.Tests.Constraints
         [TestCase((ulong)9500)]
         [TestCase((ulong)10000)]
         [TestCase((ulong)10500)]
+        [TestCase((nint)9500)]
+        [TestCase((nint)10000)]
+        [TestCase((nint)10500)]
+        [TestCase((nuint)9500)]
+        [TestCase((nuint)10000)]
+        [TestCase((nuint)10500)]
         [Test]
         public void CanMatchIntegralsWithPercentage(object value)
         {
@@ -192,6 +200,57 @@ namespace NUnit.Framework.Tests.Constraints
         public void FailsOnDecimalIsPartOfIsFixedPointNumericMethod()
         {
             Assert.That(Numerics.IsFixedPointNumeric(1000m), Is.False);
+        }
+
+        [Test]
+        public void IntPtrIsRecognizedAsNumeric()
+        {
+            Assert.That(Numerics.IsNumericType((nint)5), Is.True);
+            Assert.That(Numerics.IsNumericType(typeof(nint)), Is.True);
+            Assert.That(Numerics.IsFixedPointNumeric((nint)5), Is.True);
+            Assert.That(Numerics.IsFixedPointNumeric(typeof(nint)), Is.True);
+        }
+
+        [Test]
+        public void UIntPtrIsRecognizedAsNumeric()
+        {
+            Assert.That(Numerics.IsNumericType((nuint)5), Is.True);
+            Assert.That(Numerics.IsNumericType(typeof(nuint)), Is.True);
+            Assert.That(Numerics.IsFixedPointNumeric((nuint)5), Is.True);
+            Assert.That(Numerics.IsFixedPointNumeric(typeof(nuint)), Is.True);
+        }
+
+        [Test]
+        public void IntPtrComparesWithInt32ViaNumericCoercion()
+        {
+            // Issue #5340: nint should coerce against other integer types.
+            Assert.That(Numerics.Compare((nint)5, 5), Is.EqualTo(0));
+            Assert.That(Numerics.Compare((nint)10, 5), Is.GreaterThan(0));
+            Assert.That(Numerics.Compare((nint)3, 5), Is.LessThan(0));
+        }
+
+        [Test]
+        public void UIntPtrComparesWithUInt32ViaNumericCoercion()
+        {
+            Assert.That(Numerics.Compare((nuint)5, 5u), Is.EqualTo(0));
+            Assert.That(Numerics.Compare((nuint)10, 5u), Is.GreaterThan(0));
+            Assert.That(Numerics.Compare((nuint)3, 5u), Is.LessThan(0));
+        }
+
+        [Test]
+        public void IntPtrAndInt32AreEqualViaNumericCoercion()
+        {
+            // Reproduces the core scenario from issue #5340:
+            // Has.Property("Capacity").EqualTo(5) against an nint property.
+            Assert.That(Numerics.AreEqual(5, (nint)5, ref _zeroTolerance), Is.True);
+            Assert.That(Numerics.AreEqual((nint)5, 5, ref _zeroTolerance), Is.True);
+        }
+
+        [Test]
+        public void UIntPtrAndUInt32AreEqualViaNumericCoercion()
+        {
+            Assert.That(Numerics.AreEqual(5u, (nuint)5, ref _zeroTolerance), Is.True);
+            Assert.That(Numerics.AreEqual((nuint)5, 5u, ref _zeroTolerance), Is.True);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `nint` (`IntPtr`) and `nuint` (`UIntPtr`) to NUnit's built-in numeric type recognition so that numeric coercion covers all built-in integer types, as requested in #5340.

This makes scenarios like `Has.Property("Capacity").EqualTo(5)` work against an `nint Capacity { get; }` property without requiring an explicit `EqualTo((nint)5)` cast.

Fixes #5340

## What changed

### `src/NUnitFramework/framework/Constraints/Numerics.cs`
- **`IsFixedPointNumeric(object?)`** and **`IsFixedPointNumeric(Type)`**: added `IntPtr` and `UIntPtr` recognition. Uses `typeof(IntPtr)` / `typeof(UIntPtr)` (not the `nint`/`nuint` keywords) in the `Type` overload for .NET Framework compatibility, per the discussion below.
- **`AreEqual`** (both the `object` and generic `AreEqual<T1,T2>` overloads): added dispatch for `UIntPtr` → `ulong` and `IntPtr` → `long`, following the existing integer dispatch pattern.
- **`Compare`**: added dispatch for `UIntPtr` → `ulong` and `IntPtr` → `long`.
- **`Difference`**: added dispatch for `UIntPtr` → `ulong` and `IntPtr` → `long`.

### `src/NUnitFramework/framework/Is.cs`
- Added `Is.EqualTo(nint)` and `Is.EqualTo(nuint)` overloads returning `EqualNumericConstraint<nint>` / `EqualNumericConstraint<nuint>`, matching the existing overloads for other integer types. Placed inside the existing CLS-compliance `#pragma` block alongside the other non-CLS-compliant numeric overloads.

### Tests
- **`NumericsTest.cs`**: added `nint`/`nuint` cases to `CanMatchWithoutToleranceMode` and `CanMatchIntegralsWithPercentage`; added dedicated tests for `IntPtr`/`UIntPtr` type recognition, comparison, and cross-type equality with `Int32`/`UInt32` (the core scenario from the issue).
- **`EqualConstraintTests.cs`**: updated the existing tests that asserted `new IntPtr(0)` does **not** equal `0`. Since `IntPtr` is now a recognized numeric type, `Assert.That(new IntPtr(0), Is.EqualTo(0))` now succeeds via numeric coercion. Replaced `SameValueDifferentTypeExactMessageMatch` with `IntPtrNowCoercesAsNumericAndEqualsInt32` and removed the `IntPtr` entry from `DifferentTypeSameValueTestData`.

## Design notes

- `IntPtr` is dispatched to `long` and `UIntPtr` to `ulong` — the natural signed/unsigned mapping for native integers. This reuses the existing, well-tested `AreEqual`/`Compare`/`Difference` implementations for `long`/`ulong` rather than duplicating logic.
- The type-recognition checks use `typeof(IntPtr)` / `typeof(UIntPtr)` instead of the `nint` / `nuint` keywords so the code is safe on all target frameworks (`net462`, `net8.0`, `net10.0`). As @tannergooding noted, `RuntimeFeature.NumericIntPtr` is not defined on older frameworks and there are historical quirks between `IntPtr` and `nint`. The `typeof` check is safe everywhere since `nint` and `IntPtr` are the same type in IL.
- `EqualNumericConstraint<nint>` works because `IntPtr`/`UIntPtr` satisfy the `where T : struct, IConvertible` constraint (they implement `IConvertible` via explicit interface members on all supported target frameworks) and `Numerics.IsNumericType(typeof(nint))` now returns `true`.

## Maintainer discussion

This fix follows the approach agreed upon by @stevenaw, @OsirisTerje, and @manfred-brands in the issue comments:
- @stevenaw: *"I suspect this to just be a matter of adding the mapping in our Numerics class."*
- @OsirisTerje: *"Just add it in. We are just in beta, so we can add more fixes."* and *"Assume we need to use the basic types for nint => System.IntPtr and nuint => System.UIntPtr so that it compiles on .net framework and .net 8 too."*
- @manfred-brands: *"You will need overloads in Is and add support for nint and nuint to Numerics.cs"*

The scope is intentionally limited to `nint`/`nuint` (the built-in native integer types). The other types mentioned in the issue (`Half`, `Int128`, `UInt128`) are library types without C# keywords and are left for a separate effort, as @OsirisTerje raised.

## CLA

I have previously signed the NUnit CLA (via PR #5352).

## AI disclosure

This change was developed with AI assistance. I have reviewed every line of the diff, understand the rationale for each change, and take full responsibility for the contribution. The approach follows the maintainer-prescribed fix from the issue discussion, and the tests were written to verify the specific behavior change requested.
