### PR TITLE
NUnitLite: Display all framework run settings

### DIFF
--- a/src/NUnitFramework/nunitlite.tests/TextUITests.cs
+++ b/src/NUnitFramework/nunitlite.tests/TextUITests.cs
@@ -85,6 +85,29 @@ namespace NUnitLite.Tests
             Assert.That(Report, Does.Match("^Runtime Environment\n   OS Version:.*\n  CLR Version:.*\n\n$"));
         }
 
+        [Test]
+        public void DisplayRunSettingsIncludesEveryFrameworkSetting()
+        {
+            var settings = new Dictionary<string, object>
+            {
+                ["CustomFrameworkSetting"] = "enabled",
+                ["NumberOfTestWorkers"] = 4,
+                ["TestParametersDictionary"] = new Dictionary<string, string>
+                {
+                    ["environment"] = "ci"
+                }
+            };
+
+            CreateTextUI().DisplayRunSettings(settings);
+
+            Assert.That(Report, Is.EqualTo(
+                "Run Settings\n" +
+                "    CustomFrameworkSetting: |enabled|\n" +
+                "    NumberOfTestWorkers: |4|\n" +
+                "    TestParametersDictionary:\n" +
+                "        environment -> |ci|\n\n"));
+        }
+
         [TestCase("Off", "")]
         [TestCase("On", "")]
         [TestCase("All", "=> NUnitLite.Tests.TextUITests.MyFakeMethod\n")]

--- a/src/NUnitFramework/nunitlite/TextRunner.cs
+++ b/src/NUnitFramework/nunitlite/TextRunner.cs
@@ -272,7 +272,7 @@ namespace NUnitLite
         {
             ITestResult result = _runner.Run(this, filter);
 
-            ReportResults(result);
+            ReportResults(result, runSettings);
 
             if (_options.ResultOutputSpecifications.Count > 0)
             {
@@ -289,6 +289,11 @@ namespace NUnitLite
 
         public void ReportResults(ITestResult result)
         {
+            ReportResults(result, MakeRunSettings(_options));
+        }
+
+        private void ReportResults(ITestResult result, IDictionary<string, object> runSettings)
+        {
             Summary = new ResultSummary(result);
 
             if (Summary.ExplicitCount + Summary.SkipCount + Summary.IgnoreCount > 0)
@@ -302,7 +307,7 @@ namespace NUnitLite
                 _textUI.PrintFullReport(_result);
 #endif
 
-            _textUI.DisplayRunSettings();
+            _textUI.DisplayRunSettings(runSettings);
 
             _textUI.DisplaySummaryReport(Summary);
         }

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using NUnit;
 using NUnit.Common;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -214,31 +216,46 @@ namespace NUnitLite
 
         public void DisplayRunSettings()
         {
+            DisplayRunSettings(TextRunner.MakeRunSettings(_options));
+        }
+
+        internal void DisplayRunSettings(IDictionary<string, object> runSettings)
+        {
             if (_quiet)
                 return;
 
             WriteSectionHeader("Run Settings");
 
+            foreach (KeyValuePair<string, object> setting in runSettings)
+                WriteRunSetting(setting.Key, setting.Value);
+
+            if (!runSettings.ContainsKey(FrameworkPackageSettings.NumberOfTestWorkers))
+                WriteRunSetting(FrameworkPackageSettings.NumberOfTestWorkers, Math.Max(Environment.ProcessorCount, 2));
+
+#if !NETFRAMEWORK
             if (_options.DefaultTimeout >= 0)
-#if NETFRAMEWORK
-                Writer.WriteLabelLine("    Default timeout: ", _options.DefaultTimeout);
-#else
                 Writer.WriteLine(ColorStyle.Warning, $"    Default timeout ({_options.DefaultTimeout}) is only supported on .NET Framework; use CancelAfter on modern .NET.");
 #endif
-
-            Writer.WriteLabelLine(
-                "    Number of Test Workers: ",
-                _options.NumberOfTestWorkers >= 0
-                    ? _options.NumberOfTestWorkers
-                    : Math.Max(Environment.ProcessorCount, 2));
-
-            Writer.WriteLabelLine("    Work Directory: ", _options.WorkDirectory ?? Directory.GetCurrentDirectory());
-            Writer.WriteLabelLine("    Internal Trace: ", _options.InternalTraceLevel ?? "Off");
 
             if (_options.TeamCity)
                 Writer.WriteLine(ColorStyle.Value, "    Display TeamCity Service Messages");
 
             Writer.WriteLine();
+        }
+
+        private void WriteRunSetting(string name, object value)
+        {
+            if (value is IDictionary dictionary)
+            {
+                Writer.WriteLabelLine($"    {name}:", string.Empty);
+
+                foreach (DictionaryEntry entry in dictionary)
+                    Writer.WriteLine(ColorStyle.Value, $"        {entry.Key} -> |{entry.Value}|");
+            }
+            else
+            {
+                Writer.WriteLabelLine($"    {name}: ", $"|{value}|");
+            }
         }
 
         #endregion

--- a/src/NUnitFramework/nunitlite/TextUI.cs
+++ b/src/NUnitFramework/nunitlite/TextUI.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Reflection;
 using NUnit;
 using NUnit.Common;
+using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -230,7 +231,7 @@ namespace NUnitLite
                 WriteRunSetting(setting.Key, setting.Value);
 
             if (!runSettings.ContainsKey(FrameworkPackageSettings.NumberOfTestWorkers))
-                WriteRunSetting(FrameworkPackageSettings.NumberOfTestWorkers, Math.Max(Environment.ProcessorCount, 2));
+                WriteRunSetting(FrameworkPackageSettings.NumberOfTestWorkers, NUnitTestAssemblyRunner.DefaultLevelOfParallelism);
 
 #if !NETFRAMEWORK
             if (_options.DefaultTimeout >= 0)


### PR DESCRIPTION
## Summary

Update NUnitLite's `Run Settings` report to display every framework setting passed to the test runner instead of a hard-coded subset.

Fixes #5341.

## Root cause

`TextRunner` passed the full run-settings dictionary to the framework, but `TextUI.DisplayRunSettings()` reconstructed its output directly from a small selection of command-line options. Settings such as `RandomSeed`, `RunOnMainThread`, `StopOnError`, custom framework settings, and test-parameter dictionaries could therefore affect execution without appearing in the report.

## Changes

- Pass the actual run-settings dictionary from `TextRunner` to the report path.
- Render every scalar setting using the same delimited value style as the console runner.
- Render dictionary settings as individual key/value entries.
- Continue displaying the default worker count when it is not explicitly supplied.
- Preserve the existing modern-.NET warning for the unsupported default-timeout option and TeamCity message indicator.
- Add regression coverage for a custom setting and a test-parameter dictionary.
- Keep the existing public parameterless `DisplayRunSettings()` and `ReportResults()` methods for compatibility.

## User impact

NUnitLite output now accurately shows the settings used for a run. This makes configuration problems easier to diagnose and avoids suggesting that an accepted setting was ignored.

## Validation

- `dotnet build nunit.slnx -c Release --no-restore`
  - Succeeded with 0 warnings and 0 errors.
- `dotnet test nunit.slnx -c Release --no-build --no-restore`
  - Completed successfully with 0 failed tests.
- Ran the NUnitLite self-test executable on `net462`, `net8.0`, `net9.0`, and `net10.0`.
  - 1,589 passed, 4 skipped, 0 failed across all four targets.
- Ran the new test through the `net10.0` NUnitLite executable with `--seed=1234` and verified `RandomSeed: |1234|` appears in the real report.
- Ran scoped `dotnet format` and `git diff --check`.

